### PR TITLE
⚡ Bolt: Optimized SpawnList and Tooltip Rendering

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - Rendering Bottleneck: Per-Tile Logic
 Learning: `TileRenderer::DrawTile` executes per visible tile every frame. Tooltips are currently drawn for all items, which is intentional (labels), but this design choice inherently limits performance on large views due to string operations.
 Action: Future optimizations for tooltips should focus on caching the generated strings or using a more efficient font renderer, rather than culling them, as culling contradicts the "label" behavior.
+
+## 2025-02-18 - Safety vs Optimization in Data Transfer
+Learning: Attempted to optimize `TooltipData` by changing `std::string` to `std::string_view` for `itemName`, assuming it pointed to static data in `g_items`. However, the code reviewer correctly identified that `CreateItemTooltipData` constructs `itemName` as a local `std::string_view` from logic that might involve temporary strings or just general fragility if the source isn't guaranteed stable. Storing `string_view` in a struct passed between rendering stages creates a high risk of Use-After-Free if the lifetime isn't strictly controlled.
+Action: When optimizing data transfer structs, prefer `std::string` with move semantics (`std::move`) over `std::string_view` unless the source lifetime is undeniably static or strictly scoped (e.g., function parameters). Safety first.

--- a/source/game/spawn.h
+++ b/source/game/spawn.h
@@ -18,6 +18,8 @@
 #ifndef RME_SPAWN_H_
 #define RME_SPAWN_H_
 
+#include <vector>
+
 class Tile;
 
 class Spawn {
@@ -66,7 +68,7 @@ protected:
 };
 
 using SpawnPositionList = std::set<Position>;
-using SpawnList = std::list<Spawn*>;
+using SpawnList = std::vector<Spawn*>;
 
 class Spawns {
 public:

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -474,6 +474,7 @@ SpawnList Map::getSpawnList(Tile* where) {
 	TileLocation* tile_loc = where->getLocation();
 	if (tile_loc) {
 		if (tile_loc->getSpawnCount() > 0) {
+			list.reserve(tile_loc->getSpawnCount());
 			uint32_t found = 0;
 			if (where->spawn) {
 				++found;

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -194,7 +194,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
 		TooltipData groundData = CreateItemTooltipData(tile->ground, location->getPosition(), tile->isHouseTile());
 		if (groundData.hasVisibleFields()) {
-			tooltip_drawer->addItemTooltip(groundData);
+			tooltip_drawer->addItemTooltip(std::move(groundData));
 		}
 	}
 
@@ -228,7 +228,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 				if (options.show_tooltips && map_z == view.floor) {
 					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
 					if (itemData.hasVisibleFields()) {
-						tooltip_drawer->addItemTooltip(itemData);
+						tooltip_drawer->addItemTooltip(std::move(itemData));
 					}
 				}
 

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -44,11 +44,11 @@ void TooltipDrawer::clear() {
 	tooltips.clear();
 }
 
-void TooltipDrawer::addItemTooltip(const TooltipData& data) {
+void TooltipDrawer::addItemTooltip(TooltipData data) {
 	if (!data.hasVisibleFields()) {
 		return;
 	}
-	tooltips.push_back(data);
+	tooltips.push_back(std::move(data));
 }
 
 void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
@@ -201,6 +201,15 @@ void TooltipDrawer::draw(const RenderView& view) {
 
 	using namespace TooltipColors;
 
+	// Build content lines with word wrapping support
+	struct FieldLine {
+		std::string label;
+		std::string value;
+		uint8_t r, g, b;
+		std::vector<std::string> wrappedLines; // For multi-line values
+	};
+	std::vector<FieldLine> fields;
+
 	for (const auto& tooltip : tooltips) {
 		int unscaled_x, unscaled_y;
 		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
@@ -227,14 +236,7 @@ void TooltipDrawer::draw(const RenderView& view) {
 		float minWidth = 120.0f;
 		float maxWidth = 220.0f; // Max content width for wrapping
 
-		// Build content lines with word wrapping support
-		struct FieldLine {
-			std::string label;
-			std::string value;
-			uint8_t r, g, b;
-			std::vector<std::string> wrappedLines; // For multi-line values
-		};
-		std::vector<FieldLine> fields;
+		fields.clear();
 
 		if (tooltip.category == TooltipCategory::WAYPOINT) {
 			fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -100,8 +100,8 @@ struct TooltipData {
 		pos(p), category(TooltipCategory::WAYPOINT), waypointName(wpName) { }
 
 	// Constructor for item
-	TooltipData(Position p, uint16_t id, const std::string& name) :
-		pos(p), category(TooltipCategory::ITEM), itemId(id), itemName(name) { }
+	TooltipData(Position p, uint16_t id, std::string name) :
+		pos(p), category(TooltipCategory::ITEM), itemId(id), itemName(std::move(name)) { }
 
 	// Determine category based on fields
 	void updateCategory() {
@@ -130,7 +130,7 @@ public:
 	~TooltipDrawer();
 
 	// Add a structured tooltip for an item
-	void addItemTooltip(const TooltipData& data);
+	void addItemTooltip(TooltipData data);
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);


### PR DESCRIPTION
💡 What:
1. Changed `SpawnList` from `std::list` to `std::vector` and added `reserve()` in `Map::getSpawnList`.
2. Optimized `TooltipData` transfer by implementing move semantics in `TooltipDrawer::addItemTooltip`, avoiding deep copies of strings for every visible item.
3. Optimized `TooltipDrawer::draw` by reusing the `fields` vector capacity across iterations, reducing heap allocations.

🎯 Why:
1. `SpawnList` as `std::list` caused poor cache locality and more allocations. `std::vector` is faster for iteration and construction.
2. `TooltipData` contains strings (`itemName`, `text`, `description`). Copying it for every visible item (when tooltips are enabled) is expensive.
3. `TooltipDrawer::draw` allocated a new `vector<FieldLine>` for every tooltip, causing fragmentation and overhead.

📊 Impact:
*   Reduced allocations per frame during rendering of tooltips.
*   Improved cache locality for spawn lookups.
*   Reduced memory fragmentation.

🔬 Measurement:
*   Verify `SpawnList` logic in `Map::getSpawnList`.
*   Verify `TooltipDrawer` uses `std::move`.
*   Verify `fields` vector is cleared, not reallocated.

---
*PR created automatically by Jules for task [6142543286738898678](https://jules.google.com/task/6142543286738898678) started by @karolak6612*