### PR TITLE
[TILE/WXWIDGETS] Fix wxWidgets anti-patterns (Event Tables, GDI, newd) in UI components and resolve build errors

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -146,7 +146,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
+		for (auto it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours
 			Tile* t;
@@ -211,7 +211,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 
 	// New action for adding the destination tiles
 	action = editor.actionQueue->createAction(batchAction.get());
-	for (TileSet::iterator it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
+	for (auto it = tmp_storage.begin(); it != tmp_storage.end(); ++it) {
 		Tile* tile = (*it);
 		const Position old_pos = tile->getPosition();
 		Position new_pos;
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/ui/dcbutton.cpp
+++ b/source/ui/dcbutton.cpp
@@ -23,11 +23,6 @@
 #include "game/sprites.h"
 #include "ui/gui.h"
 
-BEGIN_EVENT_TABLE(DCButton, wxPanel)
-EVT_PAINT(DCButton::OnPaint)
-EVT_LEFT_DOWN(DCButton::OnClick)
-END_EVENT_TABLE()
-
 IMPLEMENT_DYNAMIC_CLASS(DCButton, wxPanel)
 
 DCButton::DCButton() :
@@ -38,6 +33,8 @@ DCButton::DCButton() :
 	sprite(nullptr),
 	overlay(nullptr) {
 	SetSprite(0);
+	Bind(wxEVT_PAINT, &DCButton::OnPaint, this);
+	Bind(wxEVT_LEFT_DOWN, &DCButton::OnClick, this);
 }
 
 DCButton::DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, RenderSize sz, int sprite_id) :
@@ -49,6 +46,8 @@ DCButton::DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, Rende
 	sprite(nullptr),
 	overlay(nullptr) {
 	SetSprite(sprite_id);
+	Bind(wxEVT_PAINT, &DCButton::OnPaint, this);
+	Bind(wxEVT_LEFT_DOWN, &DCButton::OnClick, this);
 }
 
 DCButton::~DCButton() {
@@ -101,23 +100,10 @@ void DCButton::OnPaint(wxPaintEvent& event) {
 		return;
 	}
 
-	static std::unique_ptr<wxPen> highlight_pen;
-	static std::unique_ptr<wxPen> dark_highlight_pen;
-	static std::unique_ptr<wxPen> light_shadow_pen;
-	static std::unique_ptr<wxPen> shadow_pen;
-
-	if (highlight_pen.get() == nullptr) {
-		highlight_pen.reset(newd wxPen(wxColor(0xFF, 0xFF, 0xFF), 1, wxSOLID));
-	}
-	if (dark_highlight_pen.get() == nullptr) {
-		dark_highlight_pen.reset(newd wxPen(wxColor(0xD4, 0xD0, 0xC8), 1, wxSOLID));
-	}
-	if (light_shadow_pen.get() == nullptr) {
-		light_shadow_pen.reset(newd wxPen(wxColor(0x80, 0x80, 0x80), 1, wxSOLID));
-	}
-	if (shadow_pen.get() == nullptr) {
-		shadow_pen.reset(newd wxPen(wxColor(0x40, 0x40, 0x40), 1, wxSOLID));
-	}
+	wxPen* highlight_pen = wxThePenList->FindOrCreatePen(wxColor(0xFF, 0xFF, 0xFF), 1, wxSOLID);
+	wxPen* dark_highlight_pen = wxThePenList->FindOrCreatePen(wxColor(0xD4, 0xD0, 0xC8), 1, wxSOLID);
+	wxPen* light_shadow_pen = wxThePenList->FindOrCreatePen(wxColor(0x80, 0x80, 0x80), 1, wxSOLID);
+	wxPen* shadow_pen = wxThePenList->FindOrCreatePen(wxColor(0x40, 0x40, 0x40), 1, wxSOLID);
 
 	int size_x = 20, size_y = 20;
 
@@ -129,7 +115,7 @@ void DCButton::OnPaint(wxPaintEvent& event) {
 		size_y = 36;
 	}
 
-	pdc.SetBrush(*wxBLACK);
+	pdc.SetBrush(*wxBLACK_BRUSH);
 	pdc.DrawRectangle(0, 0, size_x, size_y);
 	if (type == DC_BTN_TOGGLE && GetValue()) {
 		pdc.SetPen(*shadow_pen);

--- a/source/ui/dcbutton.h
+++ b/source/ui/dcbutton.h
@@ -58,7 +58,6 @@ protected:
 	Sprite* overlay;
 
 	DECLARE_DYNAMIC_CLASS(DCButton)
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -24,12 +24,6 @@
 #include "brushes/brush.h"
 #include "brushes/raw/raw_brush.h"
 
-BEGIN_EVENT_TABLE(FindItemDialog, wxDialog)
-EVT_TIMER(wxID_ANY, FindItemDialog::OnInputTimer)
-EVT_BUTTON(wxID_OK, FindItemDialog::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, FindItemDialog::OnClickCancel)
-END_EVENT_TABLE()
-
 FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onlyPickupables /* = false*/) :
 	wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600), wxDEFAULT_DIALOG_STYLE),
 	input_timer(this),
@@ -38,9 +32,9 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	only_pickupables(onlyPickupables) {
 	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
 
-	wxBoxSizer* box_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	wxBoxSizer* box_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-	wxBoxSizer* options_box_sizer = newd wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* options_box_sizer = new wxBoxSizer(wxVERTICAL);
 
 	wxString radio_boxChoices[] = { "Find by Server ID",
 									"Find by Client ID",
@@ -49,30 +43,30 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 									"Find by Properties" };
 
 	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
-	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
+	options_radio_box = new wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
 	options_radio_box->SetSelection(SearchMode::ServerIDs);
 	options_box_sizer->Add(options_radio_box, 0, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
-	server_id_spin = newd wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
+	wxStaticBoxSizer* server_id_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
+	server_id_spin = new wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
 	server_id_spin->SetToolTip("Search by server ID");
 	server_id_box_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
 
-	invalid_item = newd wxCheckBox(server_id_box_sizer->GetStaticBox(), wxID_ANY, "Force select", wxDefaultPosition, wxDefaultSize, 0);
+	invalid_item = new wxCheckBox(server_id_box_sizer->GetStaticBox(), wxID_ANY, "Force select", wxDefaultPosition, wxDefaultSize, 0);
 	invalid_item->SetToolTip("Force choose item ID that does not appear on the list.");
 	server_id_box_sizer->Add(invalid_item, 1, wxALL | wxEXPAND, 5);
 
 	options_box_sizer->Add(server_id_box_sizer, 1, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
-	client_id_spin = newd wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
+	wxStaticBoxSizer* client_id_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
+	client_id_spin = new wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
 	client_id_spin->SetToolTip("Search by client ID");
 	client_id_spin->Enable(false);
 	client_id_box_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
 	options_box_sizer->Add(client_id_box_sizer, 1, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
-	name_text_input = newd wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+	wxStaticBoxSizer* name_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
+	name_text_input = new wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
 	name_text_input->SetToolTip("Search by item name");
 	name_text_input->Enable(false);
 	name_box_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
@@ -81,11 +75,11 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	// spacer
 	options_box_sizer->Add(0, 0, 4, wxALL | wxEXPAND, 5);
 
-	buttons_box_sizer = newd wxStdDialogButtonSizer();
-	ok_button = newd wxButton(this, wxID_OK);
+	buttons_box_sizer = new wxStdDialogButtonSizer();
+	ok_button = new wxButton(this, wxID_OK);
 	ok_button->SetToolTip("Select an item to confirm");
 	buttons_box_sizer->AddButton(ok_button);
-	cancel_button = newd wxButton(this, wxID_CANCEL);
+	cancel_button = new wxButton(this, wxID_CANCEL);
 	cancel_button->SetToolTip("Cancel selection");
 	buttons_box_sizer->AddButton(cancel_button);
 	buttons_box_sizer->Realize();
@@ -95,7 +89,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	// --------------- Types ---------------
 
-	wxStaticBoxSizer* type_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Types"), wxVERTICAL);
+	wxStaticBoxSizer* type_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Types"), wxVERTICAL);
 
 	wxString types_choices[] = { "Depot",
 								 "Mailbox",
@@ -109,7 +103,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 								 "Podium" };
 
 	int types_choices_count = sizeof(types_choices) / sizeof(wxString);
-	types_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
+	types_radio_box = new wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
 	types_radio_box->SetSelection(0);
 	types_radio_box->Enable(false);
 	type_box_sizer->Add(types_radio_box, 0, wxALL | wxEXPAND, 5);
@@ -118,67 +112,67 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	// --------------- Properties ---------------
 
-	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
+	wxStaticBoxSizer* properties_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
 
-	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
+	unpassable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
 	unpassable->SetToolTip("Item blocks movement");
 	properties_box_sizer->Add(unpassable, 0, wxALL, 5);
 
-	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
+	unmovable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
 	unmovable->SetToolTip("Item cannot be moved");
 	properties_box_sizer->Add(unmovable, 0, wxALL, 5);
 
-	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
+	block_missiles = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
 	block_missiles->SetToolTip("Item blocks projectiles");
 	properties_box_sizer->Add(block_missiles, 0, wxALL, 5);
 
-	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
+	block_pathfinder = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
 	block_pathfinder->SetToolTip("Item blocks pathfinding");
 	properties_box_sizer->Add(block_pathfinder, 0, wxALL, 5);
 
-	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
+	readable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
 	readable->SetToolTip("Item has text");
 	properties_box_sizer->Add(readable, 0, wxALL, 5);
 
-	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
+	writeable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
 	writeable->SetToolTip("Item can be written on");
 	properties_box_sizer->Add(writeable, 0, wxALL, 5);
 
-	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
+	pickupable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
 	pickupable->SetToolTip("Item can be picked up");
 	pickupable->SetValue(only_pickupables);
 	pickupable->Enable(!only_pickupables);
 	properties_box_sizer->Add(pickupable, 0, wxALL, 5);
 
-	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
+	stackable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
 	stackable->SetToolTip("Item is stackable");
 	properties_box_sizer->Add(stackable, 0, wxALL, 5);
 
-	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
+	rotatable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
 	rotatable->SetToolTip("Item can be rotated");
 	properties_box_sizer->Add(rotatable, 0, wxALL, 5);
 
-	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
+	hangable = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
 	hangable->SetToolTip("Item can be hung on walls");
 	properties_box_sizer->Add(hangable, 0, wxALL, 5);
 
-	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
+	hook_east = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
 	hook_east->SetToolTip("Item hooks to the east");
 	properties_box_sizer->Add(hook_east, 0, wxALL, 5);
 
-	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
+	hook_south = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
 	hook_south->SetToolTip("Item hooks to the south");
 	properties_box_sizer->Add(hook_south, 0, wxALL, 5);
 
-	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
+	has_elevation = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
 	has_elevation->SetToolTip("Item has height (elevation)");
 	properties_box_sizer->Add(has_elevation, 0, wxALL, 5);
 
-	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
+	ignore_look = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
 	ignore_look->SetToolTip("Item is ignored when looking");
 	properties_box_sizer->Add(ignore_look, 0, wxALL, 5);
 
-	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
+	floor_change = new wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
 	floor_change->SetToolTip("Item causes floor change");
 	properties_box_sizer->Add(floor_change, 0, wxALL, 5);
 
@@ -186,8 +180,8 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	// --------------- Items list ---------------
 
-	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
-	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
+	wxStaticBoxSizer* result_box_sizer = new wxStaticBoxSizer(new wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
+	items_list = new FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
 	items_list->SetMinSize(wxSize(230, 512));
 	result_box_sizer->Add(items_list, 0, wxALL, 5);
 	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
@@ -224,6 +218,10 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	ignore_look->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
 	floor_change->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
 	invalid_item->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
+
+	Bind(wxEVT_TIMER, &FindItemDialog::OnInputTimer, this);
+	Bind(wxEVT_BUTTON, &FindItemDialog::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &FindItemDialog::OnClickCancel, this, wxID_CANCEL);
 }
 
 FindItemDialog::~FindItemDialog() {

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -111,8 +111,6 @@ private:
 	Brush* result_brush;
 	uint16_t result_id;
 	bool only_pickupables;
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif // RME_FIND_ITEM_WINDOW_H_

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -39,11 +39,6 @@
 // ============================================================================
 // Tileset Window
 
-BEGIN_EVENT_TABLE(TilesetWindow, wxDialog)
-EVT_BUTTON(wxID_OK, TilesetWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, TilesetWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
 TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
@@ -52,37 +47,37 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	tileset_field(nullptr) {
 	ASSERT(edit_item);
 
-	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
+	wxSizer* topsizer = new wxBoxSizer(wxVERTICAL);
 	wxString description = "Move to Tileset";
 
-	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, description);
+	wxSizer* boxsizer = new wxStaticBoxSizer(wxVERTICAL, this, description);
 
-	wxFlexGridSizer* subsizer = newd wxFlexGridSizer(2, 10, 10);
+	wxFlexGridSizer* subsizer = new wxFlexGridSizer(2, 10, 10);
 	subsizer->AddGrowableCol(1);
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "ID " + i2ws(item->getID())));
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "\"" + wxstr(item->getName()) + "\""));
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "ID " + i2ws(item->getID())));
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "\"" + wxstr(item->getName()) + "\""));
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Palette"));
-	palette_field = newd wxChoice(this, wxID_ANY);
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "Palette"));
+	palette_field = new wxChoice(this, wxID_ANY);
 	palette_field->SetToolTip("Select the palette category");
 
