### PR TITLE
Add detailed logging for crash investigation and fix GL dependencies

### DIFF
--- a/CMakeUserPresets.json
+++ b/CMakeUserPresets.json
@@ -4,6 +4,6 @@
         "conan": {}
     },
     "include": [
-        "build_conan/build/generators/CMakePresets.json"
+        "build_conan/build/Release/generators/CMakePresets.json"
     ]
 }

--- a/conanfile.py
+++ b/conanfile.py
@@ -48,6 +48,9 @@ class RMERecipe(ConanFile):
         tc.generate()
     
     def configure(self):
+        self.options["glad/*"].gl_profile = "core"
+        self.options["glad/*"].gl_version = "4.6"
+
         if self.settings.os != "Linux":
             # Boost components needed
             self.options["boost/*"].without_python = True

--- a/source/app/application.cpp
+++ b/source/app/application.cpp
@@ -116,6 +116,7 @@ bool Application::OnInit() {
 
 	// Configure spdlog for debug output
 	spdlog::set_level(spdlog::level::info);
+	spdlog::flush_on(spdlog::level::info);
 	spdlog::info("RME starting up - logging enabled");
 
 	std::cout << "This is free software: you are free to change and redistribute it." << std::endl;

--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -42,12 +42,15 @@
 
 #include "editor/operations/draw_operations.h"
 
+#include <spdlog/spdlog.h>
+
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 	live_manager(*this),
 	actionQueue(newd ActionQueue(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
+	spdlog::info("Editor created (Empty) [Editor={}]", (void*)this);
 	map.convert(version);
 	map.initializeEmpty();
 }
@@ -58,6 +61,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
+	spdlog::info("Editor created (From File) [Editor={}]", (void*)this);
 	// EditorPersistence handles version checking internally or assumes compatibility
 	// Usage of "version" parameter here might be redundant for loading but good for consistency/future use
 	EditorPersistence::loadMap(*this, fn);
@@ -69,10 +73,12 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* cl
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
+	spdlog::info("Editor created (Live Client) [Editor={}]", (void*)this);
 	map.convert(version);
 }
 
 Editor::~Editor() {
+	spdlog::info("Editor destroying [Editor={}]", (void*)this);
 	if (live_manager.IsLive()) {
 		live_manager.CloseServer();
 	}
@@ -80,6 +86,7 @@ Editor::~Editor() {
 	UnnamedRenderingLock();
 	selection.clear();
 	delete actionQueue;
+	spdlog::info("Editor destroyed [Editor={}]", (void*)this);
 }
 
 void Editor::notifyStateChange() {

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -55,9 +55,11 @@ bool EditorManager::IsEditorOpen() const {
 }
 
 void EditorManager::CloseCurrentEditor() {
+	spdlog::info("EditorManager::CloseCurrentEditor - Closing current tab");
 	g_palettes.RefreshPalettes();
 	g_gui.tabbook->DeleteTab(g_gui.tabbook->GetSelection());
 	g_gui.root->UpdateMenubar();
+	spdlog::info("EditorManager::CloseCurrentEditor - Closed current tab");
 }
 
 Editor* EditorManager::GetCurrentEditor() {
@@ -103,12 +105,14 @@ bool EditorManager::CloseLiveEditors(LiveSocket* sock) {
 }
 
 bool EditorManager::CloseAllEditors() {
+	spdlog::info("EditorManager::CloseAllEditors - Closing all tabs");
 	for (int i = 0; i < g_gui.tabbook->GetTabCount(); ++i) {
 		auto* mapTab = dynamic_cast<MapTab*>(g_gui.tabbook->GetTab(i));
 		if (mapTab) {
 			if (mapTab->IsUniqueReference() && mapTab->GetMap() && mapTab->GetMap()->hasChanged()) {
 				g_gui.tabbook->SetFocusedTab(i);
 				if (!g_gui.root->DoQuerySave(false)) {
+					spdlog::info("EditorManager::CloseAllEditors - Cancelled by user");
 					return false;
 				} else {
 					g_palettes.RefreshPalettes();
@@ -122,6 +126,7 @@ bool EditorManager::CloseAllEditors() {
 	if (g_gui.root) {
 		g_gui.root->UpdateMenubar();
 	}
+	spdlog::info("EditorManager::CloseAllEditors - All tabs closed");
 	return true;
 }
 
@@ -193,6 +198,7 @@ void EditorManager::SaveCurrentMap(FileName fileName, bool showdialog) {
 }
 
 bool EditorManager::NewMap() {
+	spdlog::info("EditorManager::NewMap - Creating new map");
 	g_gui.FinishWelcomeDialog();
 
 	std::unique_ptr<Editor> editor;
@@ -259,6 +265,7 @@ void EditorManager::SaveMapAs() {
 }
 
 bool EditorManager::LoadMap(const FileName& fileName) {
+	spdlog::info("EditorManager::LoadMap - Loading map: {}", nstr(fileName.GetFullPath()));
 	g_gui.FinishWelcomeDialog();
 
 	if (GetCurrentEditor() && !GetCurrentMap().hasChanged() && !GetCurrentMap().hasFile()) {

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -41,6 +41,7 @@
 #include "brushes/wall_brush.h"
 
 #include "io/iomap_otbm.h"
+#include <spdlog/spdlog.h>
 
 using attribute_t = uint8_t;
 using flags_t = uint32_t;
@@ -601,6 +602,7 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 }
 
 bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
+	spdlog::info("IOMapOTBM::loadMap - Start loading from file: {}", nstr(filename.GetFullPath()));
 #ifdef OTGZ_SUPPORT
 	if (filename.GetExt() == "otgz") {
 		// Open the archive
@@ -784,6 +786,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		// warning("Failed to load waypoints.");
 		map.waypointfile = nstr(filename.GetName()) + "-waypoint.xml";
 	}
+	spdlog::info("IOMapOTBM::loadMap - Finished loading from file: {}", nstr(filename.GetFullPath()));
 	return true;
 }
 

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -24,6 +24,7 @@
 #include <sstream>
 #include <algorithm>
 #include <unordered_set>
+#include <spdlog/spdlog.h>
 
 Map::Map() :
 	BaseMap(),
@@ -33,6 +34,7 @@ Map::Map() :
 	has_changed(false),
 	unnamed(false),
 	waypoints(*this) {
+	spdlog::info("Map created [Map={}]", (void*)this);
 	// Earliest version possible
 	// Caller is responsible for converting us to proper version
 	mapVersion.otbm = MAP_OTBM_1;
@@ -40,6 +42,7 @@ Map::Map() :
 }
 
 void Map::initializeEmpty() {
+	spdlog::info("Map::initializeEmpty [Map={}]", (void*)this);
 	height = 2048;
 	width = 2048;
 
@@ -57,6 +60,7 @@ void Map::initializeEmpty() {
 }
 
 Map::~Map() {
+	spdlog::info("Map destroying [Map={}]", (void*)this);
 	////
 }
 

--- a/source/rendering/core/gl_resources.h
+++ b/source/rendering/core/gl_resources.h
@@ -3,6 +3,7 @@
 
 #include <glad/glad.h>
 #include <utility> // for std::exchange
+#include <spdlog/spdlog.h>
 #include "rendering/core/gl_texture.h"
 
 // RAII wrapper for OpenGL Buffers (VBO, EBO, UBO, SSBO)
@@ -10,10 +11,12 @@ class GLBuffer {
 public:
 	GLBuffer() {
 		glCreateBuffers(1, &id);
+		// spdlog::trace("GLBuffer created [ID={}]", id);
 	}
 
 	~GLBuffer() {
 		if (id) {
+			// spdlog::trace("GLBuffer deleted [ID={}]", id);
 			glDeleteBuffers(1, &id);
 		}
 	}
@@ -53,10 +56,12 @@ class GLVertexArray {
 public:
 	GLVertexArray() {
 		glCreateVertexArrays(1, &id);
+		// spdlog::trace("GLVertexArray created [ID={}]", id);
 	}
 
 	~GLVertexArray() {
 		if (id) {
+			// spdlog::trace("GLVertexArray deleted [ID={}]", id);
 			glDeleteVertexArrays(1, &id);
 		}
 	}
@@ -96,10 +101,12 @@ class GLTextureResource {
 public:
 	explicit GLTextureResource(GLenum target) {
 		glCreateTextures(target, 1, &id);
+		spdlog::info("GLTextureResource created [ID={}]", id);
 	}
 
 	~GLTextureResource() {
 		if (id) {
+			spdlog::info("GLTextureResource deleted [ID={}]", id);
 			glDeleteTextures(1, &id);
 		}
 	}

--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -211,6 +211,9 @@ void TextureAtlas::unbind(uint32_t slot) const {
 }
 
 void TextureAtlas::release() {
+	if (texture_id_) {
+		spdlog::info("TextureAtlas releasing resources [ID={}]", texture_id_->GetID());
+	}
 	texture_id_.reset();
 	layer_count_ = 0;
 	allocated_layers_ = 0;

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -65,6 +65,7 @@
 
 MapDrawer::MapDrawer(MapCanvas* canvas) :
 	canvas(canvas), editor(canvas->editor) {
+	spdlog::info("MapDrawer created [Drawer={}] for [Editor={}]", (void*)this, (void*)&editor);
 	light_drawer = std::make_shared<LightDrawer>();
 	tooltip_drawer = std::make_unique<TooltipDrawer>();
 
@@ -92,6 +93,7 @@ MapDrawer::MapDrawer(MapCanvas* canvas) :
 }
 
 MapDrawer::~MapDrawer() {
+	spdlog::info("MapDrawer destroying [Drawer={}]", (void*)this);
 	Release();
 }
 
@@ -135,6 +137,7 @@ void MapDrawer::Release() {
 }
 
 void MapDrawer::Draw() {
+	// spdlog::trace("MapDrawer::Draw [Drawer={}]", (void*)this);
 	light_buffer.Clear();
 
 	// Begin Batches

--- a/source/ui/map_tab.cpp
+++ b/source/ui/map_tab.cpp
@@ -25,6 +25,8 @@
 #include "editor/editor_tabs.h"
 #include "rendering/ui/map_display.h"
 
+#include <spdlog/spdlog.h>
+
 MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 	EditorTab(),
 	MapWindow(aui, *editor),
@@ -32,6 +34,8 @@ MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 	iref = newd InternalReference;
 	iref->editor = editor;
 	iref->owner_count = 1;
+
+	spdlog::info("MapTab created (New Editor) [Tab={}]", (void*)this);
 
 	aui->AddTab(this, true);
 	FitToMap();
@@ -43,6 +47,7 @@ MapTab::MapTab(const MapTab* other) :
 	aui(other->aui),
 	iref(other->iref) {
 	iref->owner_count++;
+	spdlog::info("MapTab created (Shared Editor) [Tab={}]", (void*)this);
 	aui->AddTab(this, true);
 	FitToMap();
 	int x, y;
@@ -51,8 +56,10 @@ MapTab::MapTab(const MapTab* other) :
 }
 
 MapTab::~MapTab() {
+	spdlog::info("MapTab destroying [Tab={}] (Owner count: {})", (void*)this, iref->owner_count);
 	iref->owner_count--;
 	if (iref->owner_count <= 0) {
+		spdlog::info("MapTab destroying editor [Editor={}]", (void*)iref->editor);
 		delete iref->editor;
 		delete iref;
 	}


### PR DESCRIPTION
Added detailed logging to the map loading, resource creation, and destruction pipeline to help diagnose a crash occurring when closing map tabs.

- Instrumented `EditorManager`, `MapTab`, `Editor`, `Map`, `IOMapOTBM`, `GLTextureResource`, `MapDrawer`, and `TextureAtlas`.
- Added `spdlog::flush_on(spdlog::level::info)` to `Application::OnInit` to ensure logs are preserved in case of a hard crash.
- Updated `conanfile.py` to enforce `glad` 4.6 Core profile, ensuring OpenGL Direct State Access (DSA) functions like `glCreateBuffers` are correctly defined in the build environment.


---
*PR created automatically by Jules for task [15739984243470095822](https://jules.google.com/task/15739984243470095822) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured OpenGL support with core profile at version 4.6.

* **Chores**
  * Added logging throughout application lifecycle, editor operations, map file loading, and rendering systems.
  * Updated build configuration paths.
  * Introduced new rendering component infrastructure for map drawing.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->