### PR TITLE
[TILE/WXWIDGETS] Fix anti-patterns in properties and about windows

### DIFF
--- a/source/ui/about_window.cpp
+++ b/source/ui/about_window.cpp
@@ -58,8 +58,6 @@ protected:
 private:
 	bool paused_val;
 
-	DECLARE_EVENT_TABLE()
-
 protected:
 	bool dead;
 };
@@ -163,17 +161,15 @@ protected:
 //=============================================================================
 // About Window - Information window about the application
 
-BEGIN_EVENT_TABLE(AboutWindow, wxDialog)
-EVT_BUTTON(wxID_OK, AboutWindow::OnClickOK)
-EVT_BUTTON(ABOUT_VIEW_LICENSE, AboutWindow::OnClickLicense)
-EVT_MENU(ABOUT_RUN_TETRIS, AboutWindow::OnTetris)
-EVT_MENU(ABOUT_RUN_SNAKE, AboutWindow::OnSnake)
-EVT_MENU(wxID_CANCEL, AboutWindow::OnClickOK)
-END_EVENT_TABLE()
-
 AboutWindow::AboutWindow(wxWindow* parent) :
 	wxDialog(parent, wxID_ANY, "About", wxDefaultPosition, wxSize(300, 320), wxRESIZE_BORDER | wxCAPTION | wxCLOSE_BOX),
 	game_panel(nullptr) {
+	Bind(wxEVT_BUTTON, &AboutWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &AboutWindow::OnClickLicense, this, ABOUT_VIEW_LICENSE);
+	Bind(wxEVT_MENU, &AboutWindow::OnTetris, this, ABOUT_RUN_TETRIS);
+	Bind(wxEVT_MENU, &AboutWindow::OnSnake, this, ABOUT_RUN_SNAKE);
+	Bind(wxEVT_MENU, &AboutWindow::OnClickOK, this, wxID_CANCEL);
+
 	wxString about;
 
 	about << "OTAcademy Map Editor\n";
@@ -205,12 +201,12 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	about << "Compiled on: " << __TDATE__ << " : " << __TTIME__ << "\n";
 	about << "Compiled with: " << BOOST_COMPILER << "\n";
 
-	topsizer = newd wxBoxSizer(wxVERTICAL);
+	topsizer = new wxBoxSizer(wxVERTICAL);
 
-	topsizer->Add(newd wxStaticText(this, wxID_ANY, about), 1, wxALL, 20);
+	topsizer->Add(new wxStaticText(this, wxID_ANY, about), 1, wxALL, 20);
 
-	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
-	choicesizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
+	wxSizer* choicesizer = new wxBoxSizer(wxHORIZONTAL);
+	choicesizer->Add(new wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT | wxBOTTOM, 20);
 
 	wxAcceleratorEntry entries[3];
@@ -254,7 +250,7 @@ void AboutWindow::OnClickLicense(wxCommandEvent& WXUNUSED(event)) {
 void AboutWindow::OnTetris(wxCommandEvent&) {
 	if (!game_panel) {
 		DestroyChildren();
-		game_panel = newd TetrisPanel(this);
+		game_panel = new TetrisPanel(this);
 		topsizer->Add(game_panel, 1, wxALIGN_CENTER | wxALL, 7);
 		Fit();
 		game_panel->SetFocus();
@@ -266,7 +262,7 @@ void AboutWindow::OnTetris(wxCommandEvent&) {
 void AboutWindow::OnSnake(wxCommandEvent&) {
 	if (!game_panel) {
 		DestroyChildren();
-		game_panel = newd SnakePanel(this);
+		game_panel = new SnakePanel(this);
 		topsizer->Add(game_panel, 1, wxALIGN_CENTER | wxALL, 7);
 		Fit();
 		game_panel->SetFocus();
@@ -278,17 +274,15 @@ void AboutWindow::OnSnake(wxCommandEvent&) {
 //=============================================================================
 // GamePanel - Abstract class for games
 
-BEGIN_EVENT_TABLE(GamePanel, wxPanel)
-EVT_KEY_DOWN(GamePanel::OnKeyDown)
-EVT_KEY_UP(GamePanel::OnKeyUp)
-EVT_PAINT(GamePanel::OnPaint)
-EVT_IDLE(GamePanel::OnIdle)
-END_EVENT_TABLE()
-
 GamePanel::GamePanel(wxWindow* parent, int width, int height) :
 	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(width, height), wxWANTS_CHARS),
 	paused_val(false),
 	dead(false) {
+	Bind(wxEVT_KEY_DOWN, &GamePanel::OnKeyDown, this);
+	Bind(wxEVT_KEY_UP, &GamePanel::OnKeyUp, this);
+	Bind(wxEVT_PAINT, &GamePanel::OnPaint, this);
+	Bind(wxEVT_IDLE, &GamePanel::OnIdle, this);
+
 	// Receive idle events
 	SetExtraStyle(wxWS_EX_PROCESS_IDLE);
 	// Complete redraw
@@ -355,10 +349,10 @@ const wxBrush& TetrisPanel::GetBrush(Color color) const {
 	static std::unique_ptr<wxBrush> purple_brush;
 
 	if (yellow_brush.get() == nullptr) {
-		yellow_brush.reset(newd wxBrush(wxColor(255, 255, 0)));
+		yellow_brush.reset(new wxBrush(wxColor(255, 255, 0)));
 	}
 	if (purple_brush.get() == nullptr) {
-		purple_brush.reset(newd wxBrush(wxColor(128, 0, 255)));
+		purple_brush.reset(new wxBrush(wxColor(128, 0, 255)));
 	}
 
 	const wxBrush* brush = nullptr;

--- a/source/ui/about_window.h
+++ b/source/ui/about_window.h
@@ -36,8 +36,6 @@ public:
 private:
 	wxSizer* topsizer;
 	GamePanel* game_panel;
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/ui/properties/container_properties_window.cpp
+++ b/source/ui/properties/container_properties_window.cpp
@@ -5,6 +5,8 @@
 #include "app/main.h"
 #include "ui/properties/container_properties_window.h"
 
+#include <wx/wrapsizer.h>
+
 #include "game/complexitem.h"
 #include "ui/dialog_util.h"
 #include "ui/properties/property_validator.h"
@@ -30,67 +32,49 @@ ContainerPropertiesWindow::ContainerPropertiesWindow(wxWindow* win_parent, const
 	Bind(wxEVT_MENU, &ContainerPropertiesWindow::OnEditItem, this, CONTAINER_POPUP_MENU_EDIT);
 	Bind(wxEVT_MENU, &ContainerPropertiesWindow::OnRemoveItem, this, CONTAINER_POPUP_MENU_REMOVE);
 
-	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
-	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Container Properties");
+	wxSizer* topsizer = new wxBoxSizer(wxVERTICAL);
+	wxSizer* boxsizer = new wxStaticBoxSizer(wxVERTICAL, this, "Container Properties");
 
-	wxFlexGridSizer* subsizer = newd wxFlexGridSizer(2, 10, 10);
+	wxFlexGridSizer* subsizer = new wxFlexGridSizer(2, 10, 10);
 	subsizer->AddGrowableCol(1);
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "ID " + i2ws(item->getID())));
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "\"" + wxstr(item->getName()) + "\""));
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "ID " + i2ws(item->getID())));
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "\"" + wxstr(item->getName()) + "\""));
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Action ID"));
-	action_id_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "Action ID"));
+	action_id_field = new wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
 	subsizer->Add(action_id_field, wxSizerFlags(1).Expand());
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Unique ID"));
-	unique_id_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "Unique ID"));
+	unique_id_field = new wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
 	subsizer->Add(unique_id_field, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(subsizer, wxSizerFlags(0).Expand());
 
 	// Now we add the subitems!
-	wxSizer* contents_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Contents");
+	wxSizer* contents_sizer = new wxStaticBoxSizer(wxVERTICAL, this, "Contents");
+	wxSizer* wrap_sizer = new wxWrapSizer(wxHORIZONTAL);
 
 	bool use_large_sprites = g_settings.getBoolean(Config::USE_LARGE_CONTAINER_ICONS);
-	wxSizer* horizontal_sizer = nullptr;
-	int32_t maxColumns;
-	if (use_large_sprites) {
-		maxColumns = 6;
-	} else {
-		maxColumns = 12;
-	}
 
 	for (uint32_t index = 0; index < container->getVolume(); ++index) {
-		if (!horizontal_sizer) {
-			horizontal_sizer = newd wxBoxSizer(wxHORIZONTAL);
-		}
-
 		Item* sub_item = container->getItem(index);
-		ContainerItemButton* containerItemButton = newd ContainerItemButton(this, use_large_sprites, index, map, sub_item);
+		ContainerItemButton* containerItemButton = new ContainerItemButton(this, use_large_sprites, index, map, sub_item);
 		containerItemButton->Bind(wxEVT_BUTTON, &ContainerPropertiesWindow::OnContainerItemClick, this);
 		containerItemButton->Bind(wxEVT_RIGHT_UP, &ContainerPropertiesWindow::OnContainerItemRightClick, this);
 
 		container_items.push_back(containerItemButton);
-		horizontal_sizer->Add(containerItemButton);
-
-		if (((index + 1) % maxColumns) == 0) {
-			contents_sizer->Add(horizontal_sizer);
-			horizontal_sizer = nullptr;
-		}
+		wrap_sizer->Add(containerItemButton, wxSizerFlags(0).Border(wxALL, 2));
 	}
 
-	if (horizontal_sizer != nullptr) {
-		contents_sizer->Add(horizontal_sizer);
-	}
-
+	contents_sizer->Add(wrap_sizer, wxSizerFlags(1).Expand());
 	boxsizer->Add(contents_sizer, wxSizerFlags(2).Expand());
 
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxALL, 20));
 
