### PR TITLE
UX Improvements: Responsive Layouts & Dynamic Tooltips

### DIFF
--- a/source/palette/palette_brushlist.cpp
+++ b/source/palette/palette_brushlist.cpp
@@ -19,6 +19,7 @@
 
 #include "palette/palette_brushlist.h"
 #include "ui/gui.h"
+#include <wx/wrapsizer.h>
 #include "brushes/brush.h"
 #include "ui/add_tileset_window.h"
 #include "ui/add_item_window.h"
@@ -421,40 +422,20 @@ BrushIconBox::BrushIconBox(wxWindow* parent, const TilesetCategory* _tileset, Re
 	BrushBoxInterface(_tileset),
 	icon_size(rsz) {
 	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	int width;
-	if (icon_size == RENDER_SIZE_32x32) {
-		width = max(g_settings.getInteger(Config::PALETTE_COL_COUNT) / 2 + 1, 1);
-	} else {
-		width = max(g_settings.getInteger(Config::PALETTE_COL_COUNT) + 1, 1);
-	}
 
-	// Create buttons
-	wxSizer* stacksizer = newd wxBoxSizer(wxVERTICAL);
-	wxSizer* rowsizer = nullptr;
-	int item_counter = 0;
+	wxSizer* sizer = newd wxWrapSizer(wxHORIZONTAL);
+
 	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
 		ASSERT(*iter);
-		++item_counter;
-
-		if (!rowsizer) {
-			rowsizer = newd wxBoxSizer(wxHORIZONTAL);
-		}
 
 		BrushButton* bb = newd BrushButton(this, *iter, rsz);
-		rowsizer->Add(bb);
+		sizer->Add(bb, 0, wxALL, 1);
 		brush_buttons.push_back(bb);
-
-		if (item_counter % width == 0) { // newd row
-			stacksizer->Add(rowsizer);
-			rowsizer = nullptr;
-		}
-	}
-	if (rowsizer) {
-		stacksizer->Add(rowsizer);
 	}
 
-	SetScrollbars(20, 20, 8, item_counter / width, 0, 0);
-	SetSizer(stacksizer);
+	SetSizer(sizer);
+	FitInside();
+	SetScrollRate(10, 10);
 }
 
 BrushIconBox::~BrushIconBox() {

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -163,6 +163,18 @@ bool MainMenuBar::IsItemChecked(MenuBar::ActionID id) const {
 	return false;
 }
 
+wxString MainMenuBar::GetShortcutText(MenuBar::ActionID id) const {
+	std::map<MenuBar::ActionID, std::list<wxMenuItem*>>::const_iterator fi = items.find(id);
+	if (fi == items.end() || fi->second.empty()) {
+		return "";
+	}
+	wxAcceleratorEntry* accel = fi->second.front()->GetAccel();
+	if (accel) {
+		return accel->ToString();
+	}
+	return "";
+}
+
 void MainMenuBar::Update() {
 	using namespace MenuBar;
 	// This updates all buttons and sets them to proper enabled/disabled state

--- a/source/ui/main_menubar.h
+++ b/source/ui/main_menubar.h
@@ -187,6 +187,8 @@ public:
 	void CheckItem(MenuBar::ActionID id, bool check);
 	bool IsItemChecked(MenuBar::ActionID id) const;
 
+	wxString GetShortcutText(MenuBar::ActionID id) const;
+
 	// Handlers
 	void OnNew(wxCommandEvent& event);
 	void OnOpen(wxCommandEvent& event);

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -28,6 +28,7 @@
 #include "ui/properties/teleport_service.h"
 
 #include <wx/grid.h>
+#include <wx/wrapsizer.h>
 
 BEGIN_EVENT_TABLE(PropertiesWindow, wxDialog)
 EVT_BUTTON(wxID_OK, PropertiesWindow::OnClickOK)
@@ -142,7 +143,7 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_CONTAINER_TAB);
 	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxSizer* gridSizer = newd wxGridSizer(6, 5, 5);
+	wxSizer* gridSizer = newd wxWrapSizer(wxHORIZONTAL);
 
 	bool use_large_sprites = g_settings.getBoolean(Config::USE_LARGE_CONTAINER_ICONS);
 	for (uint32_t i = 0; i < container->getVolume(); ++i) {
@@ -150,7 +151,7 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 		ContainerItemButton* containerItemButton = newd ContainerItemButton(panel, use_large_sprites, i, edit_map, item);
 
 		container_items.push_back(containerItemButton);
-		gridSizer->Add(containerItemButton, wxSizerFlags(0));
+		gridSizer->Add(containerItemButton, wxSizerFlags(0).Border(wxALL, 5));
 	}
 
 	topSizer->Add(gridSizer, wxSizerFlags(1).Expand());

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -9,6 +9,7 @@
 #include "editor/editor.h"
 #include "editor/action_queue.h"
 #include "ui/artprovider.h"
+#include "ui/main_menubar.h"
 #include <wx/artprov.h>
 
 const wxString StandardToolBar::PANE_NAME = "standard_toolbar";
@@ -25,19 +26,27 @@ StandardToolBar::StandardToolBar(wxWindow* parent) {
 	wxBitmap copy_bitmap = wxArtProvider::GetBitmap(wxART_COPY, wxART_TOOLBAR, icon_size);
 	wxBitmap paste_bitmap = wxArtProvider::GetBitmap(wxART_PASTE, wxART_TOOLBAR, icon_size);
 
+	auto getTooltip = [&](const wxString& text, MenuBar::ActionID id) {
+		wxString shortcut = g_gui.root->GetMainMenuBar()->GetShortcutText(id);
+		if (!shortcut.IsEmpty()) {
+			return text + " (" + shortcut + ")";
+		}
+		return text;
+	};
+
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_STANDARD, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
-	toolbar->AddTool(wxID_NEW, wxEmptyString, new_bitmap, wxNullBitmap, wxITEM_NORMAL, "New Map (Ctrl+N)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_OPEN, wxEmptyString, open_bitmap, wxNullBitmap, wxITEM_NORMAL, "Open Map (Ctrl+O)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_SAVE, wxEmptyString, save_bitmap, wxNullBitmap, wxITEM_NORMAL, "Save Map (Ctrl+S)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_SAVEAS, wxEmptyString, saveas_bitmap, wxNullBitmap, wxITEM_NORMAL, "Save Map As... (Ctrl+Alt+S)", wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_NEW, wxEmptyString, new_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("New Map", MenuBar::NEW), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_OPEN, wxEmptyString, open_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Open Map", MenuBar::OPEN), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_SAVE, wxEmptyString, save_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Save Map", MenuBar::SAVE), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_SAVEAS, wxEmptyString, saveas_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Save Map As...", MenuBar::SAVE_AS), wxEmptyString, nullptr);
 	toolbar->AddSeparator();
