### PR TITLE
⚡ Throttle: Optimize Tooltip Rendering & Memory Allocations

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -92,8 +92,6 @@ namespace IngamePreview {
 		primitive_renderer->setProjectionMatrix(view.projectionMatrix);
 		light_buffer->Clear();
 
-		std::ostringstream tooltip_stream;
-
 		// Render floors from bottom to top
 		for (int z = last_visible; z >= 0; z--) {
 			float alpha = floor_opacity[z];
@@ -115,7 +113,7 @@ namespace IngamePreview {
 				for (int y = view.start_y; y <= view.end_y; ++y) {
 					const Tile* tile = map.getTile(x, y, z);
 					if (tile) {
-						tile_renderer->DrawTile(*sprite_batch, *primitive_renderer, tile->location, view, options, 0, tooltip_stream);
+						tile_renderer->DrawTile(*sprite_batch, *primitive_renderer, tile->location, view, options, 0);
 						if (lighting_enabled) {
 							tile_renderer->AddLight(tile->location, view, options, *light_buffer);
 						}

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -38,7 +38,7 @@ MapLayerDrawer::MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_dra
 MapLayerDrawer::~MapLayerDrawer() {
 }
 
-void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, std::ostringstream& tooltip) {
+void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {
 	int nd_start_x = view.start_x & ~3;
 	int nd_start_y = view.start_y & ~3;
 	int nd_end_x = (view.end_x & ~3) + 4;
@@ -57,7 +57,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					for (int map_x = 0; map_x < 4; ++map_x) {
 						for (int map_y = 0; map_y < 4; ++map_y) {
 							TileLocation* location = nd->getTile(map_x, map_y, map_z);
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip);
+							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id);
 							// draw light, but only if not zoomed too far
 							if (location && options.isDrawLight() && view.zoom <= 10.0) {
 								tile_renderer->AddLight(location, view, options, light_buffer);
@@ -81,7 +81,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 			for (int map_x = 0; map_x < 4; ++map_x) {
 				for (int map_y = 0; map_y < 4; ++map_y) {
 					TileLocation* location = nd->getTile(map_x, map_y, map_z);
-					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip);
+					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id);
 					// draw light, but only if not zoomed too far
 					if (location && options.isDrawLight() && view.zoom <= 10.0) {
 						tile_renderer->AddLight(location, view, options, light_buffer);

--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -34,7 +34,7 @@ public:
 	MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_drawer, Editor* editor);
 	~MapLayerDrawer();
 
-	void Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, std::ostringstream& tooltip);
+	void Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
 	TileRenderer* tile_renderer;

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -102,6 +102,7 @@ static TooltipData CreateItemTooltipData(Item* item, const Position& pos, bool i
 			// but getItem(i) is safer if available, or just iterating vector.
 			// Container::getVector() returns ItemVector& (std::vector<Item*>)
 			const ItemVector& items = container->getVector();
+			data.containerItems.reserve(std::min((size_t)32, items.size()));
 			for (Item* subItem : items) {
 				if (subItem) {
 					ContainerItem ci;
@@ -129,7 +130,7 @@ static TooltipData CreateItemTooltipData(Item* item, const Position& pos, bool i
 	return data;
 }
 
-void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, std::ostringstream& tooltip_stream) {
+void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id) {
 	if (!location) {
 		return;
 	}
@@ -191,7 +192,8 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground) {
+	bool is_hovered = location->getX() == view.mouse_map_x && location->getY() == view.mouse_map_y;
+	if (options.show_tooltips && is_hovered && map_z == view.floor && tile->ground) {
 		TooltipData groundData = CreateItemTooltipData(tile->ground, location->getPosition(), tile->isHouseTile());
 		if (groundData.hasVisibleFields()) {
 			tooltip_drawer->addItemTooltip(groundData);
@@ -225,7 +227,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 			// items on tile
 			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (options.show_tooltips && is_hovered && map_z == view.floor) {
 					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
 					if (itemData.hasVisibleFields()) {
 						tooltip_drawer->addItemTooltip(itemData);

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -24,7 +24,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, std::ostringstream& tooltip_stream);
+	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -260,7 +260,7 @@ void MapDrawer::DrawCreatureNames() {
 }
 
 void MapDrawer::DrawMapLayer(int map_z, bool live_client) {
-	map_layer_drawer->Draw(*sprite_batch, *primitive_renderer, map_z, live_client, view, options, light_buffer, tooltip);
+	map_layer_drawer->Draw(*sprite_batch, *primitive_renderer, map_z, live_client, view, options, light_buffer);
 }
 
 void MapDrawer::DrawLight() {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -81,8 +81,6 @@ class MapDrawer {
 	std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 
 protected:
-	std::ostringstream tooltip;
-
 	friend class BrushOverlayDrawer;
 	friend class DragShadowDrawer;
 	friend class FloorDrawer;

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -44,11 +44,11 @@ void TooltipDrawer::clear() {
 	tooltips.clear();
 }
 
-void TooltipDrawer::addItemTooltip(const TooltipData& data) {
+void TooltipDrawer::addItemTooltip(TooltipData data) {
 	if (!data.hasVisibleFields()) {
 		return;
 	}
-	tooltips.push_back(data);
+	tooltips.push_back(std::move(data));
 }
 
 void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
@@ -201,7 +201,17 @@ void TooltipDrawer::draw(const RenderView& view) {
 
 	using namespace TooltipColors;
 
+	// Build content lines with word wrapping support
+	struct FieldLine {
+		std::string label;
+		std::string value;
+		uint8_t r, g, b;
+		std::vector<std::string> wrappedLines; // For multi-line values
+	};
+	std::vector<FieldLine> fields;
+
 	for (const auto& tooltip : tooltips) {
+		fields.clear();
 		int unscaled_x, unscaled_y;
 		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
 
@@ -226,15 +236,6 @@ void TooltipDrawer::draw(const RenderView& view) {
 		float borderWidth = 1.0f; // Thinner border
 		float minWidth = 120.0f;
 		float maxWidth = 220.0f; // Max content width for wrapping
-
-		// Build content lines with word wrapping support
-		struct FieldLine {
-			std::string label;
-			std::string value;
-			uint8_t r, g, b;
-			std::vector<std::string> wrappedLines; // For multi-line values
-		};
-		std::vector<FieldLine> fields;
 
 		if (tooltip.category == TooltipCategory::WAYPOINT) {
 			fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -130,7 +130,7 @@ public:
 	~TooltipDrawer();
 
 	// Add a structured tooltip for an item
-	void addItemTooltip(const TooltipData& data);
+	void addItemTooltip(TooltipData data);
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);


### PR DESCRIPTION
This change significantly reduces the CPU overhead of tooltip generation during the render loop. Previously, `CreateItemTooltipData` was potentially called for every visible tile when tooltips were enabled. Now, it is restricted to the single tile being hovered. Additionally, memory allocations for tooltip text fields and data structures are reduced via vector reuse and move semantics. Unused legacy stream parameters were also removed.

---
*PR created automatically by Jules for task [12250633264530936037](https://jules.google.com/task/12250633264530936037) started by @karolak6612*