### PR TITLE
📜 Auditor: Modernize Container Usage

### DIFF
--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -86,6 +86,9 @@ public:
 	size_t size() const {
 		return tiles.size();
 	}
+	bool empty() const {
+		return tiles.empty();
+	}
 	void updateSelectionCount();
 	TileSet::iterator begin() {
 		return tiles.begin();

--- a/source/map/basemap.cpp
+++ b/source/map/basemap.cpp
@@ -268,7 +268,7 @@ MapIterator& MapIterator::operator++() {
 		}
 
 		nodestack.pop_back();
-		if (nodestack.size() == 0) {
+		if (nodestack.empty()) {
 			// Set all values to "end"
 			local_z = -1;
 			local_i = -1;

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -288,7 +288,7 @@ void Tile::addItem(Item* item) {
 }
 
 void Tile::select() {
-	if (size() == 0) {
+	if (empty()) {
 		return;
 	}
 	if (ground) {
@@ -492,7 +492,7 @@ void Tile::update() {
 	}
 
 	if ((statflags & TILESTATE_BLOCKING) == 0) {
-		if (ground == nullptr && items.size() == 0) {
+		if (ground == nullptr && items.empty()) {
 			statflags |= TILESTATE_BLOCKING;
 		}
 	}

--- a/source/rendering/core/atlas_manager.cpp
+++ b/source/rendering/core/atlas_manager.cpp
@@ -99,7 +99,7 @@ bool AtlasManager::hasSprite(uint32_t sprite_id) const {
 	if (sprite_id < DIRECT_LOOKUP_SIZE) {
 		return direct_lookup_[sprite_id] != nullptr;
 	}
-	return sprite_regions_.find(sprite_id) != sprite_regions_.end();
+	return sprite_regions_.contains(sprite_id);
 }
 
 void AtlasManager::bind(uint32_t slot) const {

--- a/source/rendering/ui/clipboard_handler.cpp
+++ b/source/rendering/ui/clipboard_handler.cpp
@@ -48,7 +48,7 @@ void ClipboardHandler::doDelete(Editor& editor) {
 }
 
 void ClipboardHandler::copyPosition(const Selection& selection) {
-	if (selection.size() == 0) {
+	if (selection.empty()) {
 		return;
 	}
 

--- a/source/ui/gui.cpp
+++ b/source/ui/gui.cpp
@@ -129,7 +129,7 @@ void GUI::SetDrawingMode() {
 	for (int idx = 0; idx < tabbook->GetTabCount(); ++idx) {
 		EditorTab* editorTab = tabbook->GetTab(idx);
 		if (auto* mapTab = dynamic_cast<MapTab*>(editorTab)) {
-			if (al.find(mapTab) != al.end()) {
+			if (al.contains(mapTab)) {
 				continue;
 			}
 


### PR DESCRIPTION
Modernized container usage in `source/rendering/core/atlas_manager.cpp`, `source/ui/gui.cpp`, `source/rendering/ui/clipboard_handler.cpp`, `source/map/basemap.cpp`, and `source/map/tile.cpp`.
- Replaced `size() == 0` with `empty()` in `ClipboardHandler`, `MapIterator`, and `Tile` usage.
- Replaced `find() != end()` with `contains()` in `AtlasManager::hasSprite` and `GUI::SetDrawingMode` (C++20).
- Added `empty()` method to `Selection` class to support modernization.


---
*PR created automatically by Jules for task [10590342810702697859](https://jules.google.com/task/10590342810702697859) started by @karolak6612*