### PR TITLE
[UB FIX] Fix critical spawn handling bugs (DOS, Logic, Infinite Loop)

### DIFF
--- a/source/game/spawn.h
+++ b/source/game/spawn.h
@@ -53,7 +53,12 @@ public:
 	}
 
 	void setSize(int newsize) {
-		ASSERT(size < 100);
+		// Clamp size to prevent DOS/UB with large values
+		if (newsize < 1) {
+			newsize = 1;
+		} else if (newsize > 100) {
+			newsize = 100;
+		}
 		size = newsize;
 	}
 	int getSize() const {

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1147,6 +1147,9 @@ bool IOMapOTBM::loadSpawns(Map& map, pugi::xml_document& doc) {
 			warning("Couldn't read radius of spawn.. discarding spawn...");
 			continue;
 		}
+		if (radius > g_settings.getInteger(Config::MAX_SPAWN_RADIUS)) {
+			radius = g_settings.getInteger(Config::MAX_SPAWN_RADIUS);
+		}
 
 		Tile* tile = map.getTile(spawnPosition);
 		if (tile && tile->spawn) {
@@ -1245,6 +1248,12 @@ bool IOMapOTBM::loadSpawns(Map& map, pugi::xml_document& doc) {
 				creatureTile->spawn = spawn;
 				map.addSpawn(creatureTile);
 			}
+		}
+
+		if (spawn->getSize() != radius) {
+			map.removeSpawn(tile);
+			spawn->setSize(radius);
+			map.addSpawn(tile);
 		}
 	}
 	return true;

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -484,7 +484,14 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int z = where->getZ();
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
+
+			int radius = 1;
 			while (found != tile_loc->getSpawnCount()) {
+				if (radius++ > 150) {
+					spdlog::warn("Map::getSpawnList: Potential infinite loop detected. Found {} spawns out of expected {}.", found, tile_loc->getSpawnCount());
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {


### PR DESCRIPTION
This PR addresses three critical issues identified by the 'Phantom' agent role:

1.  **DOS/UB Vulnerability:** Large `radius` values in OTBM files could cause integer overflows and massive loops in `Map::addSpawn`. Fixed by clamping `Spawn` size to a safe limit (100) in both `Spawn::setSize` (runtime) and `IOMapOTBM::loadSpawns` (loading).
2.  **Logic Bug:** The spawn radius expansion logic in `IOMapOTBM::loadSpawns` updated a local variable but failed to update the actual `Spawn` object, leading to inconsistent map state. Fixed by ensuring the `Spawn` object is updated and re-registered with the map if the radius grows.
3.  **Infinite Loop:** `Map::getSpawnList` could loop indefinitely if the map's `spawnCount` was corrupted (ghost spawn). Fixed by adding a safety break if the search radius exceeds 150 tiles.


---
*PR created automatically by Jules for task [10211514651954567710](https://jules.google.com/task/10211514651954567710) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved spawn size validation with automatic normalization to acceptable ranges.
  * Enhanced spawn radius handling with configured limits and consistency checks.
  * Added safeguards to prevent invalid spawn configurations and data inconsistencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->