### PR TITLE
[WXWIDGETS] Fix deprecated event handling in dialogs

### DIFF
--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -129,13 +129,6 @@ void BrowseTileListBox::UpdateItems() {
 // ============================================================================
 //
 
-BEGIN_EVENT_TABLE(BrowseTileWindow, wxDialog)
-EVT_BUTTON(wxID_REMOVE, BrowseTileWindow::OnClickDelete)
-EVT_BUTTON(wxID_FIND, BrowseTileWindow::OnClickSelectRaw)
-EVT_BUTTON(wxID_OK, BrowseTileWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, BrowseTileWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, "Browse Field", position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
@@ -175,12 +168,14 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	SetSizerAndFit(sizer);
 
 	// Connect Events
-	item_list->Connect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(BrowseTileWindow::OnItemSelected), nullptr, this);
+	item_list->Bind(wxEVT_LISTBOX, &BrowseTileWindow::OnItemSelected, this);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickDelete, this, wxID_REMOVE);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickSelectRaw, this, wxID_FIND);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickCancel, this, wxID_CANCEL);
 }
 
 BrowseTileWindow::~BrowseTileWindow() {
-	// Disconnect Events
-	item_list->Disconnect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(BrowseTileWindow::OnItemSelected), nullptr, this);
 }
 
 void BrowseTileWindow::OnItemSelected(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -229,24 +229,16 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	Centre(wxBOTH);
 
 	// Connect Events
-	list->Connect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(ReplaceItemsDialog::OnListSelected), nullptr, this);
-	replace_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnReplaceItemClicked), nullptr, this);
-	with_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnWithItemClicked), nullptr, this);
-	add_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnAddButtonClicked), nullptr, this);
-	remove_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnRemoveButtonClicked), nullptr, this);
-	execute_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnExecuteButtonClicked), nullptr, this);
-	close_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnCancelButtonClicked), nullptr, this);
+	list->Bind(wxEVT_LISTBOX, &ReplaceItemsDialog::OnListSelected, this);
+	replace_button->Bind(wxEVT_LEFT_DOWN, &ReplaceItemsDialog::OnReplaceItemClicked, this);
+	with_button->Bind(wxEVT_LEFT_DOWN, &ReplaceItemsDialog::OnWithItemClicked, this);
+	add_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnAddButtonClicked, this);
+	remove_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnRemoveButtonClicked, this);
+	execute_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnExecuteButtonClicked, this);
+	close_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnCancelButtonClicked, this);
 }
 
 ReplaceItemsDialog::~ReplaceItemsDialog() {
-	// Disconnect Events
-	list->Disconnect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(ReplaceItemsDialog::OnListSelected), nullptr, this);
-	replace_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnReplaceItemClicked), nullptr, this);
-	with_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnWithItemClicked), nullptr, this);
-	add_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnAddButtonClicked), nullptr, this);
-	remove_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnRemoveButtonClicked), nullptr, this);
-	execute_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnExecuteButtonClicked), nullptr, this);
-	close_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnCancelButtonClicked), nullptr, this);
 }
 
 void ReplaceItemsDialog::UpdateWidgets() {

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -39,11 +39,6 @@
 // ============================================================================
 // Tileset Window
 
-BEGIN_EVENT_TABLE(TilesetWindow, wxDialog)
-EVT_BUTTON(wxID_OK, TilesetWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, TilesetWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
 TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
@@ -74,7 +69,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	palette_field->Append("Raw", newd int(TILESET_RAW));
 	palette_field->SetSelection(3);
 
-	palette_field->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(TilesetWindow::OnChangePalette), nullptr, this);
+	palette_field->Bind(wxEVT_CHOICE, &TilesetWindow::OnChangePalette, this);
 	subsizer->Add(palette_field, wxSizerFlags(1).Expand());
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));
@@ -98,6 +93,9 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	SetSizerAndFit(topsizer);
 	Centre(wxBOTH);
+
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickCancel, this, wxID_CANCEL);
 }
 
 void TilesetWindow::OnChangePalette(wxCommandEvent& WXUNUSED(event)) {


### PR DESCRIPTION
ISSUE: Legacy Connect/Disconnect usage and Event Tables in ReplaceItemsDialog, BrowseTileWindow, and TilesetWindow.
IMPACT: Reduced type safety and maintainability. Anti-pattern for modern wxWidgets.
FIX: Replaced Connect/Disconnect and BEGIN_EVENT_TABLE with Bind.
DOMAIN CONTEXT: Modernizing wxWidgets usage as per Atlas directives.
TESTED: Compiled successfully with ninja.

---
*PR created automatically by Jules for task [11549817190687764936](https://jules.google.com/task/11549817190687764936) started by @karolak6612*