### PR TITLE
📜 Auditor: Modernize containers, casts and lookups

### DIFF
--- a/source/editor/editor.h
+++ b/source/editor/editor.h
@@ -70,7 +70,7 @@ public: // Functions
 
 	// Selection
 	bool hasSelection() const {
-		return selection.size() != 0;
+		return !selection.empty();
 	}
 	// Some simple actions that work on the map (these will work through the undo queue)
 	// Moves the selected area by the offset

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -403,7 +403,7 @@ bool EditorManager::DoUndo() {
 	Editor* editor = GetCurrentEditor();
 	if (editor && editor->actionQueue->canUndo()) {
 		editor->actionQueue->undo();
-		if (editor->selection.size() > 0) {
+		if (!editor->selection.empty()) {
 			g_gui.SetSelectionMode();
 		}
 		g_status.SetStatusText("Undo action");
@@ -419,7 +419,7 @@ bool EditorManager::DoRedo() {
 	Editor* editor = GetCurrentEditor();
 	if (editor && editor->actionQueue->canRedo()) {
 		editor->actionQueue->redo();
-		if (editor->selection.size() > 0) {
+		if (!editor->selection.empty()) {
 			g_gui.SetSelectionMode();
 		}
 		g_status.SetStatusText("Redo action");

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -17,7 +17,7 @@
 #include <sstream>
 
 void CopyOperations::copy(Editor& editor, CopyBuffer& buffer, int floor) {
-	if (editor.selection.size() == 0) {
+	if (editor.selection.empty()) {
 		g_gui.SetStatusText("No tiles to copy.");
 		return;
 	}
@@ -72,7 +72,7 @@ void CopyOperations::copy(Editor& editor, CopyBuffer& buffer, int floor) {
 }
 
 void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
-	if (editor.selection.size() == 0) {
+	if (editor.selection.empty()) {
 		g_gui.SetStatusText("No tiles to cut.");
 		return;
 	}

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -97,7 +97,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 		}
 		batch->addAndCommitAction(std::move(action));
 
-		if (tilestoborder.size() > 0) {
+		if (!tilestoborder.empty()) {
 			action = editor.actionQueue->createAction(batch.get());
 
 			// Remove duplicates

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -43,7 +43,7 @@ void SelectionOperations::removeDuplicateWalls(Tile* buffer, Tile* tile) {
 }
 
 void SelectionOperations::borderizeSelection(Editor& editor) {
-	if (editor.selection.size() == 0) {
+	if (editor.selection.empty()) {
 		g_gui.SetStatusText("No items selected. Can't borderize.");
 	}
 
@@ -58,7 +58,7 @@ void SelectionOperations::borderizeSelection(Editor& editor) {
 }
 
 void SelectionOperations::randomizeSelection(Editor& editor) {
-	if (editor.selection.size() == 0) {
+	if (editor.selection.empty()) {
 		g_gui.SetStatusText("No items selected. Can't randomize.");
 	}
 
@@ -342,7 +342,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 }
 
 void SelectionOperations::destroySelection(Editor& editor) {
-	if (editor.selection.size() == 0) {
+	if (editor.selection.empty()) {
 		g_gui.SetStatusText("No selected items to delete.");
 	} else {
 		int tile_count = 0;

--- a/source/editor/persistence/tileset_exporter.cpp
+++ b/source/editor/persistence/tileset_exporter.cpp
@@ -37,7 +37,7 @@ void TilesetExporter::exportTilesets(const FileName& directory, const std::strin
 				for (const auto& kv : palettes) {
 					TilesetCategory* tilesetCategory = tileset_ptr->getCategory(kv.second);
 
-					if (kv.second != TILESET_RAW && tilesetCategory->brushlist.size() > 0) {
+					if (kv.second != TILESET_RAW && !tilesetCategory->brushlist.empty()) {
 						blocked = 0;
 					}
 				}
@@ -53,7 +53,7 @@ void TilesetExporter::exportTilesets(const FileName& directory, const std::strin
 			for (const auto& kv : palettes) {
 				TilesetCategory* tilesetCategory = tileset_ptr->getCategory(kv.second);
 
-				if (tilesetCategory->brushlist.size() > 0) {
+				if (!tilesetCategory->brushlist.empty()) {
 					std::string data = kv.first;
 					std::transform(data.begin(), data.end(), data.begin(), [](unsigned char c) { return std::tolower(c); });
 

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -86,6 +86,9 @@ public:
 	size_t size() const {
 		return tiles.size();
 	}
+	bool empty() const {
+		return tiles.empty();
+	}
 	void updateSelectionCount();
 	TileSet::iterator begin() {
 		return tiles.begin();

--- a/source/game/item.cpp
+++ b/source/game/item.cpp
@@ -127,7 +127,7 @@ Item* transformItem(Item* old_item, uint16_t new_id, Tile* parent) {
 			}
 		}
 
-		while (containers.size() != 0) {
+		while (!containers.empty()) {
 			Container* container = containers.front();
 			ItemVector& v = container->getVector();
 			for (ItemVector::iterator item_iter = v.begin(); item_iter != v.end(); ++item_iter) {

--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -40,9 +40,9 @@ namespace IngamePreview {
 			float target = (z >= first_visible && z <= last_visible) ? 1.0f : 0.0f;
 			float current = floor_opacity[z];
 			if (current < target) {
-				current = std::min(target, current + (float)(dt * fade_speed));
+				current = std::min(target, current + static_cast<float>(dt * fade_speed));
 			} else if (current > target) {
-				current = std::max(target, current - (float)(dt * fade_speed));
+				current = std::max(target, current - static_cast<float>(dt * fade_speed));
 			}
 			floor_opacity[z] = current;
 		}
@@ -71,17 +71,17 @@ namespace IngamePreview {
 		// Proper coordinate alignment
 		// We want camera_pos to be at the center of the viewport
 		int offset = (camera_pos.z <= GROUND_LAYER) ? (GROUND_LAYER - camera_pos.z) * TileSize : 0;
-		view.view_scroll_x = (camera_pos.x * TileSize) - offset - (int)(viewport_width * zoom / 2.0f);
-		view.view_scroll_y = (camera_pos.y * TileSize) - offset - (int)(viewport_height * zoom / 2.0f);
+		view.view_scroll_x = (camera_pos.x * TileSize) - offset - static_cast<int>(viewport_width * zoom / 2.0f);
+		view.view_scroll_y = (camera_pos.y * TileSize) - offset - static_cast<int>(viewport_height * zoom / 2.0f);
 
 		// Matching RME's projection (width * zoom x height * zoom)
-		view.projectionMatrix = glm::ortho(0.0f, (float)viewport_width * zoom, (float)viewport_height * zoom, 0.0f, -1.0f, 1.0f);
+		view.projectionMatrix = glm::ortho(0.0f, static_cast<float>(viewport_width) * zoom, static_cast<float>(viewport_height) * zoom, 0.0f, -1.0f, 1.0f);
 		view.viewMatrix = glm::translate(glm::mat4(1.0f), glm::vec3(0.375f, 0.375f, 0.0f));
 
 		DrawingOptions options;
 		options.SetIngame();
 		options.show_lights = lighting_enabled;
-		options.ambient_light_level = (float)ambient_light / 255.0f;
+		options.ambient_light_level = static_cast<float>(ambient_light) / 255.0f;
 		options.light_intensity = light_intensity;
 
 		// Initialize GL state
@@ -106,10 +106,10 @@ namespace IngamePreview {
 			sprite_batch->setGlobalTint(1.0f, 1.0f, 1.0f, alpha);
 
 			// Dynamic viewport culling
-			view.start_x = (int)std::floor((view.view_scroll_x - TileSize * 2) / (float)TileSize);
-			view.start_y = (int)std::floor((view.view_scroll_y - TileSize * 2) / (float)TileSize);
-			view.end_x = (int)std::ceil((view.view_scroll_x + viewport_width * zoom + TileSize * 2) / (float)TileSize);
-			view.end_y = (int)std::ceil((view.view_scroll_y + viewport_height * zoom + TileSize * 2) / (float)TileSize);
+			view.start_x = static_cast<int>(std::floor((view.view_scroll_x - TileSize * 2) / static_cast<float>(TileSize)));
+			view.start_y = static_cast<int>(std::floor((view.view_scroll_y - TileSize * 2) / static_cast<float>(TileSize)));
+			view.end_x = static_cast<int>(std::ceil((view.view_scroll_x + viewport_width * zoom + TileSize * 2) / static_cast<float>(TileSize)));
+			view.end_y = static_cast<int>(std::ceil((view.view_scroll_y + viewport_height * zoom + TileSize * 2) / static_cast<float>(TileSize)));
 
 			for (int x = view.start_x; x <= view.end_x; ++x) {
 				for (int y = view.start_y; y <= view.end_y; ++y) {

--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -139,7 +139,7 @@ namespace IngamePreview {
 		if (follow_selection) {
 			Position target;
 			// Prioritize Active Selection
-			if (active_editor->selection.size() > 0) {
+			if (!active_editor->selection.empty()) {
 				Position min = active_editor->selection.minPosition();
 				Position max = active_editor->selection.maxPosition();
 				target = Position(min.x + (max.x - min.x) / 2, min.y + (max.y - min.y) / 2, min.z);

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1643,7 +1643,7 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 			f.endNode();
 
 			bool supportWaypoints = version.otbm >= MAP_OTBM_3;
-			if (supportWaypoints || map.waypoints.waypoints.size() > 0) {
+			if (supportWaypoints || !map.waypoints.waypoints.empty()) {
 				if (!supportWaypoints) {
 					waypointsWarning = true;
 				}

--- a/source/map/basemap.cpp
+++ b/source/map/basemap.cpp
@@ -268,7 +268,7 @@ MapIterator& MapIterator::operator++() {
 		}
 
 		nodestack.pop_back();
-		if (nodestack.size() == 0) {
+		if (nodestack.empty()) {
 			// Set all values to "end"
 			local_z = -1;
 			local_i = -1;

--- a/source/map/map.h
+++ b/source/map/map.h
@@ -55,13 +55,13 @@ public:
 
 	// Errors/warnings
 	bool hasWarnings() const {
-		return warnings.size() != 0;
+		return !warnings.empty();
 	}
 	const wxArrayString& getWarnings() const {
 		return warnings;
 	}
 	bool hasError() const {
-		return error.size() != 0;
+		return !error.empty();
 	}
 	wxString getError() const {
 		return error;

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -492,7 +492,7 @@ void Tile::update() {
 	}
 
 	if ((statflags & TILESTATE_BLOCKING) == 0) {
-		if (ground == nullptr && items.size() == 0) {
+		if (ground == nullptr && items.empty()) {
 			statflags |= TILESTATE_BLOCKING;
 		}
 	}

--- a/source/rendering/core/atlas_manager.cpp
+++ b/source/rendering/core/atlas_manager.cpp
@@ -99,7 +99,7 @@ bool AtlasManager::hasSprite(uint32_t sprite_id) const {
 	if (sprite_id < DIRECT_LOOKUP_SIZE) {
 		return direct_lookup_[sprite_id] != nullptr;
 	}
-	return sprite_regions_.find(sprite_id) != sprite_regions_.end();
+	return sprite_regions_.contains(sprite_id);
 }
 
 void AtlasManager::bind(uint32_t slot) const {

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -202,18 +202,18 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw helper border for selected house tiles
 	// Only draw on the current floor (grid)
-	if (options.show_houses && tile->isHouseTile() && (int)tile->getHouseID() == current_house_id && map_z == view.floor) {
+	if (options.show_houses && tile->isHouseTile() && static_cast<int>(tile->getHouseID()) == current_house_id && map_z == view.floor) {
 
 		uint8_t hr, hg, hb;
 		TileColorCalculator::GetHouseColor(tile->getHouseID(), hr, hg, hb);
 
 		float intensity = 0.5f + (0.5f * options.highlight_pulse);
-		glm::vec4 border_color((float)hr / 255.0f, (float)hg / 255.0f, (float)hb / 255.0f, intensity); // House color border with pulsing alpha
+		glm::vec4 border_color(static_cast<float>(hr) / 255.0f, static_cast<float>(hg) / 255.0f, static_cast<float>(hb) / 255.0f, intensity); // House color border with pulsing alpha
 
 		// Map coordinates to screen coordinates
 		// draw_x, draw_y are defined in the beginning of function and are top-left of the tile
-		float x = (float)draw_x;
-		float y = (float)draw_y;
+		float x = static_cast<float>(draw_x);
+		float y = static_cast<float>(draw_y);
 		float s = 32.0f; // Standard tile size
 
 		// Draw 1px solid border using geometry generation
@@ -249,17 +249,17 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 						TileColorCalculator::GetHouseColor(house_id, hr, hg, hb);
 
 						// Apply house color tint
-						ir = (uint8_t)((int)ir * hr / 255);
-						ig = (uint8_t)((int)ig * hg / 255);
-						ib = (uint8_t)((int)ib * hb / 255);
+						ir = static_cast<uint8_t>(static_cast<int>(ir) * hr / 255);
+						ig = static_cast<uint8_t>(static_cast<int>(ig) * hg / 255);
+						ib = static_cast<uint8_t>(static_cast<int>(ib) * hb / 255);
 
-						if ((int)house_id == current_house_id) {
+						if (static_cast<int>(house_id) == current_house_id) {
 							// Pulse effect matching the tile pulse
 							if (options.highlight_pulse > 0.0f) {
 								float boost = options.highlight_pulse * 0.6f;
-								ir = (uint8_t)std::min(255, (int)(ir + (255 - ir) * boost));
-								ig = (uint8_t)std::min(255, (int)(ig + (255 - ig) * boost));
-								ib = (uint8_t)std::min(255, (int)(ib + (255 - ib) * boost));
+								ir = static_cast<uint8_t>(std::min(255, static_cast<int>(ir + (255 - ir) * boost)));
+								ig = static_cast<uint8_t>(std::min(255, static_cast<int>(ig + (255 - ig) * boost)));
+								ib = static_cast<uint8_t>(std::min(255, static_cast<int>(ib + (255 - ib) * boost)));
 							}
 						}
 					}

--- a/source/rendering/io/game_sprite_loader.cpp
+++ b/source/rendering/io/game_sprite_loader.cpp
@@ -145,13 +145,13 @@ bool GameSpriteLoader::LoadSpriteMetadata(GraphicManager* manager, const wxFileN
 						file.getU32(min);
 						file.getU32(max);
 						FrameDuration* frame_duration = sType->animator->getFrameDuration(i);
-						frame_duration->setValues(int(min), int(max));
+						frame_duration->setValues(static_cast<int>(min), static_cast<int>(max));
 					}
 					sType->animator->reset();
 				}
 			}
 
-			sType->numsprites = (int)sType->width * (int)sType->height * (int)sType->layers * (int)sType->pattern_x * (int)sType->pattern_y * sType->pattern_z * (int)sType->frames;
+			sType->numsprites = static_cast<int>(sType->width) * static_cast<int>(sType->height) * static_cast<int>(sType->layers) * static_cast<int>(sType->pattern_x) * static_cast<int>(sType->pattern_y) * sType->pattern_z * static_cast<int>(sType->frames);
 
 			// Read the sprite ids
 			for (uint32_t i = 0; i < sType->numsprites; ++i) {

--- a/source/rendering/ui/clipboard_handler.cpp
+++ b/source/rendering/ui/clipboard_handler.cpp
@@ -48,7 +48,7 @@ void ClipboardHandler::doDelete(Editor& editor) {
 }
 
 void ClipboardHandler::copyPosition(const Selection& selection) {
-	if (selection.size() == 0) {
+	if (selection.empty()) {
 		return;
 	}
 

--- a/source/rendering/ui/popup_action_handler.cpp
+++ b/source/rendering/ui/popup_action_handler.cpp
@@ -36,7 +36,7 @@ void PopupActionHandler::RotateItem(Editor& editor) {
 	std::unique_ptr<Tile> new_tile(tile->deepCopy(editor.map));
 
 	ItemVector selected_items = new_tile->getSelectedItems();
-	ASSERT(selected_items.size() > 0);
+	ASSERT(!selected_items.empty());
 
 	selected_items.front()->doRotate();
 
@@ -49,7 +49,7 @@ void PopupActionHandler::RotateItem(Editor& editor) {
 void PopupActionHandler::GotoDestination(Editor& editor) {
 	Tile* tile = editor.selection.getSelectedTile();
 	ItemVector selected_items = tile->getSelectedItems();
-	ASSERT(selected_items.size() > 0);
+	ASSERT(!selected_items.empty());
 	Teleport* teleport = dynamic_cast<Teleport*>(selected_items.front());
 	if (teleport) {
 		Position pos = teleport->getDestination();
@@ -65,7 +65,7 @@ void PopupActionHandler::SwitchDoor(Editor& editor) {
 	std::unique_ptr<Tile> new_tile(tile->deepCopy(editor.map));
 
 	ItemVector selected_items = new_tile->getSelectedItems();
-	ASSERT(selected_items.size() > 0);
+	ASSERT(!selected_items.empty());
 
 	DoorBrush::switchDoor(selected_items.front());
 

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -266,7 +266,7 @@ void FindBrushDialog::RefreshContentsInternal() {
 			item_list->AddBrush(raw_brush);
 		}
 
-		while (raws.size() > 0) {
+		while (!raws.empty()) {
 			item_list->AddBrush(const_cast<RAWBrush*>(raws.front()));
 			raws.pop_front();
 		}

--- a/source/ui/gui.cpp
+++ b/source/ui/gui.cpp
@@ -129,7 +129,7 @@ void GUI::SetDrawingMode() {
 	for (int idx = 0; idx < tabbook->GetTabCount(); ++idx) {
 		EditorTab* editorTab = tabbook->GetTab(idx);
 		if (auto* mapTab = dynamic_cast<MapTab*>(editorTab)) {
-			if (al.find(mapTab) != al.end()) {
+			if (al.contains(mapTab)) {
 				continue;
 			}
 

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -477,7 +477,7 @@ void MainMenuBar::OnToggleFullscreen(wxCommandEvent& WXUNUSED(event)) {
 
 void MainMenuBar::OnTakeScreenshot(wxCommandEvent& WXUNUSED(event)) {
 	wxString path = wxstr(g_settings.getString(Config::SCREENSHOT_DIRECTORY));
-	if (path.size() > 0 && (path.Last() == '/' || path.Last() == '\\')) {
+	if (!path.empty() && (path.Last() == '/' || path.Last() == '\\')) {
 		path = path + "/";
 	}
 

--- a/source/ui/map/towns_window.cpp
+++ b/source/ui/map/towns_window.cpp
@@ -123,7 +123,7 @@ void EditTownsDialog::UpdateSelection(int new_selection) {
 	long tmplong;
 
 	// Save old values
-	if (town_list.size() > 0) {
+	if (!town_list.empty()) {
 		if (id_field->GetValue().ToLong(&tmplong)) {
 			uint32_t old_town_id = tmplong;
 
@@ -253,7 +253,7 @@ void EditTownsDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 
 	if (Validate() && TransferDataFromWindow()) {
 		// Save old values
-		if (town_list.size() > 0 && id_field->GetValue().ToLong(&tmplong)) {
+		if (!town_list.empty() && id_field->GetValue().ToLong(&tmplong)) {
 			uint32_t old_town_id = tmplong;
 
 			Town* old_town = nullptr;

--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -46,7 +46,7 @@ void MapPopupMenu::Update() {
 		Delete(m_item);
 	}
 
-	bool anything_selected = editor.selection.size() != 0;
+	bool anything_selected = !editor.selection.empty();
 
 	wxMenuItem* cutItem = Append(MAP_POPUP_MENU_CUT, "&Cut\tCTRL+X", "Cut out all selected items");
 	cutItem->Enable(anything_selected);

--- a/source/ui/numbertextctrl.cpp
+++ b/source/ui/numbertextctrl.cpp
@@ -91,7 +91,7 @@ void NumberTextCtrl::CheckRange() {
 
 	// Check that value is in range
 	long v;
-	if (ntext.size() != 0 && ntext.ToLong(&v)) {
+	if (!ntext.empty() && ntext.ToLong(&v)) {
 		if (v < minval) {
 			v = minval;
 		} else if (v > maxval) {

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -104,7 +104,7 @@ void TilesetWindow::OnChangePalette(wxCommandEvent& WXUNUSED(event)) {
 	tileset_field->Clear();
 
 	for (TilesetContainer::iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
-		if (iter->second->getCategory(TilesetCategoryType(*static_cast<int*>(palette_field->GetClientData(palette_field->GetSelection()))))->brushlist.size() > 0) {
+		if (!iter->second->getCategory(TilesetCategoryType(*static_cast<int*>(palette_field->GetClientData(palette_field->GetSelection()))))->brushlist.empty()) {
 			tileset_field->Append(wxstr(iter->second->name), newd std::string(iter->second->name));
 		}
 	}


### PR DESCRIPTION
This PR modernizes the codebase by:
1. Adopting C++20 `contains()` for `std::map` and `std::set` lookups in `AtlasManager` and `GUI`.
2. Replacing legacy container checks (`size() == 0`) with the more readable and standard `.empty()` across 20+ files.
3. Enforcing type safety by replacing C-style casts with `static_cast` in `GameSpriteLoader`, `TileRenderer`, and `IngamePreviewRenderer`.
4. Adding a missing `empty()` method to the `Selection` class to support the refactoring.

All changes were verified via compilation and code review.

---
*PR created automatically by Jules for task [13218660716691788083](https://jules.google.com/task/13218660716691788083) started by @karolak6612*