### PR TITLE
Refactor editor draw logic and add LiveManager

### DIFF
--- a/.agent/workflows/api.md
+++ b/.agent/workflows/api.md
@@ -1,0 +1,5 @@
+---
+description: always add doxygen style api
+---
+
+After finishing a task, or editing a file, or implementation plan, always add doxygen style api withn /* and *\ wrappers to the CPP files.

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ cmake-build-debug/
 # vcpkg
 /vcpkg_installed/
 
+/.agent/rules

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -26,6 +26,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/editor/action.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/copybuffer.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/editor.h
+    ${CMAKE_CURRENT_LIST_DIR}/editor/operations/draw_operations.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/operations/selection_operations.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/persistence/editor_persistence.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/editor_tabs.h
@@ -55,6 +56,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/live/live_client.h
     ${CMAKE_CURRENT_LIST_DIR}/live/live_packets.h
     ${CMAKE_CURRENT_LIST_DIR}/live/live_peer.h
+    ${CMAKE_CURRENT_LIST_DIR}/live/live_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/live/live_server.h
     ${CMAKE_CURRENT_LIST_DIR}/live/live_socket.h
     ${CMAKE_CURRENT_LIST_DIR}/live/live_tab.h
@@ -205,6 +207,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/editor/action.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/copybuffer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/editor.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/editor/operations/draw_operations.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/operations/selection_operations.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/persistence/editor_persistence.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/editor_tabs.cpp
@@ -228,6 +231,7 @@ set(rme_SRC
     #${CMAKE_CURRENT_LIST_DIR}/io/iomap_otmm.cpp
     ${CMAKE_CURRENT_LIST_DIR}/live/live_action.cpp
     ${CMAKE_CURRENT_LIST_DIR}/live/live_client.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/live/live_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/live/live_peer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/live/live_server.cpp
     ${CMAKE_CURRENT_LIST_DIR}/live/live_socket.cpp

--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -39,9 +39,10 @@
 #include "live/live_client.h"
 #include "live/live_action.h"
 
+#include "editor/operations/draw_operations.h"
+
 Editor::Editor(CopyBuffer& copybuffer) :
-	live_server(nullptr),
-	live_client(nullptr),
+	live_manager(*this),
 	actionQueue(newd ActionQueue(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
@@ -91,63 +92,16 @@ Editor::Editor(CopyBuffer& copybuffer) :
 }
 
 Editor::Editor(CopyBuffer& copybuffer, const FileName& fn) :
-	live_server(nullptr),
-	live_client(nullptr),
+	live_manager(*this),
 	actionQueue(newd ActionQueue(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
-	MapVersion ver;
-	if (!IOMapOTBM::getVersionInfo(fn, ver)) {
-		// g_gui.PopupDialog("Error", "Could not open file \"" + fn.GetFullPath() + "\".", wxOK);
-		throw std::runtime_error("Could not open file \"" + nstr(fn.GetFullPath()) + "\".\nThis is not a valid OTBM file or it does not exist.");
-	}
-
-	/*
-	if(ver < CLIENT_VERSION_760) {
-		long b = g_gui.PopupDialog("Error", "Unsupported Client Version (pre 7.6), do you want to try to load the map anyways?", wxYES | wxNO);
-		if(b == wxID_NO) {
-			valid_state = false;
-			return;
-		}
-	}
-	*/
-
-	bool success = true;
-	if (g_gui.GetCurrentVersionID() != ver.client) {
-		wxString error;
-		wxArrayString warnings;
-		if (g_gui.CloseAllEditors()) {
-			success = g_gui.LoadVersion(ver.client, error, warnings);
-			if (!success) {
-				g_gui.PopupDialog("Error", error, wxOK);
-			} else {
-				g_gui.ListDialog("Warnings", warnings);
-			}
-		} else {
-			throw std::runtime_error("All maps of different versions were not closed.");
-		}
-	}
-
-	if (success) {
-		ScopedLoadingBar LoadingBar("Loading OTBM map...");
-		success = map.open(nstr(fn.GetFullPath()));
-		/* TODO
-		if(success && ver.client == CLIENT_VERSION_854_BAD) {
-			int ok = g_gui.PopupDialog("Incorrect OTB", "This map has been saved with an incorrect OTB version, do you want to convert it to the new OTB version?\n\nIf you are not sure, click Yes.", wxYES | wxNO);
-
-			if(ok == wxID_YES){
-				ver.client = CLIENT_VERSION_854;
-				map.convert(ver);
-			}
-		}
-		*/
-	}
+	EditorPersistence::loadMap(*this, fn);
 }
 
 Editor::Editor(CopyBuffer& copybuffer, LiveClient* client) :
