### PR TITLE
Optimize Linux build using pre-built Conan binaries

### DIFF
--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -4,6 +4,6 @@
         "conan": {}
     },
     "include": [
-        "build_conan/build/generators/CMakePresets.json"
+        "build_conan/build/Release/generators/CMakePresets.json"
     ]
 }

--- a/build_linux.sh
+++ b/build_linux.sh
@@ -28,7 +28,7 @@ fi
 echo "[2/4] Installing dependencies with Conan..."
 echo "[2/4] Installing dependencies..." >> "$LOG_FILE"
 
-conan install "$SCRIPT_DIR" -of "$BUILD_DIR" --build=missing -s build_type=Release -s compiler.cppstd=20 -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True >> "$LOG_FILE" 2>&1
+conan install "$SCRIPT_DIR" -of "$BUILD_DIR" --build=missing -s build_type=Release -s compiler.cppstd=gnu17 -c tools.system.package_manager:mode=install -c tools.system.package_manager:sudo=True >> "$LOG_FILE" 2>&1
 
 echo "[3/4] Configuring CMake..."
 echo "[3/4] Configuring CMake..." >> "$LOG_FILE"

--- a/conanfile.py
+++ b/conanfile.py
@@ -40,10 +40,6 @@ class RMERecipe(ConanFile):
         tc.generate()
     
     def configure(self):
-        # Boost components needed
-        self.options["boost/*"].without_python = True
-        self.options["boost/*"].without_test = True
-        
         # wxWidgets components needed
         self.options["wxwidgets/*"].opengl = True
         self.options["wxwidgets/*"].aui = True


### PR DESCRIPTION
Modified `build_linux.sh` to use `compiler.cppstd=gnu17` for Conan, enabling the use of pre-built binaries for most dependencies (especially Boost), significantly reducing build time.
Modified `conanfile.py` to remove custom Boost options, aligning with standard Conan Center binaries.
Retained `wxwidgets` options as they are required for functionality (OpenGL, AUI), accepting that it builds from source.
This setup solves the build timeout issue by avoiding the compilation of Boost from source.

---
*PR created automatically by Jules for task [14519096643281029213](https://jules.google.com/task/14519096643281029213) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CMake build configuration paths for improved preset discovery and integration
  * Modified C++ standard specification for Linux builds to optimize available language features
  * Re-enabled Python support and test framework components in library dependencies for enhanced build flexibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->