### PR TITLE
✨ Designer: UX Improvements (Jump to Brush, Tooltips, Status Bar)

### DIFF
--- a/source/brushes/managers/brush_manager.cpp
+++ b/source/brushes/managers/brush_manager.cpp
@@ -8,6 +8,7 @@
 #include "brushes/brush.h"
 #include "brushes/managers/doodad_preview_manager.h"
 #include "brushes/spawn/spawn_brush.h"
+#include "ui/managers/status_manager.h"
 #include "palette/managers/palette_manager.h"
 #include "palette/palette_window.h"
 #include "palette/house/house_palette.h"
@@ -98,6 +99,8 @@ void BrushManager::SelectBrushInternal(Brush* brush) {
 	if (!current_brush) {
 		return;
 	}
+
+	g_status.SetStatusText("Selected brush: " + wxstr(brush->getName()));
 
 	brush_variation = std::min(brush_variation, brush->getMaxVariation());
 	// If we are switching away from a doodad brush, we need to clear the secondary map

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -189,6 +189,7 @@ void EditorManager::SaveCurrentMap(FileName fileName, bool showdialog) {
 			stream << position;
 			g_settings.setString(Config::RECENT_EDITED_MAP_PATH, path);
 			g_settings.setString(Config::RECENT_EDITED_MAP_POSITION, stream.str());
+			g_status.SetStatusText("Map saved.");
 		}
 	}
 

--- a/source/palette/controls/virtual_brush_grid.cpp
+++ b/source/palette/controls/virtual_brush_grid.cpp
@@ -8,6 +8,7 @@ EVT_PAINT(VirtualBrushGrid::OnPaint)
 EVT_SIZE(VirtualBrushGrid::OnSize)
 EVT_LEFT_DOWN(VirtualBrushGrid::OnMouse)
 EVT_ERASE_BACKGROUND(VirtualBrushGrid::OnEraseBackground)
+EVT_MOTION(VirtualBrushGrid::OnMotion)
 END_EVENT_TABLE()
 
 VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz) :
@@ -196,4 +197,20 @@ bool VirtualBrushGrid::SelectBrush(const Brush* brush) {
 	selected_index = -1;
 	Refresh();
 	return false;
+}
+
+void VirtualBrushGrid::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1) {
+		Brush* brush = tileset->brushlist[index];
+		if (brush) {
+			wxString tip = wxstr(brush->getName());
+			if (GetToolTipText() != tip) {
+				SetToolTip(tip);
+			}
+		}
+	} else {
+		UnsetToolTip();
+	}
+	event.Skip();
 }

--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -26,6 +26,7 @@ public:
 	void OnEraseBackground(wxEraseEvent& event);
 
 protected:
+	void OnMotion(wxMouseEvent& event);
 	void UpdateVirtualSize();
 	int HitTest(int x, int y) const;
 	wxRect GetItemRect(int index) const;

--- a/source/ui/gui.cpp
+++ b/source/ui/gui.cpp
@@ -236,6 +236,7 @@ void GUI::ChangeFloor(int new_floor) {
 
 		if (old_floor != new_floor) {
 			tab->GetCanvas()->ChangeFloor(new_floor);
+			g_status.SetStatusText(wxString::Format("Floor: %d", new_floor));
 		}
 	}
 }

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -6,6 +6,7 @@
 #include "ui/toolbar/standard_toolbar.h"
 #include "ui/gui.h"
 #include "ui/gui_ids.h"
+#include "ui/main_menubar.h"
 #include "editor/editor.h"
 #include "editor/action_queue.h"
 #include "ui/artprovider.h"
@@ -24,6 +25,7 @@ StandardToolBar::StandardToolBar(wxWindow* parent) {
 	wxBitmap cut_bitmap = wxArtProvider::GetBitmap(wxART_CUT, wxART_TOOLBAR, icon_size);
 	wxBitmap copy_bitmap = wxArtProvider::GetBitmap(wxART_COPY, wxART_TOOLBAR, icon_size);
 	wxBitmap paste_bitmap = wxArtProvider::GetBitmap(wxART_PASTE, wxART_TOOLBAR, icon_size);
+	wxBitmap find_bitmap = wxArtProvider::GetBitmap(wxART_FIND, wxART_TOOLBAR, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_STANDARD, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
@@ -38,6 +40,8 @@ StandardToolBar::StandardToolBar(wxWindow* parent) {
 	toolbar->AddTool(wxID_CUT, wxEmptyString, cut_bitmap, wxNullBitmap, wxITEM_NORMAL, "Cut (Ctrl+X)", wxEmptyString, nullptr);
 	toolbar->AddTool(wxID_COPY, wxEmptyString, copy_bitmap, wxNullBitmap, wxITEM_NORMAL, "Copy (Ctrl+C)", wxEmptyString, nullptr);
 	toolbar->AddTool(wxID_PASTE, wxEmptyString, paste_bitmap, wxNullBitmap, wxITEM_NORMAL, "Paste (Ctrl+V)", wxEmptyString, nullptr);
+	toolbar->AddSeparator();
+	toolbar->AddTool(MAIN_FRAME_MENU + MenuBar::JUMP_TO_BRUSH, wxEmptyString, find_bitmap, wxNullBitmap, wxITEM_NORMAL, "Jump to Brush (J)", wxEmptyString, nullptr);
 	toolbar->Realize();
 
 	toolbar->Bind(wxEVT_COMMAND_MENU_SELECTED, &StandardToolBar::OnButtonClick, this);
@@ -108,6 +112,7 @@ void StandardToolBar::OnButtonClick(wxCommandEvent& event) {
 			g_gui.PreparePaste();
 			break;
 		default:
+			event.Skip();
 			break;
 	}
 }


### PR DESCRIPTION
This PR implements several UX improvements requested by the Designer agent:

1.  **"Jump to Brush" Toolbar Button**: Added a new button to the Standard Toolbar that triggers the "Jump to Brush" dialog. This improves discoverability and provides quick access to finding brushes.
2.  **Palette Tooltips**: `VirtualBrushGrid` now displays tooltips with the name of the brush under the cursor when hovering. This addresses the lack of feedback on icons.
3.  **Status Bar Feedback**: Added status bar updates for:
    *   Selecting a brush (shows brush name).
    *   Changing floors (shows new floor number).
    *   Saving the map (confirms save).
4.  **Event Propagation Fix**: Modified `StandardToolBar::OnButtonClick` to `Skip()` unhandled events, ensuring that the new toolbar button (which uses a Main Menu ID) correctly propagates the event to the `MainFrame` where it is handled.

These changes collectively reduce friction and improve feedback for the user.

---
*PR created automatically by Jules for task [4021343351089355595](https://jules.google.com/task/4021343351089355595) started by @karolak6612*