-	live_server(nullptr),
-	live_client(client),
+	live_manager(*this, client),
 	actionQueue(newd NetworkedActionQueue(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
@@ -230,609 +184,67 @@ void Editor::destroySelection() {
 // Helper functions moved to SelectionOperations
 
 void Editor::drawInternal(Position offset, bool alt, bool dodraw) {
-	Brush* brush = g_gui.GetCurrentBrush();
-	if (!brush) {
-		return;
-	}
-
-	if (brush->isDoodad()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-		BaseMap* buffer_map = g_gui.doodad_buffer_map;
-
-		Position delta_pos = offset - Position(0x8000, 0x8000, 0x8);
-		PositionList tilestoborder;
-
-		for (MapIterator it = buffer_map->begin(); it != buffer_map->end(); ++it) {
-			Tile* buffer_tile = (*it)->get();
-			Position pos = buffer_tile->getPosition() + delta_pos;
-			if (!pos.isValid()) {
-				continue;
-			}
-
-			TileLocation* location = map.createTileL(pos);
-			Tile* tile = location->get();
-			DoodadBrush* doodad_brush = brush->asDoodad();
-
-			if (doodad_brush->placeOnBlocking() || alt) {
-				if (tile) {
-					bool place = true;
-					if (!doodad_brush->placeOnDuplicate() && !alt) {
-						for (ItemVector::const_iterator iter = tile->items.begin(); iter != tile->items.end(); ++iter) {
-							if (doodad_brush->ownsItem(*iter)) {
-								place = false;
-								break;
-							}
-						}
-					}
-					if (place) {
-						Tile* new_tile = tile->deepCopy(map);
-						SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
-						SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
-						new_tile->merge(buffer_tile);
-						action->addChange(newd Change(new_tile));
-					}
-				} else {
-					Tile* new_tile = map.allocator(location);
-					SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
-					SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
-					new_tile->merge(buffer_tile);
-					action->addChange(newd Change(new_tile));
-				}
-			} else {
-				if (tile && !tile->isBlocking()) {
-					bool place = true;
-					if (!doodad_brush->placeOnDuplicate() && !alt) {
-						for (ItemVector::const_iterator iter = tile->items.begin(); iter != tile->items.end(); ++iter) {
-							if (doodad_brush->ownsItem(*iter)) {
-								place = false;
-								break;
-							}
-						}
-					}
-					if (place) {
-						Tile* new_tile = tile->deepCopy(map);
-						SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
-						SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
-						new_tile->merge(buffer_tile);
-						action->addChange(newd Change(new_tile));
-					}
-				}
-			}
-		}
-		batch->addAndCommitAction(action);
-
-		if (tilestoborder.size() > 0) {
-			Action* action = actionQueue->createAction(batch);
-
-			// Remove duplicates
-			tilestoborder.sort();
-			tilestoborder.unique();
-
-			for (PositionList::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
-				Tile* tile = map.getTile(*it);
-				if (tile) {
-					Tile* new_tile = tile->deepCopy(map);
-					new_tile->borderize(&map);
-					new_tile->wallize(&map);
-					action->addChange(newd Change(new_tile));
-				}
-			}
-			batch->addAndCommitAction(action);
-		}
-		addBatch(batch, 2);
-	} else if (brush->isHouseExit()) {
-		HouseExitBrush* house_exit_brush = brush->asHouseExit();
-		if (!house_exit_brush->canDraw(&map, offset)) {
-			return;
-		}
-
-		House* house = map.houses.getHouse(house_exit_brush->getHouseID());
-		if (!house) {
-			return;
-		}
-
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-		action->addChange(Change::Create(house, offset));
-		batch->addAndCommitAction(action);
-		addBatch(batch, 2);
-	} else if (brush->isWaypoint()) {
-		WaypointBrush* waypoint_brush = brush->asWaypoint();
-		if (!waypoint_brush->canDraw(&map, offset)) {
-			return;
-		}
-
-		Waypoint* waypoint = map.waypoints.getWaypoint(waypoint_brush->getWaypoint());
-		if (!waypoint || waypoint->pos == offset) {
-			return;
-		}
-
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-		action->addChange(Change::Create(waypoint, offset));
-		batch->addAndCommitAction(action);
-		addBatch(batch, 2);
-	} else if (brush->isWall()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-		// This will only occur with a size 0, when clicking on a tile (not drawing)
-		Tile* tile = map.getTile(offset);
-		Tile* new_tile = nullptr;
-		if (tile) {
-			new_tile = tile->deepCopy(map);
-		} else {
-			new_tile = map.allocator(map.createTileL(offset));
-		}
-
-		if (dodraw) {
-			bool b = true;
-			brush->asWall()->draw(&map, new_tile, &b);
-		} else {
-			brush->asWall()->undraw(&map, new_tile);
-		}
-		action->addChange(newd Change(new_tile));
-		batch->addAndCommitAction(action);
-		addBatch(batch, 2);
-	} else if (brush->isSpawn() || brush->isCreature()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-
-		Tile* tile = map.getTile(offset);
-		Tile* new_tile = nullptr;
-		if (tile) {
-			new_tile = tile->deepCopy(map);
-		} else {
-			new_tile = map.allocator(map.createTileL(offset));
-		}
-		int param;
-		if (!brush->isCreature()) {
-			param = g_gui.GetBrushSize();
-		}
-		if (dodraw) {
-			brush->draw(&map, new_tile, &param);
-		} else {
-			brush->undraw(&map, new_tile);
-		}
-		action->addChange(newd Change(new_tile));
-		batch->addAndCommitAction(action);
-		addBatch(batch, 2);
-	}
+	DrawOperations::draw(*this, offset, alt, dodraw);
 }
 
 void Editor::drawInternal(const PositionVector& tilestodraw, bool alt, bool dodraw) {
-	Brush* brush = g_gui.GetCurrentBrush();
-	if (!brush) {
-		return;
-	}
-
-#ifdef __DEBUG__
-	if (brush->isGround() || brush->isWall()) {
-		// Wrong function, end call
-		return;
-	}
-#endif
-
-	Action* action = actionQueue->createAction(ACTION_DRAW);
-
-	if (brush->isOptionalBorder()) {
-		// We actually need to do borders, but on the same tiles we draw to
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				if (dodraw) {
-					Tile* new_tile = tile->deepCopy(map);
-					brush->draw(&map, new_tile);
-					new_tile->borderize(&map);
-					action->addChange(newd Change(new_tile));
-				} else if (!dodraw && tile->hasOptionalBorder()) {
-					Tile* new_tile = tile->deepCopy(map);
-					brush->undraw(&map, new_tile);
-					new_tile->borderize(&map);
-					action->addChange(newd Change(new_tile));
-				}
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				brush->draw(&map, new_tile);
-				new_tile->borderize(&map);
-				if (new_tile->size() == 0) {
-					delete new_tile;
-					continue;
-				}
-				action->addChange(newd Change(new_tile));
-			}
-		}
-	} else {
-
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				Tile* new_tile = tile->deepCopy(map);
-				if (dodraw) {
-					brush->draw(&map, new_tile, &alt);
-				} else {
-					brush->undraw(&map, new_tile);
-				}
-				action->addChange(newd Change(new_tile));
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				brush->draw(&map, new_tile, &alt);
-				action->addChange(newd Change(new_tile));
-			}
-		}
-	}
-	addAction(action, 2);
+	DrawOperations::draw(*this, tilestodraw, alt, dodraw);
 }
 
 void Editor::drawInternal(const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
-	Brush* brush = g_gui.GetCurrentBrush();
-	if (!brush) {
-		return;
-	}
-
-	if (brush->isGround() || brush->isEraser()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				Tile* new_tile = tile->deepCopy(map);
-				if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
-					new_tile->cleanBorders();
-				}
-				if (dodraw) {
-					if (brush->isGround() && alt) {
-						std::pair<bool, GroundBrush*> param;
-						if (replace_brush) {
-							param.first = false;
-							param.second = replace_brush;
-						} else {
-							param.first = true;
-							param.second = nullptr;
-						}
-						g_gui.GetCurrentBrush()->draw(&map, new_tile, &param);
-					} else {
-						g_gui.GetCurrentBrush()->draw(&map, new_tile, nullptr);
-					}
-				} else {
-					g_gui.GetCurrentBrush()->undraw(&map, new_tile);
-					tilestoborder.push_back(*it);
-				}
-				action->addChange(newd Change(new_tile));
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				if (brush->isGround() && alt) {
-					std::pair<bool, GroundBrush*> param;
-					if (replace_brush) {
-						param.first = false;
-						param.second = replace_brush;
-					} else {
-						param.first = true;
-						param.second = nullptr;
-					}
-					g_gui.GetCurrentBrush()->draw(&map, new_tile, &param);
-				} else {
-					g_gui.GetCurrentBrush()->draw(&map, new_tile, nullptr);
-				}
-				action->addChange(newd Change(new_tile));
-			}
-		}
-
-		// Commit changes to map
-		batch->addAndCommitAction(action);
-
-		if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
-			// Do borders!
-			action = actionQueue->createAction(batch);
-			for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
-				TileLocation* location = map.createTileL(*it);
-				Tile* tile = location->get();
-				if (tile) {
-					Tile* new_tile = tile->deepCopy(map);
-					if (brush->isEraser()) {
-						new_tile->wallize(&map);
-						new_tile->tableize(&map);
-						new_tile->carpetize(&map);
-					}
-					new_tile->borderize(&map);
-					action->addChange(newd Change(new_tile));
-				} else {
-					Tile* new_tile = map.allocator(location);
-					if (brush->isEraser()) {
-						// There are no carpets/tables/walls on empty tiles...
-						// new_tile->wallize(map);
-						// new_tile->tableize(map);
-						// new_tile->carpetize(map);
-					}
-					new_tile->borderize(&map);
-					if (new_tile->size() > 0) {
-						action->addChange(newd Change(new_tile));
-					} else {
-						delete new_tile;
-					}
-				}
-			}
-			batch->addAndCommitAction(action);
-		}
-
-		addBatch(batch, 2);
-	} else if (brush->isTable() || brush->isCarpet()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				Tile* new_tile = tile->deepCopy(map);
-				if (dodraw) {
-					g_gui.GetCurrentBrush()->draw(&map, new_tile, nullptr);
-				} else {
-					g_gui.GetCurrentBrush()->undraw(&map, new_tile);
-				}
-				action->addChange(newd Change(new_tile));
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				g_gui.GetCurrentBrush()->draw(&map, new_tile, nullptr);
-				action->addChange(newd Change(new_tile));
-			}
-		}
-
-		// Commit changes to map
-		batch->addAndCommitAction(action);
-
-		// Do borders!
-		action = actionQueue->createAction(batch);
-		for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
-			Tile* tile = map.getTile(*it);
-			if (brush->isTable()) {
-				if (tile && tile->hasTable()) {
-					Tile* new_tile = tile->deepCopy(map);
-					new_tile->tableize(&map);
-					action->addChange(newd Change(new_tile));
-				}
-			} else if (brush->isCarpet()) {
-				if (tile && tile->hasCarpet()) {
-					Tile* new_tile = tile->deepCopy(map);
-					new_tile->carpetize(&map);
-					action->addChange(newd Change(new_tile));
-				}
-			}
-		}
-		batch->addAndCommitAction(action);
-
-		addBatch(batch, 2);
-	} else if (brush->isWall()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-
-		if (alt && dodraw) {
-			// This is exempt from USE_AUTOMAGIC
-			g_gui.doodad_buffer_map->clear();
-			BaseMap* draw_map = g_gui.doodad_buffer_map;
-
-			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-				TileLocation* location = map.createTileL(*it);
-				Tile* tile = location->get();
-				if (tile) {
-					Tile* new_tile = tile->deepCopy(map);
-					new_tile->cleanWalls(brush->isWall());
-					g_gui.GetCurrentBrush()->draw(draw_map, new_tile);
-					draw_map->setTile(*it, new_tile, true);
-				} else if (dodraw) {
-					Tile* new_tile = map.allocator(location);
-					g_gui.GetCurrentBrush()->draw(draw_map, new_tile);
-					draw_map->setTile(*it, new_tile, true);
-				}
-			}
-			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-				// Get the correct tiles from the draw map instead of the editor map
-				Tile* tile = draw_map->getTile(*it);
-				if (tile) {
-					tile->wallize(draw_map);
-					action->addChange(newd Change(tile));
-				}
-			}
-			draw_map->clear(false);
-			// Commit
-			batch->addAndCommitAction(action);
-		} else {
-			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-				TileLocation* location = map.createTileL(*it);
-				Tile* tile = location->get();
-				if (tile) {
-					Tile* new_tile = tile->deepCopy(map);
-					// Wall cleaning is exempt from automagic
-					new_tile->cleanWalls(brush->isWall());
-					if (dodraw) {
-						g_gui.GetCurrentBrush()->draw(&map, new_tile);
-					} else {
-						g_gui.GetCurrentBrush()->undraw(&map, new_tile);
-					}
-					action->addChange(newd Change(new_tile));
-				} else if (dodraw) {
-					Tile* new_tile = map.allocator(location);
-					g_gui.GetCurrentBrush()->draw(&map, new_tile);
-					action->addChange(newd Change(new_tile));
-				}
-			}
-
-			// Commit changes to map
-			batch->addAndCommitAction(action);
-
-			if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
-				// Do borders!
-				action = actionQueue->createAction(batch);
-				for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
-					Tile* tile = map.getTile(*it);
-					if (tile) {
-						Tile* new_tile = tile->deepCopy(map);
-						new_tile->wallize(&map);
-						// if(*tile == *new_tile) delete new_tile;
-						action->addChange(newd Change(new_tile));
-					}
-				}
-				batch->addAndCommitAction(action);
-			}
-		}
-
-		actionQueue->addBatch(batch, 2);
-	} else if (brush->isDoor()) {
-		BatchAction* batch = actionQueue->createBatch(ACTION_DRAW);
-		Action* action = actionQueue->createAction(batch);
-		DoorBrush* door_brush = brush->asDoor();
-
-		// Loop is kind of redundant since there will only ever be one index.
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				Tile* new_tile = tile->deepCopy(map);
-				// Wall cleaning is exempt from automagic
-				if (brush->isWall()) {
-					new_tile->cleanWalls(brush->asWall());
-				}
-				if (dodraw) {
-					door_brush->draw(&map, new_tile, &alt);
-				} else {
-					door_brush->undraw(&map, new_tile);
-				}
-				action->addChange(newd Change(new_tile));
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				door_brush->draw(&map, new_tile, &alt);
-				action->addChange(newd Change(new_tile));
-			}
-		}
-
-		// Commit changes to map
-		batch->addAndCommitAction(action);
-
-		if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
-			// Do borders!
-			action = actionQueue->createAction(batch);
-			for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
-				Tile* tile = map.getTile(*it);
-				if (tile) {
-					Tile* new_tile = tile->deepCopy(map);
-					new_tile->wallize(&map);
-					// if(*tile == *new_tile) delete new_tile;
-					action->addChange(newd Change(new_tile));
-				}
-			}
-			batch->addAndCommitAction(action);
-		}
-
-		addBatch(batch, 2);
-	} else {
-		Action* action = actionQueue->createAction(ACTION_DRAW);
-		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
-			TileLocation* location = map.createTileL(*it);
-			Tile* tile = location->get();
-			if (tile) {
-				Tile* new_tile = tile->deepCopy(map);
-				if (dodraw) {
-					g_gui.GetCurrentBrush()->draw(&map, new_tile);
-				} else {
-					g_gui.GetCurrentBrush()->undraw(&map, new_tile);
-				}
-				action->addChange(newd Change(new_tile));
-			} else if (dodraw) {
-				Tile* new_tile = map.allocator(location);
-				g_gui.GetCurrentBrush()->draw(&map, new_tile);
-				action->addChange(newd Change(new_tile));
-			}
-		}
-		addAction(action, 2);
-	}
+	DrawOperations::draw(*this, tilestodraw, tilestoborder, alt, dodraw);
 }
 
 ///////////////////////////////////////////////////////////////////////////////
 // Live!
 
 bool Editor::IsLiveClient() const {
-	return live_client != nullptr;
+	return live_manager.IsClient();
 }
 
 bool Editor::IsLiveServer() const {
-	return live_server != nullptr;
+	return live_manager.IsServer();
 }
 
 bool Editor::IsLive() const {
-	return IsLiveClient() || IsLiveServer();
+	return live_manager.IsLive();
 }
 
 bool Editor::IsLocal() const {
-	return !IsLive();
+	return live_manager.IsLocal();
 }
 
 LiveClient* Editor::GetLiveClient() const {
-	return live_client;
+	return live_manager.GetClient();
 }
 
 LiveServer* Editor::GetLiveServer() const {
-	return live_server;
+	return live_manager.GetServer();
 }
 
 LiveSocket& Editor::GetLive() const {
-	if (live_server) {
-		return *live_server;
-	}
-	return *live_client;
+	return live_manager.GetSocket();
 }
 
 LiveServer* Editor::StartLiveServer() {
-	ASSERT(IsLocal());
-	live_server = newd LiveServer(*this);
-
-	delete actionQueue;
-	actionQueue = newd NetworkedActionQueue(*this);
-
-	return live_server;
+	return live_manager.StartServer();
 }
 
 void Editor::BroadcastNodes(DirtyList& dirtyList) {
-	if (IsLiveClient()) {
-		live_client->sendChanges(dirtyList);
-	} else {
-		live_server->broadcastNodes(dirtyList);
-	}
+	live_manager.BroadcastNodes(dirtyList);
 }
 
 void Editor::CloseLiveServer() {
-	ASSERT(IsLive());
-	if (live_client) {
-		live_client->close();
-
-		delete live_client;
-		live_client = nullptr;
-	}
-
-	if (live_server) {
-		live_server->close();
-
-		delete live_server;
-		live_server = nullptr;
-
-		delete actionQueue;
-		actionQueue = newd ActionQueue(*this);
-	}
-
-	NetworkConnection& connection = NetworkConnection::getInstance();
-	connection.stop();
+	live_manager.CloseServer();
 }
 
 void Editor::QueryNode(int ndx, int ndy, bool underground) {
-	ASSERT(live_client);
-	live_client->queryNode(ndx, ndy, underground);
+	ASSERT(live_manager.GetClient());
+	live_manager.GetClient()->queryNode(ndx, ndy, underground);
 }
 
 void Editor::SendNodeRequests() {
-	if (live_client) {
-		live_client->sendNodeRequests();
+	if (live_manager.GetClient()) {
+		live_manager.GetClient()->sendNodeRequests();
 	}
 }

--- a/source/editor/editor.h
+++ b/source/editor/editor.h
@@ -35,17 +35,17 @@ class LiveClient;
 class LiveServer;
 class LiveSocket;
 
-class Editor {
+#include "live/live_manager.h"
+
+class Editor : public wxFrame {
 public:
 	Editor(CopyBuffer& copybuffer, LiveClient* client);
 	Editor(CopyBuffer& copybuffer, const FileName& fn);
 	Editor(CopyBuffer& copybuffer);
 	~Editor();
 
-protected:
-	// Live Server
-	LiveServer* live_server;
-	LiveClient* live_client;
+	// Live Manager
+	LiveManager live_manager;
 
 public:
 	// Public members

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -1,0 +1,544 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#include "app/main.h"
+#include "editor/operations/draw_operations.h"
+#include "editor/editor.h"
+#include "ui/gui.h"
+#include "brushes/brush.h"
+#include "brushes/doodad_brush.h"
+#include "brushes/ground_brush.h"
+#include "brushes/house_exit_brush.h"
+#include "brushes/waypoint_brush.h"
+#include "brushes/wall_brush.h"
+#include "brushes/carpet_brush.h"
+#include "brushes/table_brush.h"
+#include "brushes/creature_brush.h"
+#include "brushes/spawn_brush.h"
+#include "map/map.h"
+#include "map/map.h"
+#include "map/tile.h"
+#include "app/settings.h"
+
+void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw) {
+	Brush* brush = g_gui.GetCurrentBrush();
+	if (!brush) {
+		return;
+	}
+
+	if (brush->isDoodad()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+		BaseMap* buffer_map = g_gui.doodad_buffer_map;
+
+		Position delta_pos = offset - Position(0x8000, 0x8000, 0x8);
+		PositionList tilestoborder;
+
+		for (MapIterator it = buffer_map->begin(); it != buffer_map->end(); ++it) {
+			Tile* buffer_tile = (*it)->get();
+			Position pos = buffer_tile->getPosition() + delta_pos;
+			if (!pos.isValid()) {
+				continue;
+			}
+
+			TileLocation* location = editor.map.createTileL(pos);
+			Tile* tile = location->get();
+			DoodadBrush* doodad_brush = brush->asDoodad();
+
+			if (doodad_brush->placeOnBlocking() || alt) {
+				if (tile) {
+					bool place = true;
+					if (!doodad_brush->placeOnDuplicate() && !alt) {
+						for (ItemVector::const_iterator iter = tile->items.begin(); iter != tile->items.end(); ++iter) {
+							if (doodad_brush->ownsItem(*iter)) {
+								place = false;
+								break;
+							}
+						}
+					}
+					if (place) {
+						Tile* new_tile = tile->deepCopy(editor.map);
+						SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
+						SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
+						new_tile->merge(buffer_tile);
+						action->addChange(newd Change(new_tile));
+					}
+				} else {
+					Tile* new_tile = editor.map.allocator(location);
+					SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
+					SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
+					new_tile->merge(buffer_tile);
+					action->addChange(newd Change(new_tile));
+				}
+			} else {
+				if (tile && !tile->isBlocking()) {
+					bool place = true;
+					if (!doodad_brush->placeOnDuplicate() && !alt) {
+						for (ItemVector::const_iterator iter = tile->items.begin(); iter != tile->items.end(); ++iter) {
+							if (doodad_brush->ownsItem(*iter)) {
+								place = false;
+								break;
+							}
+						}
+					}
+					if (place) {
+						Tile* new_tile = tile->deepCopy(editor.map);
+						SelectionOperations::removeDuplicateWalls(buffer_tile, new_tile);
+						SelectionOperations::doSurroundingBorders(doodad_brush, tilestoborder, buffer_tile, new_tile);
+						new_tile->merge(buffer_tile);
+						action->addChange(newd Change(new_tile));
+					}
+				}
+			}
+		}
+		batch->addAndCommitAction(action);
+
+		if (tilestoborder.size() > 0) {
+			Action* action = editor.actionQueue->createAction(batch);
+
+			// Remove duplicates
+			tilestoborder.sort();
+			tilestoborder.unique();
+
+			for (PositionList::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
+				Tile* tile = editor.map.getTile(*it);
+				if (tile) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					new_tile->borderize(&editor.map);
+					new_tile->wallize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				}
+			}
+			batch->addAndCommitAction(action);
+		}
+		editor.addBatch(batch, 2);
+	} else if (brush->isHouseExit()) {
+		HouseExitBrush* house_exit_brush = brush->asHouseExit();
+		if (!house_exit_brush->canDraw(&editor.map, offset)) {
+			return;
+		}
+
+		House* house = editor.map.houses.getHouse(house_exit_brush->getHouseID());
+		if (!house) {
+			return;
+		}
+
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+		action->addChange(Change::Create(house, offset));
+		batch->addAndCommitAction(action);
+		editor.addBatch(batch, 2);
+	} else if (brush->isWaypoint()) {
+		WaypointBrush* waypoint_brush = brush->asWaypoint();
+		if (!waypoint_brush->canDraw(&editor.map, offset)) {
+			return;
+		}
+
+		Waypoint* waypoint = editor.map.waypoints.getWaypoint(waypoint_brush->getWaypoint());
+		if (!waypoint || waypoint->pos == offset) {
+			return;
+		}
+
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+		action->addChange(Change::Create(waypoint, offset));
+		batch->addAndCommitAction(action);
+		editor.addBatch(batch, 2);
+	} else if (brush->isWall()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+		// This will only occur with a size 0, when clicking on a tile (not drawing)
+		Tile* tile = editor.map.getTile(offset);
+		Tile* new_tile = nullptr;
+		if (tile) {
+			new_tile = tile->deepCopy(editor.map);
+		} else {
+			new_tile = editor.map.allocator(editor.map.createTileL(offset));
+		}
+
+		if (dodraw) {
+			bool b = true;
+			brush->asWall()->draw(&editor.map, new_tile, &b);
+		} else {
+			brush->asWall()->undraw(&editor.map, new_tile);
+		}
+		action->addChange(newd Change(new_tile));
+		batch->addAndCommitAction(action);
+		editor.addBatch(batch, 2);
+	} else if (brush->isSpawn() || brush->isCreature()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+
+		Tile* tile = editor.map.getTile(offset);
+		Tile* new_tile = nullptr;
+		if (tile) {
+			new_tile = tile->deepCopy(editor.map);
+		} else {
+			new_tile = editor.map.allocator(editor.map.createTileL(offset));
+		}
+		int param;
+		if (!brush->isCreature()) {
+			param = g_gui.GetBrushSize();
+		}
+		if (dodraw) {
+			brush->draw(&editor.map, new_tile, &param);
+		} else {
+			brush->undraw(&editor.map, new_tile);
+		}
+		action->addChange(newd Change(new_tile));
+		batch->addAndCommitAction(action);
+		editor.addBatch(batch, 2);
+	}
+}
+
+void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, bool alt, bool dodraw) {
+	Brush* brush = g_gui.GetCurrentBrush();
+	if (!brush) {
+		return;
+	}
+
+#ifdef __DEBUG__
+	if (brush->isGround() || brush->isWall()) {
+		// Wrong function, end call
+		return;
+	}
+#endif
+
+	Action* action = editor.actionQueue->createAction(ACTION_DRAW);
+
+	if (brush->isOptionalBorder()) {
+		// We actually need to do borders, but on the same tiles we draw to
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				if (dodraw) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					brush->draw(&editor.map, new_tile);
+					new_tile->borderize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				} else if (!dodraw && tile->hasOptionalBorder()) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					brush->undraw(&editor.map, new_tile);
+					new_tile->borderize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				}
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				brush->draw(&editor.map, new_tile);
+				new_tile->borderize(&editor.map);
+				if (new_tile->size() == 0) {
+					delete new_tile;
+					continue;
+				}
+				action->addChange(newd Change(new_tile));
+			}
+		}
+	} else {
+
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				Tile* new_tile = tile->deepCopy(editor.map);
+				if (dodraw) {
+					brush->draw(&editor.map, new_tile, &alt);
+				} else {
+					brush->undraw(&editor.map, new_tile);
+				}
+				action->addChange(newd Change(new_tile));
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				brush->draw(&editor.map, new_tile, &alt);
+				action->addChange(newd Change(new_tile));
+			}
+		}
+	}
+	editor.addAction(action, 2);
+}
+
+void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
+	Brush* brush = g_gui.GetCurrentBrush();
+	if (!brush) {
+		return;
+	}
+
+	if (brush->isGround() || brush->isEraser()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				Tile* new_tile = tile->deepCopy(editor.map);
+				if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
+					new_tile->cleanBorders();
+				}
+				if (dodraw) {
+					if (brush->isGround() && alt) {
+						std::pair<bool, GroundBrush*> param;
+						if (editor.replace_brush) {
+							param.first = false;
+							param.second = editor.replace_brush;
+						} else {
+							param.first = true;
+							param.second = nullptr;
+						}
+						g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, &param);
+					} else {
+						g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, nullptr);
+					}
+				} else {
+					g_gui.GetCurrentBrush()->undraw(&editor.map, new_tile);
+					tilestoborder.push_back(*it);
+				}
+				action->addChange(newd Change(new_tile));
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				if (brush->isGround() && alt) {
+					std::pair<bool, GroundBrush*> param;
+					if (editor.replace_brush) {
+						param.first = false;
+						param.second = editor.replace_brush;
+					} else {
+						param.first = true;
+						param.second = nullptr;
+					}
+					g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, &param);
+				} else {
+					g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, nullptr);
+				}
+				action->addChange(newd Change(new_tile));
+			}
+		}
+
+		// Commit changes to map
+		batch->addAndCommitAction(action);
+
+		if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
+			// Do borders!
+			action = editor.actionQueue->createAction(batch);
+			for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
+				TileLocation* location = editor.map.createTileL(*it);
+				Tile* tile = location->get();
+				if (tile) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					if (brush->isEraser()) {
+						new_tile->wallize(&editor.map);
+						new_tile->tableize(&editor.map);
+						new_tile->carpetize(&editor.map);
+					}
+					new_tile->borderize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				} else {
+					Tile* new_tile = editor.map.allocator(location);
+					if (brush->isEraser()) {
+						// There are no carpets/tables/walls on empty tiles...
+						// new_tile->wallize(map);
+						// new_tile->tableize(map);
+						// new_tile->carpetize(map);
+					}
+					new_tile->borderize(&editor.map);
+					if (new_tile->size() > 0) {
+						action->addChange(newd Change(new_tile));
+					} else {
+						delete new_tile;
+					}
+				}
+			}
+			batch->addAndCommitAction(action);
+		}
+
+		editor.addBatch(batch, 2);
+	} else if (brush->isTable() || brush->isCarpet()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				Tile* new_tile = tile->deepCopy(editor.map);
+				if (dodraw) {
+					g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, nullptr);
+				} else {
+					g_gui.GetCurrentBrush()->undraw(&editor.map, new_tile);
+				}
+				action->addChange(newd Change(new_tile));
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				g_gui.GetCurrentBrush()->draw(&editor.map, new_tile, nullptr);
+				action->addChange(newd Change(new_tile));
+			}
+		}
+
+		// Commit changes to map
+		batch->addAndCommitAction(action);
+
+		// Do borders!
+		action = editor.actionQueue->createAction(batch);
+		for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
+			Tile* tile = editor.map.getTile(*it);
+			if (brush->isTable()) {
+				if (tile && tile->hasTable()) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					new_tile->tableize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				}
+			} else if (brush->isCarpet()) {
+				if (tile && tile->hasCarpet()) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					new_tile->carpetize(&editor.map);
+					action->addChange(newd Change(new_tile));
+				}
+			}
+		}
+		batch->addAndCommitAction(action);
+
+		editor.addBatch(batch, 2);
+	} else if (brush->isWall()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+
+		if (alt && dodraw) {
+			// This is exempt from USE_AUTOMAGIC
+			g_gui.doodad_buffer_map->clear();
+			BaseMap* draw_map = g_gui.doodad_buffer_map;
+
+			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+				TileLocation* location = editor.map.createTileL(*it);
+				Tile* tile = location->get();
+				if (tile) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					new_tile->cleanWalls(brush->isWall());
+					g_gui.GetCurrentBrush()->draw(draw_map, new_tile);
+					draw_map->setTile(*it, new_tile, true);
+				} else if (dodraw) {
+					Tile* new_tile = editor.map.allocator(location);
+					g_gui.GetCurrentBrush()->draw(draw_map, new_tile);
+					draw_map->setTile(*it, new_tile, true);
+				}
+			}
+			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+				// Get the correct tiles from the draw map instead of the editor map
+				Tile* tile = draw_map->getTile(*it);
+				if (tile) {
+					tile->wallize(draw_map);
+					action->addChange(newd Change(tile));
+				}
+			}
+			draw_map->clear(false);
+			// Commit
+			batch->addAndCommitAction(action);
+		} else {
+			for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+				TileLocation* location = editor.map.createTileL(*it);
+				Tile* tile = location->get();
+				if (tile) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					// Wall cleaning is exempt from automagic
+					new_tile->cleanWalls(brush->isWall());
+					if (dodraw) {
+						g_gui.GetCurrentBrush()->draw(&editor.map, new_tile);
+					} else {
+						g_gui.GetCurrentBrush()->undraw(&editor.map, new_tile);
+					}
+					action->addChange(newd Change(new_tile));
+				} else if (dodraw) {
+					Tile* new_tile = editor.map.allocator(location);
+					g_gui.GetCurrentBrush()->draw(&editor.map, new_tile);
+					action->addChange(newd Change(new_tile));
+				}
+			}
+
+			// Commit changes to map
+			batch->addAndCommitAction(action);
+
+			if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
+				// Do borders!
+				action = editor.actionQueue->createAction(batch);
+				for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
+					Tile* tile = editor.map.getTile(*it);
+					if (tile) {
+						Tile* new_tile = tile->deepCopy(editor.map);
+						new_tile->wallize(&editor.map);
+						// if(*tile == *new_tile) delete new_tile;
+						action->addChange(newd Change(new_tile));
+					}
+				}
+				batch->addAndCommitAction(action);
+			}
+		}
+
+		editor.actionQueue->addBatch(batch, 2);
+	} else if (brush->isDoor()) {
+		BatchAction* batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		Action* action = editor.actionQueue->createAction(batch);
+		DoorBrush* door_brush = brush->asDoor();
+
+		// Loop is kind of redundant since there will only ever be one index.
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				Tile* new_tile = tile->deepCopy(editor.map);
+				// Wall cleaning is exempt from automagic
+				if (brush->isWall()) {
+					new_tile->cleanWalls(brush->asWall());
+				}
+				if (dodraw) {
+					door_brush->draw(&editor.map, new_tile, &alt);
+				} else {
+					door_brush->undraw(&editor.map, new_tile);
+				}
+				action->addChange(newd Change(new_tile));
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				door_brush->draw(&editor.map, new_tile, &alt);
+				action->addChange(newd Change(new_tile));
+			}
+		}
+
+		// Commit changes to map
+		batch->addAndCommitAction(action);
+
+		if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
+			// Do borders!
+			action = editor.actionQueue->createAction(batch);
+			for (PositionVector::const_iterator it = tilestoborder.begin(); it != tilestoborder.end(); ++it) {
+				Tile* tile = editor.map.getTile(*it);
+				if (tile) {
+					Tile* new_tile = tile->deepCopy(editor.map);
+					new_tile->wallize(&editor.map);
+					// if(*tile == *new_tile) delete new_tile;
+					action->addChange(newd Change(new_tile));
+				}
+			}
+			batch->addAndCommitAction(action);
+		}
+
+		editor.addBatch(batch, 2);
+	} else {
+		Action* action = editor.actionQueue->createAction(ACTION_DRAW);
+		for (PositionVector::const_iterator it = tilestodraw.begin(); it != tilestodraw.end(); ++it) {
+			TileLocation* location = editor.map.createTileL(*it);
+			Tile* tile = location->get();
+			if (tile) {
+				Tile* new_tile = tile->deepCopy(editor.map);
+				if (dodraw) {
+					g_gui.GetCurrentBrush()->draw(&editor.map, new_tile);
+				} else {
+					g_gui.GetCurrentBrush()->undraw(&editor.map, new_tile);
+				}
+				action->addChange(newd Change(new_tile));
+			} else if (dodraw) {
+				Tile* new_tile = editor.map.allocator(location);
+				g_gui.GetCurrentBrush()->draw(&editor.map, new_tile);
+				action->addChange(newd Change(new_tile));
+			}
+		}
+		editor.addAction(action, 2);
+	}
+}

