### PR TITLE
👻 Phantom: Fix wxGridSizer, Event Tables and Absolute Positioning

### DIFF
--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -5,15 +5,11 @@
 #include "palette/palette_window.h" // For PaletteWindow dynamic_casts
 #include "palette/controls/virtual_brush_grid.h"
 #include <spdlog/spdlog.h>
+#include <wx/wrapsizer.h>
 
 // ============================================================================
 // Brush Panel
 // A container of brush buttons
-
-BEGIN_EVENT_TABLE(BrushPanel, wxPanel)
-// Listbox style
-EVT_LISTBOX(wxID_ANY, BrushPanel::OnClickListBoxRow)
-END_EVENT_TABLE()
 
 BrushPanel::BrushPanel(wxWindow* parent) :
 	wxPanel(parent, wxID_ANY),
@@ -23,6 +19,8 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	list_type(BRUSHLIST_LISTBOX) {
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
+
+	Bind(wxEVT_LISTBOX, &BrushPanel::OnClickListBoxRow, this, wxID_ANY);
 }
 
 BrushPanel::~BrushPanel() {
@@ -159,50 +157,32 @@ void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
 // ============================================================================
 // BrushIconBox
 
-BEGIN_EVENT_TABLE(BrushIconBox, wxScrolledWindow)
-// Listbox style
-EVT_TOGGLEBUTTON(wxID_ANY, BrushIconBox::OnClickBrushButton)
-END_EVENT_TABLE()
-
 BrushIconBox::BrushIconBox(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz) :
 	wxScrolledWindow(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxVSCROLL),
 	BrushBoxInterface(_tileset),
 	icon_size(rsz) {
 	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	int width;
-	if (icon_size == RENDER_SIZE_32x32) {
-		width = max(g_settings.getInteger(Config::PALETTE_COL_COUNT) / 2 + 1, 1);
-	} else {
-		width = max(g_settings.getInteger(Config::PALETTE_COL_COUNT) + 1, 1);
-	}
+
+	Bind(wxEVT_TOGGLEBUTTON, &BrushIconBox::OnClickBrushButton, this, wxID_ANY);
+	Bind(wxEVT_SIZE, [this](wxSizeEvent& ev) {
+		Layout();
+		FitInside();
+		ev.Skip();
+	});
 
 	// Create buttons
-	wxSizer* stacksizer = newd wxBoxSizer(wxVERTICAL);
-	wxSizer* rowsizer = nullptr;
-	int item_counter = 0;
+	wxSizer* sizer = newd wxWrapSizer(wxHORIZONTAL);
 	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
 		ASSERT(*iter);
-		++item_counter;
-
-		if (!rowsizer) {
-			rowsizer = newd wxBoxSizer(wxHORIZONTAL);
-		}
 
 		BrushButton* bb = newd BrushButton(this, *iter, rsz);
-		rowsizer->Add(bb);
+		sizer->Add(bb);
 		brush_buttons.push_back(bb);
-
-		if (item_counter % width == 0) { // newd row
-			stacksizer->Add(rowsizer);
-			rowsizer = nullptr;
-		}
-	}
-	if (rowsizer) {
-		stacksizer->Add(rowsizer);
 	}
 
-	SetScrollbars(20, 20, 8, item_counter / width, 0, 0);
-	SetSizer(stacksizer);
+	SetSizer(sizer);
+	SetScrollRate(20, 20);
+	FitInside();
 }
 
 BrushIconBox::~BrushIconBox() {
@@ -300,14 +280,11 @@ void BrushIconBox::OnClickBrushButton(wxCommandEvent& event) {
 // ============================================================================
 // BrushListBox
 
-BEGIN_EVENT_TABLE(BrushListBox, wxVListBox)
-EVT_KEY_DOWN(BrushListBox::OnKey)
-END_EVENT_TABLE()
-
 BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
 	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
 	BrushBoxInterface(tileset) {
 	SetItemCount(tileset->size());
+	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
 }
 
 BrushListBox::~BrushListBox() {

--- a/source/ui/managers/loading_manager.cpp
+++ b/source/ui/managers/loading_manager.cpp
@@ -31,7 +31,6 @@ void LoadingManager::CreateLoadBar(wxString message, bool canCancel) {
 	currentProgress = -1;
 
 	progressBar = newd wxGenericProgressDialog("Loading", progressText + " (0%)", 100, g_gui.root, wxPD_APP_MODAL | wxPD_SMOOTH | (canCancel ? wxPD_CAN_ABORT : 0));
-	progressBar->SetSize(280, -1);
 	progressBar->Show(true);
 
 	if (g_gui.tabbook) {

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -28,18 +28,7 @@
 #include "ui/properties/teleport_service.h"
 
 #include <wx/grid.h>
-
-BEGIN_EVENT_TABLE(PropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, PropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, PropertiesWindow::OnClickCancel)
-
-EVT_BUTTON(ITEM_PROPERTIES_ADD_ATTRIBUTE, PropertiesWindow::OnClickAddAttribute)
-EVT_BUTTON(ITEM_PROPERTIES_REMOVE_ATTRIBUTE, PropertiesWindow::OnClickRemoveAttribute)
-
-EVT_NOTEBOOK_PAGE_CHANGED(wxID_ANY, PropertiesWindow::OnNotebookPageChanged)
-
-EVT_GRID_CELL_CHANGED(PropertiesWindow::OnGridValueChanged)
-END_EVENT_TABLE()
+#include <wx/wrapsizer.h>
 
 PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Item Properties", map, tile_parent, item, pos),
@@ -49,6 +38,17 @@ PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile*
 	tier_field(nullptr),
 	currentPanel(nullptr) {
 	ASSERT(edit_item);
+
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickCancel, this, wxID_CANCEL);
+
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickAddAttribute, this, ITEM_PROPERTIES_ADD_ATTRIBUTE);
+	Bind(wxEVT_BUTTON, &PropertiesWindow::OnClickRemoveAttribute, this, ITEM_PROPERTIES_REMOVE_ATTRIBUTE);
+
+	Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &PropertiesWindow::OnNotebookPageChanged, this, wxID_ANY);
+
+	Bind(wxEVT_GRID_CELL_CHANGED, &PropertiesWindow::OnGridValueChanged, this);
+
 	createUI();
 }
 
@@ -142,7 +142,7 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_CONTAINER_TAB);
 	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxSizer* gridSizer = newd wxGridSizer(6, 5, 5);
+	wxSizer* gridSizer = newd wxWrapSizer(wxHORIZONTAL);
 
 	bool use_large_sprites = g_settings.getBoolean(Config::USE_LARGE_CONTAINER_ICONS);
 	for (uint32_t i = 0; i < container->getVolume(); ++i) {
@@ -150,7 +150,7 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 		ContainerItemButton* containerItemButton = newd ContainerItemButton(panel, use_large_sprites, i, edit_map, item);
 
 		container_items.push_back(containerItemButton);
-		gridSizer->Add(containerItemButton, wxSizerFlags(0));
+		gridSizer->Add(containerItemButton, wxSizerFlags(0).Border(wxALL, 2));
 	}
 
 	topSizer->Add(gridSizer, wxSizerFlags(1).Expand());


### PR DESCRIPTION
This PR addresses several wxWidgets violations identified by the Phantom agent:
1.  **Layout Violations**: Replaced `wxGridSizer` and manual grid layouts with `wxWrapSizer` in `PropertiesWindow` and `BrushIconBox` to enable responsive design.
2.  **Event Handling**: Updated legacy event tables to use `Bind()` for better type safety and code clarity in `PropertiesWindow` and `BrushPanel`.
3.  **Absolute Positioning**: Removed `SetSize(280, -1)` in `LoadingManager` to allow the progress dialog to size itself naturally.

Verified by compiling the modified files using ninja.

---
*PR created automatically by Jules for task [3851334603554258442](https://jules.google.com/task/3851334603554258442) started by @karolak6612*