### PR TITLE
🎨 Palette: Add tooltips to improve UX and accessibility

### DIFF
--- a/source/palette/palette_brushlist.cpp
+++ b/source/palette/palette_brushlist.cpp
@@ -51,9 +51,11 @@ BrushPalettePanel::BrushPalettePanel(wxWindow* parent, const TilesetContainer& t
 	if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
 		wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 		wxButton* buttonAddTileset = newd wxButton(this, wxID_NEW, "Add new Tileset");
+		buttonAddTileset->SetToolTip("Create a new custom tileset");
 		tmpsizer->Add(buttonAddTileset, wxSizerFlags(0).Center());
 
 		wxButton* buttonAddItemToTileset = newd wxButton(this, wxID_ADD, "Add new Item");
+		buttonAddItemToTileset->SetToolTip("Add a new item to the current tileset");
 		tmpsizer->Add(buttonAddItemToTileset, wxSizerFlags(0).Center());
 
 		topsizer->Add(tmpsizer, 0, wxCENTER, 10);

--- a/source/palette/palette_common.cpp
+++ b/source/palette/palette_common.cpp
@@ -890,10 +890,12 @@ BrushThicknessPanel::BrushThicknessPanel(wxWindow* parent) :
 	wxSizer* thickness_sub_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	thickness_sub_sizer->Add(20, 10);
 	use_button = newd wxCheckBox(this, PALETTE_DOODAD_USE_THICKNESS, "Use custom thickness");
+	use_button->SetToolTip("Enable custom thickness for this brush");
 	thickness_sub_sizer->Add(use_button);
 	thickness_sizer->Add(thickness_sub_sizer, 1, wxEXPAND);
 
 	slider = newd wxSlider(this, PALETTE_DOODAD_SLIDER, 5, 1, 10, wxDefaultPosition);
+	slider->SetToolTip("Adjust brush thickness");
 	thickness_sizer->Add(slider, 1, wxEXPAND);
 
 	SetSizerAndFit(thickness_sizer);

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -55,6 +55,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
 	server_id_spin = newd wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
+	server_id_spin->SetToolTip("Search by server ID");
 	server_id_box_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
 
 	invalid_item = newd wxCheckBox(server_id_box_sizer->GetStaticBox(), wxID_ANY, "Force select", wxDefaultPosition, wxDefaultSize, 0);
@@ -65,12 +66,14 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
 	client_id_spin = newd wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
+	client_id_spin->SetToolTip("Search by client ID");
 	client_id_spin->Enable(false);
 	client_id_box_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
 	options_box_sizer->Add(client_id_box_sizer, 1, wxALL | wxEXPAND, 5);
 
 	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
 	name_text_input = newd wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+	name_text_input->SetToolTip("Search by item name");
 	name_text_input->Enable(false);
 	name_box_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
 	options_box_sizer->Add(name_box_sizer, 1, wxALL | wxEXPAND, 5);
@@ -80,6 +83,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	buttons_box_sizer = newd wxStdDialogButtonSizer();
 	ok_button = newd wxButton(this, wxID_OK);
+	ok_button->SetToolTip("Select an item to confirm");
 	buttons_box_sizer->AddButton(ok_button);
 	cancel_button = newd wxButton(this, wxID_CANCEL);
 	buttons_box_sizer->AddButton(cancel_button);
@@ -259,6 +263,7 @@ void FindItemDialog::EnableProperties(bool enable) {
 void FindItemDialog::RefreshContentsInternal() {
 	items_list->Clear();
 	ok_button->Enable(false);
+	ok_button->SetToolTip("Select an item to continue");
 
 	SearchMode selection = (SearchMode)options_radio_box->GetSelection();
 	bool found_search_results = false;
@@ -383,6 +388,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	if (found_search_results) {
 		items_list->SetSelection(0);
 		ok_button->Enable(true);
+		ok_button->SetToolTip("Confirm selection");
 	} else {
 		items_list->SetNoMatches();
 	}

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -90,6 +90,7 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* export_button = newd wxButton(dg, wxID_OK, "Export as XML");
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
+	export_button->SetToolTip("Not implemented yet");
 	export_button->Enable(false);
 	choicesizer->Add(newd wxButton(dg, wxID_CANCEL, "OK"), wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());

--- a/source/ui/map_window.cpp
+++ b/source/ui/map_window.cpp
@@ -36,6 +36,7 @@ MapWindow::MapWindow(wxWindow* parent, Editor& editor) :
 	hScroll = newd MapScrollBar(this, MAP_WINDOW_HSCROLL, wxHORIZONTAL, canvas);
 
 	gem = newd DCButton(this, MAP_WINDOW_GEM, wxDefaultPosition, DC_BTN_NORMAL, RENDER_SIZE_16x16, EDITOR_SPRITE_SELECTION_GEM);
+	gem->SetToolTip("Switch between Drawing and Selection mode (Space)");
 
 	wxFlexGridSizer* topsizer = newd wxFlexGridSizer(2, 0, 0);
 

--- a/source/ui/positionctrl.cpp
+++ b/source/ui/positionctrl.cpp
@@ -23,14 +23,17 @@
 PositionCtrl::PositionCtrl(wxWindow* parent, const wxString& label, int x, int y, int z, int maxx /*= MAP_MAX_WIDTH*/, int maxy /*= MAP_MAX_HEIGHT*/, int maxz /*= MAP_MAX_LAYER*/) :
 	wxStaticBoxSizer(wxHORIZONTAL, parent, label) {
 	x_field = newd NumberTextCtrl(parent, wxID_ANY, x, 0, maxx, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, wxSize(60, 20));
+	x_field->SetToolTip("X Coordinate");
 	x_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(x_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
 
 	y_field = newd NumberTextCtrl(parent, wxID_ANY, y, 0, maxy, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, wxSize(60, 20));
+	y_field->SetToolTip("Y Coordinate");
 	y_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(y_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
 
 	z_field = newd NumberTextCtrl(parent, wxID_ANY, z, 0, maxz, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, wxSize(35, 20));
+	z_field->SetToolTip("Z Coordinate (Layer)");
 	z_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(z_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -203,16 +203,19 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	wxBoxSizer* buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	add_button = new wxButton(this, wxID_ANY, wxT("Add"));
+	add_button->SetToolTip("Add replacement rule to list");
 	add_button->Enable(false);
 	buttons_sizer->Add(add_button, 0, wxALL, 5);
 
 	remove_button = new wxButton(this, wxID_ANY, wxT("Remove"));
+	remove_button->SetToolTip("Remove selected rule");
 	remove_button->Enable(false);
 	buttons_sizer->Add(remove_button, 0, wxALL, 5);
 
 	buttons_sizer->Add(0, 0, 1, wxEXPAND, 5);
 
 	execute_button = new wxButton(this, wxID_ANY, wxT("Execute"));
+	execute_button->SetToolTip("Execute all replacement rules");
 	execute_button->Enable(false);
 	buttons_sizer->Add(execute_button, 0, wxALL, 5);
 
@@ -250,8 +253,25 @@ void ReplaceItemsDialog::UpdateWidgets() {
 	const uint16_t replaceId = replace_button->GetItemId();
 	const uint16_t withId = with_button->GetItemId();
 	add_button->Enable(list->CanAdd(replaceId, withId));
+	if (add_button->IsEnabled()) {
+		add_button->SetToolTip("Add replacement rule to list");
+	} else {
+		add_button->SetToolTip("Select replacement and target items to add.");
+	}
+
 	remove_button->Enable(list->GetCount() != 0 && list->GetSelection() != wxNOT_FOUND);
+	if (remove_button->IsEnabled()) {
+		remove_button->SetToolTip("Remove selected rule");
+	} else {
+		remove_button->SetToolTip("Select a rule to remove.");
+	}
+
 	execute_button->Enable(list->GetCount() != 0);
+	if (execute_button->IsEnabled()) {
+		execute_button->SetToolTip("Execute all replacement rules");
+	} else {
+		execute_button->SetToolTip("Add rules to list first.");
+	}
 }
 
 void ReplaceItemsDialog::OnListSelected(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -65,6 +65,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Palette"));
 	palette_field = newd wxChoice(this, wxID_ANY);
+	palette_field->SetToolTip("Select the palette category");
 
 	palette_field->Append("Terrain", newd int(TILESET_TERRAIN));
 	palette_field->Append("Collections", newd int(TILESET_COLLECTION));
@@ -78,6 +79,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));
 	tileset_field = newd wxChoice(this, wxID_ANY);
+	tileset_field->SetToolTip("Select the target tileset");
 
 	for (TilesetContainer::iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
 		tileset_field->Append(wxstr(iter->second->name), newd std::string(iter->second->name));


### PR DESCRIPTION
Implemented tooltips for various UI elements across the editor, including:
- Replace Items Dialog: Dynamic tooltips for Add/Remove/Execute buttons explaining disabled states.
- Find Item Dialog: Tooltips for inputs and OK button (including disabled reason).
- Tileset Window: Tooltips for Palette and Tileset selection.
- Brush Palette: Tooltips for "Add Tileset" and "Add Item" buttons.
- Brush Thickness: Tooltips for slider and checkbox.
- Map Statistics: Tooltip for disabled "Export" button.
- Position Control: Tooltips for X, Y, Z coordinate fields.
- Map Window: Tooltip for the mode switching Gem button.

These changes align with the "Palette" agent's goal of micro-UX improvements.

---
*PR created automatically by Jules for task [6998519528907095427](https://jules.google.com/task/6998519528907095427) started by @karolak6612*