--- a/source/editor/operations/draw_operations.h
+++ b/source/editor/operations/draw_operations.h
@@ -1,0 +1,17 @@
+#ifndef RME_EDITOR_OPERATIONS_DRAW_OPERATIONS_H
+#define RME_EDITOR_OPERATIONS_DRAW_OPERATIONS_H
+
+#include "app/rme_forward_declarations.h"
+#include "map/position.h"
+// We don't want partial define of Editor, so forward declare or include?
+// Ideally forward declare to avoid circular dependency if Editor includes this.
+class Editor;
+
+class DrawOperations {
+public:
+	static void draw(Editor& editor, Position offset, bool alt, bool dodraw);
+	static void draw(Editor& editor, const PositionVector& tilestodraw, bool alt, bool dodraw);
+	static void draw(Editor& editor, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw);
+};
+
+#endif

--- a/source/editor/persistence/editor_persistence.h
+++ b/source/editor/persistence/editor_persistence.h
@@ -11,6 +11,7 @@ class Editor;
 class EditorPersistence {
 public:
 	static void saveMap(Editor& editor, FileName filename, bool showdialog);
+	static void loadMap(Editor& editor, const FileName& filename);
 	static bool importMap(Editor& editor, FileName filename, int import_x_offset, int import_y_offset, ImportType house_import_type, ImportType spawn_import_type);
 	static bool exportSelectionAsMiniMap(Editor& editor, FileName directory, wxString fileName);
 };

