### PR TITLE
📊 Profiler: Fix CPU/IO bottlenecks in rendering loop

### DIFF
--- a/.jules/profiler.md
+++ b/.jules/profiler.md
@@ -2,3 +2,8 @@
 Finding: Generating tooltip data for every item in the viewport involved excessive string allocation and copying, even for items with no tooltip info. Additionally, the render loop calculated screen coordinates twice for every visible tile.
 Impact: Significantly reduced memory allocations per frame by avoiding string copies for items without text/description. Reduced arithmetic operations per tile by ~50% in the hot loop.
 Learning: `std::string` return by value in accessor methods (`getText`) can be a silent killer in tight loops. Combining visibility checks with coordinate calculation avoids redundant math.
+
+## 2024-10-27 - Tooltip Generation and House Color Optimization
+Finding: `TileRenderer` was allocating `std::string` and `std::vector` for tooltip data for *every* item in the viewport on the active floor, regardless of hover state. Also, house color was recalculated for every item on a house tile.
+Impact: Eliminated thousands of allocations per frame by restricting tooltip generation to the hovered tile. Reduced house color calculation overhead by hoisting it out of the item loop. Stopped per-frame console logging in `SpriteDrawer`.
+Learning: Unconditional data generation in render loops (especially involving heap allocation) is a major bottleneck. Always check if the data is actually needed (e.g., hover state) before generating it.

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/drawers/entities/sprite_drawer.cpp
+++ b/source/rendering/drawers/entities/sprite_drawer.cpp
@@ -20,9 +20,13 @@ SpriteDrawer::~SpriteDrawer() {
 
 void SpriteDrawer::ResetCache() {
 	last_bound_texture_ = 0;
-	// Log stats each frame
-	if (s_blitCount > 0) {
-		spdlog::info("SpriteDrawer: {} sprites drawn, {} zero-texture skipped", s_blitCount, s_zeroTextureCount);
+	// Log stats every 600 frames (approx 10s at 60fps)
+	static int log_counter = 0;
+	if (++log_counter >= 600) {
+		if (s_blitCount > 0) {
+			spdlog::info("SpriteDrawer: {} sprites drawn, {} zero-texture skipped", s_blitCount, s_zeroTextureCount);
+		}
+		log_counter = 0;
 	}
 	s_blitCount = 0;
 	s_zeroTextureCount = 0;

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
Perform rendering optimizations and fix build errors:
- **Bottleneck Fix:** Restrict `CreateItemTooltipData` to only the hovered tile. Previously, it generated strings/vectors for all items in the viewport, causing high memory churn.
- **Bottleneck Fix:** Hoist `TileColorCalculator::GetHouseColor` out of the item loop to avoid redundant calculations per item.
- **Bottleneck Fix:** Throttle `SpriteDrawer::ResetCache` logging to run every 600 frames instead of every frame.
- **Build Fix:** Replace `TileSet::iterator` with `auto` in `SelectionOperations` and `DragShadowDrawer` to fix compilation errors with `std::set`.
- **Build Fix:** Remove `DECLARE_EVENT_TABLE` from `brush_panel.h` and `properties_window.h` to fix linker errors (classes use `Bind`).

---
*PR created automatically by Jules for task [14937286891030934730](https://jules.google.com/task/14937286891030934730) started by @karolak6612*