-	wxSizer* std_sizer = newd wxBoxSizer(wxHORIZONTAL);
-	std_sizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	std_sizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxSizer* std_sizer = new wxBoxSizer(wxHORIZONTAL);
+	std_sizer->Add(new wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	std_sizer->Add(new wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(std_sizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);
@@ -211,9 +195,9 @@ void ContainerPropertiesWindow::OnEditItem(wxCommandEvent& WXUNUSED(event)) {
 
 	wxDialog* d;
 	if (edit_map->getVersion().otbm >= MAP_OTBM_4) {
-		d = newd PropertiesWindow(this, edit_map, nullptr, sub_item, newDialogAt);
+		d = new PropertiesWindow(this, edit_map, nullptr, sub_item, newDialogAt);
 	} else {
-		d = newd OldPropertiesWindow(this, edit_map, nullptr, sub_item, newDialogAt);
+		d = new OldPropertiesWindow(this, edit_map, nullptr, sub_item, newDialogAt);
 	}
 
 	d->ShowModal();

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -28,18 +28,7 @@
 #include "ui/properties/teleport_service.h"
 
 #include <wx/grid.h>
-
-BEGIN_EVENT_TABLE(PropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, PropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, PropertiesWindow::OnClickCancel)
-
-EVT_BUTTON(ITEM_PROPERTIES_ADD_ATTRIBUTE, PropertiesWindow::OnClickAddAttribute)
-EVT_BUTTON(ITEM_PROPERTIES_REMOVE_ATTRIBUTE, PropertiesWindow::OnClickRemoveAttribute)
-
-EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, PropertiesWindow::OnNotebookPageChanged)
-
-EVT_GRID_CELL_CHANGED(PropertiesWindow::OnGridValueChanged)
-END_EVENT_TABLE()
+#include <wx/wrapsizer.h>
 
 PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Item Properties", map, tile_parent, item, pos),
@@ -49,11 +38,22 @@ PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile*
 	tier_field(nullptr),
 	currentPanel(nullptr) {
 	ASSERT(edit_item);
+
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickCancel, this, wxID_CANCEL);
+
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickAddAttribute, this, ITEM_PROPERTIES_ADD_ATTRIBUTE);
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickRemoveAttribute, this, ITEM_PROPERTIES_REMOVE_ATTRIBUTE);
+
+	Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &PropertiesWindow::OnNotebookPageChanged, this, wxID_ANY);
+
+	Bind(wxEVT_GRID_CELL_CHANGED, &PropertiesWindow::OnGridValueChanged, this);
+
 	createUI();
 }
 
 void PropertiesWindow::createUI() {
-	notebook = newd wxNotebook(this, wxID_ANY, wxDefaultPosition, wxSize(600, 300));
+	notebook = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxSize(600, 300));
 
 	notebook->AddPage(createGeneralPanel(notebook), "Simple", true);
 	if (dynamic_cast<Container*>(edit_item)) {
@@ -61,12 +61,12 @@ void PropertiesWindow::createUI() {
 	}
 	notebook->AddPage(createAttributesPanel(notebook), "Advanced");
 
-	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
+	wxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 	topSizer->Add(notebook, wxSizerFlags(1).DoubleBorder());
 
-	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
-	optSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(0).Center());
-	optSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(0).Center());
+	wxSizer* optSizer = new wxBoxSizer(wxHORIZONTAL);
+	optSizer->Add(new wxButton(this, wxID_OK, "OK"), wxSizerFlags(0).Center());
+	optSizer->Add(new wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
 
 	SetSizerAndFit(topSizer);
@@ -88,8 +88,8 @@ void PropertiesWindow::Update() {
 }
 
 wxWindow* PropertiesWindow::createGeneralPanel(wxWindow* parent) {
-	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_GENERAL_TAB);
-	wxFlexGridSizer* gridsizer = newd wxFlexGridSizer(2, 10, 10);
+	wxPanel* panel = new wxPanel(parent, ITEM_PROPERTIES_GENERAL_TAB);
+	wxFlexGridSizer* gridsizer = new wxFlexGridSizer(2, 10, 10);
 	gridsizer->AddGrowableCol(1);
 
 	createGeneralFields(gridsizer, panel);
@@ -100,10 +100,10 @@ wxWindow* PropertiesWindow::createGeneralPanel(wxWindow* parent) {
 }
 
 void PropertiesWindow::createGeneralFields(wxFlexGridSizer* gridsizer, wxWindow* panel) {
-	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "ID " + i2ws(edit_item->getID())));
-	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "\"" + wxstr(edit_item->getName()) + "\""));
+	gridsizer->Add(new wxStaticText(panel, wxID_ANY, "ID " + i2ws(edit_item->getID())));
+	gridsizer->Add(new wxStaticText(panel, wxID_ANY, "\"" + wxstr(edit_item->getName()) + "\""));
 
