### PR TITLE
[MODERNIZE] Use range-based loops and static_cast in various files

### DIFF
--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -925,16 +925,15 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 					}
 					f.endNode(); // OTMM_SPAWN_AREA
 				}
-				for (CreatureList::iterator iter = creature_list.begin(); iter != creature_list.end(); ++iter) {
-					(*iter)->reset();
+				for (Creature* creature : creature_list) {
+					creature->reset();
 				}
 			}
 			f.endNode(); // OTMM_SPAWN_DATA
 
 			f.addNode(OTMM_TOWN_DATA);
 			{
-				for (TownMap::const_iterator it = map.towns.begin(); it != map.towns.end(); ++it) {
-					const Town* town = it->second;
+				for (const auto& [id, town] : map.towns) {
 					f.addNode(OTMM_TOWN);
 					{
 						f.addU32(town->getID());
@@ -950,8 +949,7 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 
 			f.addNode(OTMM_HOUSE_DATA);
 			{
-				for (HouseMap::const_iterator it = map.houses.begin(); it != map.houses.end(); ++it) {
-					const House* house = it->second;
+				for (const auto& [id, house] : map.houses) {
 					f.addNode(OTMM_HOUSE);
 					{
 						f.addU32(house->id);

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -119,8 +119,8 @@ bool BrushPanel::SelectBrush(const Brush* whatbrush) {
 		return brushbox->SelectBrush(whatbrush);
 	}
 
-	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
-		if (*iter == whatbrush) {
+	for (const auto& brush : tileset->brushlist) {
+		if (brush == whatbrush) {
 			LoadContents();
 			return brushbox->SelectBrush(whatbrush);
 		}
@@ -180,15 +180,15 @@ BrushIconBox::BrushIconBox(wxWindow* parent, const TilesetCategory* _tileset, Re
 	wxSizer* stacksizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* rowsizer = nullptr;
 	int item_counter = 0;
-	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
-		ASSERT(*iter);
+	for (const auto& brush : tileset->brushlist) {
+		ASSERT(brush);
 		++item_counter;
 
 		if (!rowsizer) {
 			rowsizer = newd wxBoxSizer(wxHORIZONTAL);
 		}
 
-		BrushButton* bb = newd BrushButton(this, *iter, rsz);
+		BrushButton* bb = newd BrushButton(this, brush, rsz);
 		rowsizer->Add(bb);
 		brush_buttons.push_back(bb);
 
@@ -222,9 +222,9 @@ Brush* BrushIconBox::GetSelectedBrush() const {
 		return nullptr;
 	}
 
-	for (std::vector<BrushButton*>::const_iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		if ((*it)->GetValue()) {
-			return (*it)->brush;
+	for (const auto& btn : brush_buttons) {
+		if (btn->GetValue()) {
+			return btn->brush;
 		}
 	}
 	return nullptr;
@@ -232,10 +232,10 @@ Brush* BrushIconBox::GetSelectedBrush() const {
 
 bool BrushIconBox::SelectBrush(const Brush* whatbrush) {
 	DeselectAll();
-	for (std::vector<BrushButton*>::iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		if ((*it)->brush == whatbrush) {
-			(*it)->SetValue(true);
-			EnsureVisible(*it);
+	for (auto& btn : brush_buttons) {
+		if (btn->brush == whatbrush) {
+			btn->SetValue(true);
+			EnsureVisible(btn);
 			return true;
 		}
 	}
@@ -243,8 +243,8 @@ bool BrushIconBox::SelectBrush(const Brush* whatbrush) {
 }
 
 void BrushIconBox::DeselectAll() {
-	for (std::vector<BrushButton*>::iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		(*it)->SetValue(false);
+	for (auto& btn : brush_buttons) {
+		btn->SetValue(false);
 	}
 }
 

--- a/source/rendering/io/game_sprite_loader.cpp
+++ b/source/rendering/io/game_sprite_loader.cpp
@@ -145,13 +145,13 @@ bool GameSpriteLoader::LoadSpriteMetadata(GraphicManager* manager, const wxFileN
 						file.getU32(min);
 						file.getU32(max);
 						FrameDuration* frame_duration = sType->animator->getFrameDuration(i);
-						frame_duration->setValues(int(min), int(max));
+						frame_duration->setValues(static_cast<int>(min), static_cast<int>(max));
 					}
 					sType->animator->reset();
 				}
 			}
 
-			sType->numsprites = (int)sType->width * (int)sType->height * (int)sType->layers * (int)sType->pattern_x * (int)sType->pattern_y * sType->pattern_z * (int)sType->frames;
+			sType->numsprites = static_cast<int>(sType->width) * static_cast<int>(sType->height) * static_cast<int>(sType->layers) * static_cast<int>(sType->pattern_x) * static_cast<int>(sType->pattern_y) * sType->pattern_z * static_cast<int>(sType->frames);
 
 			// Read the sprite ids
 			for (uint32_t i = 0; i < sType->numsprites; ++i) {
@@ -408,8 +408,8 @@ bool GameSpriteLoader::LoadSpriteData(GraphicManager* manager, const wxFileName&
 
 	// Now read individual sprites
 	int id = 1;
-	for (std::vector<uint32_t>::iterator sprite_iter = sprite_indexes.begin(); sprite_iter != sprite_indexes.end(); ++sprite_iter, ++id) {
-		uint32_t index = *sprite_iter + 3;
+	for (const auto& sprite_index : sprite_indexes) {
+		uint32_t index = sprite_index + 3;
 		fh.seek(index);
 		uint16_t size;
 		safe_get(U16, size);
@@ -436,6 +436,7 @@ bool GameSpriteLoader::LoadSpriteData(GraphicManager* manager, const wxFileName&
 		} else {
 			fh.seekRelative(size);
 		}
+		++id;
 	}
 #undef safe_get
 	manager->unloaded = false;


### PR DESCRIPTION
Modernize C++ code by replacing raw iterator loops with range-based for loops and C-style casts with static_cast in `source/rendering/io/game_sprite_loader.cpp`, `source/io/iomap_otmm.cpp`, and `source/palette/panels/brush_panel.cpp`.

---
*PR created automatically by Jules for task [303597753864731679](https://jules.google.com/task/303597753864731679) started by @karolak6612*