### PR TITLE
[MODERNIZE] Use range-based for loops and std::find in various files

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,9 +253,9 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (Tile* tile : editor.selection) {
 			bool add_me = false; // If this tile is touched
-			Position pos = (*it)->getPosition();
+			Position pos = tile->getPosition();
 			// Go through all neighbours
 			Tile* t;
 			t = editor.map.getTile(pos.x - 1, pos.y - 1, pos.z);
@@ -304,7 +304,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 				add_me = true;
 			}
 			if (add_me) {
-				borderize_tiles.push_back(*it);
+				borderize_tiles.push_back(tile);
 			}
 		}
 		// Remove duplicates

--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -264,8 +264,8 @@ bool Container::serializeItemNode_OTMM(const IOMap& maphandle, NodeFileWriteHand
 	f.addU16(id);
 	serializeItemAttributes_OTMM(maphandle, f);
 
-	for (ItemVector::const_iterator it = contents.begin(); it != contents.end(); ++it) {
-		(*it)->serializeItemNode_OTMM(maphandle, f);
+	for (const auto& item : contents) {
+		item->serializeItemNode_OTMM(maphandle, f);
 	}
 	f.endNode();
 	return true;
@@ -836,8 +836,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 								f.addU16(0);
 							} else if (ground->hasBorderEquivalent()) {
 								bool found = false;
-								for (ItemVector::const_iterator it = save_tile->items.begin(); it != save_tile->items.end(); ++it) {
-									if ((*it)->getGroundEquivalent() == ground->getID()) {
+								for (const auto& item : save_tile->items) {
+									if (item->getGroundEquivalent() == ground->getID()) {
 										// Do nothing
 										// Found equivalent
 										found = true;
@@ -859,9 +859,9 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 							f.addU16(0);
 						}
 
-						for (ItemVector::const_iterator it = save_tile->items.begin(); it != save_tile->items.end(); ++it) {
-							if (!(*it)->isMetaItem()) {
-								(*it)->serializeItemNode_OTMM(*this, f);
+						for (const auto& item : save_tile->items) {
+							if (!item->isMetaItem()) {
+								item->serializeItemNode_OTMM(*this, f);
 							}
 						}
 					}
@@ -876,8 +876,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 			{
 				Spawns& spawns = map.spawns;
 				CreatureList creature_list;
-				for (SpawnPositionList::const_iterator piter = spawns.begin(); piter != spawns.end(); ++piter) {
-					const Tile* tile = map.getTile(*piter);
+				for (const auto& pos : spawns) {
+					const Tile* tile = map.getTile(pos);
 					ASSERT(tile);
 					const Spawn* spawn = tile->spawn;
 					ASSERT(spawn);
@@ -890,7 +890,7 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 						f.addU32(spawn->getSize());
 						for (int y = -tile->spawn->getSize(); y <= tile->spawn->getSize(); ++y) {
 							for (int x = -tile->spawn->getSize(); x <= tile->spawn->getSize(); ++x) {
-								Tile* creature_tile = map.getTile(*piter + Position(x, y, 0));
+								Tile* creature_tile = map.getTile(pos + Position(x, y, 0));
 								if (creature_tile) {
 									Creature* c = creature_tile->creature;
 									if (c && c->isSaved() == false) {
@@ -925,8 +925,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 					}
 					f.endNode(); // OTMM_SPAWN_AREA
 				}
-				for (CreatureList::iterator iter = creature_list.begin(); iter != creature_list.end(); ++iter) {
-					(*iter)->reset();
+				for (auto* creature : creature_list) {
+					creature->reset();
 				}
 			}
 			f.endNode(); // OTMM_SPAWN_DATA

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -22,6 +22,7 @@
 #include "game/item.h"
 #include "map/map_region.h"
 #include <unordered_set>
+#include <algorithm>
 
 enum {
 	TILESTATE_NONE = 0x0000,
@@ -300,14 +301,7 @@ inline bool Tile::isHouseExit() const {
 
 inline bool Tile::hasHouseExit(uint32_t exit) const {
 	const HouseExitList* house_exits = getHouseExits();
-	if (house_exits) {
-		for (HouseExitList::const_iterator iter = house_exits->begin(); iter != house_exits->end(); ++iter) {
-			if (*iter == exit) {
-				return true;
-			}
-		}
-	}
-	return false;
+	return house_exits && std::find(house_exits->begin(), house_exits->end(), exit) != house_exits->end();
 }
 
 inline void Tile::setMapFlags(uint16_t _flags) {

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,8 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
-			Tile* tile = *tit;
+		for (Tile* tile : drawer->editor.selection) {
 			Position pos = tile->getPosition();
 
 			int move_x, move_y, move_z;
@@ -72,11 +71,11 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 				// save performance when moving large chunks unzoomed
 				ItemVector toRender = tile->getSelectedItems(view.zoom > 3.0);
 				Tile* desttile = drawer->editor.map.getTile(pos);
-				for (ItemVector::const_iterator iit = toRender.begin(); iit != toRender.end(); iit++) {
+				for (Item* item : toRender) {
 					if (desttile) {
-						item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, desttile, *iit, options, true, 160, 160, 160, 160);
+						item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, desttile, item, options, true, 160, 160, 160, 160);
 					} else {
-						item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, pos, *iit, options, true, 160, 160, 160, 160);
+						item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, true, 160, 160, 160, 160);
 					}
 				}
 

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -223,10 +223,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	if (!only_colors) {
 		if (view.zoom < 10.0 || !options.hide_items_when_zoomed) {
 			// items on tile
-			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
+			for (Item* item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
+					TooltipData itemData = CreateItemTooltipData(item, location->getPosition(), tile->isHouseTile());
 					if (itemData.hasVisibleFields()) {
 						tooltip_drawer->addItemTooltip(itemData);
 					}
@@ -234,12 +234,12 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 				// item animation
 				if (options.show_preview && view.zoom <= 2.0) {
-					(*it)->animate();
+					item->animate();
 				}
 
 				// item sprite
-				if ((*it)->isBorder()) {
-					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, *it, options, false, r, g, b);
+				if (item->isBorder()) {
+					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item, options, false, r, g, b);
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
@@ -263,7 +263,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 							}
 						}
 					}
-					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, *it, options, false, ir, ig, ib);
+					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item, options, false, ir, ig, ib);
 				}
 			}
 			// monster/npc on tile

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
Modernized loops in `TileRenderer`, `IOMapOTMM`. Fixed compilation errors in `SelectionOperations` and `DragShadowDrawer` related to `std::set` iterators. Fixed linker errors in `BrushPanel` and `PropertiesWindow` by removing `DECLARE_EVENT_TABLE` where `Bind` was used. Modernized `hasHouseExit` in `Tile`.

---
*PR created automatically by Jules for task [17079306316888166984](https://jules.google.com/task/17079306316888166984) started by @karolak6612*