### PR TITLE
[Phantom] Fix shift overflow in QTreeNode and infinite loop in Spawn

### DIFF
--- a/source/game/spawn.h
+++ b/source/game/spawn.h
@@ -53,7 +53,12 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		if (newsize > 100) {
+			newsize = 100;
+		}
+		if (newsize < 1) {
+			newsize = 1;
+		}
 		size = newsize;
 	}
 	int getSize() const {

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1140,6 +1140,8 @@ bool IOMapOTBM::loadSpawns(Map& map, pugi::xml_document& doc) {
 		}
 
 		int32_t radius = spawnNode.attribute("radius").as_int();
+		radius = std::min<int32_t>(radius, g_settings.getInteger(Config::MAX_SPAWN_RADIUS));
+
 		if (radius < 1) {
 			warning("Couldn't read radius of spawn.. discarding spawn...");
 			continue;

--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -172,9 +172,15 @@ void QTreeNode::clearVisible(uint32_t u) {
 
 bool QTreeNode::isVisible(uint32_t client, bool underground) {
 	if (underground) {
-		return testFlags(visible >> MAP_LAYERS, static_cast<uint64_t>(1) << client);
+		if (client >= 16) {
+			return false;
+		}
+		return testFlags(visible >> MAP_LAYERS, 1U << client);
 	} else {
-		return testFlags(visible, static_cast<uint64_t>(1) << client);
+		if (client >= 32) {
+			return false;
+		}
+		return testFlags(visible, 1U << client);
 	}
 }
 
@@ -203,10 +209,20 @@ void QTreeNode::setRequested(bool underground, bool r) {
 }
 
 void QTreeNode::setVisible(uint32_t client, bool underground, bool value) {
-	if (value) {
-		visible |= (1 << client << (underground ? MAP_LAYERS : 0));
+	if (underground) {
+		if (client >= 16) {
+			return;
+		}
 	} else {
-		visible &= ~(1 << client << (underground ? MAP_LAYERS : 0));
+		if (client >= 32) {
+			return;
+		}
+	}
+
+	if (value) {
+		visible |= (1U << client << (underground ? MAP_LAYERS : 0));
+	} else {
+		visible &= ~(1U << client << (underground ? MAP_LAYERS : 0));
 	}
 }
 


### PR DESCRIPTION
BUG TYPE: Undefined Behavior / Logic Bug
SEVERITY: HIGH
ISSUE 1: Shift overflow in QTreeNode::setVisible/isVisible. `1 << client` with signed 1 overflows if client is large or shifts into sign bit.
TRIGGER: Large client ID or specific conditions in Live mode.
CONSEQUENCES: Undefined behavior, potential logic errors in visibility.
FIX: Use `1U` for unsigned shift and validate client ID range.

ISSUE 2: Logic Bug / DoS in Spawn radius. Malformed OTBM with large radius could cause infinite loop in saveSpawns due to signed integer overflow.
TRIGGER: Loading a map with huge spawn radius.
CONSEQUENCES: Editor hang (DoS) or crash.
FIX: Clamp radius in `IOMapOTBM` and `Spawn::setSize`.

---
*PR created automatically by Jules for task [9900615432312709090](https://jules.google.com/task/9900615432312709090) started by @karolak6612*