--- a/source/game/items.h
+++ b/source/game/items.h
@@ -20,6 +20,11 @@
 
 #include "io/filehandle.h"
 #include "brushes/brush_enums.h"
+#include "ext/pugixml.hpp"
+#include "util/con_vector.h"
+#include <wx/string.h>
+#include <map>
+#include <vector>
 
 class Brush;
 class GroundBrush;

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -1,0 +1,99 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#include "app/main.h"
+#include "live/live_manager.h"
+#include "editor/editor.h"
+#include "live/live_server.h"
+#include "live/live_client.h"
+#include "live/live_action.h"
+#include "net/net_connection.h"
+#include "app/definitions.h" // For ASSERT/newd
+
+LiveManager::LiveManager(Editor& editor) :
+	editor(editor),
+	live_server(nullptr),
+	live_client(nullptr) {
+}
+
+LiveManager::LiveManager(Editor& editor, LiveClient* client) :
+	editor(editor),
+	live_server(nullptr),
+	live_client(client) {
+}
+
+LiveManager::~LiveManager() {
+	if (IsLive()) {
+		CloseServer();
+	}
+}
+
+bool LiveManager::IsClient() const {
+	return live_client != nullptr;
+}
+
+bool LiveManager::IsServer() const {
+	return live_server != nullptr;
+}
+
+bool LiveManager::IsLive() const {
+	return IsClient() || IsServer();
+}
+
+bool LiveManager::IsLocal() const {
+	return !IsLive();
+}
+
+LiveClient* LiveManager::GetClient() const {
+	return live_client;
+}
+
+LiveServer* LiveManager::GetServer() const {
+	return live_server;
+}
+
+LiveSocket& LiveManager::GetSocket() const {
+	if (live_server) {
+		return *live_server;
+	}
+	return *live_client;
+}
+
+LiveServer* LiveManager::StartServer() {
+	ASSERT(IsLocal());
+	live_server = newd LiveServer(editor);
+
+	delete editor.actionQueue;
+	editor.actionQueue = newd NetworkedActionQueue(editor);
+
+	return live_server;
+}
+
+void LiveManager::CloseServer() {
+	if (live_server) {
+		live_server->close();
+		delete live_server;
+		live_server = nullptr;
+	}
+
+	if (live_client) {
+		live_client->close();
+		delete live_client;
+		live_client = nullptr;
+	}
+
+	delete editor.actionQueue;
+	editor.actionQueue = newd ActionQueue(editor);
+
+	NetworkConnection& connection = NetworkConnection::getInstance();
+	connection.stop();
+}
+
+void LiveManager::BroadcastNodes(DirtyList& dirtyList) {
+	if (IsClient()) {
+		live_client->sendChanges(dirtyList);
+	} else if (IsServer()) {
+		live_server->broadcastNodes(dirtyList);
+	}
+}

