### PR TITLE
Refactor Live system and Editor ownership to use RAII

### DIFF
--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -46,7 +46,7 @@
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::make_unique<ActionQueue>(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -57,7 +57,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName& fn) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::make_unique<ActionQueue>(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -67,9 +67,9 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName
 	EditorPersistence::loadMap(*this, fn);
 }
 
-Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* client) :
-	live_manager(*this, client),
-	actionQueue(newd NetworkedActionQueue(*this)),
+Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, std::unique_ptr<LiveClient> client) :
+	live_manager(*this, std::move(client)),
+	actionQueue(std::unique_ptr<NetworkedActionQueue>(new NetworkedActionQueue(*this))),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -85,7 +85,6 @@ Editor::~Editor() {
 
 	UnnamedRenderingLock();
 	selection.clear();
-	delete actionQueue;
 	spdlog::info("Editor destroyed [Editor={}]", (void*)this);
 }
 

--- a/source/editor/editor.h
+++ b/source/editor/editor.h
@@ -28,6 +28,7 @@
 #include "editor/operations/selection_operations.h"
 #include "map/operations/map_processor.h"
 #include "editor/persistence/editor_persistence.h"
+#include <memory>
 
 class BaseMap;
 class CopyBuffer;
@@ -41,17 +42,14 @@ class LiveSocket;
 
 class Editor {
 public:
-	Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* client);
+	Editor(CopyBuffer& copybuffer, const MapVersion& version, std::unique_ptr<LiveClient> client);
 	Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName& fn);
 	Editor(CopyBuffer& copybuffer, const MapVersion& version);
 	~Editor();
 
-	// Live Manager
-	LiveManager live_manager;
-
 public:
 	// Public members
-	ActionQueue* actionQueue;
+	std::unique_ptr<ActionQueue> actionQueue;
 	Selection selection;
 	CopyBuffer& copybuffer;
 	GroundBrush* replace_brush;
@@ -106,6 +104,10 @@ protected:
 
 	Editor(const Editor&);
 	Editor& operator=(const Editor&);
