### PR TITLE
Profiler: Performance fixes and build repairs

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/core/graphics.cpp
+++ b/source/rendering/core/graphics.cpp
@@ -164,6 +164,14 @@ bool GraphicManager::loadEditorSprites() {
 	return EditorSpriteLoader::Load(this);
 }
 
+void GraphicManager::updateTime() {
+	cached_time = time(nullptr);
+}
+
+time_t GraphicManager::getCachedTime() const {
+	return cached_time;
+}
+
 bool GraphicManager::loadOTFI(const FileName& filename, wxString& error, wxArrayString& warnings) {
 	return GameSpriteLoader::LoadOTFI(this, filename, error, warnings);
 }
@@ -426,7 +434,7 @@ GameSprite::Image::~Image() {
 }
 
 void GameSprite::Image::visit() {
-	lastaccess = time(nullptr);
+	lastaccess = g_gui.gfx.getCachedTime();
 }
 
 void GameSprite::Image::clean(int time) {

--- a/source/rendering/core/graphics.h
+++ b/source/rendering/core/graphics.h
@@ -283,6 +283,10 @@ public:
 
 	// This is part of the binary
 	bool loadEditorSprites();
+
+	void updateTime();
+	time_t getCachedTime() const;
+
 	// Metadata should be loaded first
 	// This fills the item / creature adress space
 
@@ -332,6 +336,8 @@ private:
 	SpriteMap sprite_space;
 	using ImageMap = std::unordered_map<int, std::unique_ptr<GameSprite::Image>>;
 	ImageMap image_space;
+
+	time_t cached_time = 0;
 
 	DatFormat dat_format;
 	uint16_t item_count;

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/drawers/entities/sprite_drawer.cpp
+++ b/source/rendering/drawers/entities/sprite_drawer.cpp
@@ -22,7 +22,10 @@ void SpriteDrawer::ResetCache() {
 	last_bound_texture_ = 0;
 	// Log stats each frame
 	if (s_blitCount > 0) {
-		spdlog::info("SpriteDrawer: {} sprites drawn, {} zero-texture skipped", s_blitCount, s_zeroTextureCount);
+		static int log_counter = 0;
+		if (log_counter++ % 600 == 0) {
+			spdlog::info("SpriteDrawer: {} sprites drawn, {} zero-texture skipped", s_blitCount, s_zeroTextureCount);
+		}
 	}
 	s_blitCount = 0;
 	s_zeroTextureCount = 0;

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -191,7 +191,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground) {
+	if (options.show_tooltips && map_z == view.floor && tile->ground && map_x == view.mouse_map_x && map_y == view.mouse_map_y) {
 		TooltipData groundData = CreateItemTooltipData(tile->ground, location->getPosition(), tile->isHouseTile());
 		if (groundData.hasVisibleFields()) {
 			tooltip_drawer->addItemTooltip(groundData);
@@ -225,7 +225,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 			// items on tile
 			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (options.show_tooltips && map_z == view.floor && map_x == view.mouse_map_x && map_y == view.mouse_map_y) {
 					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
 					if (itemData.hasVisibleFields()) {
 						tooltip_drawer->addItemTooltip(itemData);

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -183,6 +183,8 @@ void MapCanvas::OnPaint(wxPaintEvent& event) {
 	SetCurrent(*g_gui.GetGLContext(this));
 
 	if (g_gui.IsRenderingEnabled()) {
+		g_gui.gfx.updateTime();
+
 		DrawingOptions& options = drawer->getOptions();
 		if (screenshot_controller->IsCapturing()) {
 			options.SetIngame();

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
Implemented 3 key performance optimizations identified by Profiler:
1.  **Restricted Tooltip Generation:** `TileRenderer::DrawTile` now only generates tooltip data for the tile under the mouse cursor, changing complexity from O(N) (all visible items) to O(1).
2.  **Cached Time Syscall:** `GraphicManager` now caches the current time once per frame (updated in `MapCanvas::OnPaint`), allowing `GameSprite::Image::visit` to use the cached value instead of calling `time(nullptr)` for every sprite part every frame.
3.  **Throttled Logging:** `SpriteDrawer::ResetCache` now logs debug info every 600 calls instead of every frame.

Additionally, fixed build errors preventing compilation:
*   Fixed iterator type mismatches in `SelectionOperations` and `DragShadowDrawer` caused by `editor.selection` type change (from vector to set) by using `auto`.
*   Fixed linker errors in `BrushPanel` and `PropertiesWindow` by removing legacy `DECLARE_EVENT_TABLE` macros from headers, as these classes have been migrated to `Bind()`.

---
*PR created automatically by Jules for task [7829509950659442318](https://jules.google.com/task/7829509950659442318) started by @karolak6612*