-	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, (edit_item->isCharged() ? "Charges" : "Count")));
+	gridsizer->Add(new wxStaticText(panel, wxID_ANY, (edit_item->isCharged() ? "Charges" : "Count")));
 	int max_count = 100;
 	if (edit_item->isClientCharged()) {
 		max_count = 250;
@@ -111,54 +111,54 @@ void PropertiesWindow::createGeneralFields(wxFlexGridSizer* gridsizer, wxWindow*
 	if (edit_item->isExtraCharged()) {
 		max_count = 65500;
 	}
-	count_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getCount()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, max_count, edit_item->getCount());
+	count_field = new wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getCount()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, max_count, edit_item->getCount());
 	if (!edit_item->isStackable() && !edit_item->isCharged()) {
 		count_field->Enable(false);
 	}
 	gridsizer->Add(count_field, wxSizerFlags(1).Expand());
 
-	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Action ID"));
-	action_id_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
+	gridsizer->Add(new wxStaticText(panel, wxID_ANY, "Action ID"));
+	action_id_field = new wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
 	gridsizer->Add(action_id_field, wxSizerFlags(1).Expand());
 
-	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Unique ID"));
-	unique_id_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
+	gridsizer->Add(new wxStaticText(panel, wxID_ANY, "Unique ID"));
+	unique_id_field = new wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
 	gridsizer->Add(unique_id_field, wxSizerFlags(1).Expand());
 }
 
 void PropertiesWindow::createClassificationFields(wxFlexGridSizer* gridsizer, wxWindow* panel) {
 	if (g_items.MajorVersion >= 3 && g_items.MinorVersion >= 60 && (edit_item->getClassification() > 0 || edit_item->isWeapon() || edit_item->isWearableEquipment())) {
-		gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Classification"));
-		gridsizer->Add(newd wxStaticText(panel, wxID_ANY, i2ws(edit_item->getClassification())));
+		gridsizer->Add(new wxStaticText(panel, wxID_ANY, "Classification"));
+		gridsizer->Add(new wxStaticText(panel, wxID_ANY, i2ws(edit_item->getClassification())));
 
-		gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Tier"));
-		tier_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getTier()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFF, edit_item->getTier());
+		gridsizer->Add(new wxStaticText(panel, wxID_ANY, "Tier"));
+		tier_field = new wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getTier()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFF, edit_item->getTier());
 		gridsizer->Add(tier_field, wxSizerFlags(1).Expand());
 	}
 }
 
 wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 	Container* container = (Container*)edit_item;
