### PR TITLE
⚡ Throttle: Optimize Map Drawing with Quadtree Traversal

### DIFF
--- a/build_resume.log
+++ b/build_resume.log
@@ -1,0 +1,238 @@
+[1/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/entities/creature_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/entities/creature_drawer.cpp:12:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[2/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/entities/item_drawer.cpp.o
+In file included from /app/source/rendering/drawers/entities/item_drawer.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+/app/source/rendering/drawers/entities/item_drawer.cpp: In member function ‘void ItemDrawer::BlitItem(SpriteBatch&, PrimitiveRenderer&, SpriteDrawer*, CreatureDrawer*, int&, int&, const Position&, Item*, const DrawingOptions&, bool, int, int, int, int, const Tile*)’:
+/app/source/rendering/drawers/entities/item_drawer.cpp:89:42: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+   89 |                 if (it.clientID >= 39092 && it.clientID <= 39100 || it.clientID == 39236 || it.clientID == 39367 || it.clientID == 39368) {
+      |                     ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+/app/source/rendering/drawers/entities/item_drawer.cpp:97:78: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+   97 |         if (it.isMetaItem() || spr == nullptr || !ephemeral && it.pickupable && !options.show_items) {
+      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~
+/app/source/rendering/drawers/entities/item_drawer.cpp: In member function ‘void ItemDrawer::DrawRawBrush(SpriteBatch&, SpriteDrawer*, int, int, ItemType*, uint8_t, uint8_t, uint8_t, uint8_t)’:
+/app/source/rendering/drawers/entities/item_drawer.cpp:262:26: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+  262 |         if (cid >= 39092 && cid <= 39100 || cid == 39236 || cid == 39367 || cid == 39368) {
+      |             ~~~~~~~~~~~~~^~~~~~~~~~~~~~~
+[3/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/cursors/live_cursor_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/cursors/live_cursor_drawer.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[4/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/entities/sprite_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/entities/sprite_drawer.cpp:6:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[5/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/map_layer_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/map_layer_drawer.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[6/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/minimap_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/minimap_drawer.cpp:5:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[7/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/overlays/brush_overlay_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/overlays/brush_overlay_drawer.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[8/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/minimap_renderer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/rendering/drawers/minimap_renderer.cpp:2:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[9/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/overlays/grid_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/overlays/grid_drawer.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[10/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/overlays/marker_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/overlays/marker_drawer.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[11/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/overlays/preview_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/overlays/preview_drawer.cpp:11:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[12/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/overlays/selection_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/overlays/selection_drawer.cpp:11:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[13/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/tiles/floor_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/tiles/floor_drawer.cpp:15:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[14/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/tiles/shade_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/drawers/tiles/shade_drawer.cpp:15:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[15/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/tiles/tile_color_calculator.cpp.o
+[16/133] Building CXX object CMakeFiles/rme.dir/source/rendering/drawers/tiles/tile_renderer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/drawers/tiles/tile_renderer.cpp:6:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[17/133] Building CXX object CMakeFiles/rme.dir/source/rendering/io/editor_sprite_loader.cpp.o
+[18/133] Building CXX object CMakeFiles/rme.dir/source/rendering/io/screen_capture.cpp.o
+[19/133] Building CXX object CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o
+FAILED: CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o
+/usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -DUNICODE="" -DWXUSINGDLL -DWXWIN_COMPATIBILITY_3_3 -D_FILE_OFFSET_BITS=64 -D_UNICODE="" -D__WXGTK__ -I/app/build_conan/build/Release/_deps/wxmaterialdesignartprovider-src -I/app/source -I/app/ext/nanovg/src -isystem /usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.2 -isystem /usr/include/wx-3.2 -isystem /home/jules/.conan2/p/b/gladefaf68f0fac23/p/include -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result -pthread -O3 -DNDEBUG -std=gnu++20 -pthread -MD -MT CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o -MF CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o.d -o CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o -c /app/source/rendering/io/screenshot_saver.cpp
+In file included from /app/source/rendering/io/screenshot_saver.cpp:5:
+/app/source/rendering/io/screenshot_saver.h:24:9: error: ‘uint8_t’ does not name a type
+   24 |         uint8_t* GetBuffer() const {
+      |         ^~~~~~~
+/app/source/rendering/io/screenshot_saver.h:12:1: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
+   11 | #include <wx/bitmap.h>
+  +++ |+#include <cstdint>
+   12 |
+/app/source/rendering/io/screenshot_saver.h:34:9: error: ‘uint8_t’ does not name a type
+   34 |         uint8_t* buffer;
+      |         ^~~~~~~
+/app/source/rendering/io/screenshot_saver.h:34:9: note: ‘uint8_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
+/app/source/rendering/io/screenshot_saver.h: In constructor ‘ScreenshotSaver::ScreenshotSaver()’:
+/app/source/rendering/io/screenshot_saver.h:16:17: error: class ‘ScreenshotSaver’ does not have any field named ‘buffer’
+   16 |                 buffer(nullptr) { }
+      |                 ^~~~~~
+/app/source/rendering/io/screenshot_saver.h: In member function ‘bool ScreenshotSaver::IsCapturing() const’:
+/app/source/rendering/io/screenshot_saver.h:28:24: error: ‘buffer’ was not declared in this scope; did you mean ‘setbuffer’?
+   28 |                 return buffer != nullptr;
+      |                        ^~~~~~
+      |                        setbuffer
+/app/source/rendering/io/screenshot_saver.cpp: In member function ‘wxString ScreenshotSaver::SaveCapture(const wxFileName&, const wxString&, int, int)’:
+/app/source/rendering/io/screenshot_saver.cpp:31:14: error: ‘buffer’ was not declared in this scope; did you mean ‘boost::asio::buffer’?
+   31 |         if (!buffer) {
+      |              ^~~~~~
+      |              boost::asio::buffer
+In file included from /usr/include/boost/asio/detail/buffer_sequence_adapter.hpp:22,
+                 from /usr/include/boost/asio/detail/reactive_socket_service.hpp:27,
+                 from /usr/include/boost/asio/basic_socket.hpp:38,
+                 from /usr/include/boost/asio/basic_datagram_socket.hpp:20,
+                 from /usr/include/boost/asio.hpp:32,
+                 from /app/source/app/main.h:54,
+                 from /app/source/rendering/io/screenshot_saver.cpp:6:
+/usr/include/boost/asio/registered_buffer.hpp:299:32: note: ‘boost::asio::buffer’ declared here
+  299 | inline const_registered_buffer buffer(
+      |                                ^~~~~~
+/app/source/rendering/io/screenshot_saver.cpp:35:43: error: ‘buffer’ was not declared in this scope; did you mean ‘boost::asio::buffer’?
+   35 |         wxImage screenshot(width, height, buffer, true);
+      |                                           ^~~~~~
+      |                                           boost::asio::buffer
+/usr/include/boost/asio/registered_buffer.hpp:299:32: note: ‘boost::asio::buffer’ declared here
+  299 | inline const_registered_buffer buffer(
+      |                                ^~~~~~
+/app/source/rendering/io/screenshot_saver.cpp: In member function ‘void ScreenshotSaver::PrepareCapture(int, int)’:
+/app/source/rendering/io/screenshot_saver.cpp:76:9: error: ‘buffer’ was not declared in this scope; did you mean ‘boost::asio::buffer’?
+   76 |         buffer = newd uint8_t[3 * width * height];
+      |         ^~~~~~
+      |         boost::asio::buffer
+/usr/include/boost/asio/registered_buffer.hpp:299:32: note: ‘boost::asio::buffer’ declared here
+  299 | inline const_registered_buffer buffer(
+      |                                ^~~~~~
+/app/source/rendering/io/screenshot_saver.cpp: In member function ‘void ScreenshotSaver::Cleanup()’:
+/app/source/rendering/io/screenshot_saver.cpp:80:13: error: ‘buffer’ was not declared in this scope; did you mean ‘boost::asio::buffer’?
+   80 |         if (buffer) {
+      |             ^~~~~~
+      |             boost::asio::buffer
+/usr/include/boost/asio/registered_buffer.hpp:299:32: note: ‘boost::asio::buffer’ declared here
+  299 | inline const_registered_buffer buffer(
+      |                                ^~~~~~
+/app/source/rendering/io/screenshot_saver.cpp:81:17: error: type ‘<type error>’ argument given to ‘delete’, expected pointer
+   81 |                 delete[] buffer;
+      |                 ^~~~~~~~~~~~~~~
+[20/133] Building CXX object CMakeFiles/rme.dir/source/rendering/io/game_sprite_loader.cpp.o
+In file included from /app/source/rendering/io/game_sprite_loader.cpp:9:
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = unsigned char]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+  124 |                 fread(&ref, sizeof(ref), 1, file);
+      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = int]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = signed char]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = unsigned int]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = short unsigned int]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+[21/133] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/brush_selector.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/ui/brush_selector.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[22/133] Building CXX object CMakeFiles/rme.dir/source/rendering/map_drawer.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/map_drawer.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+ninja: build stopped: subcommand failed.

--- a/build_resume_2.log
+++ b/build_resume_2.log
@@ -1,0 +1,752 @@
+[1/112] Building CXX object CMakeFiles/rme.dir/source/rendering/io/screenshot_saver.cpp.o
+[2/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/keyboard_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/rendering/ui/keyboard_handler.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[3/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/clipboard_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/clipboard_handler.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[4/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/drawing_controller.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/drawing_controller.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[5/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/map_menu_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/map_menu_handler.cpp:19:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[6/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/map_display.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/ui/map_display.cpp:26:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /app/source/app/application.h:27,
+                 from /app/source/ui/map_tab.h:22:
+/app/source/rendering/ui/map_display.h: In constructor ‘MapCanvas::MapCanvas(MapWindow*, Editor&, int*)’:
+/app/source/rendering/ui/map_display.h:173:14: warning: ‘MapCanvas::renderer_initialized’ will be initialized after [-Wreorder]
+  173 |         bool renderer_initialized = false;
+      |              ^~~~~~~~~~~~~~~~~~~~
+/app/source/rendering/ui/map_display.h:121:13: warning:   ‘int MapCanvas::cursor_x’ [-Wreorder]
+  121 |         int cursor_x;
+      |             ^~~~~~~~
+/app/source/rendering/ui/map_display.cpp:120:1: warning:   when initialized here [-Wreorder]
+  120 | MapCanvas::MapCanvas(MapWindow* parent, Editor& editor, int* attriblist) :
+      | ^~~~~~~~~
+[7/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/map_status_updater.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/ui/map_status_updater.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[8/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/minimap_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/minimap_window.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[9/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/navigation_controller.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/rendering/ui/navigation_controller.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[10/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/popup_action_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/popup_action_handler.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[11/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/screenshot_controller.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/ui/screenshot_controller.cpp:22:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[12/112] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/fps_counter.cpp.o
+[13/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/selection_controller.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/rendering/ui/selection_controller.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[14/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o
+FAILED: CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o
+/usr/bin/c++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -DUNICODE="" -DWXUSINGDLL -DWXWIN_COMPATIBILITY_3_3 -D_FILE_OFFSET_BITS=64 -D_UNICODE="" -D__WXGTK__ -I/app/build_conan/build/Release/_deps/wxmaterialdesignartprovider-src -I/app/source -I/app/ext/nanovg/src -isystem /usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.2 -isystem /usr/include/wx-3.2 -isystem /home/jules/.conan2/p/b/gladefaf68f0fac23/p/include -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result -pthread -O3 -DNDEBUG -std=gnu++20 -pthread -MD -MT CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o -MF CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o.d -o CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o -c /app/source/rendering/ui/tooltip_drawer.cpp
+/app/source/rendering/ui/tooltip_drawer.cpp: In member function ‘void TooltipDrawer::draw(const RenderView&)’:
+/app/source/rendering/ui/tooltip_drawer.cpp:127:41: error: no matching function for call to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::push_back(<brace-enclosed initializer list>)’
+  127 |                         fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
+      |                         ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+In file included from /usr/include/c++/13/vector:66,
+                 from /app/source/map/position.h:23,
+                 from /app/source/rendering/ui/tooltip_drawer.h:23,
+                 from /app/source/rendering/ui/tooltip_drawer.cpp:18:
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&’ {aka ‘const TooltipDrawer::draw(const RenderView&)::FieldLine&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&&’ {aka ‘TooltipDrawer::draw(const RenderView&)::FieldLine&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/app/source/rendering/ui/tooltip_drawer.cpp:143:49: error: no matching function for call to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::push_back(<brace-enclosed initializer list>)’
+  143 |                                 fields.push_back({ "Description", tooltip.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
+      |                                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&’ {aka ‘const TooltipDrawer::draw(const RenderView&)::FieldLine&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&&’ {aka ‘TooltipDrawer::draw(const RenderView&)::FieldLine&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+/app/source/rendering/ui/tooltip_drawer.cpp:146:65: error: no match for ‘operator+’ (operand types are ‘const char [2]’ and ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’})
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                            ~~~~ ^ ~~~~~~~~~~~~
+      |                                                            |              |
+      |                                                            const char [2] const std::string_view {aka const std::basic_string_view<char>}
+In file included from /usr/include/wx-3.2/wx/time.h:13,
+                 from /usr/include/wx-3.2/wx/log.h:65,
+                 from /usr/include/wx-3.2/wx/wx.h:23,
+                 from /app/source/app/main.h:63,
+                 from /app/source/util/common.h:21,
+                 from /app/source/rendering/core/graphics.h:22,
+                 from /app/source/rendering/ui/tooltip_drawer.cpp:19:
+/usr/include/wx-3.2/wx/longlong.h:1059:20: note: candidate: ‘wxULongLong operator+(long unsigned int, const wxULongLong&)’
+ 1059 | inline wxULongLong operator+(unsigned long l, const wxULongLong& ull) { return ull + l; }
+      |                    ^~~~~~~~
+/usr/include/wx-3.2/wx/longlong.h:1059:66: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxULongLong&’ {aka ‘const wxULongLongNative&’}
+ 1059 | inline wxULongLong operator+(unsigned long l, const wxULongLong& ull) { return ull + l; }
+      |                                               ~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/longlong.h:1046:19: note: candidate: ‘wxLongLong operator+(long int, const wxLongLong&)’
+ 1046 | inline wxLongLong operator+(long l, const wxLongLong& ll) { return ll + l; }
+      |                   ^~~~~~~~
+/usr/include/wx-3.2/wx/longlong.h:1046:55: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxLongLong&’ {aka ‘const wxLongLongNative&’}
+ 1046 | inline wxLongLong operator+(long l, const wxLongLong& ll) { return ll + l; }
+      |                                     ~~~~~~~~~~~~~~~~~~^~
+In file included from /usr/include/wx-3.2/wx/memory.h:15,
+                 from /usr/include/wx-3.2/wx/object.h:19,
+                 from /usr/include/wx-3.2/wx/wx.h:15:
+/usr/include/wx-3.2/wx/string.h:3862:17: note: candidate: ‘wxString operator+(wchar_t, const wxString&)’
+ 3862 | inline wxString operator+(wchar_t ch, const wxString& string)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3862:55: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxString&’
+ 3862 | inline wxString operator+(wchar_t ch, const wxString& string)
+      |                                       ~~~~~~~~~~~~~~~~^~~~~~
+/usr/include/wx-3.2/wx/string.h:3860:17: note: candidate: ‘wxString operator+(char, const wxString&)’
+ 3860 | inline wxString operator+(char ch, const wxString& string)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3860:52: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxString&’
+ 3860 | inline wxString operator+(char ch, const wxString& string)
+      |                                    ~~~~~~~~~~~~~~~~^~~~~~
+/usr/include/wx-3.2/wx/string.h:3850:27: note: candidate: ‘wxString operator+(wxUniChar, const wxString&)’
+ 3850 | wxString WXDLLIMPEXP_BASE operator+(wxUniChar ch, const wxString& string);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2159:76: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxString&’
+ 2159 |   friend wxString WXDLLIMPEXP_BASE operator+(wxUniChar ch, const wxString& string);
+      |                                                            ~~~~~~~~~~~~~~~~^~~~~~
+/usr/include/wx-3.2/wx/string.h:3832:41: note: candidate: ‘wxString::const_reverse_iterator operator+(ptrdiff_t, wxString::const_reverse_iterator)’
+ 3832 | inline wxString::const_reverse_iterator operator+(ptrdiff_t n, wxString::const_reverse_iterator i)
+      |                                         ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3832:97: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxString::const_reverse_iterator’ {aka ‘wxString::reverse_iterator_impl<wxString::const_iterator>’}
+ 3832 | inline wxString::const_reverse_iterator operator+(ptrdiff_t n, wxString::const_reverse_iterator i)
+      |                                                                ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+/usr/include/wx-3.2/wx/string.h:3830:35: note: candidate: ‘wxString::reverse_iterator operator+(ptrdiff_t, wxString::reverse_iterator)’
+ 3830 | inline wxString::reverse_iterator operator+(ptrdiff_t n, wxString::reverse_iterator i)
+      |                                   ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3830:85: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxString::reverse_iterator’ {aka ‘wxString::reverse_iterator_impl<wxString::iterator>’}
+ 3830 | inline wxString::reverse_iterator operator+(ptrdiff_t n, wxString::reverse_iterator i)
+      |                                                          ~~~~~~~~~~~~~~~~~~~~~~~~~~~^
+/usr/include/wx-3.2/wx/string.h:3828:33: note: candidate: ‘wxString::const_iterator operator+(ptrdiff_t, wxString::const_iterator)’
+ 3828 | inline wxString::const_iterator operator+(ptrdiff_t n, wxString::const_iterator i)
+      |                                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3828:81: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxString::const_iterator’
+ 3828 | inline wxString::const_iterator operator+(ptrdiff_t n, wxString::const_iterator i)
+      |                                                        ~~~~~~~~~~~~~~~~~~~~~~~~~^
+/usr/include/wx-3.2/wx/string.h:3826:27: note: candidate: ‘wxString::iterator operator+(ptrdiff_t, wxString::iterator)’
+ 3826 | inline wxString::iterator operator+(ptrdiff_t n, wxString::iterator i)
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3826:69: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxString::iterator’
+ 3826 | inline wxString::iterator operator+(ptrdiff_t n, wxString::iterator i)
+      |                                                  ~~~~~~~~~~~~~~~~~~~^
+In file included from /usr/include/c++/13/string:48,
+                 from /usr/include/c++/13/bits/locale_classes.h:40,
+                 from /usr/include/c++/13/bits/ios_base.h:41,
+                 from /usr/include/c++/13/ios:44,
+                 from /usr/include/c++/13/ostream:40,
+                 from /usr/include/c++/13/iostream:41,
+                 from /app/source/rendering/ui/tooltip_drawer.h:22:
+/usr/include/c++/13/bits/stl_iterator.h:634:5: note: candidate: ‘template<class _Iterator> constexpr std::reverse_iterator<_IteratorL> std::operator+(typename reverse_iterator<_IteratorL>::difference_type, const reverse_iterator<_IteratorL>&)’
+  634 |     operator+(typename reverse_iterator<_Iterator>::difference_type __n,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:634:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::reverse_iterator<_IteratorL>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/stl_iterator.h:1808:5: note: candidate: ‘template<class _Iterator> constexpr std::move_iterator<_IteratorL> std::operator+(typename move_iterator<_IteratorL>::difference_type, const move_iterator<_IteratorL>&)’
+ 1808 |     operator+(typename move_iterator<_Iterator>::difference_type __n,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/stl_iterator.h:1808:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::move_iterator<_IteratorL>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+In file included from /usr/include/c++/13/string:54:
+/usr/include/c++/13/bits/basic_string.h:3553:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3553 |     operator+(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3553:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3571:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const _CharT*, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3571 |     operator+(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3571:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3590:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(_CharT, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3590 |     operator+(_CharT __lhs, const basic_string<_CharT,_Traits,_Alloc>& __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3590:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3607:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, const _CharT*)’
+ 3607 |     operator+(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3607:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3625:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, _CharT)’
+ 3625 |     operator+(const basic_string<_CharT, _Traits, _Alloc>& __lhs, _CharT __rhs)
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3625:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3637:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, const __cxx11::basic_string<_CharT, _Traits, _Allocator>&)’
+ 3637 |     operator+(basic_string<_CharT, _Traits, _Alloc>&& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3637:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3644:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const __cxx11::basic_string<_CharT, _Traits, _Allocator>&, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&)’
+ 3644 |     operator+(const basic_string<_CharT, _Traits, _Alloc>& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3644:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3651:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&)’
+ 3651 |     operator+(basic_string<_CharT, _Traits, _Alloc>&& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3651:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3674:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(const _CharT*, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&)’
+ 3674 |     operator+(const _CharT* __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3674:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} have incompatible cv-qualifiers
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3681:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(_CharT, __cxx11::basic_string<_CharT, _Traits, _Allocator>&&)’
+ 3681 |     operator+(_CharT __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3681:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} have incompatible cv-qualifiers
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3688:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, const _CharT*)’
+ 3688 |     operator+(basic_string<_CharT, _Traits, _Alloc>&& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3688:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/basic_string.h:3695:5: note: candidate: ‘template<class _CharT, class _Traits, class _Alloc> constexpr std::__cxx11::basic_string<_CharT, _Traits, _Allocator> std::operator+(__cxx11::basic_string<_CharT, _Traits, _Allocator>&&, _CharT)’
+ 3695 |     operator+(basic_string<_CharT, _Traits, _Alloc>&& __lhs,
+      |     ^~~~~~~~
+/usr/include/c++/13/bits/basic_string.h:3695:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘std::__cxx11::basic_string<_CharT, _Traits, _Allocator>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+In file included from /usr/include/c++/13/valarray:605,
+                 from /usr/include/nlohmann/detail/conversions/from_json.hpp:21,
+                 from /usr/include/nlohmann/adl_serializer.hpp:14,
+                 from /usr/include/nlohmann/json.hpp:34,
+                 from /app/source/util/json.h:21,
+                 from /app/source/app/main.h:132:
+/usr/include/c++/13/bits/valarray_after.h:405:5: note: candidate: ‘template<class _Dom1, class _Dom2> std::_Expr<std::__detail::_BinClos<std::__plus, std::_Expr, std::_Expr, _Dom1, _Dom2>, typename std::__fun<std::__plus, typename _Dom1::value_type>::result_type> std::operator+(const _Expr<_Dom1, typename _Dom1::value_type>&, const _Expr<_Dom2, typename _Dom2::value_type>&)’
+  405 |     _DEFINE_EXPR_BINARY_OPERATOR(+, struct std::__plus)
+      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::_Expr<_Dom1, typename _Dom1::value_type>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note: candidate: ‘template<class _Dom> std::_Expr<std::__detail::_BinClos<std::__plus, std::_Expr, std::_Constant, _Dom, typename _Dom::value_type>, typename std::__fun<std::__plus, typename _Dom1::value_type>::result_type> std::operator+(const _Expr<_Dom1, typename _Dom1::value_type>&, const typename _Dom::value_type&)’
+  405 |     _DEFINE_EXPR_BINARY_OPERATOR(+, struct std::__plus)
+      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::_Expr<_Dom1, typename _Dom1::value_type>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note: candidate: ‘template<class _Dom> std::_Expr<std::__detail::_BinClos<std::__plus, std::_Constant, std::_Expr, typename _Dom::value_type, _Dom>, typename std::__fun<std::__plus, typename _Dom1::value_type>::result_type> std::operator+(const typename _Dom::value_type&, const _Expr<_Dom1, typename _Dom1::value_type>&)’
+  405 |     _DEFINE_EXPR_BINARY_OPERATOR(+, struct std::__plus)
+      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::_Expr<_Dom1, typename _Dom1::value_type>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note: candidate: ‘template<class _Dom> std::_Expr<std::__detail::_BinClos<std::__plus, std::_Expr, std::_ValArray, _Dom, typename _Dom::value_type>, typename std::__fun<std::__plus, typename _Dom1::value_type>::result_type> std::operator+(const _Expr<_Dom1, typename _Dom1::value_type>&, const valarray<typename _Dom::value_type>&)’
+  405 |     _DEFINE_EXPR_BINARY_OPERATOR(+, struct std::__plus)
+      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::_Expr<_Dom1, typename _Dom1::value_type>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note: candidate: ‘template<class _Dom> std::_Expr<std::__detail::_BinClos<std::__plus, std::_ValArray, std::_Expr, typename _Dom::value_type, _Dom>, typename std::__fun<std::__plus, typename _Dom1::value_type>::result_type> std::operator+(const valarray<typename _Dom::value_type>&, const _Expr<_Dom1, typename _Dom1::value_type>&)’
+  405 |     _DEFINE_EXPR_BINARY_OPERATOR(+, struct std::__plus)
+      |     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/valarray_after.h:405:5: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::_Expr<_Dom1, typename _Dom1::value_type>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/valarray:1196:1: note: candidate: ‘template<class _Tp> std::_Expr<std::__detail::_BinClos<std::__plus, std::_ValArray, std::_ValArray, _Tp, _Tp>, typename std::__fun<std::__plus, _Tp>::result_type> std::operator+(const valarray<_Tp>&, const valarray<_Tp>&)’
+ 1196 | _DEFINE_BINARY_OPERATOR(+, __plus)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/valarray:1196:1: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::valarray<_Tp>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/valarray:1196:1: note: candidate: ‘template<class _Tp> std::_Expr<std::__detail::_BinClos<std::__plus, std::_ValArray, std::_Constant, _Tp, _Tp>, typename std::__fun<std::__plus, _Tp>::result_type> std::operator+(const valarray<_Tp>&, const typename valarray<_Tp>::value_type&)’
+ 1196 | _DEFINE_BINARY_OPERATOR(+, __plus)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/valarray:1196:1: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   mismatched types ‘const std::valarray<_Tp>’ and ‘const char [2]’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+/usr/include/c++/13/valarray:1196:1: note: candidate: ‘template<class _Tp> std::_Expr<std::__detail::_BinClos<std::__plus, std::_Constant, std::_ValArray, _Tp, _Tp>, typename std::__fun<std::__plus, _Tp>::result_type> std::operator+(const typename valarray<_Tp>::value_type&, const valarray<_Tp>&)’
+ 1196 | _DEFINE_BINARY_OPERATOR(+, __plus)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/valarray:1196:1: note:   template argument deduction/substitution failed:
+/app/source/rendering/ui/tooltip_drawer.cpp:146:75: note:   ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} is not derived from ‘const std::valarray<_Tp>’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                                                           ^~~~
+In file included from /app/source/app/main.h:56:
+/usr/include/wx-3.2/wx/defs.h:1522:1: note: candidate: ‘int operator+(wxAlignment, wxBorder)’
+ 1522 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1522:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAlignment’
+ 1522 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxBorder)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1522:1: note: candidate: ‘int operator+(wxBorder, wxAlignment)’
+ 1522 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1522:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+ 1522 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxBorder)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1523:1: note: candidate: ‘int operator+(wxAlignment, wxDirection)’
+ 1523 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxDirection)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1523:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAlignment’
+ 1523 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxDirection)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1523:1: note: candidate: ‘int operator+(wxDirection, wxAlignment)’
+ 1523 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxDirection)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1523:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxDirection’
+ 1523 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxDirection)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1524:1: note: candidate: ‘int operator+(wxAlignment, wxGeometryCentre)’
+ 1524 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1524:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAlignment’
+ 1524 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1524:1: note: candidate: ‘int operator+(wxGeometryCentre, wxAlignment)’
+ 1524 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1524:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxGeometryCentre’
+ 1524 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1525:1: note: candidate: ‘int operator+(wxAlignment, wxSizerFlagBits)’
+ 1525 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1525:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAlignment’
+ 1525 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1525:1: note: candidate: ‘int operator+(wxSizerFlagBits, wxAlignment)’
+ 1525 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1525:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxSizerFlagBits’
+ 1525 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1526:1: note: candidate: ‘int operator+(wxAlignment, wxStretch)’
+ 1526 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1526:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAlignment’
+ 1526 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1526:1: note: candidate: ‘int operator+(wxStretch, wxAlignment)’
+ 1526 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1526:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxStretch’
+ 1526 | wxALLOW_COMBINING_ENUMS(wxAlignment, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1527:1: note: candidate: ‘int operator+(wxBorder, wxDirection)’
+ 1527 | wxALLOW_COMBINING_ENUMS(wxBorder, wxDirection)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1527:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+ 1527 | wxALLOW_COMBINING_ENUMS(wxBorder, wxDirection)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1527:1: note: candidate: ‘int operator+(wxDirection, wxBorder)’
+ 1527 | wxALLOW_COMBINING_ENUMS(wxBorder, wxDirection)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1527:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxDirection’
+ 1527 | wxALLOW_COMBINING_ENUMS(wxBorder, wxDirection)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1528:1: note: candidate: ‘int operator+(wxBorder, wxGeometryCentre)’
+ 1528 | wxALLOW_COMBINING_ENUMS(wxBorder, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1528:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+ 1528 | wxALLOW_COMBINING_ENUMS(wxBorder, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1528:1: note: candidate: ‘int operator+(wxGeometryCentre, wxBorder)’
+ 1528 | wxALLOW_COMBINING_ENUMS(wxBorder, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1528:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxGeometryCentre’
+ 1528 | wxALLOW_COMBINING_ENUMS(wxBorder, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1529:1: note: candidate: ‘int operator+(wxBorder, wxSizerFlagBits)’
+ 1529 | wxALLOW_COMBINING_ENUMS(wxBorder, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1529:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+ 1529 | wxALLOW_COMBINING_ENUMS(wxBorder, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1529:1: note: candidate: ‘int operator+(wxSizerFlagBits, wxBorder)’
+ 1529 | wxALLOW_COMBINING_ENUMS(wxBorder, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1529:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxSizerFlagBits’
+ 1529 | wxALLOW_COMBINING_ENUMS(wxBorder, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1530:1: note: candidate: ‘int operator+(wxBorder, wxStretch)’
+ 1530 | wxALLOW_COMBINING_ENUMS(wxBorder, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1530:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+ 1530 | wxALLOW_COMBINING_ENUMS(wxBorder, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1530:1: note: candidate: ‘int operator+(wxStretch, wxBorder)’
+ 1530 | wxALLOW_COMBINING_ENUMS(wxBorder, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1530:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxStretch’
+ 1530 | wxALLOW_COMBINING_ENUMS(wxBorder, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1531:1: note: candidate: ‘int operator+(wxDirection, wxGeometryCentre)’
+ 1531 | wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1531:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxDirection’
+ 1531 | wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1531:1: note: candidate: ‘int operator+(wxGeometryCentre, wxDirection)’
+ 1531 | wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1531:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxGeometryCentre’
+ 1531 | wxALLOW_COMBINING_ENUMS(wxDirection, wxGeometryCentre)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1532:1: note: candidate: ‘int operator+(wxDirection, wxStretch)’
+ 1532 | wxALLOW_COMBINING_ENUMS(wxDirection, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1532:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxDirection’
+ 1532 | wxALLOW_COMBINING_ENUMS(wxDirection, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1532:1: note: candidate: ‘int operator+(wxStretch, wxDirection)’
+ 1532 | wxALLOW_COMBINING_ENUMS(wxDirection, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1532:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxStretch’
+ 1532 | wxALLOW_COMBINING_ENUMS(wxDirection, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1533:1: note: candidate: ‘int operator+(wxDirection, wxSizerFlagBits)’
+ 1533 | wxALLOW_COMBINING_ENUMS(wxDirection, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1533:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxDirection’
+ 1533 | wxALLOW_COMBINING_ENUMS(wxDirection, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1533:1: note: candidate: ‘int operator+(wxSizerFlagBits, wxDirection)’
+ 1533 | wxALLOW_COMBINING_ENUMS(wxDirection, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1533:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxSizerFlagBits’
+ 1533 | wxALLOW_COMBINING_ENUMS(wxDirection, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1534:1: note: candidate: ‘int operator+(wxGeometryCentre, wxSizerFlagBits)’
+ 1534 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1534:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxGeometryCentre’
+ 1534 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1534:1: note: candidate: ‘int operator+(wxSizerFlagBits, wxGeometryCentre)’
+ 1534 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxSizerFlagBits)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1534:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxSizerFlagBits’
+ 1534 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxSizerFlagBits)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1535:1: note: candidate: ‘int operator+(wxGeometryCentre, wxStretch)’
+ 1535 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1535:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxGeometryCentre’
+ 1535 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1535:1: note: candidate: ‘int operator+(wxStretch, wxGeometryCentre)’
+ 1535 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1535:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxStretch’
+ 1535 | wxALLOW_COMBINING_ENUMS(wxGeometryCentre, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1536:1: note: candidate: ‘int operator+(wxSizerFlagBits, wxStretch)’
+ 1536 | wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1536:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxSizerFlagBits’
+ 1536 | wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/defs.h:1536:1: note: candidate: ‘int operator+(wxStretch, wxSizerFlagBits)’
+ 1536 | wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/defs.h:1536:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxStretch’
+ 1536 | wxALLOW_COMBINING_ENUMS(wxSizerFlagBits, wxStretch)
+      | ^
+/usr/include/wx-3.2/wx/string.h:3839:27: note: candidate: ‘wxString operator+(const wxString&, const wxString&)’
+ 3839 | wxString WXDLLIMPEXP_BASE operator+(const wxString& string1, const wxString& string2);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2155:62: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxString&’
+ 2155 |                                              const wxString& string2);
+      |                                              ~~~~~~~~~~~~~~~~^~~~~~~
+/usr/include/wx-3.2/wx/string.h:3841:27: note: candidate: ‘wxString operator+(const wxString&, const char*)’
+ 3841 | wxString WXDLLIMPEXP_BASE operator+(const wxString& string, const char *psz);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2163:58: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const char*’
+ 2163 |                                              const char *psz);
+      |                                              ~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:3843:27: note: candidate: ‘wxString operator+(const wxString&, const wchar_t*)’
+ 3843 | wxString WXDLLIMPEXP_BASE operator+(const wxString& string, const wchar_t *pwz);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2166:61: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wchar_t*’
+ 2166 |                                              const wchar_t *pwz);
+      |                                              ~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:3845:27: note: candidate: ‘wxString operator+(const char*, const wxString&)’
+ 3845 | wxString WXDLLIMPEXP_BASE operator+(const char *psz, const wxString& string);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2170:62: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxString&’
+ 2170 |                                              const wxString& string);
+      |                                              ~~~~~~~~~~~~~~~~^~~~~~
+/usr/include/wx-3.2/wx/string.h:3847:27: note: candidate: ‘wxString operator+(const wchar_t*, const wxString&)’
+ 3847 | wxString WXDLLIMPEXP_BASE operator+(const wchar_t *pwz, const wxString& string);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2172:61: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wchar_t*’
+ 2172 |   friend wxString WXDLLIMPEXP_BASE operator+(const wchar_t *pwz,
+      |                                              ~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:3849:27: note: candidate: ‘wxString operator+(const wxString&, wxUniChar)’
+ 3849 | wxString WXDLLIMPEXP_BASE operator+(const wxString& string, wxUniChar ch);
+      |                           ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:2157:80: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxUniChar’
+ 2157 |   friend wxString WXDLLIMPEXP_BASE operator+(const wxString& string, wxUniChar ch);
+      |                                                                      ~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/string.h:3852:17: note: candidate: ‘wxString operator+(const wxString&, wxUniCharRef)’
+ 3852 | inline wxString operator+(const wxString& string, wxUniCharRef ch)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3852:64: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wxUniCharRef’
+ 3852 | inline wxString operator+(const wxString& string, wxUniCharRef ch)
+      |                                                   ~~~~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/string.h:3854:17: note: candidate: ‘wxString operator+(const wxString&, char)’
+ 3854 | inline wxString operator+(const wxString& string, char ch)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3854:56: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘char’
+ 3854 | inline wxString operator+(const wxString& string, char ch)
+      |                                                   ~~~~~^~
+/usr/include/wx-3.2/wx/string.h:3856:17: note: candidate: ‘wxString operator+(const wxString&, wchar_t)’
+ 3856 | inline wxString operator+(const wxString& string, wchar_t ch)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3856:59: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘wchar_t’
+ 3856 | inline wxString operator+(const wxString& string, wchar_t ch)
+      |                                                   ~~~~~~~~^~
+/usr/include/wx-3.2/wx/string.h:3858:17: note: candidate: ‘wxString operator+(wxUniCharRef, const wxString&)’
+ 3858 | inline wxString operator+(wxUniCharRef ch, const wxString& string)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:3858:40: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxUniCharRef’
+ 3858 | inline wxString operator+(wxUniCharRef ch, const wxString& string)
+      |                           ~~~~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/string.h:4237:17: note: candidate: ‘wxString operator+(const wxString&, const wxScopedWCharBuffer&)’
+ 4237 | inline wxString operator+(const wxString& string, const wxScopedWCharBuffer& buf)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:4237:78: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxScopedWCharBuffer&’ {aka ‘const wxScopedCharTypeBuffer<wchar_t>&’}
+ 4237 | inline wxString operator+(const wxString& string, const wxScopedWCharBuffer& buf)
+      |                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:4239:17: note: candidate: ‘wxString operator+(const wxScopedWCharBuffer&, const wxString&)’
+ 4239 | inline wxString operator+(const wxScopedWCharBuffer& buf, const wxString& string)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:4239:54: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxScopedWCharBuffer&’ {aka ‘const wxScopedCharTypeBuffer<wchar_t>&’}
+ 4239 | inline wxString operator+(const wxScopedWCharBuffer& buf, const wxString& string)
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:4243:17: note: candidate: ‘wxString operator+(const wxString&, const wxScopedCharBuffer&)’
+ 4243 | inline wxString operator+(const wxString& string, const wxScopedCharBuffer& buf)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:4243:77: note:   no known conversion for argument 2 from ‘const std::string_view’ {aka ‘const std::basic_string_view<char>’} to ‘const wxScopedCharBuffer&’ {aka ‘const wxScopedCharTypeBuffer<char>&’}
+ 4243 | inline wxString operator+(const wxString& string, const wxScopedCharBuffer& buf)
+      |                                                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/string.h:4245:17: note: candidate: ‘wxString operator+(const wxScopedCharBuffer&, const wxString&)’
+ 4245 | inline wxString operator+(const wxScopedCharBuffer& buf, const wxString& string)
+      |                 ^~~~~~~~
+/usr/include/wx-3.2/wx/string.h:4245:53: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxScopedCharBuffer&’ {aka ‘const wxScopedCharTypeBuffer<char>&’}
+ 4245 | inline wxString operator+(const wxScopedCharBuffer& buf, const wxString& string)
+      |                           ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
+In file included from /usr/include/wx-3.2/wx/event.h:21,
+                 from /usr/include/wx-3.2/wx/wx.h:24:
+/usr/include/wx-3.2/wx/gdicmn.h:368:15: note: candidate: ‘wxSize operator+(const wxSize&, const wxSize&)’
+  368 | inline wxSize operator+(const wxSize& s1, const wxSize& s2)
+      |               ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:368:39: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxSize&’
+  368 | inline wxSize operator+(const wxSize& s1, const wxSize& s2)
+      |                         ~~~~~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/gdicmn.h:490:20: note: candidate: ‘wxRealPoint operator+(const wxRealPoint&, const wxRealPoint&)’
+  490 | inline wxRealPoint operator+(const wxRealPoint& p1, const wxRealPoint& p2)
+      |                    ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:490:49: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxRealPoint&’
+  490 | inline wxRealPoint operator+(const wxRealPoint& p1, const wxRealPoint& p2)
+      |                              ~~~~~~~~~~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/gdicmn.h:622:16: note: candidate: ‘wxPoint operator+(const wxPoint&, const wxPoint&)’
+  622 | inline wxPoint operator+(const wxPoint& p1, const wxPoint& p2)
+      |                ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:622:41: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxPoint&’
+  622 | inline wxPoint operator+(const wxPoint& p1, const wxPoint& p2)
+      |                          ~~~~~~~~~~~~~~~^~
+/usr/include/wx-3.2/wx/gdicmn.h:632:16: note: candidate: ‘wxPoint operator+(const wxPoint&, const wxSize&)’
+  632 | inline wxPoint operator+(const wxPoint& p, const wxSize& s)
+      |                ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:632:41: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxPoint&’
+  632 | inline wxPoint operator+(const wxPoint& p, const wxSize& s)
+      |                          ~~~~~~~~~~~~~~~^
+/usr/include/wx-3.2/wx/gdicmn.h:642:16: note: candidate: ‘wxPoint operator+(const wxSize&, const wxPoint&)’
+  642 | inline wxPoint operator+(const wxSize& s, const wxPoint& p)
+      |                ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:642:40: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxSize&’
+  642 | inline wxPoint operator+(const wxSize& s, const wxPoint& p)
+      |                          ~~~~~~~~~~~~~~^
+/usr/include/wx-3.2/wx/gdicmn.h:889:25: note: candidate: ‘wxRect operator+(const wxRect&, const wxRect&)’
+  889 | WXDLLIMPEXP_CORE wxRect operator+(const wxRect& r1, const wxRect& r2);
+      |                         ^~~~~~~~
+/usr/include/wx-3.2/wx/gdicmn.h:889:49: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxRect&’
+  889 | WXDLLIMPEXP_CORE wxRect operator+(const wxRect& r1, const wxRect& r2);
+      |                                   ~~~~~~~~~~~~~~^~
+In file included from /usr/include/wx-3.2/wx/affinematrix2dbase.h:17,
+                 from /usr/include/wx-3.2/wx/affinematrix2d.h:17,
+                 from /usr/include/wx-3.2/wx/dc.h:31,
+                 from /usr/include/wx-3.2/wx/wx.h:51:
+/usr/include/wx-3.2/wx/geometry.h:213:21: note: candidate: ‘wxPoint2DInt operator+(const wxPoint2DInt&, const wxPoint2DInt&)’
+  213 | inline wxPoint2DInt operator+(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+      |                     ^~~~~~~~
+/usr/include/wx-3.2/wx/geometry.h:213:51: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxPoint2DInt&’
+  213 | inline wxPoint2DInt operator+(const wxPoint2DInt& pt1 , const wxPoint2DInt& pt2)
+      |                               ~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/geometry.h:430:24: note: candidate: ‘wxPoint2DDouble operator+(const wxPoint2DDouble&, const wxPoint2DDouble&)’
+  430 | inline wxPoint2DDouble operator+(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+      |                        ^~~~~~~~
+/usr/include/wx-3.2/wx/geometry.h:430:57: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘const wxPoint2DDouble&’
+  430 | inline wxPoint2DDouble operator+(const wxPoint2DDouble& pt1 , const wxPoint2DDouble& pt2)
+      |                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~
+/usr/include/wx-3.2/wx/toolbar.h:64:1: note: candidate: ‘int operator+(wxToolBarStyleFlags, wxBorder)’
+   64 | wxALLOW_COMBINING_ENUMS(wxToolBarStyleFlags, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/toolbar.h:64:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxToolBarStyleFlags’
+   64 | wxALLOW_COMBINING_ENUMS(wxToolBarStyleFlags, wxBorder)
+      | ^
+/usr/include/wx-3.2/wx/toolbar.h:64:1: note: candidate: ‘int operator+(wxBorder, wxToolBarStyleFlags)’
+   64 | wxALLOW_COMBINING_ENUMS(wxToolBarStyleFlags, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/toolbar.h:64:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+   64 | wxALLOW_COMBINING_ENUMS(wxToolBarStyleFlags, wxBorder)
+      | ^
+/usr/include/wx-3.2/wx/aui/auibook.h:58:1: note: candidate: ‘int operator+(wxAuiNotebookOption, wxBorder)’
+   58 | wxALLOW_COMBINING_ENUMS(wxAuiNotebookOption, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/aui/auibook.h:58:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxAuiNotebookOption’
+   58 | wxALLOW_COMBINING_ENUMS(wxAuiNotebookOption, wxBorder)
+      | ^
+/usr/include/wx-3.2/wx/aui/auibook.h:58:1: note: candidate: ‘int operator+(wxBorder, wxAuiNotebookOption)’
+   58 | wxALLOW_COMBINING_ENUMS(wxAuiNotebookOption, wxBorder)
+      | ^~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/wx-3.2/wx/aui/auibook.h:58:1: note:   no known conversion for argument 1 from ‘const char [2]’ to ‘wxBorder’
+   58 | wxALLOW_COMBINING_ENUMS(wxAuiNotebookOption, wxBorder)
+      | ^
+/app/source/rendering/ui/tooltip_drawer.cpp:146:49: error: no matching function for call to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::push_back(<brace-enclosed initializer list>)’
+  146 |                                 fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+      |                                 ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(const value_type&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1281 |       push_back(const value_type& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1281:35: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘const std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&’ {aka ‘const TooltipDrawer::draw(const RenderView&)::FieldLine&’}
+ 1281 |       push_back(const value_type& __x)
+      |                 ~~~~~~~~~~~~~~~~~~^~~
+/usr/include/c++/13/bits/stl_vector.h:1298:7: note: candidate: ‘constexpr void std::vector<_Tp, _Alloc>::push_back(value_type&&) [with _Tp = TooltipDrawer::draw(const RenderView&)::FieldLine; _Alloc = std::allocator<TooltipDrawer::draw(const RenderView&)::FieldLine>; value_type = TooltipDrawer::draw(const RenderView&)::FieldLine]’
+ 1298 |       push_back(value_type&& __x)
+      |       ^~~~~~~~~
+/usr/include/c++/13/bits/stl_vector.h:1298:30: note:   no known conversion for argument 1 from ‘<brace-enclosed initializer list>’ to ‘std::vector<TooltipDrawer::draw(const RenderView&)::FieldLine>::value_type&&’ {aka ‘TooltipDrawer::draw(const RenderView&)::FieldLine&&’}
+ 1298 |       push_back(value_type&& __x)
+      |                 ~~~~~~~~~~~~~^~~
+[15/112] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/zoom_controller.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/rendering/ui/zoom_controller.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[16/112] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/frame_pacer.cpp.o
+[17/112] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/light_calculator.cpp.o
+ninja: build stopped: subcommand failed.

--- a/build_resume_3.log
+++ b/build_resume_3.log
@@ -1,0 +1,657 @@
+[1/96] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/tile_describer.cpp.o
+[2/96] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/light_drawer.cpp.o
+[3/96] Building CXX object CMakeFiles/rme.dir/source/rendering/utilities/sprite_icon_generator.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/rendering/utilities/sprite_icon_generator.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[4/96] Building CXX object CMakeFiles/rme.dir/source/rendering/ui/tooltip_drawer.cpp.o
+[5/96] Building CXX object CMakeFiles/rme.dir/source/ui/artprovider.cpp.o
+[6/96] Building CXX object CMakeFiles/rme.dir/source/ui/add_item_window.cpp.o
+In file included from /app/source/ui/add_item_window.cpp:24:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /app/source/ui/add_item_window.cpp:36:
+/app/source/ui/add_item_window.h: In constructor ‘AddItemWindow::AddItemWindow(wxWindow*, TilesetCategoryType, Tileset*, wxPoint)’:
+/app/source/ui/add_item_window.h:49:18: warning: ‘AddItemWindow::tileset_item’ will be initialized after [-Wreorder]
+   49 |         Tileset* tileset_item;
+      |                  ^~~~~~~~~~~~
+/app/source/ui/add_item_window.h:48:29: warning:   ‘TilesetCategoryType AddItemWindow::category_type’ [-Wreorder]
+   48 |         TilesetCategoryType category_type;
+      |                             ^~~~~~~~~~~~~
+/app/source/ui/add_item_window.cpp:50:1: warning:   when initialized here [-Wreorder]
+   50 | AddItemWindow::AddItemWindow(wxWindow* win_parent, TilesetCategoryType categoryType, Tileset* tilesetItem, wxPoint pos) :
+      | ^~~~~~~~~~~~~
+/app/source/ui/add_item_window.h:48:29: warning: ‘AddItemWindow::category_type’ will be initialized after [-Wreorder]
+   48 |         TilesetCategoryType category_type;
+      |                             ^~~~~~~~~~~~~
+/app/source/ui/add_item_window.h:43:21: warning:   ‘wxSpinCtrl* AddItemWindow::item_id_field’ [-Wreorder]
+   43 |         wxSpinCtrl* item_id_field;
+      |                     ^~~~~~~~~~~~~
+/app/source/ui/add_item_window.cpp:50:1: warning:   when initialized here [-Wreorder]
+   50 | AddItemWindow::AddItemWindow(wxWindow* win_parent, TilesetCategoryType categoryType, Tileset* tilesetItem, wxPoint pos) :
+      | ^~~~~~~~~~~~~
+[7/96] Building CXX object CMakeFiles/rme.dir/source/ui/about_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/about_window.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[8/96] Building CXX object CMakeFiles/rme.dir/source/ui/add_tileset_window.cpp.o
+In file included from /app/source/ui/add_tileset_window.cpp:24:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /app/source/ui/add_tileset_window.cpp:36:
+/app/source/ui/add_tileset_window.h: In constructor ‘AddTilesetWindow::AddTilesetWindow(wxWindow*, TilesetCategoryType, wxPoint)’:
+/app/source/ui/add_tileset_window.h:47:29: warning: ‘AddTilesetWindow::category_type’ will be initialized after [-Wreorder]
+   47 |         TilesetCategoryType category_type;
+      |                             ^~~~~~~~~~~~~
+/app/source/ui/add_tileset_window.h:44:23: warning:   ‘wxStaticText* AddTilesetWindow::item_id_label’ [-Wreorder]
+   44 |         wxStaticText* item_id_label;
+      |                       ^~~~~~~~~~~~~
+/app/source/ui/add_tileset_window.cpp:50:1: warning:   when initialized here [-Wreorder]
+   50 | AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType categoryType, wxPoint pos) :
+      | ^~~~~~~~~~~~~~~~
+/app/source/ui/add_tileset_window.h:45:23: warning: ‘AddTilesetWindow::item_name_label’ will be initialized after [-Wreorder]
+   45 |         wxStaticText* item_name_label;
+      |                       ^~~~~~~~~~~~~~~
+/app/source/ui/add_tileset_window.h:41:21: warning:   ‘wxTextCtrl* AddTilesetWindow::tileset_name_field’ [-Wreorder]
+   41 |         wxTextCtrl* tileset_name_field;
+      |                     ^~~~~~~~~~~~~~~~~~
+/app/source/ui/add_tileset_window.cpp:50:1: warning:   when initialized here [-Wreorder]
+   50 | AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType categoryType, wxPoint pos) :
+      | ^~~~~~~~~~~~~~~~
+[9/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/object_properties_base.cpp.o
+[10/96] Building CXX object CMakeFiles/rme.dir/source/ui/controls/sortable_list_box.cpp.o
+[11/96] Building CXX object CMakeFiles/rme.dir/source/ui/browse_tile_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/ui/browse_tile_window.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[12/96] Building CXX object CMakeFiles/rme.dir/source/ui/dialogs/goto_position_dialog.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/dialogs/goto_position_dialog.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[13/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/property_validator.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/ui/properties/property_validator.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[14/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/property_applier.cpp.o
+In file included from /app/source/ui/properties/property_applier.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[15/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/teleport_service.cpp.o
+[16/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/attribute_service.cpp.o
+[17/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/spawn_properties_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/ui/properties/spawn_properties_window.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[18/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/creature_properties_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/properties/creature_properties_window.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[19/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/container_properties_window.cpp.o
+In file included from /app/source/ui/properties/container_properties_window.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[20/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/podium_properties_window.cpp.o
+In file included from /app/source/ui/properties/podium_properties_window.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[21/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/writable_properties_window.cpp.o
+[22/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/splash_properties_window.cpp.o
+[23/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/depot_properties_window.cpp.o
+In file included from /app/source/ui/properties/depot_properties_window.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[24/96] Building CXX object CMakeFiles/rme.dir/source/ui/dat_debug_view.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/dat_debug_view.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[25/96] Building CXX object CMakeFiles/rme.dir/source/ui/dialog_helper.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/dialog_helper.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[26/96] Building CXX object CMakeFiles/rme.dir/source/ui/dcbutton.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/dcbutton.cpp:24:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[27/96] Building CXX object CMakeFiles/rme.dir/source/ui/dialog_util.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/dialog_util.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[28/96] Building CXX object CMakeFiles/rme.dir/source/ui/extension_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/extension_window.cpp:22:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[29/96] Building CXX object CMakeFiles/rme.dir/source/ui/find_item_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/find_item_window.cpp:22:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[30/96] Building CXX object CMakeFiles/rme.dir/source/ui/dialogs/find_dialog.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/dialogs/find_dialog.cpp:5:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[31/96] Building CXX object CMakeFiles/rme.dir/source/ui/map/map_properties_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/map/map_properties_window.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+/app/source/ui/map/map_properties_window.cpp: In member function ‘void MapPropertiesWindow::OnClickOK(wxCommandEvent&)’:
+/app/source/ui/map/map_properties_window.cpp:151:20: warning: variable ‘old_ver’ set but not used [-Wunused-but-set-variable]
+  151 |         MapVersion old_ver = map.getVersion();
+      |                    ^~~~~~~
+[32/96] Building CXX object CMakeFiles/rme.dir/source/ui/map/towns_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/map/towns_window.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[33/96] Building CXX object CMakeFiles/rme.dir/source/ui/map/import_map_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/map/import_map_window.cpp:4:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[34/96] Building CXX object CMakeFiles/rme.dir/source/ui/map/export_tilesets_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/map/export_tilesets_window.cpp:4:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[35/96] Building CXX object CMakeFiles/rme.dir/source/ui/gui.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/gui.cpp:25:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+/app/source/ui/gui.h: In constructor ‘GUI::GUI()’:
+/app/source/ui/gui.h:349:13: warning: ‘GUI::disabled_counter’ will be initialized after [-Wreorder]
+  349 |         int disabled_counter;
+      |             ^~~~~~~~~~~~~~~~
+/app/source/ui/gui.h:344:14: warning:   ‘bool GUI::hotkeys_enabled’ [-Wreorder]
+  344 |         bool hotkeys_enabled;
+      |              ^~~~~~~~~~~~~~~
+/app/source/ui/gui.cpp:65:1: warning:   when initialized here [-Wreorder]
+   65 | GUI::GUI() :
+      | ^~~
+[36/96] Building CXX object CMakeFiles/rme.dir/source/ui/main_menubar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/main_menubar.cpp:22:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+/app/source/ui/main_menubar.cpp: In constructor ‘MainMenuBar::MainMenuBar(MainFrame*)’:
+/app/source/ui/main_menubar.cpp:100:118: warning: cast between incompatible pointer to member types from ‘wxCommandEventFunction’ {aka ‘void (wxEvtHandler::*)(wxCommandEvent&)’} to ‘wxEventFunction’ {aka ‘void (wxEvtHandler::*)(wxEvent&)’} [-Wcast-function-type]
+  100 |                 frame->Connect(MAIN_FRAME_MENU + ai->second->id, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)(wxEventFunction)(ai->second->handler), nullptr, this);
+      |                                                                                                                      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[37/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/view_settings_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/view_settings_handler.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[38/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/menubar_action_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/menubar_action_manager.cpp:5:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[39/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/search_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/search_handler.cpp:4:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[40/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/map_actions_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/map_actions_handler.cpp:2:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[41/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/navigation_menu_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/navigation_menu_handler.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[42/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/file_menu_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/app/application.h:21,
+                 from /app/source/ui/menubar/file_menu_handler.cpp:2:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[43/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar/palette_menu_handler.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/menubar/palette_menu_handler.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[44/96] Building CXX object CMakeFiles/rme.dir/source/ui/main_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/main_toolbar.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[45/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/loading_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/loading_manager.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[46/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/minimap_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/minimap_manager.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[47/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/layout_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/layout_manager.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[48/96] Building CXX object CMakeFiles/rme.dir/source/brushes/managers/doodad_preview_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/brushes/managers/doodad_preview_manager.cpp:11:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[49/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/status_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/status_manager.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[50/96] Building CXX object CMakeFiles/rme.dir/source/brushes/managers/brush_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/brushes/managers/brush_manager.cpp:13:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /app/source/brushes/managers/brush_manager.cpp:7:
+/app/source/brushes/managers/brush_manager.h: In constructor ‘BrushManager::BrushManager()’:
+/app/source/brushes/managers/brush_manager.h:112:20: warning: ‘BrushManager::window_door_brush’ will be initialized after [-Wreorder]
+  112 |         DoorBrush* window_door_brush;
+      |                    ^~~~~~~~~~~~~~~~~
+/app/source/brushes/managers/brush_manager.h:110:20: warning:   ‘DoorBrush* BrushManager::normal_door_alt_brush’ [-Wreorder]
+  110 |         DoorBrush* normal_door_alt_brush;
+      |                    ^~~~~~~~~~~~~~~~~~~~~
+/app/source/brushes/managers/brush_manager.cpp:20:1: warning:   when initialized here [-Wreorder]
+   20 | BrushManager::BrushManager() :
+      | ^~~~~~~~~~~~
+[51/96] Building CXX object CMakeFiles/rme.dir/source/palette/managers/palette_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/palette/managers/palette_manager.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[52/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/recent_files_manager.cpp.o
+[53/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/gl_context_manager.cpp.o
+[54/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/search_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/search_manager.cpp:3:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[55/96] Building CXX object CMakeFiles/rme.dir/source/ui/managers/welcome_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/managers/welcome_manager.cpp:2:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[56/96] Building CXX object CMakeFiles/rme.dir/source/editor/managers/editor_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/editor/managers/editor_manager.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[57/96] Building CXX object CMakeFiles/rme.dir/source/ui/map_popup_menu.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/map_popup_menu.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+/app/source/ui/map_popup_menu.cpp: In member function ‘void MapPopupMenu::Update()’:
+/app/source/ui/map_popup_menu.cpp:182:70: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+  182 |                                 if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
+      |                                                      ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/app/source/ui/map_popup_menu.cpp:182:137: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+  182 |                                 if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
+      |                                                                                                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+/app/source/ui/map_popup_menu.cpp:210:77: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
+  210 |                                 if (hasCollection || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
+      |                                                      ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[58/96] Building CXX object CMakeFiles/rme.dir/source/ui/map_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_window.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[59/96] Building CXX object CMakeFiles/rme.dir/source/ui/map_tab.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/map_tab.cpp:20:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[60/96] Building CXX object CMakeFiles/rme.dir/source/ui/numbertextctrl.cpp.o
+[61/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/brush_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/toolbar/brush_toolbar.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[62/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/position_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/toolbar/position_toolbar.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[63/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/size_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/toolbar/size_toolbar.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[64/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/standard_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/toolbar/standard_toolbar.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[65/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/toolbar_persistence.cpp.o
+[66/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/light_toolbar.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/toolbar/light_toolbar.cpp:7:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[67/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/toolbar_registry.cpp.o
+[68/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/toolbar_factory.cpp.o
+[69/96] Building CXX object CMakeFiles/rme.dir/source/ui/toolbar/toolbar_layout.cpp.o
+[70/96] Building CXX object CMakeFiles/rme.dir/source/ui/pngfiles.cpp.o
+[71/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/old_properties_window.cpp.o
+In file included from /app/source/ui/properties/old_properties_window.cpp:9:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[72/96] Building CXX object CMakeFiles/rme.dir/source/ui/positionctrl.cpp.o
+[73/96] Building CXX object CMakeFiles/rme.dir/source/ui/properties/properties_window.cpp.o
+In file included from /app/source/ui/properties/properties_window.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[74/96] Building CXX object CMakeFiles/rme.dir/source/ui/result_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/result_window.cpp:21:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[75/96] Building CXX object CMakeFiles/rme.dir/source/ui/replace_items_window.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/replace_items_window.cpp:19:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[76/96] Building CXX object CMakeFiles/rme.dir/source/ui/tileset_window.cpp.o
+In file included from /app/source/ui/tileset_window.cpp:24:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[77/96] Building CXX object CMakeFiles/rme.dir/source/ui/welcome_dialog.cpp.o
+[78/96] Building CXX object CMakeFiles/rme.dir/source/ui/map_statistics_dialog.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/map_statistics_dialog.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[79/96] Building CXX object CMakeFiles/rme.dir/source/ui/menubar_loader.cpp.o
+[80/96] Building CXX object CMakeFiles/rme.dir/source/ui/live_dialogs.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/ui/live_dialogs.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[81/96] Building CXX object CMakeFiles/rme.dir/source/util/mt_rand.cpp.o
+[82/96] Building CXX object CMakeFiles/rme.dir/source/util/file_system.cpp.o
+/app/source/util/file_system.cpp: In static member function ‘static wxString FileSystem::GetDataDirectory()’:
+/app/source/util/file_system.cpp:29:29: warning: catching polymorphic type ‘const class std::bad_cast’ by value [-Wcatch-value=]
+   29 |         } catch (const std::bad_cast) {
+      |                             ^~~~~~~~
+/app/source/util/file_system.cpp: In static member function ‘static wxString FileSystem::GetExecDirectory()’:
+/app/source/util/file_system.cpp:42:29: warning: catching polymorphic type ‘const class std::bad_cast’ by value [-Wcatch-value=]
+   42 |         } catch (const std::bad_cast) {
+      |                             ^~~~~~~~
+[83/96] Building CXX object CMakeFiles/rme.dir/source/util/common.cpp.o
+[84/96] Building CXX object CMakeFiles/rme.dir/_deps/wxmaterialdesignartprovider-src/MaterialDesign/wxAwesomeBrandsArt.cpp.o
+[85/96] Building CXX object CMakeFiles/rme.dir/_deps/wxmaterialdesignartprovider-src/MaterialDesign/wxAwesomeRegularArt.cpp.o
+[86/96] Building CXX object CMakeFiles/rme.dir/_deps/wxmaterialdesignartprovider-src/MaterialDesign/wxMaterialDesignArtProvider.cpp.o

--- a/build_verify.log
+++ b/build_verify.log
@@ -1,0 +1,76 @@
+[1/184] Building CXX object CMakeFiles/rme.dir/source/app/preferences.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/app/preferences.cpp:24:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[2/184] Building CXX object CMakeFiles/rme.dir/source/app/application.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/app/application.h:21,
+                 from /app/source/app/application.cpp:21:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /usr/include/wx-3.2/wx/wx.h:24,
+                 from /app/source/app/main.h:63,
+                 from /app/source/app/application.cpp:18:
+/app/source/ui/gui.h:59:40: warning: cast between incompatible pointer to member types from ‘void (wxEvtHandler::*)(wxCommandEvent&)’ to ‘wxEventFunction’ {aka ‘void (wxEvtHandler::*)(wxEvent&)’} [-Wcast-function-type]
+   59 |                 (wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
+/app/source/app/application.cpp:57:1: note: in expansion of macro ‘EVT_ON_UPDATE_MENUS’
+   57 | EVT_ON_UPDATE_MENUS(wxID_ANY, MainFrame::OnUpdateMenus)
+      | ^~~~~~~~~~~~~~~~~~~
+[3/184] Building CXX object CMakeFiles/rme.dir/source/app/managers/version_manager.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/app/managers/version_manager.cpp:10:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[4/184] Building CXX object CMakeFiles/rme.dir/source/app/client_version.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/app/client_version.cpp:23:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+In file included from /app/source/app/client_version.cpp:21:
+/app/source/io/filehandle.h: In member function ‘bool FileReadHandle::getType(T&) [with T = unsigned int]’:
+/app/source/io/filehandle.h:124:22: warning: ignoring return value of ‘size_t fread(void*, size_t, size_t, FILE*)’ declared with attribute ‘warn_unused_result’ [-Wunused-result]
+  124 |                 fread(&ref, sizeof(ref), 1, file);
+      |                 ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[5/184] Building CXX object CMakeFiles/rme.dir/source/brushes/brush.cpp.o
+In file included from /app/source/brushes/brush.cpp:44:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[6/184] Building CXX object CMakeFiles/rme.dir/source/brushes/brush_utility.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/editor/editor.h:24,
+                 from /app/source/ui/replace_items_window.h:23,
+                 from /app/source/ui/map_window.h:22,
+                 from /app/source/ui/map_tab.h:23,
+                 from /app/source/ui/gui.h:12,
+                 from /app/source/brushes/brush_utility.cpp:8:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~
+[7/184] Building CXX object CMakeFiles/rme.dir/source/brushes/door/door_brush.cpp.o
+In file included from /app/source/map/map.h:26,
+                 from /app/source/brushes/door/door_brush.cpp:13:
+/app/source/game/complexitem.h:159:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
+  159 |         const uint8_t getDirection() {
+      |         ^~~~~

--- a/source/map/basemap.h
+++ b/source/map/basemap.h
@@ -123,6 +123,11 @@ public:
 		root.visitLeaves(0, 0, 65536, min_x, min_y, max_x, max_y, std::forward<Func>(func));
 	}
 
+	template <typename Func>
+	void visitLeavesForce(int min_x, int min_y, int max_x, int max_y, Func&& func) {
+		root.visitLeavesForce(0, 0, 65536, min_x, min_y, max_x, max_y, std::forward<Func>(func));
+	}
+
 	// Assigns a tile, it might seem pointless to provide position, but it is not, as the passed tile may be nullptr
 	void setTile(int _x, int _y, int _z, Tile* newtile, bool remove = false);
 	void setTile(const Position& pos, Tile* newtile, bool remove = false) {

--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -129,6 +129,44 @@ public:
 	QTreeNode* getLeaf(int x, int y); // Might return nullptr
 	QTreeNode* getLeafForce(int x, int y); // Will never return nullptr, it will create the node if it's not there
 
+	template <typename Func>
+	void visitLeavesForce(int x, int y, int size, int min_x, int min_y, int max_x, int max_y, Func&& func) {
+		if (x >= max_x || y >= max_y || x + size <= min_x || y + size <= min_y) {
+			return;
+		}
+
+		if (isLeaf) {
+			func(this, x, y);
+			return;
+		}
+
+		int child_size = size / 4;
+		for (int iy = 0; iy < 4; ++iy) {
+			int cy = y + iy * child_size;
+			if (cy >= max_y || cy + child_size <= min_y) {
+				continue;
+			}
+
+			for (int ix = 0; ix < 4; ++ix) {
+				int cx = x + ix * child_size;
+				if (cx >= max_x || cx + child_size <= min_x) {
+					continue;
+				}
+
+				int index = (iy << 2) | ix;
+				if (!child[index]) {
+					child[index] = newd QTreeNode(map);
+					// Ensure consistent visibility state with createLeaf (default invisible)
+					child[index]->setVisible(false, false);
+					if (child_size == 4) {
+						child[index]->isLeaf = true;
+					}
+				}
+				child[index]->visitLeavesForce(cx, cy, child_size, min_x, min_y, max_x, max_y, std::forward<Func>(func));
+			}
+		}
+	}
+
 	// Coordinates are NOT relative
 	TileLocation* createTile(int x, int y, int z);
 	TileLocation* getTile(int x, int y, int z);

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -45,37 +45,29 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 	int nd_end_y = (view.end_y & ~3) + 4;
 
 	if (live_client) {
-		for (int nd_map_x = nd_start_x; nd_map_x <= nd_end_x; nd_map_x += 4) {
-			for (int nd_map_y = nd_start_y; nd_map_y <= nd_end_y; nd_map_y += 4) {
-				QTreeNode* nd = editor->map.getLeaf(nd_map_x, nd_map_y);
-				if (!nd) {
-					nd = editor->map.createLeaf(nd_map_x, nd_map_y);
-					nd->setVisible(false, false);
-				}
-
-				if (nd->isVisible(map_z > GROUND_LAYER)) {
-					for (int map_x = 0; map_x < 4; ++map_x) {
-						for (int map_y = 0; map_y < 4; ++map_y) {
-							TileLocation* location = nd->getTile(map_x, map_y, map_z);
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip);
-							// draw light, but only if not zoomed too far
-							if (location && options.isDrawLight() && view.zoom <= 10.0) {
-								tile_renderer->AddLight(location, view, options, light_buffer);
-							}
+		editor->map.visitLeavesForce(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](QTreeNode* nd, int nd_map_x, int nd_map_y) {
+			if (nd->isVisible(map_z > GROUND_LAYER)) {
+				for (int map_x = 0; map_x < 4; ++map_x) {
+					for (int map_y = 0; map_y < 4; ++map_y) {
+						TileLocation* location = nd->getTile(map_x, map_y, map_z);
+						tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip);
+						// draw light, but only if not zoomed too far
+						if (location && options.isDrawLight() && view.zoom <= 10.0) {
+							tile_renderer->AddLight(location, view, options, light_buffer);
 						}
 					}
-				} else {
-					if (!nd->isRequested(map_z > GROUND_LAYER)) {
-						// Request the node
-						if (editor->live_manager.GetClient()) {
-							editor->live_manager.GetClient()->queryNode(nd_map_x, nd_map_y, map_z > GROUND_LAYER);
-						}
-						nd->setRequested(map_z > GROUND_LAYER, true);
-					}
-					grid_drawer->DrawNodeLoadingPlaceholder(sprite_batch, nd_map_x, nd_map_y, view);
 				}
+			} else {
+				if (!nd->isRequested(map_z > GROUND_LAYER)) {
+					// Request the node
+					if (editor->live_manager.GetClient()) {
+						editor->live_manager.GetClient()->queryNode(nd_map_x, nd_map_y, map_z > GROUND_LAYER);
+					}
+					nd->setRequested(map_z > GROUND_LAYER, true);
+				}
+				grid_drawer->DrawNodeLoadingPlaceholder(sprite_batch, nd_map_x, nd_map_y, view);
 			}
-		}
+		});
 	} else {
 		editor->map.visitLeaves(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](QTreeNode* nd, int, int) {
 			for (int map_x = 0; map_x < 4; ++map_x) {

--- a/source/rendering/io/screenshot_saver.h
+++ b/source/rendering/io/screenshot_saver.h
@@ -9,6 +9,7 @@
 #include <wx/filename.h>
 #include <wx/image.h>
 #include <wx/bitmap.h>
+#include <cstdint>
 
 class ScreenshotSaver {
 public:


### PR DESCRIPTION
This PR optimizes the rendering loop for the Live Client mode by replacing the repetitive `getLeaf` calls (which traverse from root each time) with a recursive `visitLeavesForce` traversal. This reduces the algorithmic complexity of gathering visible map nodes.

Additionally, it fixes a missing include in `screenshot_saver.h` that caused build failures.

Performance Impact:
- Live Client map rendering should be significantly faster on large screens/zoomed out views due to reduced tree traversal overhead.


---
*PR created automatically by Jules for task [10063198379673008433](https://jules.google.com/task/10063198379673008433) started by @karolak6612*