### PR TITLE
⚡ Bolt: Rendering Optimizations and Build Fixes

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -51,6 +51,13 @@ void TooltipDrawer::addItemTooltip(const TooltipData& data) {
 	tooltips.push_back(data);
 }
 
+void TooltipDrawer::addItemTooltip(TooltipData&& data) {
+	if (!data.hasVisibleFields()) {
+		return;
+	}
+	tooltips.push_back(std::move(data));
+}
+
 void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
 	if (name.empty()) {
 		return;

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -131,6 +131,8 @@ public:
 
 	// Add a structured tooltip for an item
 	void addItemTooltip(const TooltipData& data);
+	// ⚡ Bolt Optimization: Add move semantics support
+	void addItemTooltip(TooltipData&& data);
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
This PR implements three rendering optimizations identified by Bolt, along with necessary build fixes.

**Optimizations:**
1.  **Hoist House Color Calculation:** `TileColorCalculator::GetHouseColor` is now called once per tile in `TileRenderer::DrawTile`, reusing the result for all items on that tile.
2.  **Tooltip Memory Reservation:** `data.containerItems.reserve()` is called in `CreateItemTooltipData` based on the container size.
3.  **Tooltip Move Semantics:** `TooltipDrawer::addItemTooltip` now supports r-value references, and `TileRenderer` moves `TooltipData` instead of copying it.

**Build Fixes:**
1.  **Selection Iteration:** Fixed `SelectionOperations::moveSelection` and `DragShadowDrawer::draw` to use `auto` for iterating `editor.selection` (which is a `std::set`), resolving a type mismatch with `TileSet::iterator` (`std::vector`).
2.  **Legacy Event Tables:** Removed `DECLARE_EVENT_TABLE()` from `source/palette/panels/brush_panel.h` and `source/ui/properties/properties_window.h` as the implementation uses `Bind()` and lacks `BEGIN_EVENT_TABLE` in the source files, causing linker errors.


---
*PR created automatically by Jules for task [8746362473539703471](https://jules.google.com/task/8746362473539703471) started by @karolak6612*