-	toolbar->AddTool(wxID_UNDO, wxEmptyString, undo_bitmap, wxNullBitmap, wxITEM_NORMAL, "Undo (Ctrl+Z)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_REDO, wxEmptyString, redo_bitmap, wxNullBitmap, wxITEM_NORMAL, "Redo (Ctrl+Shift+Z)", wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_UNDO, wxEmptyString, undo_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Undo", MenuBar::UNDO), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_REDO, wxEmptyString, redo_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Redo", MenuBar::REDO), wxEmptyString, nullptr);
 	toolbar->AddSeparator();
-	toolbar->AddTool(wxID_CUT, wxEmptyString, cut_bitmap, wxNullBitmap, wxITEM_NORMAL, "Cut (Ctrl+X)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_COPY, wxEmptyString, copy_bitmap, wxNullBitmap, wxITEM_NORMAL, "Copy (Ctrl+C)", wxEmptyString, nullptr);
-	toolbar->AddTool(wxID_PASTE, wxEmptyString, paste_bitmap, wxNullBitmap, wxITEM_NORMAL, "Paste (Ctrl+V)", wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_CUT, wxEmptyString, cut_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Cut", MenuBar::CUT), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_COPY, wxEmptyString, copy_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Copy", MenuBar::COPY), wxEmptyString, nullptr);
+	toolbar->AddTool(wxID_PASTE, wxEmptyString, paste_bitmap, wxNullBitmap, wxITEM_NORMAL, getTooltip("Paste", MenuBar::PASTE), wxEmptyString, nullptr);
 	toolbar->Realize();
 
 	toolbar->Bind(wxEVT_COMMAND_MENU_SELECTED, &StandardToolBar::OnButtonClick, this);


### PR DESCRIPTION
This PR addresses UX friction by improving layout responsiveness and providing better feedback on keyboard shortcuts.

Key changes:
1.  **Responsive Grids**: `BrushIconBox` (brush palette) and `PropertiesWindow` (container items) now use `wxWrapSizer`. This means items will automatically reflow when the window is resized, instead of being stuck in a fixed grid or manually calculated layout. This fixes layout issues on different screen sizes and aspect ratios.
2.  **Dynamic Tooltips**: The Standard Toolbar now shows keyboard shortcuts in tooltips (e.g., "New Map (Ctrl+N)"). These shortcuts are fetched dynamically from the `MainMenuBar` configuration, ensuring they are always correct even if shortcuts are customized or changed in `menubar.xml`.

Implementation details:
- Replaced manual loop in `BrushIconBox` with `wxWrapSizer`.
- Replaced `wxGridSizer` in `PropertiesWindow` with `wxWrapSizer`.
- Implemented `MainMenuBar::GetShortcutText` to access `wxMenuItem::GetAccel()`.
- Verified changes via code review and static analysis. Full build was attempted but timed out on dependency installation, however code changes are standard C++/wxWidgets and localized.

---
*PR created automatically by Jules for task [4668721638084592231](https://jules.google.com/task/4668721638084592231) started by @karolak6612*