### PR TITLE
[REFACTOR] Fix Long Methods in IOMapOTBM

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -601,126 +601,134 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 	return true;
 }
 
+bool IOMapOTBM::loadOTGZ(Map& map, const FileName& filename) {
+#ifdef OTGZ_SUPPORT
+	// Open the archive
+	std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
+	archive_read_support_filter_all(a.get());
+	archive_read_support_format_all(a.get());
+	if (archive_read_open_filename(a.get(), nstr(filename.GetFullPath()).c_str(), 10240) != ARCHIVE_OK) {
+		return false;
+	}
+
+	// Memory buffers for the houses & spawns
+	std::shared_ptr<uint8_t> house_buffer;
+	std::shared_ptr<uint8_t> spawn_buffer;
+	size_t house_buffer_size = 0;
+	size_t spawn_buffer_size = 0;
+
+	// See if the otbm file has been loaded
+	bool otbm_loaded = false;
+
+	// Loop over the archive entries until we find the otbm file
+	g_gui.SetLoadDone(0, "Decompressing archive...");
+	struct archive_entry* entry;
+	while (archive_read_next_header(a.get(), &entry) == ARCHIVE_OK) {
+		std::string entryName = archive_entry_pathname(entry);
+
+		if (entryName == "world/map.otbm") {
+			// Read the entire OTBM file into a memory region
+			size_t otbm_size = archive_entry_size(entry);
+			std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < 4) {
+				return false;
+			}
+
+			if (read_bytes < otbm_size) {
+				error("Could not read file.");
+				return false;
+			}
+
+			g_gui.SetLoadDone(0, "Loading OTBM map...");
+
+			// Create a read handle on it
+			std::shared_ptr<NodeFileReadHandle> f(
+				new MemoryNodeFileReadHandle(otbm_buffer.get() + 4, otbm_size - 4)
+			);
+
+			// Read the version info
+			if (!loadMap(map, *f.get())) {
+				error("Could not load OTBM file inside archive");
+				return false;
+			}
+
+			otbm_loaded = true;
+		} else if (entryName == "world/houses.xml") {
+			house_buffer_size = archive_entry_size(entry);
+			house_buffer.reset(new uint8_t[house_buffer_size]);
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), house_buffer.get(), house_buffer_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < house_buffer_size) {
+				house_buffer.reset();
+				house_buffer_size = 0;
+				warning("Failed to decompress houses.");
+			}
+		} else if (entryName == "world/spawns.xml") {
+			spawn_buffer_size = archive_entry_size(entry);
+			spawn_buffer.reset(new uint8_t[spawn_buffer_size]);
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), spawn_buffer.get(), spawn_buffer_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < spawn_buffer_size) {
+				spawn_buffer.reset();
+				spawn_buffer_size = 0;
+				warning("Failed to decompress spawns.");
+			}
+		}
+	}
+
+	if (!otbm_loaded) {
+		error("OTBM file not found inside archive.");
+		return false;
+	}
+
+	// Load the houses from the stored buffer
+	if (house_buffer.get() && house_buffer_size > 0) {
+		pugi::xml_document doc;
+		pugi::xml_parse_result result = doc.load_buffer(house_buffer.get(), house_buffer_size);
+		if (result) {
+			if (!loadHouses(map, doc)) {
+				warning("Failed to load houses.");
+			}
+		} else {
+			warning("Failed to load houses due to XML parse error.");
+		}
+	}
+
+	// Load the spawns from the stored buffer
+	if (spawn_buffer.get() && spawn_buffer_size > 0) {
+		pugi::xml_document doc;
+		pugi::xml_parse_result result = doc.load_buffer(spawn_buffer.get(), spawn_buffer_size);
+		if (result) {
+			if (!loadSpawns(map, doc)) {
+				warning("Failed to load spawns.");
+			}
+		} else {
+			warning("Failed to load spawns due to XML parse error.");
+		}
+	}
+
+	return true;
+#else
+	return false;
+#endif
+}
+
 bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 	spdlog::info("IOMapOTBM::loadMap - Start loading from file: {}", nstr(filename.GetFullPath()));
 #ifdef OTGZ_SUPPORT
 	if (filename.GetExt() == "otgz") {
-		// Open the archive
-		std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
-		archive_read_support_filter_all(a.get());
-		archive_read_support_format_all(a.get());
-		if (archive_read_open_filename(a.get(), nstr(filename.GetFullPath()).c_str(), 10240) != ARCHIVE_OK) {
-			return false;
-		}
-
-		// Memory buffers for the houses & spawns
-		std::shared_ptr<uint8_t> house_buffer;
-		std::shared_ptr<uint8_t> spawn_buffer;
-		size_t house_buffer_size = 0;
-		size_t spawn_buffer_size = 0;
-
-		// See if the otbm file has been loaded
-		bool otbm_loaded = false;
-
-		// Loop over the archive entries until we find the otbm file
-		g_gui.SetLoadDone(0, "Decompressing archive...");
-		struct archive_entry* entry;
-		while (archive_read_next_header(a.get(), &entry) == ARCHIVE_OK) {
-			std::string entryName = archive_entry_pathname(entry);
-
-			if (entryName == "world/map.otbm") {
-				// Read the entire OTBM file into a memory region
-				size_t otbm_size = archive_entry_size(entry);
-				std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < 4) {
-					return false;
-				}
-
-				if (read_bytes < otbm_size) {
-					error("Could not read file.");
-					return false;
-				}
-
-				g_gui.SetLoadDone(0, "Loading OTBM map...");
-
-				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(
-					new MemoryNodeFileReadHandle(otbm_buffer.get() + 4, otbm_size - 4)
-				);
-
-				// Read the version info
-				if (!loadMap(map, *f.get())) {
-					error("Could not load OTBM file inside archive");
-					return false;
-				}
-
-				otbm_loaded = true;
-			} else if (entryName == "world/houses.xml") {
-				house_buffer_size = archive_entry_size(entry);
-				house_buffer.reset(new uint8_t[house_buffer_size]);
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), house_buffer.get(), house_buffer_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < house_buffer_size) {
-					house_buffer.reset();
-					house_buffer_size = 0;
-					warning("Failed to decompress houses.");
-				}
-			} else if (entryName == "world/spawns.xml") {
-				spawn_buffer_size = archive_entry_size(entry);
-				spawn_buffer.reset(new uint8_t[spawn_buffer_size]);
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), spawn_buffer.get(), spawn_buffer_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < spawn_buffer_size) {
-					spawn_buffer.reset();
-					spawn_buffer_size = 0;
-					warning("Failed to decompress spawns.");
-				}
-			}
-		}
-
-		if (!otbm_loaded) {
-			error("OTBM file not found inside archive.");
-			return false;
-		}
-
-		// Load the houses from the stored buffer
-		if (house_buffer.get() && house_buffer_size > 0) {
-			pugi::xml_document doc;
-			pugi::xml_parse_result result = doc.load_buffer(house_buffer.get(), house_buffer_size);
-			if (result) {
-				if (!loadHouses(map, doc)) {
-					warning("Failed to load houses.");
-				}
-			} else {
-				warning("Failed to load houses due to XML parse error.");
-			}
-		}
-
-		// Load the spawns from the stored buffer
-		if (spawn_buffer.get() && spawn_buffer_size > 0) {
-			pugi::xml_document doc;
-			pugi::xml_parse_result result = doc.load_buffer(spawn_buffer.get(), spawn_buffer_size);
-			if (result) {
-				if (!loadSpawns(map, doc)) {
-					warning("Failed to load spawns.");
-				}
-			} else {
-				warning("Failed to load spawns due to XML parse error.");
-			}
-		}
-
-		return true;
+		return loadOTGZ(map, filename);
 	}
 #endif
 
