### PR TITLE
[REFACTOR] Fix Long Method smells in IOMapOTBM

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -601,8 +601,7 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 	return true;
 }
 
-bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
-	spdlog::info("IOMapOTBM::loadMap - Start loading from file: {}", nstr(filename.GetFullPath()));
+bool IOMapOTBM::loadOTGZ(Map& map, const FileName& filename) {
 #ifdef OTGZ_SUPPORT
 	if (filename.GetExt() == "otgz") {
 		// Open the archive
@@ -614,8 +613,8 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		}
 
 		// Memory buffers for the houses & spawns
-		std::shared_ptr<uint8_t> house_buffer;
-		std::shared_ptr<uint8_t> spawn_buffer;
+		std::unique_ptr<uint8_t[]> house_buffer;
+		std::unique_ptr<uint8_t[]> spawn_buffer;
 		size_t house_buffer_size = 0;
 		size_t spawn_buffer_size = 0;
 
@@ -631,7 +630,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 			if (entryName == "world/map.otbm") {
 				// Read the entire OTBM file into a memory region
 				size_t otbm_size = archive_entry_size(entry);
-				std::shared_ptr<uint8_t> otbm_buffer(new uint8_t[otbm_size], [](uint8_t* p) { delete[] p; });
+				std::unique_ptr<uint8_t[]> otbm_buffer(new uint8_t[otbm_size]);
 
 				// Read from the archive
 				size_t read_bytes = archive_read_data(a.get(), otbm_buffer.get(), otbm_size);
@@ -723,6 +722,16 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		return true;
 	}
 #endif
+	return false;
+}
+
+bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
+	spdlog::info("IOMapOTBM::loadMap - Start loading from file: {}", nstr(filename.GetFullPath()));
+#ifdef OTGZ_SUPPORT
+	if (filename.GetExt() == "otgz") {
+		return loadOTGZ(map, filename);
+	}
+#endif
 
 	std::ifstream file(nstr(filename.GetFullPath()), std::ios::binary | std::ios::ate);
 	if (!file.is_open()) {
@@ -787,6 +796,200 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		map.waypointfile = nstr(filename.GetName()) + "-waypoint.xml";
 	}
 	spdlog::info("IOMapOTBM::loadMap - Finished loading from file: {}", nstr(filename.GetFullPath()));
