### PR TITLE
Optimize tile border rendering using SpriteBatch

### DIFF
--- a/source/rendering/drawers/entities/sprite_drawer.cpp
+++ b/source/rendering/drawers/entities/sprite_drawer.cpp
@@ -61,6 +61,17 @@ void SpriteDrawer::glBlitSquare(SpriteBatch& sprite_batch, int sx, int sy, int r
 	}
 }
 
+void SpriteDrawer::glDrawBox(SpriteBatch& sprite_batch, int sx, int sy, int width, int height, int red, int green, int blue, int alpha) {
+	float normalizedR = red / 255.0f;
+	float normalizedG = green / 255.0f;
+	float normalizedB = blue / 255.0f;
+	float normalizedA = alpha / 255.0f;
+
+	if (g_gui.gfx.hasAtlasManager()) {
+		sprite_batch.drawRectLines((float)sx, (float)sy, (float)width, (float)height, glm::vec4(normalizedR, normalizedG, normalizedB, normalizedA), *g_gui.gfx.getAtlasManager());
+	}
+}
+
 void SpriteDrawer::glSetColor(wxColor color) {
 	// Not needed with BatchRenderer automatic color handling in DrawQuad,
 	// but if used for stateful drawing elsewhere, we might need a state setter.

--- a/source/rendering/drawers/entities/sprite_drawer.h
+++ b/source/rendering/drawers/entities/sprite_drawer.h
@@ -25,6 +25,7 @@ public:
 
 	void glBlitAtlasQuad(SpriteBatch& sprite_batch, int sx, int sy, const AtlasRegion* region, int red, int green, int blue, int alpha);
 	void glBlitSquare(SpriteBatch& sprite_batch, int sx, int sy, int red, int green, int blue, int alpha, int size = 0);
+	void glDrawBox(SpriteBatch& sprite_batch, int sx, int sy, int width, int height, int red, int green, int blue, int alpha);
 	void glSetColor(wxColor color);
 
 	void BlitSprite(SpriteBatch& sprite_batch, int screenx, int screeny, uint32_t spriteid, int red = 255, int green = 255, int blue = 255, int alpha = 255);

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -212,12 +212,15 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 		// Map coordinates to screen coordinates
 		// draw_x, draw_y are defined in the beginning of function and are top-left of the tile
-		float x = (float)draw_x;
-		float y = (float)draw_y;
-		float s = 32.0f; // Standard tile size
-
 		// Draw 1px solid border using geometry generation
-		primitive_renderer.drawBox(glm::vec4(x, y, s, s), border_color, 1.0f);
+		// primitive_renderer.drawBox(glm::vec4(x, y, s, s), border_color, 1.0f);
+
+		// Use SpriteDrawer to keep batching unified (prevents PrimitiveRenderer flush/state change)
+		int br = (int)(border_color.r * 255.0f);
+		int bg = (int)(border_color.g * 255.0f);
+		int bb = (int)(border_color.b * 255.0f);
+		int ba = (int)(border_color.a * 255.0f);
+		sprite_drawer->glDrawBox(sprite_batch, draw_x, draw_y, 32, 32, br, bg, bb, ba);
 	}
 
 	if (!only_colors) {


### PR DESCRIPTION
OPENGL RENDERING SPECIALIST - Daily Report
Date: 2024-12-15

Quick Summary
Found 1 critical issue in TileRenderer.cpp - mixed batching systems.
Estimated improvement: Correct Z-ordering and elimination of dynamic geometry uploads.

Issues Fixed:

CRITICAL: Mixed batching systems (SpriteBatch + PrimitiveRenderer) in tile loop
Location: source/rendering/drawers/tiles/tile_renderer.cpp
Problem: DrawTile called `primitive_renderer.drawBox` (for house borders) between `SpriteBatch` calls. This split the render stream, forcing borders to always draw on top of items/sprites regardless of logical order, or requiring expensive mid-frame flushes to correct Z-order.
Fix: Implemented `glDrawBox` in `SpriteDrawer` using `SpriteBatch::drawRectLines` (which uses instancing and shares the sprite depth stream) and replaced the `primitive_renderer` call.
Result: Unified batching, correct Z-order, fewer potential draw calls.

HIGH: Static geometry uploaded every frame (House Borders)
Problem: `PrimitiveRenderer::drawBox` generated vertex data (triangles/lines) and uploaded it to the GPU via `glNamedBufferSubData` every frame for every visible house tile border.
Fix: Using `SpriteBatch` for borders leverages instanced rendering with a static quad VBO, only uploading lightweight instance data.

Other Findings (Not Fixed):
MEDIUM: Draw Call Explosion in MinimapRenderer (Low priority due to large chunk size).


---
*PR created automatically by Jules for task [13497506573398570407](https://jules.google.com/task/13497506573398570407) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rendering performance by unifying sprite batching for tile borders, eliminating unnecessary renderer state changes and flushes.
  * Enhanced rendering consistency across the graphics pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->