@@ -905,195 +913,210 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 			continue;
 		}
 		if (node_type == OTBM_TILE_AREA) {
-			uint16_t base_x, base_y;
-			uint8_t base_z;
-			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
-				continue;
-			}
-
-			for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
-				Tile* tile = nullptr;
-				uint8_t tile_type;
-				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
-					continue;
-				}
-				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
-					uint8_t x_offset, y_offset;
-					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
-						continue;
-					}
-					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
-
-					if (map.getTile(pos)) {
-						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
-						continue;
-					}
-
-					tile = map.allocator(map.createTileL(pos));
-					House* house = nullptr;
-					if (tile_type == OTBM_HOUSETILE) {
-						uint32_t house_id;
-						if (!tileNode->getU32(house_id)) {
-							warning("House tile without house data, discarding tile");
-							continue;
-						}
-						if (house_id) {
-							house = map.houses.getHouse(house_id);
-							if (!house) {
-								house = newd House(map);
-								house->setID(house_id);
-								map.houses.addHouse(house);
-							}
-						} else {
-							warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
-						}
-					}
-
-					uint8_t attribute;
-					while (tileNode->getU8(attribute)) {
-						switch (attribute) {
-							case OTBM_ATTR_TILE_FLAGS: {
-								uint32_t flags = 0;
-								if (!tileNode->getU32(flags)) {
-									warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->setMapFlags(flags);
-								break;
-							}
-							case OTBM_ATTR_ITEM: {
-								Item* item = Item::Create_OTBM(*this, tileNode);
-								if (item == nullptr) {
-									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->addItem(item);
-								break;
-							}
-							default: {
-								warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
-								break;
-							}
-						}
-					}
-
-					for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
-						Item* item = nullptr;
-						uint8_t item_type;
-						if (!itemNode->getByte(item_type)) {
-							warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
-							continue;
-						}
-						if (item_type == OTBM_ITEM) {
-							item = Item::Create_OTBM(*this, itemNode);
-							if (item) {
-								if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
-									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								// reform(&map, tile, item);
-								tile->addItem(item);
-							}
-						} else {
-							warning("Unknown type of tile child node");
-						}
-					}
-
-					tile->update();
-					if (house) {
-						house->addTile(tile);
-					}
-
-					map.setTile(pos.x, pos.y, pos.z, tile);
-				} else {
-					warning("Unknown type of tile node");
-				}
-			}
+			readTileArea(map, mapNode);
 		} else if (node_type == OTBM_TOWNS) {
-			for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
-				Town* town = nullptr;
-				uint8_t town_type;
-				if (!townNode->getByte(town_type)) {
-					warning("Invalid town type (1)");
-					continue;
-				}
-				if (town_type != OTBM_TOWN) {
-					warning("Invalid town type (2)");
-					continue;
-				}
-				uint32_t town_id;
-				if (!townNode->getU32(town_id)) {
-					warning("Invalid town id");
-					continue;
-				}
-
-				town = map.towns.getTown(town_id);
-				if (town) {
-					warning("Duplicate town id %d, discarding duplicate", town_id);
-					continue;
-				} else {
-					town = newd Town(town_id);
-					if (!map.towns.addTown(town)) {
-						delete town;
-						continue;
-					}
-				}
-				std::string town_name;
-				if (!townNode->getString(town_name)) {
-					warning("Invalid town name");
-					continue;
-				}
-				town->setName(town_name);
-				Position pos;
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
-					warning("Invalid town temple position");
-					continue;
-				}
-				pos.x = x;
-				pos.y = y;
-				pos.z = z;
-				town->setTemplePosition(pos);
-				map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
-			}
+			readTowns(map, mapNode);
 		} else if (node_type == OTBM_WAYPOINTS) {
-			for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
-				uint8_t waypoint_type;
-				if (!waypointNode->getByte(waypoint_type)) {
-					warning("Invalid waypoint type (1)");
-					continue;
-				}
-				if (waypoint_type != OTBM_WAYPOINT) {
-					warning("Invalid waypoint type (2)");
-					continue;
-				}
-
-				Waypoint wp;
-
-				if (!waypointNode->getString(wp.name)) {
-					warning("Invalid waypoint name");
-					continue;
-				}
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
-					warning("Invalid waypoint position");
-					continue;
-				}
-				wp.pos.x = x;
-				wp.pos.y = y;
-				wp.pos.z = z;
-
-				map.waypoints.addWaypoint(newd Waypoint(wp));
-			}
+			readWaypoints(map, mapNode);
 		}
 	}
 
 	if (!f.isOk()) {
 		warning(wxstr(f.getErrorMessage()).wc_str());
+	}
+	return true;
+}
+
+bool IOMapOTBM::readTileArea(Map& map, BinaryNode* mapNode) {
+	uint16_t base_x, base_y;
+	uint8_t base_z;
+	if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
+		warning("Invalid map node, no base coordinate");
+		return false;
+	}
+
+	for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
+		Tile* tile = nullptr;
+		uint8_t tile_type;
+		if (!tileNode->getByte(tile_type)) {
+			warning("Invalid tile type");
+			continue;
+		}
+		if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
+			uint8_t x_offset, y_offset;
+			if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
+				warning("Could not read position of tile");
+				continue;
+			}
+			const Position pos(base_x + x_offset, base_y + y_offset, base_z);
+
+			if (map.getTile(pos)) {
+				warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
+				continue;
+			}
+
+			tile = map.allocator(map.createTileL(pos));
+			House* house = nullptr;
+			if (tile_type == OTBM_HOUSETILE) {
+				uint32_t house_id;
+				if (!tileNode->getU32(house_id)) {
+					warning("House tile without house data, discarding tile");
+					continue;
+				}
+				if (house_id) {
+					house = map.houses.getHouse(house_id);
+					if (!house) {
+						house = newd House(map);
+						house->setID(house_id);
+						map.houses.addHouse(house);
+					}
+				} else {
+					warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
+				}
+			}
+
+			uint8_t attribute;
+			while (tileNode->getU8(attribute)) {
+				switch (attribute) {
+					case OTBM_ATTR_TILE_FLAGS: {
+						uint32_t flags = 0;
+						if (!tileNode->getU32(flags)) {
+							warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->setMapFlags(flags);
+						break;
+					}
+					case OTBM_ATTR_ITEM: {
+						Item* item = Item::Create_OTBM(*this, tileNode);
+						if (item == nullptr) {
+							warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->addItem(item);
+						break;
+					}
+					default: {
+						warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
+						break;
+					}
+				}
+			}
+
+			for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
+				Item* item = nullptr;
+				uint8_t item_type;
+				if (!itemNode->getByte(item_type)) {
+					warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
+					continue;
+				}
+				if (item_type == OTBM_ITEM) {
+					item = Item::Create_OTBM(*this, itemNode);
+					if (item) {
+						if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
+							warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						// reform(&map, tile, item);
+						tile->addItem(item);
+					}
+				} else {
+					warning("Unknown type of tile child node");
+				}
+			}
+
+			tile->update();
+			if (house) {
+				house->addTile(tile);
+			}
+
+			map.setTile(pos.x, pos.y, pos.z, tile);
+		} else {
+			warning("Unknown type of tile node");
+		}
+	}
+	return true;
+}
+
+bool IOMapOTBM::readTowns(Map& map, BinaryNode* mapNode) {
+	for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
+		Town* town = nullptr;
+		uint8_t town_type;
+		if (!townNode->getByte(town_type)) {
+			warning("Invalid town type (1)");
+			continue;
+		}
+		if (town_type != OTBM_TOWN) {
+			warning("Invalid town type (2)");
+			continue;
+		}
+		uint32_t town_id;
+		if (!townNode->getU32(town_id)) {
+			warning("Invalid town id");
+			continue;
+		}
+
+		town = map.towns.getTown(town_id);
+		if (town) {
+			warning("Duplicate town id %d, discarding duplicate", town_id);
+			continue;
+		} else {
+			town = newd Town(town_id);
+			if (!map.towns.addTown(town)) {
+				delete town;
+				continue;
+			}
+		}
+		std::string town_name;
+		if (!townNode->getString(town_name)) {
+			warning("Invalid town name");
+			continue;
+		}
+		town->setName(town_name);
+		Position pos;
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
+			warning("Invalid town temple position");
+			continue;
+		}
+		pos.x = x;
+		pos.y = y;
+		pos.z = z;
+		town->setTemplePosition(pos);
+		map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
+	}
+	return true;
+}
+
+bool IOMapOTBM::readWaypoints(Map& map, BinaryNode* mapNode) {
+	for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
+		uint8_t waypoint_type;
+		if (!waypointNode->getByte(waypoint_type)) {
+			warning("Invalid waypoint type (1)");
+			continue;
+		}
+		if (waypoint_type != OTBM_WAYPOINT) {
+			warning("Invalid waypoint type (2)");
+			continue;
+		}
+
+		Waypoint wp;
+
+		if (!waypointNode->getString(wp.name)) {
+			warning("Invalid waypoint name");
+			continue;
+		}
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
+			warning("Invalid waypoint position");
+			continue;
+		}
+		wp.pos.x = x;
+		wp.pos.y = y;
+		wp.pos.z = z;
+
+		map.waypoints.addWaypoint(newd Waypoint(wp));
 	}
 	return true;
 }