+
+public:
+	// Live Manager
+	LiveManager live_manager;
 };
 
 inline void Editor::draw(const Position& offset, bool alt) {

--- a/source/editor/editor_factory.cpp
+++ b/source/editor/editor_factory.cpp
@@ -68,7 +68,7 @@ std::unique_ptr<Editor> EditorFactory::JoinLive(CopyBuffer& copybuffer, LiveClie
 	mapVersion.otbm = g_version.GetCurrentVersion().getPrefferedMapVersionID();
 	mapVersion.client = g_version.GetCurrentVersionID();
 
-	std::unique_ptr<Editor> editor = std::make_unique<Editor>(copybuffer, mapVersion, client);
+	std::unique_ptr<Editor> editor = std::make_unique<Editor>(copybuffer, mapVersion, std::unique_ptr<LiveClient>(client));
 	SetupCallbacks(editor.get());
 	return editor;
 }

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -209,7 +209,7 @@ bool EditorManager::NewMap() {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 	mapTab->GetMap()->clearChanges();
 
@@ -300,7 +300,7 @@ bool EditorManager::LoadMap(const FileName& fileName) {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 
 	g_gui.root->AddRecentFile(fileName);

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -240,11 +240,11 @@ LiveLogTab* LiveClient::createLogWindow(wxWindow* parent) {
 	return log;
 }
 
-MapTab* LiveClient::createEditorWindow() {
+MapTab* LiveClient::createEditorWindow(std::shared_ptr<Editor> editor) {
 	MapTabbook* mtb = dynamic_cast<MapTabbook*>(g_gui.tabbook);
 	ASSERT(mtb);
 
-	MapTab* edit = newd MapTab(mtb, editor.get());
+	MapTab* edit = newd MapTab(mtb, editor);
 	edit->OnSwitchEditorMode(g_gui.IsSelectionMode() ? SELECTION_MODE : DRAWING_MODE);
 
 	return edit;
@@ -372,14 +372,16 @@ void LiveClient::parsePacket(NetworkMessage message) {
 
 void LiveClient::parseHello(NetworkMessage& message) {
 	ASSERT(editor == nullptr);
-	editor = EditorFactory::JoinLive(g_gui.copybuffer, this);
+	std::unique_ptr<Editor> new_editor = EditorFactory::JoinLive(g_gui.copybuffer, this);
 
-	Map& map = editor->map;
+	Map& map = new_editor->map;
 	map.setName("Live Map - " + message.read<std::string>());
 	map.setWidth(message.read<uint16_t>());
 	map.setHeight(message.read<uint16_t>());
 
-	createEditorWindow();
+	std::shared_ptr<Editor> shared_editor = std::move(new_editor);
+	editor = shared_editor.get();
+	createEditorWindow(shared_editor);
 }
 
 void LiveClient::parseKick(NetworkMessage& message) {

--- a/source/live/live_client.h
+++ b/source/live/live_client.h
@@ -25,6 +25,7 @@
 
 class DirtyList;
 class MapTab;
+class Editor;
 
 class LiveClient : public LiveSocket {
 public:
@@ -50,7 +51,7 @@ public:
 	void updateCursor(const Position& position);
 
 	LiveLogTab* createLogWindow(wxWindow* parent);
-	MapTab* createEditorWindow();
+	MapTab* createEditorWindow(std::shared_ptr<Editor> editor);
 
 	// send packets
 	void sendHello();
@@ -85,7 +86,7 @@ protected:
 	std::shared_ptr<boost::asio::ip::tcp::resolver> resolver;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;
 
-	std::unique_ptr<Editor> editor;
+	Editor* editor;
 
 	bool stopped;
 };

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -18,10 +18,10 @@ LiveManager::LiveManager(Editor& editor) :
 	live_client(nullptr) {
 }
 
-LiveManager::LiveManager(Editor& editor, LiveClient* client) :
+LiveManager::LiveManager(Editor& editor, std::unique_ptr<LiveClient> client) :
 	editor(editor),
 	live_server(nullptr),
-	live_client(client) {
+	live_client(std::move(client)) {
 }
 
 LiveManager::~LiveManager() {
@@ -47,11 +47,11 @@ bool LiveManager::IsLocal() const {
 }
 
 LiveClient* LiveManager::GetClient() const {
-	return live_client;
+	return live_client.get();
 }
 
 LiveServer* LiveManager::GetServer() const {
-	return live_server;
+	return live_server.get();
 }
 
 LiveSocket& LiveManager::GetSocket() const {
@@ -63,29 +63,25 @@ LiveSocket& LiveManager::GetSocket() const {
 
 LiveServer* LiveManager::StartServer() {
 	ASSERT(IsLocal());
-	live_server = newd LiveServer(editor);
+	live_server = std::make_unique<LiveServer>(editor);
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd NetworkedActionQueue(editor);
+	editor.actionQueue = std::unique_ptr<NetworkedActionQueue>(new NetworkedActionQueue(editor));
 
-	return live_server;
+	return live_server.get();
 }
 
 void LiveManager::CloseServer() {
 	if (live_server) {
 		live_server->close();
-		delete live_server;
 		live_server = nullptr;
 	}
 
 	if (live_client) {
 		live_client->close();
-		delete live_client;
 		live_client = nullptr;
 	}
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd ActionQueue(editor);
+	editor.actionQueue = std::unique_ptr<ActionQueue>(new ActionQueue(editor));
 
 	NetworkConnection& connection = NetworkConnection::getInstance();
 	connection.stop();

--- a/source/live/live_manager.h
+++ b/source/live/live_manager.h
@@ -2,6 +2,7 @@
 #define RME_LIVE_LIVE_MANAGER_H
 
 #include "app/rme_forward_declarations.h"
+#include <memory>
 
 class Editor;
 class LiveServer;
@@ -12,7 +13,7 @@ class DirtyList;
 class LiveManager {
 public:
 	LiveManager(Editor& editor);
-	LiveManager(Editor& editor, LiveClient* client);
+	LiveManager(Editor& editor, std::unique_ptr<LiveClient> client);
 	~LiveManager();
 
 	LiveServer* StartServer();
@@ -31,8 +32,8 @@ public:
 
 private:
 	Editor& editor;
-	LiveServer* live_server;
-	LiveClient* live_client;
+	std::unique_ptr<LiveServer> live_server;
+	std::unique_ptr<LiveClient> live_client;
 };
 
 #endif

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -64,9 +64,6 @@ bool LiveServer::bind() {
 }
 
 void LiveServer::close() {
-	for (auto& clientEntry : clients) {
-		delete clientEntry.second;
-	}
 	clients.clear();
 
 	if (log) {
@@ -101,11 +98,11 @@ void LiveServer::acceptClient() {
 		if (error) {
 			//
 		} else {
-			LivePeer* peer = new LivePeer(this, std::move(*socket));
+			auto peer = std::unique_ptr<LivePeer>(new LivePeer(this, std::move(*socket)));
 			peer->log = log;
 			peer->receiveHeader();
 
-			clients.insert(std::make_pair(id++, peer));
+			clients.insert(std::make_pair(id++, std::move(peer)));
 		}
 		acceptClient();
 	});
@@ -191,7 +188,7 @@ void LiveServer::broadcastNodes(DirtyList& dirtyList) {
 		}
 
 		for (auto& clientEntry : clients) {
-			LivePeer* peer = clientEntry.second;
+			LivePeer* peer = clientEntry.second.get();
 
 			const uint32_t clientId = peer->getClientId();
 			if (dirtyList.owner != 0 && dirtyList.owner == clientId) {
@@ -223,7 +220,7 @@ void LiveServer::broadcastCursor(const LiveCursor& cursor) {
 	writeCursor(message, cursor);
 
 	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+		LivePeer* peer = clientEntry.second.get();
 		if (peer->getClientId() != cursor.id) {
 			peer->send(message);
 		}

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -22,6 +22,8 @@
 #include "net/net_connection.h"
 #include "editor/action.h"
 
+#include <memory>
+
 class LivePeer;
 class LiveLogTab;
 class QTreeNode;
@@ -70,7 +72,7 @@ public:
 	void updateOperation(int32_t percent);
 
 protected:
-	std::unordered_map<uint32_t, LivePeer*> clients;
+	std::unordered_map<uint32_t, std::unique_ptr<LivePeer>> clients;
 
 	std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -196,18 +196,17 @@ void LiveLogTab::OnDeselectChatbox(wxFocusEvent& evt) {
 	g_hotkeys.EnableHotkeys();
 }
 
-void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients) {
+void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients) {
 	// Delete old rows
 	if (user_list->GetNumberRows() > 0) {
 		user_list->DeleteRows(0, user_list->GetNumberRows());
 	}
 
-	clients = updatedClients;
-	user_list->AppendRows(clients.size());
+	user_list->AppendRows(updatedClients.size());
 
 	int32_t i = 0;
-	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+	for (auto& clientEntry : updatedClients) {
+		LivePeer* peer = clientEntry.second.get();
 		user_list->SetCellBackgroundColour(i, 0, peer->getUsedColor());
 		user_list->SetCellValue(i, 1, i2ws((peer->getClientId() >> 1) + 1));
 		user_list->SetCellValue(i, 2, peer->getName());

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -52,7 +52,7 @@ public:
 		return socket;
 	}
 
-	void UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients);
+	void UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients);
 
 	void OnSelectChatbox(wxFocusEvent& evt);
 	void OnDeselectChatbox(wxFocusEvent& evt);
@@ -67,8 +67,6 @@ protected:
 	wxGrid* log;
 	wxTextCtrl* input;
 	wxGrid* user_list;
-
-	std::unordered_map<uint32_t, LivePeer*> clients;
 
 	DECLARE_EVENT_TABLE();
 };

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -357,7 +357,7 @@ protected:
 	int disabled_counter;
 
 	friend class RenderingLock;
-	friend MapTab::MapTab(MapTabbook*, Editor*);
+	friend MapTab::MapTab(MapTabbook*, std::shared_ptr<Editor>);
 	friend MapTab::MapTab(const MapTab*);
 };
 

--- a/source/ui/map_tab.h
+++ b/source/ui/map_tab.h
@@ -22,9 +22,11 @@
 #include "app/application.h"
 #include "ui/map_window.h"
 
+#include <memory>
+
 class MapTab : public EditorTab, public MapWindow {
 public:
-	MapTab(MapTabbook* aui, Editor* editor);
+	MapTab(MapTabbook* aui, std::shared_ptr<Editor> editor);
 	// Constructs a newd window, but it uses the same internal editor as 'other'
 	// AND the same parent, aui_notebook etc.
 	MapTab(const MapTab* other);
@@ -47,16 +49,12 @@ public:
 	void OnSwitchEditorMode(EditorMode mode);
 
 protected:
-	struct InternalReference {
-		Editor* editor;
-		int owner_count;
-	};
 	MapTabbook* aui;
-	InternalReference* iref;
+	std::shared_ptr<Editor> editor_ptr;
 };
 
 inline bool MapTab::HasSameReference(MapTab* other) const {
-	return other->iref == iref;
+	return other->editor_ptr == editor_ptr;
 }
 
 #endif


### PR DESCRIPTION
This PR addresses memory safety issues and modernizes the codebase according to the Keeper agent instructions. 

Key changes:
1.  **LiveServer Client Leak Fix**: Converted `clients` map to `std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>`, removing manual `delete` calls and fixing leaks in `removeClient`.
2.  **LiveManager Ownership**: Converted `live_server` and `live_client` members to `std::unique_ptr`.
3.  **Editor ActionQueue**: Converted `actionQueue` to `std::unique_ptr`, removing manual memory management.
4.  **MapTab Ownership**: Replaced `InternalReference` struct with `std::shared_ptr<Editor>`, simplifying ownership sharing between tabs.
5.  **LiveClient Ownership**: Updated `LiveClient` to not own `Editor` exclusively via `unique_ptr` but to pass shared ownership to `MapTab`. `LiveClient` now holds a raw observer pointer, while `MapTab` holds the `shared_ptr`.
6.  **Destruction Order Fix**: Reordered `live_manager` in `Editor` class to ensure it is destroyed before `actionQueue`, preventing a crash when `CloseServer` attempts to reset the queue during destruction.


---
*PR created automatically by Jules for task [17457371691081636662](https://jules.google.com/task/17457371691081636662) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored core memory management architecture to improve resource ownership and lifecycle handling across editor and live collaboration components
  * Modernized client connection and peer management for better stability and maintainability
  * Expanded Editor public interface with state change callbacks and direct map access capabilities

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->