### PR TITLE
UX: Add descriptive tooltips to Properties Window and Toolbars

### DIFF
--- a/source/ui/properties/container_properties_window.cpp
+++ b/source/ui/properties/container_properties_window.cpp
@@ -41,10 +41,12 @@ ContainerPropertiesWindow::ContainerPropertiesWindow(wxWindow* win_parent, const
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Action ID"));
 	action_id_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
+	action_id_field->SetToolTip("Action ID (0-65535). Used for scripting.");
 	subsizer->Add(action_id_field, wxSizerFlags(1).Expand());
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Unique ID"));
 	unique_id_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
+	unique_id_field->SetToolTip("Unique ID (0-65535). Must be unique on the map.");
 	subsizer->Add(unique_id_field, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(subsizer, wxSizerFlags(0).Expand());

--- a/source/ui/properties/container_properties_window.h
+++ b/source/ui/properties/container_properties_window.h
@@ -15,11 +15,14 @@ public:
 	ContainerItemButton(wxWindow* parent, bool large, uint32_t index, const Map* map, Item* item) :
 		DCButton(parent, wxID_ANY, wxDefaultPosition, DC_BTN_NORMAL, (large ? RENDER_SIZE_32x32 : RENDER_SIZE_16x16), (item ? item->getClientID() : 0)),
 		index(index),
-		item(item) { }
+		item(item) {
+		SetToolTip(item ? wxstr(item->getName()) : "Empty Slot");
+	}
 
 	void setItem(Item* new_item) {
 		item = new_item;
 		SetSprite(item ? item->getClientID() : 0);
+		SetToolTip(item ? wxstr(item->getName()) : "Empty Slot");
 	}
 
 	Item* getItem() const {

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -112,17 +112,21 @@ void PropertiesWindow::createGeneralFields(wxFlexGridSizer* gridsizer, wxWindow*
 		max_count = 65500;
 	}
 	count_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getCount()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, max_count, edit_item->getCount());
+	count_field->SetToolTip("Number of items in stack / Charges");
 	if (!edit_item->isStackable() && !edit_item->isCharged()) {
 		count_field->Enable(false);
+		count_field->SetToolTip("Only stackable or charged items can have a count.");
 	}
 	gridsizer->Add(count_field, wxSizerFlags(1).Expand());
 
 	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Action ID"));
 	action_id_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getActionID()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getActionID());
+	action_id_field->SetToolTip("Action ID (0-65535). Used for scripting.");
 	gridsizer->Add(action_id_field, wxSizerFlags(1).Expand());
 
 	gridsizer->Add(newd wxStaticText(panel, wxID_ANY, "Unique ID"));
 	unique_id_field = newd wxSpinCtrl(panel, wxID_ANY, i2ws(edit_item->getUniqueID()), wxDefaultPosition, wxSize(-1, 20), wxSP_ARROW_KEYS, 0, 0xFFFF, edit_item->getUniqueID());
+	unique_id_field->SetToolTip("Unique ID (0-65535). Must be unique on the map.");
 	gridsizer->Add(unique_id_field, wxSizerFlags(1).Expand());
 }
 
@@ -200,8 +204,14 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 	}
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
-	optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute"), wxSizerFlags(0).Center());
-	optSizer->Add(newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute"), wxSizerFlags(0).Center());
+	wxButton* addBtn = newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute");
+	addBtn->SetToolTip("Add a new custom attribute");
+	optSizer->Add(addBtn, wxSizerFlags(0).Center());
+
+	wxButton* removeBtn = newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute");
+	removeBtn->SetToolTip("Remove selected custom attribute");
+	optSizer->Add(removeBtn, wxSizerFlags(0).Center());
+
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
 
 	panel->SetSizer(topSizer);

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -52,11 +52,19 @@ void StandardToolBar::Update() {
 	if (editor) {
 		toolbar->EnableTool(wxID_UNDO, editor->actionQueue->canUndo());
 		toolbar->EnableTool(wxID_REDO, editor->actionQueue->canRedo());
-		toolbar->EnableTool(wxID_PASTE, editor->copybuffer.canPaste());
+
+		bool canPaste = editor->copybuffer.canPaste();
+		toolbar->EnableTool(wxID_PASTE, canPaste);
+		if (canPaste) {
+			toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V)");
+		} else {
+			toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - Clipboard empty");
+		}
 	} else {
 		toolbar->EnableTool(wxID_UNDO, false);
 		toolbar->EnableTool(wxID_REDO, false);
 		toolbar->EnableTool(wxID_PASTE, false);
+		toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - No editor open");
 	}
 
 	bool has_map = editor != nullptr;


### PR DESCRIPTION
Implemented 10 micro-UX improvements by adding tooltips to the Properties Window and Container Properties Window, and updating the Standard Toolbar.
- Added tooltips to Container slots showing item name or "Empty Slot".
- Added tooltips to "Add Attribute" and "Remove Attribute" buttons.
- Added tooltips to Count, Action ID, and Unique ID fields.
- Added disabled state explanation to Count field.
- Updated Paste button tooltip to indicate if clipboard is empty.

---
*PR created automatically by Jules for task [13168508486121103190](https://jules.google.com/task/13168508486121103190) started by @karolak6612*