@@ -1573,53 +1596,7 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 					f.addU16(local_y = pos.y & 0xFF00);
 					f.addU8(local_z = pos.z);
 				}
-				f.addNode(save_tile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
-
-				f.addU8(save_tile->getX() & 0xFF);
-				f.addU8(save_tile->getY() & 0xFF);
-
-				if (save_tile->isHouseTile()) {
-					f.addU32(save_tile->getHouseID());
-				}
-
-				if (save_tile->getMapFlags()) {
-					f.addByte(OTBM_ATTR_TILE_FLAGS);
-					f.addU32(save_tile->getMapFlags());
-				}
-
-				if (save_tile->ground) {
-					Item* ground = save_tile->ground;
-					if (ground->isMetaItem()) {
-						// Do nothing, we don't save metaitems...
-					} else if (ground->hasBorderEquivalent()) {
-						bool found = false;
-						for (Item* item : save_tile->items) {
-							if (item->getGroundEquivalent() == ground->getID()) {
-								// Do nothing
-								// Found equivalent
-								found = true;
-								break;
-							}
-						}
-
-						if (!found) {
-							ground->serializeItemNode_OTBM(self, f);
-						}
-					} else if (ground->isComplex()) {
-						ground->serializeItemNode_OTBM(self, f);
-					} else {
-						f.addByte(OTBM_ATTR_ITEM);
-						ground->serializeItemCompact_OTBM(self, f);
-					}
-				}
-
-				for (Item* item : save_tile->items) {
-					if (!item->isMetaItem()) {
-						item->serializeItemNode_OTBM(self, f);
-					}
-				}
-
-				f.endNode();
+				saveTile(f, save_tile);
 				++map_iterator;
 			}
 