+	return true;
+}
+
+bool IOMapOTBM::readTileArea(Map& map, BinaryNode* mapNode) {
+	uint16_t base_x, base_y;
+	uint8_t base_z;
+	if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
+		warning("Invalid map node, no base coordinate");
+		return false;
+	}
+
+	for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
+		Tile* tile = nullptr;
+		uint8_t tile_type;
+		if (!tileNode->getByte(tile_type)) {
+			warning("Invalid tile type");
+			continue;
+		}
+		if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
+			uint8_t x_offset, y_offset;
+			if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
+				warning("Could not read position of tile");
+				continue;
+			}
+			const Position pos(base_x + x_offset, base_y + y_offset, base_z);
+
+			if (map.getTile(pos)) {
+				warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
+				continue;
+			}
+
+			tile = map.allocator(map.createTileL(pos));
+			House* house = nullptr;
+			if (tile_type == OTBM_HOUSETILE) {
+				uint32_t house_id;
+				if (!tileNode->getU32(house_id)) {
+					warning("House tile without house data, discarding tile");
+					continue;
+				}
+				if (house_id) {
+					house = map.houses.getHouse(house_id);
+					if (!house) {
+						house = newd House(map);
+						house->setID(house_id);
+						map.houses.addHouse(house);
+					}
+				} else {
+					warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
+				}
+			}
+
+			uint8_t attribute;
+			while (tileNode->getU8(attribute)) {
+				switch (attribute) {
+					case OTBM_ATTR_TILE_FLAGS: {
+						uint32_t flags = 0;
+						if (!tileNode->getU32(flags)) {
+							warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->setMapFlags(flags);
+						break;
+					}
+					case OTBM_ATTR_ITEM: {
+						Item* item = Item::Create_OTBM(*this, tileNode);
+						if (item == nullptr) {
+							warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->addItem(item);
+						break;
+					}
+					default: {
+						warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
+						break;
+					}
+				}
+			}
+
+			for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
+				Item* item = nullptr;
+				uint8_t item_type;
+				if (!itemNode->getByte(item_type)) {
+					warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
+					continue;
+				}
+				if (item_type == OTBM_ITEM) {
+					item = Item::Create_OTBM(*this, itemNode);
+					if (item) {
+						if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
+							warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						// reform(&map, tile, item);
+						tile->addItem(item);
+					}
+				} else {
+					warning("Unknown type of tile child node");
+				}
+			}
+
+			tile->update();
+			if (house) {
+				house->addTile(tile);
+			}
+
+			map.setTile(pos.x, pos.y, pos.z, tile);
+		} else {
+			warning("Unknown type of tile node");
+		}
+	}
+	return true;
+}
+
+bool IOMapOTBM::readTowns(Map& map, BinaryNode* mapNode) {
+	for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
+		Town* town = nullptr;
+		uint8_t town_type;
+		if (!townNode->getByte(town_type)) {
+			warning("Invalid town type (1)");
+			continue;
+		}
+		if (town_type != OTBM_TOWN) {
+			warning("Invalid town type (2)");
+			continue;
+		}
+		uint32_t town_id;
+		if (!townNode->getU32(town_id)) {
+			warning("Invalid town id");
+			continue;
+		}
+
+		town = map.towns.getTown(town_id);
+		if (town) {
+			warning("Duplicate town id %d, discarding duplicate", town_id);
+			continue;
+		} else {
+			town = newd Town(town_id);
+			if (!map.towns.addTown(town)) {
+				delete town;
+				continue;
+			}
+		}
+		std::string town_name;
+		if (!townNode->getString(town_name)) {
+			warning("Invalid town name");
+			continue;
+		}
+		town->setName(town_name);
+		Position pos;
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
+			warning("Invalid town temple position");
+			continue;
+		}
+		pos.x = x;
+		pos.y = y;
+		pos.z = z;
+		town->setTemplePosition(pos);
+		map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
+	}
+	return true;
+}
+
+bool IOMapOTBM::readWaypoints(Map& map, BinaryNode* mapNode) {
+	for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
+		uint8_t waypoint_type;
+		if (!waypointNode->getByte(waypoint_type)) {
+			warning("Invalid waypoint type (1)");
+			continue;
+		}
+		if (waypoint_type != OTBM_WAYPOINT) {
+			warning("Invalid waypoint type (2)");
+			continue;
+		}
+
+		Waypoint wp;
+
+		if (!waypointNode->getString(wp.name)) {
+			warning("Invalid waypoint name");
+			continue;
+		}
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
+			warning("Invalid waypoint position");
+			continue;
+		}
+		wp.pos.x = x;
+		wp.pos.y = y;
+		wp.pos.z = z;
+
+		map.waypoints.addWaypoint(newd Waypoint(wp));
+	}
 	return true;
 }
 
