### PR TITLE
UX: Add tooltips to improve interface accessibility

### DIFF
--- a/source/palette/palette_common.cpp
+++ b/source/palette/palette_common.cpp
@@ -238,10 +238,10 @@ void BrushSizePanel::LoadAllContents() {
 	}
 
 	sub_sizer->Add(brushshapeSquareButton = newd DCButton(this, PALETTE_BRUSHSHAPE_SQUARE, wxDefaultPosition, DC_BTN_TOGGLE, render_size, EDITOR_SPRITE_BRUSH_SD_9x9));
-	brushshapeSquareButton->SetToolTip("Square brush");
+	brushshapeSquareButton->SetToolTip("Square brush shape (Draw rectangular areas)");
 
 	sub_sizer->Add(brushshapeCircleButton = newd DCButton(this, PALETTE_BRUSHSHAPE_CIRCLE, wxDefaultPosition, DC_BTN_TOGGLE, render_size, EDITOR_SPRITE_BRUSH_CD_9x9));
-	brushshapeCircleButton->SetToolTip("Circle brush");
+	brushshapeCircleButton->SetToolTip("Circle brush shape (Draw circular areas)");
 	brushshapeSquareButton->SetValue(true);
 
 	if (large_icons) {
@@ -477,23 +477,23 @@ void BrushToolPanel::LoadAllContents() {
 
 		ASSERT(g_brush_manager.eraser);
 		sub_sizer->Add(eraserButton = newd BrushButton(this, g_brush_manager.eraser, RENDER_SIZE_32x32, PALETTE_TERRAIN_ERASER));
-		eraserButton->SetToolTip("Eraser");
+		eraserButton->SetToolTip("Eraser Tool (Remove items and tiles)");
 
 		ASSERT(g_brush_manager.pz_brush);
 		sub_sizer->Add(pzBrushButton = newd BrushButton(this, g_brush_manager.pz_brush, RENDER_SIZE_32x32, PALETTE_TERRAIN_PZ_TOOL));
-		pzBrushButton->SetToolTip("PZ Tool");
+		pzBrushButton->SetToolTip("Protected Zone (No combat allowed)");
 
 		ASSERT(g_brush_manager.rook_brush);
 		sub_sizer->Add(nopvpBrushButton = newd BrushButton(this, g_brush_manager.rook_brush, RENDER_SIZE_32x32, PALETTE_TERRAIN_NOPVP_TOOL));
-		nopvpBrushButton->SetToolTip("NO PVP Tool");
+		nopvpBrushButton->SetToolTip("No PvP Zone (No player combat)");
 
 		ASSERT(g_brush_manager.nolog_brush);
 		sub_sizer->Add(nologBrushButton = newd BrushButton(this, g_brush_manager.nolog_brush, RENDER_SIZE_32x32, PALETTE_TERRAIN_NOLOGOUT_TOOL));
-		nologBrushButton->SetToolTip("No Logout Tool");
+		nologBrushButton->SetToolTip("No Logout Zone (Players cannot logout)");
 
 		ASSERT(g_brush_manager.pvp_brush);
 		sub_sizer->Add(pvpzoneBrushButton = newd BrushButton(this, g_brush_manager.pvp_brush, RENDER_SIZE_32x32, PALETTE_TERRAIN_PVPZONE_TOOL));
-		pvpzoneBrushButton->SetToolTip("PVP Zone Tool");
+		pvpzoneBrushButton->SetToolTip("PvP Zone (Combat allowed)");
 
 		// New row
 		size_sizer->Add(sub_sizer);
@@ -544,7 +544,7 @@ void BrushToolPanel::LoadAllContents() {
 
 		ASSERT(g_brush_manager.eraser);
 		sub_sizer->Add(eraserButton = newd BrushButton(this, g_brush_manager.eraser, RENDER_SIZE_16x16, PALETTE_TERRAIN_ERASER));
-		eraserButton->SetToolTip("Eraser");
+		eraserButton->SetToolTip("Eraser Tool (Remove items and tiles)");
 
 		// sub_sizer->AddSpacer(20);
 		ASSERT(g_brush_manager.normal_door_alt_brush);
@@ -585,19 +585,19 @@ void BrushToolPanel::LoadAllContents() {
 
 		ASSERT(g_brush_manager.pz_brush);
 		sub_sizer->Add(pzBrushButton = newd BrushButton(this, g_brush_manager.pz_brush, RENDER_SIZE_16x16, PALETTE_TERRAIN_PZ_TOOL));
-		pzBrushButton->SetToolTip("PZ Tool");
+		pzBrushButton->SetToolTip("Protected Zone (No combat allowed)");
 
 		ASSERT(g_brush_manager.rook_brush);
 		sub_sizer->Add(nopvpBrushButton = newd BrushButton(this, g_brush_manager.rook_brush, RENDER_SIZE_16x16, PALETTE_TERRAIN_NOPVP_TOOL));
-		nopvpBrushButton->SetToolTip("NO PVP Tool");
+		nopvpBrushButton->SetToolTip("No PvP Zone (No player combat)");
 
 		ASSERT(g_brush_manager.nolog_brush);
 		sub_sizer->Add(nologBrushButton = newd BrushButton(this, g_brush_manager.nolog_brush, RENDER_SIZE_16x16, PALETTE_TERRAIN_NOLOGOUT_TOOL));
-		nologBrushButton->SetToolTip("No Logout Tool");
+		nologBrushButton->SetToolTip("No Logout Zone (Players cannot logout)");
 
 		ASSERT(g_brush_manager.pvp_brush);
 		sub_sizer->Add(pvpzoneBrushButton = newd BrushButton(this, g_brush_manager.pvp_brush, RENDER_SIZE_16x16, PALETTE_TERRAIN_PVPZONE_TOOL));
-		pvpzoneBrushButton->SetToolTip("PVP Zone Tool");
+		pvpzoneBrushButton->SetToolTip("PvP Zone (Combat allowed)");
 	}
 
 	sub_sizer->AddSpacer(large_icons ? 42 : 24);
@@ -893,12 +893,12 @@ BrushThicknessPanel::BrushThicknessPanel(wxWindow* parent) :
 	wxSizer* thickness_sub_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	thickness_sub_sizer->Add(20, 10);
 	use_button = newd wxCheckBox(this, PALETTE_DOODAD_USE_THICKNESS, "Use custom thickness");
-	use_button->SetToolTip("Enable custom thickness for this brush");
+	use_button->SetToolTip("Enable custom thickness override");
 	thickness_sub_sizer->Add(use_button);
 	thickness_sizer->Add(thickness_sub_sizer, 1, wxEXPAND);
 
 	slider = newd wxSlider(this, PALETTE_DOODAD_SLIDER, 5, 1, 10, wxDefaultPosition);
-	slider->SetToolTip("Adjust brush thickness");
+	slider->SetToolTip("Adjust brush thickness (For Doodad brushes)");
 	thickness_sizer->Add(slider, 1, wxEXPAND);
 
 	SetSizerAndFit(thickness_sizer);

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -55,7 +55,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
 	server_id_spin = newd wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
-	server_id_spin->SetToolTip("Search by server ID");
+	server_id_spin->SetToolTip("Search by Server ID (Item ID)");
 	server_id_box_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
 
 	invalid_item = newd wxCheckBox(server_id_box_sizer->GetStaticBox(), wxID_ANY, "Force select", wxDefaultPosition, wxDefaultSize, 0);
@@ -66,14 +66,14 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
 	client_id_spin = newd wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
-	client_id_spin->SetToolTip("Search by client ID");
+	client_id_spin->SetToolTip("Search by Client ID (Sprite ID)");
 	client_id_spin->Enable(false);
 	client_id_box_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
 	options_box_sizer->Add(client_id_box_sizer, 1, wxALL | wxEXPAND, 5);
 
 	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
 	name_text_input = newd wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
-	name_text_input->SetToolTip("Search by item name");
+	name_text_input->SetToolTip("Search by item name (min. 2 characters)");
 	name_text_input->Enable(false);
 	name_box_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
 	options_box_sizer->Add(name_box_sizer, 1, wxALL | wxEXPAND, 5);

--- a/source/ui/map_window.cpp
+++ b/source/ui/map_window.cpp
@@ -33,7 +33,9 @@ MapWindow::MapWindow(wxWindow* parent, Editor& editor) :
 	canvas = newd MapCanvas(this, editor, GL_settings);
 
 	vScroll = newd MapScrollBar(this, MAP_WINDOW_VSCROLL, wxVERTICAL, canvas);
+	vScroll->SetToolTip("Scroll map vertically");
 	hScroll = newd MapScrollBar(this, MAP_WINDOW_HSCROLL, wxHORIZONTAL, canvas);
+	hScroll->SetToolTip("Scroll map horizontally");
 
 	gem = newd DCButton(this, MAP_WINDOW_GEM, wxDefaultPosition, DC_BTN_NORMAL, RENDER_SIZE_16x16, EDITOR_SPRITE_SELECTION_GEM);
 	gem->SetToolTip("Switch between Drawing and Selection mode (Space)");

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -196,6 +196,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 
 	progress = new wxGauge(this, wxID_ANY, 100);
 	progress->SetValue(0);
+	progress->SetToolTip("Replacement operation progress");
 	items_sizer->Add(progress, 0, wxALL, 5);
 
 	sizer->Add(items_sizer, 1, wxALL | wxEXPAND, 5);
@@ -203,7 +204,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	wxBoxSizer* buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	add_button = new wxButton(this, wxID_ANY, wxT("Add"));
-	add_button->SetToolTip("Add replacement rule to list");
+	add_button->SetToolTip("Add this rule to the list");
 	add_button->Enable(false);
 	buttons_sizer->Add(add_button, 0, wxALL, 5);
 
@@ -215,7 +216,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	buttons_sizer->Add(0, 0, 1, wxEXPAND, 5);
 
 	execute_button = new wxButton(this, wxID_ANY, wxT("Execute"));
-	execute_button->SetToolTip("Execute all replacement rules");
+	execute_button->SetToolTip("Run the replacement on the map");
 	execute_button->Enable(false);
 	buttons_sizer->Add(execute_button, 0, wxALL, 5);
 
@@ -254,7 +255,7 @@ void ReplaceItemsDialog::UpdateWidgets() {
 	const uint16_t withId = with_button->GetItemId();
 	add_button->Enable(list->CanAdd(replaceId, withId));
 	if (add_button->IsEnabled()) {
-		add_button->SetToolTip("Add replacement rule to list");
+		add_button->SetToolTip("Add this rule to the list");
 	} else {
 		add_button->SetToolTip("Select replacement and target items to add.");
 	}
@@ -268,7 +269,7 @@ void ReplaceItemsDialog::UpdateWidgets() {
 
 	execute_button->Enable(list->GetCount() != 0);
 	if (execute_button->IsEnabled()) {
-		execute_button->SetToolTip("Execute all replacement rules");
+		execute_button->SetToolTip("Run the replacement on the map");
 	} else {
 		execute_button->SetToolTip("Add rules to list first.");
 	}

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -65,7 +65,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Palette"));
 	palette_field = newd wxChoice(this, wxID_ANY);
-	palette_field->SetToolTip("Select the palette category");
+	palette_field->SetToolTip("Select the source palette category");
 
 	palette_field->Append("Terrain", newd int(TILESET_TERRAIN));
 	palette_field->Append("Collections", newd int(TILESET_COLLECTION));
@@ -79,7 +79,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));
 	tileset_field = newd wxChoice(this, wxID_ANY);
-	tileset_field->SetToolTip("Select the target tileset");
+	tileset_field->SetToolTip("Select the destination tileset");
 
 	for (TilesetContainer::iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
 		tileset_field->Append(wxstr(iter->second->name), newd std::string(iter->second->name));
@@ -92,8 +92,14 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 20));
 
 	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
-	subsizer_->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	subsizer_->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* ok_button = newd wxButton(this, wxID_OK, "OK");
+	ok_button->SetToolTip("Save changes and close");
+	subsizer_->Add(ok_button, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
+	wxButton* cancel_button = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancel_button->SetToolTip("Discard changes and close");
+	subsizer_->Add(cancel_button, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -93,13 +93,17 @@ WelcomeDialogPanel::WelcomeDialogPanel(WelcomeDialog* dialog, const wxSize& size
 	auto* new_map_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "New");
 	new_map_button->SetAction(wxID_NEW);
 	new_map_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
+	new_map_button->SetToolTip("Create a new map");
 
 	auto* open_map_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "Open");
 	open_map_button->SetAction(wxID_OPEN);
 	open_map_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
+	open_map_button->SetToolTip("Open an existing map");
+
 	auto* preferences_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "Preferences");
 	preferences_button->SetAction(wxID_PREFERENCES);
 	preferences_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
+	preferences_button->SetToolTip("Configure editor settings");
 
 	Bind(wxEVT_PAINT, &WelcomeDialogPanel::OnPaint, this);
 


### PR DESCRIPTION
Implemented 10+ micro-UX improvements by adding or refining tooltips across multiple dialogs and panels to make the interface more intuitive and accessible, following the Palette agent instructions.

---
*PR created automatically by Jules for task [8057869852628602316](https://jules.google.com/task/8057869852628602316) started by @karolak6612*