-	palette_field->Append("Terrain", newd int(TILESET_TERRAIN));
-	palette_field->Append("Collections", newd int(TILESET_COLLECTION));
-	palette_field->Append("Doodad", newd int(TILESET_DOODAD));
-	palette_field->Append("Item", newd int(TILESET_ITEM));
-	palette_field->Append("Raw", newd int(TILESET_RAW));
+	palette_field->Append("Terrain", new int(TILESET_TERRAIN));
+	palette_field->Append("Collections", new int(TILESET_COLLECTION));
+	palette_field->Append("Doodad", new int(TILESET_DOODAD));
+	palette_field->Append("Item", new int(TILESET_ITEM));
+	palette_field->Append("Raw", new int(TILESET_RAW));
 	palette_field->SetSelection(3);
 
-	palette_field->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(TilesetWindow::OnChangePalette), nullptr, this);
+	palette_field->Bind(wxEVT_COMMAND_CHOICE_SELECTED, &TilesetWindow::OnChangePalette, this);
 	subsizer->Add(palette_field, wxSizerFlags(1).Expand());
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));
-	tileset_field = newd wxChoice(this, wxID_ANY);
+	subsizer->Add(new wxStaticText(this, wxID_ANY, "Tileset"));
+	tileset_field = new wxChoice(this, wxID_ANY);
 	tileset_field->SetToolTip("Select the target tileset");
 
 	for (TilesetContainer::iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
-		tileset_field->Append(wxstr(iter->second->name), newd std::string(iter->second->name));
+		tileset_field->Append(wxstr(iter->second->name), new std::string(iter->second->name));
 	}
 	tileset_field->SetSelection(0);
 	subsizer->Add(tileset_field, wxSizerFlags(1).Expand());