@@ -905,190 +1108,11 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 			continue;
 		}
 		if (node_type == OTBM_TILE_AREA) {
-			uint16_t base_x, base_y;
-			uint8_t base_z;
-			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
-				continue;
-			}
-
-			for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
-				Tile* tile = nullptr;
-				uint8_t tile_type;
-				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
-					continue;
-				}
-				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
-					uint8_t x_offset, y_offset;
-					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
-						continue;
-					}
-					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
-
-					if (map.getTile(pos)) {
-						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
-						continue;
-					}
-
-					tile = map.allocator(map.createTileL(pos));
-					House* house = nullptr;
-					if (tile_type == OTBM_HOUSETILE) {
-						uint32_t house_id;
-						if (!tileNode->getU32(house_id)) {
-							warning("House tile without house data, discarding tile");
-							continue;
-						}
-						if (house_id) {
-							house = map.houses.getHouse(house_id);
-							if (!house) {
-								house = newd House(map);
-								house->setID(house_id);
-								map.houses.addHouse(house);
-							}
-						} else {
-							warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
-						}
-					}
-
-					uint8_t attribute;
-					while (tileNode->getU8(attribute)) {
-						switch (attribute) {
-							case OTBM_ATTR_TILE_FLAGS: {
-								uint32_t flags = 0;
-								if (!tileNode->getU32(flags)) {
-									warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->setMapFlags(flags);
-								break;
-							}
-							case OTBM_ATTR_ITEM: {
-								Item* item = Item::Create_OTBM(*this, tileNode);
-								if (item == nullptr) {
-									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->addItem(item);
-								break;
-							}
-							default: {
-								warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
-								break;
-							}
-						}
-					}
-
-					for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
-						Item* item = nullptr;
-						uint8_t item_type;
-						if (!itemNode->getByte(item_type)) {
-							warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
-							continue;
-						}
-						if (item_type == OTBM_ITEM) {
-							item = Item::Create_OTBM(*this, itemNode);
-							if (item) {
-								if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
-									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								// reform(&map, tile, item);
-								tile->addItem(item);
-							}
-						} else {
-							warning("Unknown type of tile child node");
-						}
-					}
-
-					tile->update();
-					if (house) {
-						house->addTile(tile);
-					}
-
-					map.setTile(pos.x, pos.y, pos.z, tile);
-				} else {
-					warning("Unknown type of tile node");
-				}
-			}
+			readTileArea(map, mapNode);
 		} else if (node_type == OTBM_TOWNS) {
-			for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
-				Town* town = nullptr;
-				uint8_t town_type;
-				if (!townNode->getByte(town_type)) {
-					warning("Invalid town type (1)");
-					continue;
-				}
-				if (town_type != OTBM_TOWN) {
-					warning("Invalid town type (2)");
-					continue;
-				}
-				uint32_t town_id;
-				if (!townNode->getU32(town_id)) {
-					warning("Invalid town id");
-					continue;
-				}
-
-				town = map.towns.getTown(town_id);
-				if (town) {
-					warning("Duplicate town id %d, discarding duplicate", town_id);
-					continue;
-				} else {
-					town = newd Town(town_id);
-					if (!map.towns.addTown(town)) {
-						delete town;
-						continue;
-					}
-				}
-				std::string town_name;
-				if (!townNode->getString(town_name)) {
-					warning("Invalid town name");
-					continue;
-				}
-				town->setName(town_name);
-				Position pos;
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
-					warning("Invalid town temple position");
-					continue;
-				}
-				pos.x = x;
-				pos.y = y;
-				pos.z = z;
-				town->setTemplePosition(pos);
-				map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
-			}
+			readTowns(map, mapNode);
 		} else if (node_type == OTBM_WAYPOINTS) {
-			for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
-				uint8_t waypoint_type;
-				if (!waypointNode->getByte(waypoint_type)) {
-					warning("Invalid waypoint type (1)");
-					continue;
-				}
-				if (waypoint_type != OTBM_WAYPOINT) {
-					warning("Invalid waypoint type (2)");
-					continue;
-				}
-
-				Waypoint wp;
-
-				if (!waypointNode->getString(wp.name)) {
-					warning("Invalid waypoint name");
-					continue;
-				}
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
-					warning("Invalid waypoint position");
-					continue;
-				}
-				wp.pos.x = x;
-				wp.pos.y = y;
-				wp.pos.z = z;
-
-				map.waypoints.addWaypoint(newd Waypoint(wp));
-			}
+			readWaypoints(map, mapNode);
 		}
 	}
 
@@ -1488,6 +1512,57 @@ bool IOMapOTBM::saveMap(Map& map, const FileName& identifier) {
 	return true;
 }
 