-	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_CONTAINER_TAB);
-	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
+	wxPanel* panel = new wxPanel(parent, ITEM_PROPERTIES_CONTAINER_TAB);
+	wxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 
-	wxSizer* gridSizer = newd wxGridSizer(6, 5, 5);
+	wxSizer* gridSizer = new wxWrapSizer(wxHORIZONTAL);
 
 	bool use_large_sprites = g_settings.getBoolean(Config::USE_LARGE_CONTAINER_ICONS);
 	for (uint32_t i = 0; i < container->getVolume(); ++i) {
 		Item* item = container->getItem(i);
-		ContainerItemButton* containerItemButton = newd ContainerItemButton(panel, use_large_sprites, i, edit_map, item);
+		ContainerItemButton* containerItemButton = new ContainerItemButton(panel, use_large_sprites, i, edit_map, item);
 
 		container_items.push_back(containerItemButton);
-		gridSizer->Add(containerItemButton, wxSizerFlags(0));
+		gridSizer->Add(containerItemButton, wxSizerFlags(0).Border(wxALL, 2));
 	}
 
 	topSizer->Add(gridSizer, wxSizerFlags(1).Expand());
 
 	/*
-	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
-	optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Item"), wxSizerFlags(0).Center());
-	// optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute"), wxSizerFlags(0).Center());
+	wxSizer* optSizer = new wxBoxSizer(wxHORIZONTAL);
+	optSizer->Add(new wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Item"), wxSizerFlags(0).Center());
+	// optSizer->Add(new wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute"), wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
 	*/
 