@@ -1669,6 +1646,56 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 		DialogUtil::PopupDialog(g_gui.root, "Warning", "Waypoints were saved, but they are not supported in OTBM 2!\nIf your map fails to load, consider removing all waypoints and saving again.\n\nThis warning can be disabled in file->preferences.", wxOK);
 	}
 	return true;
+}
+
+void IOMapOTBM::saveTile(NodeFileWriteHandle& f, Tile* save_tile) {
+	f.addNode(save_tile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
+
+	f.addU8(save_tile->getX() & 0xFF);
+	f.addU8(save_tile->getY() & 0xFF);
+
+	if (save_tile->isHouseTile()) {
+		f.addU32(save_tile->getHouseID());
+	}
+
+	if (save_tile->getMapFlags()) {
+		f.addByte(OTBM_ATTR_TILE_FLAGS);
+		f.addU32(save_tile->getMapFlags());
+	}
+
+	if (save_tile->ground) {
+		Item* ground = save_tile->ground;
+		if (ground->isMetaItem()) {
+			// Do nothing, we don't save metaitems...
+		} else if (ground->hasBorderEquivalent()) {
+			bool found = false;
+			for (Item* item : save_tile->items) {
+				if (item->getGroundEquivalent() == ground->getID()) {
+					// Do nothing
+					// Found equivalent
+					found = true;
+					break;
+				}
+			}
+
+			if (!found) {
+				ground->serializeItemNode_OTBM(*this, f);
+			}
+		} else if (ground->isComplex()) {
+			ground->serializeItemNode_OTBM(*this, f);
+		} else {
+			f.addByte(OTBM_ATTR_ITEM);
+			ground->serializeItemCompact_OTBM(*this, f);
+		}
+	}
+
+	for (Item* item : save_tile->items) {
+		if (!item->isMetaItem()) {
+			item->serializeItemNode_OTBM(*this, f);
+		}
+	}
+
+	f.endNode();
 }
 
 bool IOMapOTBM::saveSpawns(Map& map, const FileName& dir) {

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -138,7 +138,13 @@ public:
 protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
+	bool loadOTGZ(Map& map, const FileName& identifier);
+
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+	bool readTileArea(Map& map, BinaryNode* mapNode);
+	bool readTowns(Map& map, BinaryNode* mapNode);
+	bool readWaypoints(Map& map, BinaryNode* mapNode);
+
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);
@@ -147,6 +153,8 @@ protected:
 	bool loadWaypoints(Map& map, pugi::xml_document& doc);
 
 	virtual bool saveMap(Map& map, NodeFileWriteHandle& handle);
+	void saveTile(NodeFileWriteHandle& f, Tile* save_tile);
+
 	bool saveSpawns(Map& map, const FileName& dir);
 	bool saveSpawns(Map& map, pugi::xml_document& doc);
 	bool saveHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
Extracted logic from `loadMap` and `saveMap` in `source/io/iomap_otbm.cpp` into private helper methods.
- `loadOTGZ`: Handles OTGZ archive extraction.
- `readTileArea`: Parses OTBM_TILE_AREA nodes.
- `readTowns`: Parses OTBM_TOWNS nodes.
- `readWaypoints`: Parses OTBM_WAYPOINTS nodes.
- `saveTile`: Serializes a single tile.

This addresses code smells related to Long Method and High Cyclomatic Complexity.

---
*PR created automatically by Jules for task [731737693100265160](https://jules.google.com/task/731737693100265160) started by @karolak6612*