### PR TITLE
[WXWIDGETS] Modernize Event Handling in Windows

### DIFF
--- a/source/palette/palette_window.cpp
+++ b/source/palette/palette_window.cpp
@@ -34,14 +34,6 @@
 // ============================================================================
 // Palette window
 
-BEGIN_EVENT_TABLE(PaletteWindow, wxPanel)
-EVT_CHOICEBOOK_PAGE_CHANGING(PALETTE_CHOICEBOOK, PaletteWindow::OnSwitchingPage)
-EVT_CHOICEBOOK_PAGE_CHANGED(PALETTE_CHOICEBOOK, PaletteWindow::OnPageChanged)
-EVT_CLOSE(PaletteWindow::OnClose)
-
-EVT_KEY_DOWN(PaletteWindow::OnKey)
-END_EVENT_TABLE()
-
 PaletteWindow::PaletteWindow(wxWindow* parent, const TilesetContainer& tilesets) :
 	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(230, 250)),
 	choicebook(nullptr),
@@ -81,6 +73,11 @@ PaletteWindow::PaletteWindow(wxWindow* parent, const TilesetContainer& tilesets)
 
 	raw_palette = static_cast<BrushPalettePanel*>(CreateRAWPalette(choicebook, tilesets));
 	choicebook->AddPage(raw_palette, raw_palette->GetName());
+
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGING, &PaletteWindow::OnSwitchingPage, this, PALETTE_CHOICEBOOK);
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &PaletteWindow::OnPageChanged, this, PALETTE_CHOICEBOOK);
+	Bind(wxEVT_CLOSE_WINDOW, &PaletteWindow::OnClose, this);
+	Bind(wxEVT_KEY_DOWN, &PaletteWindow::OnKey, this);
 
 	// Setup sizers
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);

--- a/source/palette/palette_window.h
+++ b/source/palette/palette_window.h
@@ -82,8 +82,6 @@ protected:
 	HousePalettePanel* house_palette;
 	WaypointPalettePanel* waypoint_palette;
 	BrushPalettePanel* raw_palette;
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/ui/about_window.cpp
+++ b/source/ui/about_window.cpp
@@ -58,8 +58,6 @@ protected:
 private:
 	bool paused_val;
 
-	DECLARE_EVENT_TABLE()
-
 protected:
 	bool dead;
 };
@@ -163,17 +161,14 @@ protected:
 //=============================================================================
 // About Window - Information window about the application
 
-BEGIN_EVENT_TABLE(AboutWindow, wxDialog)
-EVT_BUTTON(wxID_OK, AboutWindow::OnClickOK)
-EVT_BUTTON(ABOUT_VIEW_LICENSE, AboutWindow::OnClickLicense)
-EVT_MENU(ABOUT_RUN_TETRIS, AboutWindow::OnTetris)
-EVT_MENU(ABOUT_RUN_SNAKE, AboutWindow::OnSnake)
-EVT_MENU(wxID_CANCEL, AboutWindow::OnClickOK)
-END_EVENT_TABLE()
-
 AboutWindow::AboutWindow(wxWindow* parent) :
 	wxDialog(parent, wxID_ANY, "About", wxDefaultPosition, wxSize(300, 320), wxRESIZE_BORDER | wxCAPTION | wxCLOSE_BOX),
 	game_panel(nullptr) {
+	Bind(wxEVT_BUTTON, &AboutWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &AboutWindow::OnClickLicense, this, ABOUT_VIEW_LICENSE);
+	Bind(wxEVT_MENU, &AboutWindow::OnTetris, this, ABOUT_RUN_TETRIS);
+	Bind(wxEVT_MENU, &AboutWindow::OnSnake, this, ABOUT_RUN_SNAKE);
+	Bind(wxEVT_MENU, &AboutWindow::OnClickOK, this, wxID_CANCEL);
 	wxString about;
 
 	about << "OTAcademy Map Editor\n";
@@ -278,17 +273,14 @@ void AboutWindow::OnSnake(wxCommandEvent&) {
 //=============================================================================
 // GamePanel - Abstract class for games
 
-BEGIN_EVENT_TABLE(GamePanel, wxPanel)
-EVT_KEY_DOWN(GamePanel::OnKeyDown)
-EVT_KEY_UP(GamePanel::OnKeyUp)
-EVT_PAINT(GamePanel::OnPaint)
-EVT_IDLE(GamePanel::OnIdle)
-END_EVENT_TABLE()
-
 GamePanel::GamePanel(wxWindow* parent, int width, int height) :
 	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(width, height), wxWANTS_CHARS),
 	paused_val(false),
 	dead(false) {
+	Bind(wxEVT_KEY_DOWN, &GamePanel::OnKeyDown, this);
+	Bind(wxEVT_KEY_UP, &GamePanel::OnKeyUp, this);
+	Bind(wxEVT_PAINT, &GamePanel::OnPaint, this);
+	Bind(wxEVT_IDLE, &GamePanel::OnIdle, this);
 	// Receive idle events
 	SetExtraStyle(wxWS_EX_PROCESS_IDLE);
 	// Complete redraw

--- a/source/ui/about_window.h
+++ b/source/ui/about_window.h
@@ -36,8 +36,6 @@ public:
 private:
 	wxSizer* topsizer;
 	GamePanel* game_panel;
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -39,11 +39,6 @@
 // ============================================================================
 // Tileset Window
 
-BEGIN_EVENT_TABLE(TilesetWindow, wxDialog)
-EVT_BUTTON(wxID_OK, TilesetWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, TilesetWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
 TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
@@ -73,7 +68,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	palette_field->Append("Raw", newd int(TILESET_RAW));
 	palette_field->SetSelection(3);
 
-	palette_field->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(TilesetWindow::OnChangePalette), nullptr, this);
+	palette_field->Bind(wxEVT_CHOICE, &TilesetWindow::OnChangePalette, this);
 	subsizer->Add(palette_field, wxSizerFlags(1).Expand());
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));
@@ -93,6 +88,9 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	subsizer_->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	subsizer_->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
+
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickCancel, this, wxID_CANCEL);
 
 	SetSizerAndFit(topsizer);
 	Centre(wxBOTH);

--- a/source/ui/tileset_window.h
+++ b/source/ui/tileset_window.h
@@ -39,8 +39,6 @@ protected:
 	// tileset
 	wxChoice* palette_field;
 	wxChoice* tileset_field;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif


### PR DESCRIPTION
Modernized event handling in three UI windows (`AboutWindow`, `PaletteWindow`, `TilesetWindow`) by replacing legacy `BEGIN_EVENT_TABLE` macros with `Bind()` calls. This addresses the "wxWidgets Anti-Patterns" task from `Domain.md`.

---
*PR created automatically by Jules for task [18210181715539932930](https://jules.google.com/task/18210181715539932930) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal event handling mechanisms across multiple UI components for improved code maintainability. No changes to user-facing functionality or behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->