+bool IOMapOTBM::saveTile(NodeFileWriteHandle& f, Tile* save_tile) const {
+	f.addNode(save_tile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
+
+	f.addU8(save_tile->getX() & 0xFF);
+	f.addU8(save_tile->getY() & 0xFF);
+
+	if (save_tile->isHouseTile()) {
+		f.addU32(save_tile->getHouseID());
+	}
+
+	if (save_tile->getMapFlags()) {
+		f.addByte(OTBM_ATTR_TILE_FLAGS);
+		f.addU32(save_tile->getMapFlags());
+	}
+
+	if (save_tile->ground) {
+		Item* ground = save_tile->ground;
+		if (ground->isMetaItem()) {
+			// Do nothing, we don't save metaitems...
+		} else if (ground->hasBorderEquivalent()) {
+			bool found = false;
+			for (Item* item : save_tile->items) {
+				if (item->getGroundEquivalent() == ground->getID()) {
+					// Do nothing
+					// Found equivalent
+					found = true;
+					break;
+				}
+			}
+
+			if (!found) {
+				ground->serializeItemNode_OTBM(*this, f);
+			}
+		} else if (ground->isComplex()) {
+			ground->serializeItemNode_OTBM(*this, f);
+		} else {
+			f.addByte(OTBM_ATTR_ITEM);
+			ground->serializeItemCompact_OTBM(*this, f);
+		}
+	}
+
+	for (Item* item : save_tile->items) {
+		if (!item->isMetaItem()) {
+			item->serializeItemNode_OTBM(*this, f);
+		}
+	}
+
+	f.endNode();
+	return true;
+}
+
 bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 	/* STOP!
 	 * Before you even think about modifying this, please reconsider.
@@ -1573,53 +1648,7 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 					f.addU16(local_y = pos.y & 0xFF00);
 					f.addU8(local_z = pos.z);
 				}
-				f.addNode(save_tile->isHouseTile() ? OTBM_HOUSETILE : OTBM_TILE);
-
-				f.addU8(save_tile->getX() & 0xFF);
-				f.addU8(save_tile->getY() & 0xFF);
-
-				if (save_tile->isHouseTile()) {
-					f.addU32(save_tile->getHouseID());
-				}
-
-				if (save_tile->getMapFlags()) {
-					f.addByte(OTBM_ATTR_TILE_FLAGS);
-					f.addU32(save_tile->getMapFlags());
-				}
-
-				if (save_tile->ground) {
-					Item* ground = save_tile->ground;
-					if (ground->isMetaItem()) {
-						// Do nothing, we don't save metaitems...
-					} else if (ground->hasBorderEquivalent()) {
-						bool found = false;
-						for (Item* item : save_tile->items) {
-							if (item->getGroundEquivalent() == ground->getID()) {
-								// Do nothing
-								// Found equivalent
-								found = true;
-								break;
-							}
-						}
-
-						if (!found) {
-							ground->serializeItemNode_OTBM(self, f);
-						}
-					} else if (ground->isComplex()) {
-						ground->serializeItemNode_OTBM(self, f);
-					} else {
-						f.addByte(OTBM_ATTR_ITEM);
-						ground->serializeItemCompact_OTBM(self, f);
-					}
-				}
-
-				for (Item* item : save_tile->items) {
-					if (!item->isMetaItem()) {
-						item->serializeItemNode_OTBM(self, f);
-					}
-				}
-
-				f.endNode();
+				saveTile(f, save_tile);
 				++map_iterator;
 			}
 

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -139,6 +139,14 @@ protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+	bool loadOTGZ(Map& map, const FileName& filename);
+
+	bool readTileArea(Map& map, BinaryNode* mapNode);
+	bool readTowns(Map& map, BinaryNode* mapNode);
+	bool readWaypoints(Map& map, BinaryNode* mapNode);
+
+	bool saveTile(NodeFileWriteHandle& f, Tile* save_tile) const;
+
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
This PR addresses "Long Method" and "Bloater" code smells in `source/io/iomap_otbm.cpp` as identified by the Smeller agent instructions.

**Changes:**
1.  **Refactored `IOMapOTBM::loadMap` (File Loading):** Extracted the logic for loading `.otgz` archives into a private helper method `loadOTGZ`.
2.  **Refactored `IOMapOTBM::loadMap` (Parsing):** Extracted the parsing logic for `OTBM_TILE_AREA`, `OTBM_TOWNS`, and `OTBM_WAYPOINTS` into separate private helper methods (`readTileArea`, `readTowns`, `readWaypoints`). This significantly reduces the cyclomatic complexity and length of the main loading loop.
3.  **Refactored `IOMapOTBM::saveMap`:** Extracted the logic for saving a single tile into a `const` private helper method `saveTile`.
4.  **Fixed Resource Management:** Replaced `std::shared_ptr<uint8_t>` with `std::unique_ptr<uint8_t[]>` for `house_buffer`, `spawn_buffer`, and `otbm_buffer` in `loadOTGZ`. This fixes a mismatched `new[]`/`delete` warning (undefined behavior) and enforces better RAII for array buffers.

**Verification:**
- Validated that the code compiles successfully using `ninja`.
- Verified that the refactored methods maintain the original logic and control flow.

---
*PR created automatically by Jules for task [39426098011617814](https://jules.google.com/task/39426098011617814) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Maps can now be loaded from OTGZ compressed archives with automatic decompression and seamless data extraction.

* **Chores**
  * Refactored internal map parsing and serialization logic for improved code organization.
  * Enhanced memory management for buffer allocation during map loading operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->