@@ -91,10 +86,13 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 20));
 
-	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
-	subsizer_->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	subsizer_->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxSizer* subsizer_ = new wxBoxSizer(wxHORIZONTAL);
+	subsizer_->Add(new wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	subsizer_->Add(new wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
+
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickCancel, this, wxID_CANCEL);
 
 	SetSizerAndFit(topsizer);
 	Centre(wxBOTH);
@@ -105,7 +103,7 @@ void TilesetWindow::OnChangePalette(wxCommandEvent& WXUNUSED(event)) {
 
 	for (TilesetContainer::iterator iter = g_materials.tilesets.begin(); iter != g_materials.tilesets.end(); ++iter) {
 		if (iter->second->getCategory(TilesetCategoryType(*static_cast<int*>(palette_field->GetClientData(palette_field->GetSelection()))))->brushlist.size() > 0) {
-			tileset_field->Append(wxstr(iter->second->name), newd std::string(iter->second->name));
+			tileset_field->Append(wxstr(iter->second->name), new std::string(iter->second->name));
 		}
 	}
 

--- a/source/ui/tileset_window.h
+++ b/source/ui/tileset_window.h
@@ -39,8 +39,6 @@ protected:
 	// tileset
 	wxChoice* palette_field;
 	wxChoice* tileset_field;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif


### PR DESCRIPTION
ISSUE: Several UI components used legacy wxWidgets macros (`BEGIN_EVENT_TABLE`, `newd`) and inefficient GDI object management. Additionally, the build was broken due to iterator type mismatches in selection operations.
IMPACT: The code was harder to maintain, used deprecated features, and the project failed to compile in Release mode.
FIX:
1.  Refactored `DCButton`, `TilesetWindow`, and `FindItemDialog` to use `Bind()`.
2.  Replaced `newd` with `new`.
3.  Used `wxThePenList` for caching pens in `DCButton`.
4.  Updated `selection_operations.cpp` and `drag_shadow_drawer.cpp` to use `auto` iterators for `editor.selection` loops.
DOMAIN CONTEXT: This aligns with the "Atlas" agent's goal of modernizing wxWidgets usage and fixing domain-specific issues.
PERFORMANCE: Minor improvement in GDI resource usage (caching).
TESTED: Verified that the refactored files compile successfully using Ninja. Verified that the previously failing files (`selection_operations.cpp`, `drag_shadow_drawer.cpp`) now compile.

---
*PR created automatically by Jules for task [15703119755089251925](https://jules.google.com/task/15703119755089251925) started by @karolak6612*