### PR TITLE
[Phantom] Fix QTreeNode visibility logic, div-by-zero in IO, and compilation errors

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -896,7 +896,9 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
 		++nodes_loaded;
 		if (nodes_loaded % 2048 == 0) {
-			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			if (f.size() > 0) {
+				g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			}
 		}
 
 		uint8_t node_type;
@@ -1545,7 +1547,9 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 				// Update progressbar
 				++tiles_saved;
 				if (tiles_saved % 8192 == 0) {
-					g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
+					if (map.getTileCount() > 0) {
+						g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
+					}
 				}
 
 				// Get tile

--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -380,7 +380,9 @@ bool IOMapOTMM::loadMap(Map& map, NodeFileReadHandle& f, const FileName& identif
 		do {
 			++nodes_loaded;
 			if (showdialog && nodes_loaded % 15 == 0) {
-				g_gui.SetLoadDone(int(100.0 * f.tell() / f.size()));
+				if (f.size() > 0) {
+					g_gui.SetLoadDone(int(100.0 * f.tell() / f.size()));
+				}
 			}
 			uint8_t node_type;
 			if (!mapNode->getByte(node_type)) {
@@ -802,7 +804,9 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 					// Update progressbar
 					++tiles_saved;
 					if (showdialog && tiles_saved % 8192 == 0) {
-						g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
+						if (map.getTileCount() > 0) {
+							g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
+						}
 					}
 
 					// Get tile

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -120,7 +120,7 @@ void LiveServer::removeClient(uint32_t id) {
 	const uint32_t clientId = it->second->getClientId();
 	if (clientId != 0) {
 		clientIds &= ~clientId;
-		editor->map.clearVisible(clientIds);
+		editor->map.clearVisible(clientId);
 	}
 
 	clients.erase(it);
@@ -158,7 +158,8 @@ bool LiveServer::setPort(int32_t newPort) {
 }
 
 uint32_t LiveServer::getFreeClientId() {
-	for (int32_t bit = 1; bit < (1 << 16); bit <<= 1) {
+	// Start at bit 4 (16) to avoid conflict with internal QTreeNode flags (bits 0-3)
+	for (int32_t bit = (1 << 4); bit < (1 << 16); bit <<= 1) {
 		if (!testFlags(clientIds, bit)) {
 			clientIds |= bit;
 			return bit;

--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -158,23 +158,24 @@ bool QTreeNode::isRequested(bool underground) {
 	}
 }
 
-void QTreeNode::clearVisible(uint32_t u) {
+void QTreeNode::clearVisible(uint32_t clientMask) {
+	uint32_t mask = clientMask | (clientMask << MAP_LAYERS);
 	if (isLeaf) {
-		visible &= u;
+		visible &= ~mask;
 	} else {
 		for (int i = 0; i < MAP_LAYERS; ++i) {
 			if (child[i]) {
-				child[i]->clearVisible(u);
+				child[i]->clearVisible(clientMask);
 			}
 		}
 	}
 }
 
-bool QTreeNode::isVisible(uint32_t client, bool underground) {
+bool QTreeNode::isVisible(uint32_t clientMask, bool underground) {
 	if (underground) {
-		return testFlags(visible >> MAP_LAYERS, static_cast<uint64_t>(1) << client);
+		return testFlags(visible >> MAP_LAYERS, clientMask);
 	} else {
-		return testFlags(visible, static_cast<uint64_t>(1) << client);
+		return testFlags(visible, clientMask);
 	}
 }
 
@@ -202,11 +203,11 @@ void QTreeNode::setRequested(bool underground, bool r) {
 	}
 }
 
-void QTreeNode::setVisible(uint32_t client, bool underground, bool value) {
+void QTreeNode::setVisible(uint32_t clientMask, bool underground, bool value) {
 	if (value) {
-		visible |= (1 << client << (underground ? MAP_LAYERS : 0));
+		visible |= (clientMask << (underground ? MAP_LAYERS : 0));
 	} else {
-		visible &= ~(1 << client << (underground ? MAP_LAYERS : 0));
+		visible &= ~(clientMask << (underground ? MAP_LAYERS : 0));
 	}
 }
 

--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -177,9 +177,9 @@ public:
 	}
 
 	void setVisible(bool overground, bool underground);
-	void setVisible(uint32_t client, bool underground, bool value);
-	bool isVisible(uint32_t client, bool underground);
-	void clearVisible(uint32_t client);
+	void setVisible(uint32_t clientMask, bool underground, bool value);
+	bool isVisible(uint32_t clientMask, bool underground);
+	void clearVisible(uint32_t clientMask);
 
 	void setRequested(bool underground, bool r);
 	bool isVisible(bool underground);

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 


### PR DESCRIPTION
This PR addresses critical bugs identified by the Phantom agent:
1.  **Logic Bug / UB in `QTreeNode`**: `setVisible`/`isVisible` treated `client` as an index (`1 << client`) but callers passed a mask. This caused visibility data corruption and UB. Fixed by using `clientMask` directly.
2.  **Resource Conflict**: `LiveServer` client IDs (bits 0-3) conflicted with internal `QTreeNode` flags (bits 0-3). Fixed by starting client allocation at bit 4 (16).
3.  **Division by Zero**: Added checks to prevent division by zero in `IOMapOTBM` and `IOMapOTMM` load/save progress bars.
4.  **Compilation Errors**: Fixed iterator type mismatch in `SelectionOperations` and `DragShadowDrawer` by using `auto` type deduction for `editor.selection` iteration.

---
*PR created automatically by Jules for task [11945346057066771364](https://jules.google.com/task/11945346057066771364) started by @karolak6612*