### PR TITLE
[TILE/WXWIDGETS] Fix legacy event tables, GDI context management, and selection iterator mismatches

### DIFF
--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); it++) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1552,7 +1552,7 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 				Tile* save_tile = (*map_iterator)->get();
 
 				// Is it an empty tile that we can skip? (Leftovers...)
-				if (!save_tile || save_tile->size() == 0) {
+				if (!save_tile || save_tile->empty()) {
 					++map_iterator;
 					continue;
 				}

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -77,36 +77,6 @@
 #include "brushes/carpet/carpet_brush.h"
 #include "brushes/table/table_brush.h"
 
-BEGIN_EVENT_TABLE(MapCanvas, wxGLCanvas)
-EVT_KEY_DOWN(MapCanvas::OnKeyDown)
-EVT_KEY_DOWN(MapCanvas::OnKeyUp)
-
-// Mouse events
-EVT_MOTION(MapCanvas::OnMouseMove)
-EVT_LEFT_UP(MapCanvas::OnMouseLeftRelease)
-EVT_LEFT_DOWN(MapCanvas::OnMouseLeftClick)
-EVT_LEFT_DCLICK(MapCanvas::OnMouseLeftDoubleClick)
-EVT_MIDDLE_DOWN(MapCanvas::OnMouseCenterClick)
-EVT_MIDDLE_UP(MapCanvas::OnMouseCenterRelease)
-EVT_RIGHT_DOWN(MapCanvas::OnMouseRightClick)
-EVT_RIGHT_UP(MapCanvas::OnMouseRightRelease)
-EVT_MOUSEWHEEL(MapCanvas::OnWheel)
-EVT_ENTER_WINDOW(MapCanvas::OnGainMouse)
-EVT_LEAVE_WINDOW(MapCanvas::OnLoseMouse)
-
-// Drawing events
-EVT_PAINT(MapCanvas::OnPaint)
-EVT_ERASE_BACKGROUND(MapCanvas::OnEraseBackground)
-
-// Menu events
-// Menu events
-//----
-// ----
-// ----
-// ----
-// ----
-END_EVENT_TABLE()
-
 bool MapCanvas::processed[] = { 0 };
 
 // Helper to create attributes
@@ -145,6 +115,25 @@ MapCanvas::MapCanvas(MapWindow* parent, Editor& editor, int* attriblist) :
 
 	last_mmb_click_x(-1),
 	last_mmb_click_y(-1) {
+
+	Bind(wxEVT_KEY_DOWN, &MapCanvas::OnKeyDown, this);
+	Bind(wxEVT_KEY_UP, &MapCanvas::OnKeyUp, this);
+
+	Bind(wxEVT_MOTION, &MapCanvas::OnMouseMove, this);
+	Bind(wxEVT_LEFT_UP, &MapCanvas::OnMouseLeftRelease, this);
+	Bind(wxEVT_LEFT_DOWN, &MapCanvas::OnMouseLeftClick, this);
+	Bind(wxEVT_LEFT_DCLICK, &MapCanvas::OnMouseLeftDoubleClick, this);
+	Bind(wxEVT_MIDDLE_DOWN, &MapCanvas::OnMouseCenterClick, this);
+	Bind(wxEVT_MIDDLE_UP, &MapCanvas::OnMouseCenterRelease, this);
+	Bind(wxEVT_RIGHT_DOWN, &MapCanvas::OnMouseRightClick, this);
+	Bind(wxEVT_RIGHT_UP, &MapCanvas::OnMouseRightRelease, this);
+	Bind(wxEVT_MOUSEWHEEL, &MapCanvas::OnWheel, this);
+	Bind(wxEVT_ENTER_WINDOW, &MapCanvas::OnGainMouse, this);
+	Bind(wxEVT_LEAVE_WINDOW, &MapCanvas::OnLoseMouse, this);
+
+	Bind(wxEVT_PAINT, &MapCanvas::OnPaint, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &MapCanvas::OnEraseBackground, this);
+
 	popup_menu = std::make_unique<MapPopupMenu>(editor);
 	animation_timer = std::make_unique<AnimationTimer>(this);
 	drawer = std::make_unique<MapDrawer>(this);

--- a/source/rendering/ui/map_display.h
+++ b/source/rendering/ui/map_display.h
@@ -162,8 +162,6 @@ public:
 	friend class SelectionController;
 	friend class DrawingController;
 
-	DECLARE_EVENT_TABLE()
-
 	std::unique_ptr<SelectionController> selection_controller;
 	std::unique_ptr<DrawingController> drawing_controller;
 	std::unique_ptr<MapMenuHandler> menu_handler;

--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -29,16 +29,6 @@
 
 #include "rendering/drawers/minimap_drawer.h"
 
-BEGIN_EVENT_TABLE(MinimapWindow, wxPanel)
-EVT_LEFT_DOWN(MinimapWindow::OnMouseClick)
-EVT_SIZE(MinimapWindow::OnSize)
-EVT_PAINT(MinimapWindow::OnPaint)
-EVT_ERASE_BACKGROUND(MinimapWindow::OnEraseBackground)
-EVT_CLOSE(MinimapWindow::OnClose)
-EVT_TIMER(wxID_ANY, MinimapWindow::OnDelayedUpdate)
-EVT_KEY_DOWN(MinimapWindow::OnKey)
-END_EVENT_TABLE()
-
 // Helper to create attributes
 static wxGLAttributes& GetCoreProfileAttributes() {
 	static wxGLAttributes vAttrs = []() {
@@ -51,19 +41,25 @@ static wxGLAttributes& GetCoreProfileAttributes() {
 
 MinimapWindow::MinimapWindow(wxWindow* parent) :
 	wxGLCanvas(parent, GetCoreProfileAttributes(), wxID_ANY, wxDefaultPosition, wxSize(205, 130)),
-	update_timer(this),
-	context(nullptr) {
+	update_timer(this) {
+
+	Bind(wxEVT_LEFT_DOWN, &MinimapWindow::OnMouseClick, this);
+	Bind(wxEVT_SIZE, &MinimapWindow::OnSize, this);
+	Bind(wxEVT_PAINT, &MinimapWindow::OnPaint, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &MinimapWindow::OnEraseBackground, this);
+	Bind(wxEVT_CLOSE_WINDOW, &MinimapWindow::OnClose, this);
+	Bind(wxEVT_TIMER, &MinimapWindow::OnDelayedUpdate, this, wxID_ANY);
+	Bind(wxEVT_KEY_DOWN, &MinimapWindow::OnKey, this);
+
 	spdlog::info("MinimapWindow::MinimapWindow - Creating context");
-	context = new wxGLContext(this);
+	context = std::make_unique<wxGLContext>(this);
 	if (!context->IsOK()) {
 		spdlog::error("MinimapWindow::MinimapWindow - Context creation failed");
 	}
 	drawer = std::make_unique<MinimapDrawer>();
 }
 
-MinimapWindow::~MinimapWindow() {
-	delete context;
-}
+MinimapWindow::~MinimapWindow() = default;
 
 void MinimapWindow::OnSize(wxSizeEvent& event) {
 	Refresh();

--- a/source/rendering/ui/minimap_window.h
+++ b/source/rendering/ui/minimap_window.h
@@ -39,9 +39,7 @@ public:
 protected:
 	std::unique_ptr<MinimapDrawer> drawer;
 	wxTimer update_timer;
-	wxGLContext* context;
-
-	DECLARE_EVENT_TABLE()
+	std::unique_ptr<wxGLContext> context;
 };
 
 #endif


### PR DESCRIPTION
This PR addresses multiple domain-specific issues identified during the "Atlas" agent run:

1.  **wxWidgets Anti-Patterns:**
    -   `MinimapWindow` and `MapCanvas` were using legacy `BEGIN_EVENT_TABLE` macros. These have been converted to dynamic `Bind()` calls in the constructor, which is the modern and safer approach in wxWidgets.
    -   In `MapCanvas`, `EVT_KEY_DOWN` was doubly bound to both `OnKeyDown` and `OnKeyUp`. This was corrected to bind `OnKeyUp` to `wxEVT_KEY_UP`.
    -   `MinimapWindow` was manually managing `wxGLContext`. This has been updated to use `std::unique_ptr` for automatic resource cleanup.

2.  **Tile Engine Issues:**
    -   Build failures were occurring due to type mismatches when iterating over `editor.selection` (which is a `std::set`) using `TileSet::iterator` (which is a `std::vector::iterator`). This was fixed in `source/editor/operations/selection_operations.cpp` and `source/rendering/drawers/cursors/drag_shadow_drawer.cpp` by using `auto`.
    -   `IOMapOTBM::saveMap` was checking `save_tile->size() == 0` to identify empty tiles. This has been replaced with the more expressive `save_tile->empty()`.

All changes were verified by compiling with Ninja.

---
*PR created automatically by Jules for task [6362250260458941201](https://jules.google.com/task/6362250260458941201) started by @karolak6612*