--- a/source/live/live_manager.h
+++ b/source/live/live_manager.h
@@ -1,0 +1,38 @@
+#ifndef RME_LIVE_LIVE_MANAGER_H
+#define RME_LIVE_LIVE_MANAGER_H
+
+#include "app/rme_forward_declarations.h"
+
+class Editor;
+class LiveServer;
+class LiveClient;
+class LiveSocket;
+class DirtyList;
+
+class LiveManager {
+public:
+	LiveManager(Editor& editor);
+	LiveManager(Editor& editor, LiveClient* client);
+	~LiveManager();
+
+	LiveServer* StartServer();
+	void CloseServer();
+
+	LiveClient* GetClient() const;
+	LiveServer* GetServer() const;
+	LiveSocket& GetSocket() const;
+
+	bool IsLive() const;
+	bool IsLocal() const;
+	bool IsServer() const;
+	bool IsClient() const;
+
+	void BroadcastNodes(DirtyList& dirty_list);
+
+private:
+	Editor& editor;
+	LiveServer* live_server;
+	LiveClient* live_client;
+};
+
+#endif


### PR DESCRIPTION
Moved drawing operations from Editor to a new DrawOperations module for better separation of concerns. Introduced LiveManager to encapsulate live server/client logic, replacing direct LiveServer/LiveClient members in Editor. Updated CMakeLists and includes accordingly, and added new source files for draw operations and live manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal architecture for map editor drawing operations and live collaboration features
  * Streamlined map initialization and file-loading processes with enhanced version handling

* **Chores**
  * Updated build configuration to include new editor and live system modules
  * Added API documentation guidelines
  * Updated build ignore patterns

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->