### PR TITLE
⚡ Bolt: Optimize Tooltip Data and Tile Rendering

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -84,7 +84,7 @@ static TooltipData CreateItemTooltipData(Item* item, const Position& pos, bool i
 		itemName = "Item";
 	}
 
-	TooltipData data(pos, id, std::string(itemName));
+	TooltipData data(pos, id, itemName);
 	data.actionId = action;
 	data.uniqueId = unique;
 	data.doorId = doorId;
@@ -221,6 +221,17 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	}
 
 	if (!only_colors) {
+		bool use_house_tint = false;
+		uint8_t house_r = 255, house_g = 255, house_b = 255;
+		bool is_current_house = false;
+
+		if (options.extended_house_shader && options.show_houses && tile->isHouseTile()) {
+			use_house_tint = true;
+			uint32_t house_id = tile->getHouseID();
+			TileColorCalculator::GetHouseColor(house_id, house_r, house_g, house_b);
+			is_current_house = ((int)house_id == (int)current_house_id);
+		}
+
 		if (view.zoom < 10.0 || !options.hide_items_when_zoomed) {
 			// items on tile
 			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
@@ -243,17 +254,13 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
-					if (options.extended_house_shader && options.show_houses && tile->isHouseTile()) {
-						uint32_t house_id = tile->getHouseID();
-						uint8_t hr = 255, hg = 255, hb = 255;
-						TileColorCalculator::GetHouseColor(house_id, hr, hg, hb);
-
+					if (use_house_tint) {
 						// Apply house color tint
-						ir = (uint8_t)((int)ir * hr / 255);
-						ig = (uint8_t)((int)ig * hg / 255);
-						ib = (uint8_t)((int)ib * hb / 255);
+						ir = (uint8_t)((int)ir * house_r / 255);
+						ig = (uint8_t)((int)ig * house_g / 255);
+						ib = (uint8_t)((int)ib * house_b / 255);
 
-						if ((int)house_id == current_house_id) {
+						if (is_current_house) {
 							// Pulse effect matching the tile pulse
 							if (options.highlight_pulse > 0.0f) {
 								float boost = options.highlight_pulse * 0.6f;

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -51,7 +51,7 @@ void TooltipDrawer::addItemTooltip(const TooltipData& data) {
 	tooltips.push_back(data);
 }
 
-void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
+void TooltipDrawer::addWaypointTooltip(Position pos, std::string_view name) {
 	if (name.empty()) {
 		return;
 	}
@@ -237,7 +237,7 @@ void TooltipDrawer::draw(const RenderView& view) {
 		std::vector<FieldLine> fields;
 
 		if (tooltip.category == TooltipCategory::WAYPOINT) {
-			fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
+			fields.push_back({ "Waypoint", std::string(tooltip.waypointName), WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
 		} else {
 			if (tooltip.actionId > 0) {
 				fields.push_back({ "Action ID", std::to_string(tooltip.actionId), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B, {} });
@@ -253,10 +253,10 @@ void TooltipDrawer::draw(const RenderView& view) {
 				fields.push_back({ "Destination", dest, TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B, {} });
 			}
 			if (!tooltip.description.empty()) {
-				fields.push_back({ "Description", tooltip.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
+				fields.push_back({ "Description", std::string(tooltip.description), BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
 			}
 			if (!tooltip.text.empty()) {
-				fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+				fields.push_back({ "Text", "\"" + std::string(tooltip.text) + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
 			}
 		}
 

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -24,6 +24,7 @@
 #include "rendering/core/render_view.h"
 #include <vector>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <map>
 
@@ -76,18 +77,18 @@ struct TooltipData {
 
 	// Header info
 	uint16_t itemId = 0;
-	std::string itemName;
+	std::string_view itemName;
 
 	// Optional fields (0 or empty = not shown)
 	uint16_t actionId = 0;
 	uint16_t uniqueId = 0;
 	uint8_t doorId = 0;
-	std::string text;
-	std::string description;
+	std::string_view text;
+	std::string_view description;
 	Position destination; // For teleports (check if valid via destination.x > 0)
 
 	// Waypoint-specific
-	std::string waypointName;
+	std::string_view waypointName;
 
 	// Container contents
 	std::vector<ContainerItem> containerItems;
@@ -96,11 +97,11 @@ struct TooltipData {
 	TooltipData() = default;
 
 	// Constructor for waypoint
-	TooltipData(Position p, const std::string& wpName) :
+	TooltipData(Position p, std::string_view wpName) :
 		pos(p), category(TooltipCategory::WAYPOINT), waypointName(wpName) { }
 
 	// Constructor for item
-	TooltipData(Position p, uint16_t id, const std::string& name) :
+	TooltipData(Position p, uint16_t id, std::string_view name) :
 		pos(p), category(TooltipCategory::ITEM), itemId(id), itemName(name) { }
 
 	// Determine category based on fields
@@ -133,7 +134,7 @@ public:
 	void addItemTooltip(const TooltipData& data);
 
 	// Add a waypoint tooltip
-	void addWaypointTooltip(Position pos, const std::string& name);
+	void addWaypointTooltip(Position pos, std::string_view name);
 
 	// Draw all tooltips
 	void draw(const RenderView& view);

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
Implemented performance optimizations for rendering:
1.  **TooltipData Optimization**: Converted `itemName`, `text`, `description`, and `waypointName` in `TooltipData` to `std::string_view`. This avoids allocating `std::string` for every tooltip generated per frame (which can be thousands if enabled).
2.  **DrawTile Optimization**: Hoisted `TileColorCalculator::GetHouseColor` out of the item loop in `TileRenderer::DrawTile`. Now calculated once per tile if extended house shaders are on, instead of for every item on the tile.
3.  **Build Fixes**: 
    *   Fixed build errors in `selection_operations.cpp` and `drag_shadow_drawer.cpp` where `TileSet::iterator` (vector) was used to iterate `editor.selection` (set). Replaced with `auto`.
    *   Removed `DECLARE_EVENT_TABLE()` from `BrushPanel`, `BrushIconBox`, `BrushListBox`, and `PropertiesWindow` headers as they use `Bind()` and caused linker errors.

Verified build passes with `ninja -C build_conan/build/Release`.

---
*PR created automatically by Jules for task [11523972509119818720](https://jules.google.com/task/11523972509119818720) started by @karolak6612*