### PR TITLE
[TILE/WXWIDGETS] Fix Layout, Events and Selection Optimization

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -93,7 +93,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 	TileSet tmp_storage;
 
 	// Update the tiles with the newd positions
-	for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
+	for (auto it = editor.selection.begin(); it != editor.selection.end(); ++it) {
 		// First we get the old tile and it's position
 		Tile* tile = (*it);
 		// const Position pos = tile->getPosition();
@@ -352,7 +352,7 @@ void SelectionOperations::destroySelection(Editor& editor) {
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DELETE_TILES);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); ++it) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); ++it) {
 			tile_count++;
 
 			Tile* tile = *it;

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -193,10 +193,7 @@ void Selection::addInternal(Tile* tile) {
 	if (deferred) {
 		pending_adds.push_back(tile);
 	} else {
-		auto it = std::lower_bound(tiles.begin(), tiles.end(), tile, std::less<Tile*>());
-		if (it == tiles.end() || *it != tile) {
-			tiles.insert(it, tile);
-		}
+		tiles.insert(tile);
 	}
 }
 
@@ -205,10 +202,7 @@ void Selection::removeInternal(Tile* tile) {
 	if (deferred) {
 		pending_removes.push_back(tile);
 	} else {
-		auto it = std::lower_bound(tiles.begin(), tiles.end(), tile, std::less<Tile*>());
-		if (it != tiles.end() && *it == tile) {
-			tiles.erase(it);
-		}
+		tiles.erase(tile);
 	}
 }
 
@@ -217,22 +211,13 @@ void Selection::flush() {
 		return;
 	}
 
-	std::sort(pending_adds.begin(), pending_adds.end(), std::less<Tile*>());
-	pending_adds.erase(std::unique(pending_adds.begin(), pending_adds.end()), pending_adds.end());
+	for (Tile* t : pending_removes) {
+		tiles.erase(t);
+	}
 
-	std::sort(pending_removes.begin(), pending_removes.end(), std::less<Tile*>());
-	pending_removes.erase(std::unique(pending_removes.begin(), pending_removes.end()), pending_removes.end());
-
-	TileSet temp;
-	temp.reserve(tiles.size());
-
-	// Remove
-	std::set_difference(tiles.begin(), tiles.end(), pending_removes.begin(), pending_removes.end(), std::back_inserter(temp), std::less<Tile*>());
-
-	// Add
-	tiles.clear();
-	tiles.reserve(temp.size() + pending_adds.size());
-	std::set_union(temp.begin(), temp.end(), pending_adds.begin(), pending_adds.end(), std::back_inserter(tiles), std::less<Tile*>());
+	for (Tile* t : pending_adds) {
+		tiles.insert(t);
+	}
 
 	pending_adds.clear();
 	pending_removes.clear();

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -20,6 +20,7 @@
 
 #include "map/position.h"
 #include <functional>
+#include <set>
 
 class Action;
 class Editor;
@@ -87,13 +88,13 @@ public:
 		return tiles.size();
 	}
 	void updateSelectionCount();
-	TileSet::iterator begin() {
+	auto begin() {
 		return tiles.begin();
 	}
-	TileSet::iterator end() {
+	auto end() {
 		return tiles.end();
 	}
-	TileSet& getTiles() {
+	const std::set<Tile*>& getTiles() const {
 		return tiles;
 	}
 	Tile* getSelectedTile() {
@@ -114,7 +115,7 @@ private:
 	std::unique_ptr<BatchAction> session;
 	std::unique_ptr<Action> subsession;
 
-	TileSet tiles;
+	std::set<Tile*> tiles;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;
 

--- a/source/ui/managers/loading_manager.cpp
+++ b/source/ui/managers/loading_manager.cpp
@@ -31,7 +31,6 @@ void LoadingManager::CreateLoadBar(wxString message, bool canCancel) {
 	currentProgress = -1;
 
 	progressBar = newd wxGenericProgressDialog("Loading", progressText + " (0%)", 100, g_gui.root, wxPD_APP_MODAL | wxPD_SMOOTH | (canCancel ? wxPD_CAN_ABORT : 0));
-	progressBar->SetSize(280, -1);
 	progressBar->Show(true);
 
 	if (g_gui.tabbook) {

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -230,24 +230,16 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	Centre(wxBOTH);
 
 	// Connect Events
-	list->Connect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(ReplaceItemsDialog::OnListSelected), nullptr, this);
-	replace_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnReplaceItemClicked), nullptr, this);
-	with_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnWithItemClicked), nullptr, this);
-	add_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnAddButtonClicked), nullptr, this);
-	remove_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnRemoveButtonClicked), nullptr, this);
-	execute_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnExecuteButtonClicked), nullptr, this);
-	close_button->Connect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnCancelButtonClicked), nullptr, this);
+	list->Bind(wxEVT_LISTBOX, &ReplaceItemsDialog::OnListSelected, this);
+	replace_button->Bind(wxEVT_LEFT_DOWN, &ReplaceItemsDialog::OnReplaceItemClicked, this);
+	with_button->Bind(wxEVT_LEFT_DOWN, &ReplaceItemsDialog::OnWithItemClicked, this);
+	add_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnAddButtonClicked, this);
+	remove_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnRemoveButtonClicked, this);
+	execute_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnExecuteButtonClicked, this);
+	close_button->Bind(wxEVT_BUTTON, &ReplaceItemsDialog::OnCancelButtonClicked, this);
 }
 
 ReplaceItemsDialog::~ReplaceItemsDialog() {
-	// Disconnect Events
-	list->Disconnect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(ReplaceItemsDialog::OnListSelected), nullptr, this);
-	replace_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnReplaceItemClicked), nullptr, this);
-	with_button->Disconnect(wxEVT_LEFT_DOWN, wxMouseEventHandler(ReplaceItemsDialog::OnWithItemClicked), nullptr, this);
-	add_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnAddButtonClicked), nullptr, this);
-	remove_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnRemoveButtonClicked), nullptr, this);
-	execute_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnExecuteButtonClicked), nullptr, this);
-	close_button->Disconnect(wxEVT_COMMAND_BUTTON_CLICKED, wxCommandEventHandler(ReplaceItemsDialog::OnCancelButtonClicked), nullptr, this);
 }
 
 void ReplaceItemsDialog::UpdateWidgets() {


### PR DESCRIPTION
**ISSUE:**
1. `LoadingManager` used fixed size `SetSize(280, -1)`, violating layout rules.
2. `ReplaceItemsDialog` used legacy `Connect`/`Disconnect`.
3. `Selection` used `std::vector` with O(N) insertion, causing performance issues on large selections.

**IMPACT:**
1. Poor layout on high-DPI or different fonts.
2. Maintainability risk and legacy code usage.
3. Slow selection operations (O(N^2) worst case without batching, O(N) with batching but with expensive copies).

**FIX:**
1. Removed `SetSize` from `LoadingManager`.
2. Refactored `ReplaceItemsDialog` to use `Bind`.
3. Converted `Selection` to use `std::set<Tile*>` for O(log N) insertion and O(1) removal, while preserving deterministic order.

**DOMAIN CONTEXT:**
Optimized `Selection` class handles tile map selections. Using `std::set` improves performance for large edit operations while maintaining safe iteration order.

**PERFORMANCE:**
Selection insertion complexity improved from O(N) to O(log N). Flush operation avoids full vector copy.

**TESTED:**
Visual verification not possible in headless, but code compiles and logic is standard. Preserved existing iteration logic using `auto`.

---
*PR created automatically by Jules for task [5631085612126141367](https://jules.google.com/task/5631085612126141367) started by @karolak6612*