### PR TITLE
🗝️ Keeper: Modernize LiveServer and MapTab memory management

### DIFF
--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -68,7 +68,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName
 }
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* client) :
-	live_manager(*this, client),
+	live_manager(*this, std::unique_ptr<LiveClient>(client)),
 	actionQueue(newd NetworkedActionQueue(*this)),
 	selection(*this),
 	copybuffer(copybuffer),

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -209,7 +209,7 @@ bool EditorManager::NewMap() {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 	mapTab->GetMap()->clearChanges();
 
@@ -300,7 +300,7 @@ bool EditorManager::LoadMap(const FileName& fileName) {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 
 	g_gui.root->AddRecentFile(fileName);

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -240,11 +240,11 @@ LiveLogTab* LiveClient::createLogWindow(wxWindow* parent) {
 	return log;
 }
 
-MapTab* LiveClient::createEditorWindow() {
+MapTab* LiveClient::createEditorWindow(std::shared_ptr<Editor> editor) {
 	MapTabbook* mtb = dynamic_cast<MapTabbook*>(g_gui.tabbook);
 	ASSERT(mtb);
 
-	MapTab* edit = newd MapTab(mtb, editor.get());
+	MapTab* edit = newd MapTab(mtb, editor);
 	edit->OnSwitchEditorMode(g_gui.IsSelectionMode() ? SELECTION_MODE : DRAWING_MODE);
 
 	return edit;
@@ -372,14 +372,15 @@ void LiveClient::parsePacket(NetworkMessage message) {
 
 void LiveClient::parseHello(NetworkMessage& message) {
 	ASSERT(editor == nullptr);
-	editor = EditorFactory::JoinLive(g_gui.copybuffer, this);
+	std::shared_ptr<Editor> sharedEditor = EditorFactory::JoinLive(g_gui.copybuffer, this);
+	editor = sharedEditor.get();
 
 	Map& map = editor->map;
 	map.setName("Live Map - " + message.read<std::string>());
 	map.setWidth(message.read<uint16_t>());
 	map.setHeight(message.read<uint16_t>());
 
-	createEditorWindow();
+	createEditorWindow(sharedEditor);
 }
 
 void LiveClient::parseKick(NetworkMessage& message) {

--- a/source/live/live_client.h
+++ b/source/live/live_client.h
@@ -50,7 +50,7 @@ public:
 	void updateCursor(const Position& position);
 
 	LiveLogTab* createLogWindow(wxWindow* parent);
-	MapTab* createEditorWindow();
+	MapTab* createEditorWindow(std::shared_ptr<Editor> editor);
 
 	// send packets
 	void sendHello();
@@ -85,7 +85,7 @@ protected:
 	std::shared_ptr<boost::asio::ip::tcp::resolver> resolver;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;
 
-	std::unique_ptr<Editor> editor;
+	Editor* editor;
 
 	bool stopped;
 };

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -18,10 +18,10 @@ LiveManager::LiveManager(Editor& editor) :
 	live_client(nullptr) {
 }
 
-LiveManager::LiveManager(Editor& editor, LiveClient* client) :
+LiveManager::LiveManager(Editor& editor, std::unique_ptr<LiveClient> client) :
 	editor(editor),
 	live_server(nullptr),
-	live_client(client) {
+	live_client(std::move(client)) {
 }
 
 LiveManager::~LiveManager() {
@@ -47,11 +47,11 @@ bool LiveManager::IsLocal() const {
 }
 
 LiveClient* LiveManager::GetClient() const {
-	return live_client;
+	return live_client.get();
 }
 
 LiveServer* LiveManager::GetServer() const {
-	return live_server;
+	return live_server.get();
 }
 
 LiveSocket& LiveManager::GetSocket() const {
@@ -63,25 +63,23 @@ LiveSocket& LiveManager::GetSocket() const {
 
 LiveServer* LiveManager::StartServer() {
 	ASSERT(IsLocal());
-	live_server = newd LiveServer(editor);
+	live_server = std::make_unique<LiveServer>(editor);
 
 	delete editor.actionQueue;
 	editor.actionQueue = newd NetworkedActionQueue(editor);
 
-	return live_server;
+	return live_server.get();
 }
 
 void LiveManager::CloseServer() {
 	if (live_server) {
 		live_server->close();
-		delete live_server;
-		live_server = nullptr;
+		live_server.reset();
 	}
 
 	if (live_client) {
 		live_client->close();
-		delete live_client;
-		live_client = nullptr;
+		live_client.reset();
 	}
 
 	delete editor.actionQueue;

--- a/source/live/live_manager.h
+++ b/source/live/live_manager.h
@@ -12,7 +12,7 @@ class DirtyList;
 class LiveManager {
 public:
 	LiveManager(Editor& editor);
-	LiveManager(Editor& editor, LiveClient* client);
+	LiveManager(Editor& editor, std::unique_ptr<LiveClient> client);
 	~LiveManager();
 
 	LiveServer* StartServer();
@@ -31,8 +31,8 @@ public:
 
 private:
 	Editor& editor;
-	LiveServer* live_server;
-	LiveClient* live_client;
+	std::unique_ptr<LiveServer> live_server;
+	std::unique_ptr<LiveClient> live_client;
 };
 
 #endif

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -70,7 +70,7 @@ public:
 	void updateOperation(int32_t percent);
 
 protected:
-	std::unordered_map<uint32_t, LivePeer*> clients;
+	std::unordered_map<uint32_t, std::unique_ptr<LivePeer>> clients;
 
 	std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -196,18 +196,17 @@ void LiveLogTab::OnDeselectChatbox(wxFocusEvent& evt) {
 	g_hotkeys.EnableHotkeys();
 }
 
-void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients) {
+void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients) {
 	// Delete old rows
 	if (user_list->GetNumberRows() > 0) {
 		user_list->DeleteRows(0, user_list->GetNumberRows());
 	}
 
-	clients = updatedClients;
-	user_list->AppendRows(clients.size());
+	user_list->AppendRows(updatedClients.size());
 
 	int32_t i = 0;
-	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+	for (auto& clientEntry : updatedClients) {
+		LivePeer* peer = clientEntry.second.get();
 		user_list->SetCellBackgroundColour(i, 0, peer->getUsedColor());
 		user_list->SetCellValue(i, 1, i2ws((peer->getClientId() >> 1) + 1));
 		user_list->SetCellValue(i, 2, peer->getName());

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -52,7 +52,7 @@ public:
 		return socket;
 	}
 
-	void UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients);
+	void UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients);
 
 	void OnSelectChatbox(wxFocusEvent& evt);
 	void OnDeselectChatbox(wxFocusEvent& evt);
@@ -67,8 +67,6 @@ protected:
 	wxGrid* log;
 	wxTextCtrl* input;
 	wxGrid* user_list;
-
-	std::unordered_map<uint32_t, LivePeer*> clients;
 
 	DECLARE_EVENT_TABLE();
 };

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -357,7 +357,7 @@ protected:
 	int disabled_counter;
 
 	friend class RenderingLock;
-	friend MapTab::MapTab(MapTabbook*, Editor*);
+	friend MapTab::MapTab(MapTabbook*, std::shared_ptr<Editor>);
 	friend MapTab::MapTab(const MapTab*);
 };
 

--- a/source/ui/map_tab.cpp
+++ b/source/ui/map_tab.cpp
@@ -27,14 +27,11 @@
 
 #include <spdlog/spdlog.h>
 
-MapTab::MapTab(MapTabbook* aui, Editor* editor) :
+MapTab::MapTab(MapTabbook* aui, std::shared_ptr<Editor> editor) :
 	EditorTab(),
 	MapWindow(aui, *editor),
-	aui(aui) {
-	iref = newd InternalReference;
-	iref->editor = editor;
-	iref->owner_count = 1;
-
+	aui(aui),
+	editor_ptr(editor) {
 	spdlog::info("MapTab created (New Editor) [Tab={}]", (void*)this);
 
 	aui->AddTab(this, true);
@@ -43,10 +40,9 @@ MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 
 MapTab::MapTab(const MapTab* other) :
 	EditorTab(),
-	MapWindow(other->aui, *other->iref->editor),
+	MapWindow(other->aui, *other->editor_ptr),
 	aui(other->aui),
-	iref(other->iref) {
-	iref->owner_count++;
+	editor_ptr(other->editor_ptr) {
 	spdlog::info("MapTab created (Shared Editor) [Tab={}]", (void*)this);
 	aui->AddTab(this, true);
 	FitToMap();
@@ -56,17 +52,11 @@ MapTab::MapTab(const MapTab* other) :
 }
 
 MapTab::~MapTab() {
-	spdlog::info("MapTab destroying [Tab={}] (Owner count: {})", (void*)this, iref->owner_count);
-	iref->owner_count--;
-	if (iref->owner_count <= 0) {
-		spdlog::info("MapTab destroying editor [Editor={}]", (void*)iref->editor);
-		delete iref->editor;
-		delete iref;
-	}
+	spdlog::info("MapTab destroying [Tab={}] (Ref count: {})", (void*)this, editor_ptr.use_count());
 }
 
 bool MapTab::IsUniqueReference() const {
-	return iref->owner_count == 1;
+	return editor_ptr.unique();
 }
 
 wxWindow* MapTab::GetWindow() const {
@@ -83,16 +73,16 @@ MapWindow* MapTab::GetView() const {
 
 wxString MapTab::GetTitle() const {
 	wxString ss;
-	ss << wxstr(iref->editor->map.getName()) << (iref->editor->map.hasChanged() ? "*" : "");
+	ss << wxstr(editor_ptr->map.getName()) << (editor_ptr->map.hasChanged() ? "*" : "");
 	return ss;
 }
 
 Editor* MapTab::GetEditor() const {
-	return &editor;
+	return editor_ptr.get();
 }
 
 Map* MapTab::GetMap() const {
-	return &editor.map;
+	return &editor_ptr->map;
 }
 
 void MapTab::VisibilityCheck() {

--- a/source/ui/map_tab.h
+++ b/source/ui/map_tab.h
@@ -24,7 +24,7 @@
 
 class MapTab : public EditorTab, public MapWindow {
 public:
-	MapTab(MapTabbook* aui, Editor* editor);
+	MapTab(MapTabbook* aui, std::shared_ptr<Editor> editor);
 	// Constructs a newd window, but it uses the same internal editor as 'other'
 	// AND the same parent, aui_notebook etc.
 	MapTab(const MapTab* other);
@@ -47,16 +47,12 @@ public:
 	void OnSwitchEditorMode(EditorMode mode);
 
 protected:
-	struct InternalReference {
-		Editor* editor;
-		int owner_count;
-	};
 	MapTabbook* aui;
-	InternalReference* iref;
+	std::shared_ptr<Editor> editor_ptr;
 };
 
 inline bool MapTab::HasSameReference(MapTab* other) const {
-	return other->iref == iref;
+	return other->editor_ptr == editor_ptr;
 }
 
 #endif

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
This PR modernizes memory management in the Live mapping and Editor tab systems.

Key changes:
- `LiveServer::clients` is now `std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>`, ensuring automatic cleanup of peers.
- `LiveManager` now owns `LiveServer` and `LiveClient` via `std::unique_ptr`.
- `MapTab` now shares `Editor` ownership via `std::shared_ptr<Editor>`, removing the custom ref-counting implementation.
- `LiveClient` no longer owns `Editor` but passes ownership to `MapTab` upon creation, breaking a reference cycle.
- Fixed iterator type mismatches in `selection_operations.cpp` and `drag_shadow_drawer.cpp` (using `auto` for `std::set` iterators).
- Removed unimplemented `DECLARE_EVENT_TABLE` macros from `brush_panel.h` and `properties_window.h` to resolve linker errors.

---
*PR created automatically by Jules for task [9333078734020201676](https://jules.google.com/task/9333078734020201676) started by @karolak6612*