### PR TITLE
🗝️ Keeper: Fix Critical UB in OTBM Loader & Modernize LiveServer

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -614,8 +614,8 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		}
 
 		// Memory buffers for the houses & spawns
-		std::shared_ptr<uint8_t> house_buffer;
-		std::shared_ptr<uint8_t> spawn_buffer;
+		std::unique_ptr<uint8_t[]> house_buffer;
+		std::unique_ptr<uint8_t[]> spawn_buffer;
 		size_t house_buffer_size = 0;
 		size_t spawn_buffer_size = 0;
 
@@ -631,7 +631,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 			if (entryName == "world/map.otbm") {
 				// Read the entire OTBM file into a memory region
 				size_t otbm_size = archive_entry_size(entry);
-				std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
+				auto otbm_buffer = std::make_unique<uint8_t[]>(otbm_size);
 
 				// Read from the archive
 				size_t read_bytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
@@ -662,7 +662,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 				otbm_loaded = true;
 			} else if (entryName == "world/houses.xml") {
 				house_buffer_size = archive_entry_size(entry);
-				house_buffer.reset(new uint8_t[house_buffer_size]);
+				house_buffer = std::make_unique<uint8_t[]>(house_buffer_size);
 
 				// Read from the archive
 				size_t read_bytes = archive_read_data(a.get(), house_buffer.get(), house_buffer_size);
@@ -675,7 +675,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 				}
 			} else if (entryName == "world/spawns.xml") {
 				spawn_buffer_size = archive_entry_size(entry);
-				spawn_buffer.reset(new uint8_t[spawn_buffer_size]);
+				spawn_buffer = std::make_unique<uint8_t[]>(spawn_buffer_size);
 
 				// Read from the archive
 				size_t read_bytes = archive_read_data(a.get(), spawn_buffer.get(), spawn_buffer_size);

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -64,9 +64,6 @@ bool LiveServer::bind() {
 }
 
 void LiveServer::close() {
-	for (auto& clientEntry : clients) {
-		delete clientEntry.second;
-	}
 	clients.clear();
 
 	if (log) {
@@ -101,11 +98,11 @@ void LiveServer::acceptClient() {
 		if (error) {
 			//
 		} else {
-			LivePeer* peer = new LivePeer(this, std::move(*socket));
+			auto peer = std::make_unique<LivePeer>(this, std::move(*socket));
 			peer->log = log;
 			peer->receiveHeader();
 
-			clients.insert(std::make_pair(id++, peer));
+			clients.emplace(id++, std::move(peer));
 		}
 		acceptClient();
 	});
@@ -191,7 +188,7 @@ void LiveServer::broadcastNodes(DirtyList& dirtyList) {
 		}
 
 		for (auto& clientEntry : clients) {
-			LivePeer* peer = clientEntry.second;
+			LivePeer* peer = clientEntry.second.get();
 
 			const uint32_t clientId = peer->getClientId();
 			if (dirtyList.owner != 0 && dirtyList.owner == clientId) {
@@ -223,7 +220,7 @@ void LiveServer::broadcastCursor(const LiveCursor& cursor) {
 	writeCursor(message, cursor);
 
 	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+		LivePeer* peer = clientEntry.second.get();
 		if (peer->getClientId() != cursor.id) {
 			peer->send(message);
 		}

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -70,7 +70,7 @@ public:
 	void updateOperation(int32_t percent);
 
 protected:
-	std::unordered_map<uint32_t, LivePeer*> clients;
+	std::unordered_map<uint32_t, std::unique_ptr<LivePeer>> clients;
 
 	std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -196,18 +196,17 @@ void LiveLogTab::OnDeselectChatbox(wxFocusEvent& evt) {
 	g_hotkeys.EnableHotkeys();
 }
 
-void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients) {
+void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients) {
 	// Delete old rows
 	if (user_list->GetNumberRows() > 0) {
 		user_list->DeleteRows(0, user_list->GetNumberRows());
 	}
 
-	clients = updatedClients;
-	user_list->AppendRows(clients.size());
+	user_list->AppendRows(updatedClients.size());
 
 	int32_t i = 0;
-	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+	for (auto& clientEntry : updatedClients) {
+		LivePeer* peer = clientEntry.second.get();
 		user_list->SetCellBackgroundColour(i, 0, peer->getUsedColor());
 		user_list->SetCellValue(i, 1, i2ws((peer->getClientId() >> 1) + 1));
 		user_list->SetCellValue(i, 2, peer->getName());

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -52,7 +52,7 @@ public:
 		return socket;
 	}
 
-	void UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients);
+	void UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients);
 
 	void OnSelectChatbox(wxFocusEvent& evt);
 	void OnDeselectChatbox(wxFocusEvent& evt);
@@ -67,8 +67,6 @@ protected:
 	wxGrid* log;
 	wxTextCtrl* input;
 	wxGrid* user_list;
-
-	std::unordered_map<uint32_t, LivePeer*> clients;
 
 	DECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
This PR addresses a critical undefined behavior risk in `IOMapOTBM` where `std::shared_ptr` was being reset with `new []` (array) which would default to `delete` (scalar). It replaces these buffers with `std::unique_ptr<uint8_t[]>`.

Additionally, it refactors `LiveServer` to use `std::unique_ptr<LivePeer>` for client management, eliminating manual `delete` calls and ensuring exception-safe cleanup. `LiveLogTab` was also updated to reflect these changes.

Note: `NetworkedAction` changes were reverted as `std::make_unique` cannot access protected constructors, preserving the existing factory pattern safety.

---
*PR created automatically by Jules for task [14532968123181316902](https://jules.google.com/task/14532968123181316902) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal memory management optimizations for improved code stability and maintainability across archive handling and server components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->