@@ -167,10 +167,10 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 }
 
 wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
-	wxPanel* panel = newd wxPanel(parent, wxID_ANY);
-	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
+	wxPanel* panel = new wxPanel(parent, wxID_ANY);
+	wxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 
-	attributesGrid = newd wxGrid(panel, ITEM_PROPERTIES_ADVANCED_TAB, wxDefaultPosition, wxSize(-1, 160));
+	attributesGrid = new wxGrid(panel, ITEM_PROPERTIES_ADVANCED_TAB, wxDefaultPosition, wxSize(-1, 160));
 	topSizer->Add(attributesGrid, wxSizerFlags(1).Expand());
 
 	wxFont time_font(*wxSWISS_FONT);
@@ -199,9 +199,9 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 		AttributeService::setGridValue(attributesGrid, i, aiter->first, aiter->second);
 	}
 
-	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
-	optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute"), wxSizerFlags(0).Center());
-	optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute"), wxSizerFlags(0).Center());
+	wxSizer* optSizer = new wxBoxSizer(wxHORIZONTAL);
+	optSizer->Add(new wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute"), wxSizerFlags(0).Center());
+	optSizer->Add(new wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute"), wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
 
 	panel->SetSizer(topSizer);

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
This PR addresses domain-specific wxWidgets issues identified by the 'Atlas' agent. It modernizes event handling by moving from static event tables to dynamic `Bind()` calls, cleans up memory allocation macros (`newd` -> `new`), and improves UI layout responsiveness by adopting `wxWrapSizer` for item grids in property windows. These changes improve code maintainability, type safety, and UI behavior on resize.

---
*PR created automatically by Jules for task [17575872167883519179](https://jules.google.com/task/17575872167883519179) started by @karolak6612*