### PR TITLE
🎨 Palette: Micro-UX improvements and build fixes

### DIFF
--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -183,6 +183,10 @@ void EditorManager::SaveCurrentMap(FileName fileName, bool showdialog) {
 		if (editor) {
 			EditorPersistence::saveMap(*editor, fileName, showdialog);
 
+			if (!editor->map.hasChanged()) {
+				g_status.SetStatusText("Map saved successfully.");
+			}
+
 			const std::string& path = editor->map.getFilename();
 			const Position& position = mapTab->GetScreenCenterPosition();
 			std::ostringstream stream;

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -253,7 +253,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		action = editor.actionQueue->createAction(batchAction.get());
 		TileList borderize_tiles;
 		// Go through all modified (selected) tiles (might be slow)
-		for (TileSet::iterator it = editor.selection.begin(); it != editor.selection.end(); it++) {
+		for (auto it = editor.selection.begin(); it != editor.selection.end(); ++it) {
 			bool add_me = false; // If this tile is touched
 			Position pos = (*it)->getPosition();
 			// Go through all neighbours

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -56,8 +56,6 @@ public:
 	virtual wxCoord OnMeasureItem(size_t n) const;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushIconBox : public wxScrolledWindow, public BrushBoxInterface {
@@ -90,8 +88,6 @@ protected:
 protected:
 	std::vector<BrushButton*> brush_buttons;
 	RenderSize icon_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 class BrushPanel : public wxPanel {
@@ -132,8 +128,6 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
+++ b/source/rendering/drawers/cursors/drag_shadow_drawer.cpp
@@ -39,7 +39,7 @@ void DragShadowDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Draw dragging shadow
 	if (!drawer->editor.selection.isBusy() && options.dragging && !options.ingame) {
-		for (TileSet::iterator tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); tit++) {
+		for (auto tit = drawer->editor.selection.begin(); tit != drawer->editor.selection.end(); ++tit) {
 			Tile* tile = *tit;
 			Position pos = tile->getPosition();
 

--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -58,6 +58,7 @@ MinimapWindow::MinimapWindow(wxWindow* parent) :
 	if (!context->IsOK()) {
 		spdlog::error("MinimapWindow::MinimapWindow - Context creation failed");
 	}
+	SetToolTip("Click to move camera");
 	drawer = std::make_unique<MinimapDrawer>();
 }
 

--- a/source/ui/about_window.cpp
+++ b/source/ui/about_window.cpp
@@ -24,6 +24,8 @@
 #include <fstream>
 #include <typeinfo>
 #include <memory>
+#include <wx/clipbrd.h>
+#include <wx/dataobj.h>
 
 //=============================================================================
 // About Window - Information window about the application
@@ -57,7 +59,8 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	about << "\n\n";
 
 	about << "Using " << wxVERSION_STRING << " interface\n";
-	about << "OpenGL version " << wxString((char*)glGetString(GL_VERSION), wxConvUTF8) << "\n";
+	const char* gl_version = (const char*)glGetString(GL_VERSION);
+	about << "OpenGL version " << (gl_version ? wxString(gl_version, wxConvUTF8) : "Unknown") << "\n";
 	about << "\n";
 	about << "This program comes with ABSOLUTELY NO WARRANTY;\n";
 	about << "for details see the LICENSE file.\n";
@@ -73,6 +76,16 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	choicesizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
+
+	wxButton* copyBtn = newd wxButton(this, wxID_COPY, "Copy Version Info");
+	copyBtn->Bind(wxEVT_BUTTON, [about](wxCommandEvent&) {
+		if (wxTheClipboard->Open()) {
+			wxTheClipboard->SetData(new wxTextDataObject(about));
+			wxTheClipboard->Close();
+		}
+	});
+	choicesizer->Add(copyBtn, wxSizerFlags(1).Center().Border(wxLEFT, 10));
+
 	topsizer->Add(choicesizer, 0, wxALIGN_CENTER | wxLEFT | wxRIGHT | wxBOTTOM, 20);
 
 	wxAcceleratorEntry entries[1];

--- a/source/ui/map/map_properties_window.cpp
+++ b/source/ui/map/map_properties_window.cpp
@@ -29,11 +29,13 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 	// Description
 	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "Map Description"));
 	description_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getMapDescription()), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
+	description_ctrl->SetToolTip("Enter a description for the map");
 	grid_sizer->Add(description_ctrl, wxSizerFlags(1).Expand());
 
 	// Map version
 	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "Map Version"));
 	version_choice = newd wxChoice(this, MAP_PROPERTIES_VERSION);
+	version_choice->SetToolTip("Select the OTBM version");
 	version_choice->Append("OTServ 0.5.0");
 	version_choice->Append("OTServ 0.6.0");
 	version_choice->Append("OTServ 0.6.1");
@@ -61,6 +63,7 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 	// Version
 	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "Client Version"));
 	protocol_choice = newd wxChoice(this, wxID_ANY);
+	protocol_choice->SetToolTip("Select the client version");
 
 	protocol_choice->SetStringSelection(wxstr(g_version.GetCurrentVersion().getName()));
 
@@ -73,9 +76,11 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 		subsizer->Add(
 			width_spin = newd wxSpinCtrl(this, wxID_ANY, wxstr(i2s(map.getWidth())), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 256, MAP_MAX_WIDTH), wxSizerFlags(1).Expand()
 		);
+		width_spin->SetToolTip("Map width in tiles");
 		subsizer->Add(
 			height_spin = newd wxSpinCtrl(this, wxID_ANY, wxstr(i2s(map.getHeight())), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 256, MAP_MAX_HEIGHT), wxSizerFlags(1).Expand()
 		);
+		height_spin->SetToolTip("Map height in tiles");
 		grid_sizer->Add(subsizer, 1, wxEXPAND);
 	}
 
@@ -87,6 +92,7 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 	grid_sizer->Add(
 		house_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getHouseFilename())), 1, wxEXPAND
 	);
+	house_filename_ctrl->SetToolTip("External house XML file");
 
 	grid_sizer->Add(
 		newd wxStaticText(this, wxID_ANY, "External Spawnfile")
@@ -95,12 +101,18 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 	grid_sizer->Add(
 		spawn_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getSpawnFilename())), 1, wxEXPAND
 	);
+	spawn_filename_ctrl->SetToolTip("External spawn XML file");
 
 	topsizer->Add(grid_sizer, wxSizerFlags(1).Expand().Border(wxALL, 20));
 
 	wxSizer* subsizer = newd wxBoxSizer(wxHORIZONTAL);
-	subsizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
-	subsizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center());
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Confirm changes");
+	subsizer->Add(okBtn, wxSizerFlags(1).Center());
+
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Discard changes");
+	subsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	topsizer->Add(subsizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT | wxBOTTOM, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -76,8 +76,6 @@ private:
 	void createUI();
 	void createGeneralFields(wxFlexGridSizer* sizer, wxWindow* parent);
 	void createClassificationFields(wxFlexGridSizer* sizer, wxWindow* parent);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/ui/result_window.cpp
+++ b/source/ui/result_window.cpp
@@ -34,8 +34,13 @@ SearchResultWindow::SearchResultWindow(wxWindow* parent) :
 	sizer->Add(result_list, wxSizerFlags(1).Expand());
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_FILE, "Export"), wxSizerFlags(0).Center());
-	buttonsSizer->Add(newd wxButton(this, wxID_CLEAR, "Clear"), wxSizerFlags(0).Center());
+	wxButton* exportBtn = newd wxButton(this, wxID_FILE, "Export");
+	exportBtn->SetToolTip("Export results to text file");
+	buttonsSizer->Add(exportBtn, wxSizerFlags(0).Center());
+
+	wxButton* clearBtn = newd wxButton(this, wxID_CLEAR, "Clear");
+	clearBtn->SetToolTip("Clear search results");
+	buttonsSizer->Add(clearBtn, wxSizerFlags(0).Center());
 	sizer->Add(buttonsSizer, wxSizerFlags(0).Center().DoubleBorder());
 	SetSizerAndFit(sizer);
 }

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -92,8 +92,13 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 20));
 
 	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
-	subsizer_->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	subsizer_->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Confirm changes");
+	subsizer_->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Discard changes");
+	subsizer_->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -80,20 +80,25 @@ void BrushToolBar::Update() {
 	Editor* editor = g_gui.GetCurrentEditor();
 	bool has_map = editor != nullptr;
 
-	toolbar->EnableTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_ERASER, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_PZ_TOOL, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_NOPVP_TOOL, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_NOLOGOUT_TOOL, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_PVPZONE_TOOL, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_NORMAL_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_LOCKED_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_MAGIC_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_QUEST_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_NORMAL_ALT_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_ARCHWAY_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_HATCH_DOOR, has_map);
-	toolbar->EnableTool(PALETTE_TERRAIN_WINDOW_DOOR, has_map);
+	auto updateTool = [&](int id, const wxString& name) {
+		toolbar->EnableTool(id, has_map);
+		toolbar->SetToolShortHelp(id, has_map ? name : name + " - No map open");
+	};
+
+	updateTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, "Border");
+	updateTool(PALETTE_TERRAIN_ERASER, "Eraser");
+	updateTool(PALETTE_TERRAIN_PZ_TOOL, "Protected Zone");
+	updateTool(PALETTE_TERRAIN_NOPVP_TOOL, "No PvP Zone");
+	updateTool(PALETTE_TERRAIN_NOLOGOUT_TOOL, "No Logout Zone");
+	updateTool(PALETTE_TERRAIN_PVPZONE_TOOL, "PvP Zone");
+	updateTool(PALETTE_TERRAIN_NORMAL_DOOR, "Normal Door");
+	updateTool(PALETTE_TERRAIN_LOCKED_DOOR, "Locked Door");
+	updateTool(PALETTE_TERRAIN_MAGIC_DOOR, "Magic Door");
+	updateTool(PALETTE_TERRAIN_QUEST_DOOR, "Quest Door");
+	updateTool(PALETTE_TERRAIN_NORMAL_ALT_DOOR, "Normal Door (alt)");
+	updateTool(PALETTE_TERRAIN_ARCHWAY_DOOR, "Archway");
+	updateTool(PALETTE_TERRAIN_HATCH_DOOR, "Hatch Window");
+	updateTool(PALETTE_TERRAIN_WINDOW_DOOR, "Window");
 
 	Brush* brush = g_gui.GetCurrentBrush();
 	if (brush) {

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -50,19 +50,22 @@ StandardToolBar::~StandardToolBar() {
 void StandardToolBar::Update() {
 	Editor* editor = g_gui.GetCurrentEditor();
 	if (editor) {
-		toolbar->EnableTool(wxID_UNDO, editor->actionQueue->canUndo());
-		toolbar->EnableTool(wxID_REDO, editor->actionQueue->canRedo());
+		bool canUndo = editor->actionQueue->canUndo();
+		toolbar->EnableTool(wxID_UNDO, canUndo);
+		toolbar->SetToolShortHelp(wxID_UNDO, canUndo ? "Undo (Ctrl+Z)" : "Undo (Ctrl+Z) - Nothing to undo");
+
+		bool canRedo = editor->actionQueue->canRedo();
+		toolbar->EnableTool(wxID_REDO, canRedo);
+		toolbar->SetToolShortHelp(wxID_REDO, canRedo ? "Redo (Ctrl+Shift+Z)" : "Redo (Ctrl+Shift+Z) - Nothing to redo");
 
 		bool canPaste = editor->copybuffer.canPaste();
 		toolbar->EnableTool(wxID_PASTE, canPaste);
-		if (canPaste) {
-			toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V)");
-		} else {
-			toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - Clipboard empty");
-		}
+		toolbar->SetToolShortHelp(wxID_PASTE, canPaste ? "Paste (Ctrl+V)" : "Paste (Ctrl+V) - Clipboard empty");
 	} else {
 		toolbar->EnableTool(wxID_UNDO, false);
+		toolbar->SetToolShortHelp(wxID_UNDO, "Undo (Ctrl+Z) - No editor open");
 		toolbar->EnableTool(wxID_REDO, false);
+		toolbar->SetToolShortHelp(wxID_REDO, "Redo (Ctrl+Shift+Z) - No editor open");
 		toolbar->EnableTool(wxID_PASTE, false);
 		toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - No editor open");
 	}
@@ -71,9 +74,16 @@ void StandardToolBar::Update() {
 	bool is_host = has_map && !editor->live_manager.IsClient();
 
 	toolbar->EnableTool(wxID_SAVE, is_host);
+	toolbar->SetToolShortHelp(wxID_SAVE, is_host ? "Save Map (Ctrl+S)" : (has_map ? "Save Map (Ctrl+S) - Client cannot save" : "Save Map (Ctrl+S) - No map open"));
+
 	toolbar->EnableTool(wxID_SAVEAS, is_host);
+	toolbar->SetToolShortHelp(wxID_SAVEAS, is_host ? "Save Map As... (Ctrl+Alt+S)" : (has_map ? "Save Map As... (Ctrl+Alt+S) - Client cannot save" : "Save Map As... (Ctrl+Alt+S) - No map open"));
+
 	toolbar->EnableTool(wxID_CUT, has_map);
+	toolbar->SetToolShortHelp(wxID_CUT, has_map ? "Cut (Ctrl+X)" : "Cut (Ctrl+X) - No map open");
+
 	toolbar->EnableTool(wxID_COPY, has_map);
+	toolbar->SetToolShortHelp(wxID_COPY, has_map ? "Copy (Ctrl+C)" : "Copy (Ctrl+C) - No map open");
 
 	toolbar->Refresh();
 }

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -92,13 +92,16 @@ WelcomeDialogPanel::WelcomeDialogPanel(WelcomeDialog* dialog, const wxSize& size
 	wxPoint newMapButtonPoint(button_pos_center_x, button_pos_center_y);
 	auto* new_map_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "New");
 	new_map_button->SetAction(wxID_NEW);
+	new_map_button->SetToolTip("Create a new map");
 	new_map_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
 
 	auto* open_map_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "Open");
 	open_map_button->SetAction(wxID_OPEN);
+	open_map_button->SetToolTip("Open an existing map");
 	open_map_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
 	auto* preferences_button = newd WelcomeDialogButton(this, wxDefaultPosition, button_size, button_base_colour, "Preferences");
 	preferences_button->SetAction(wxID_PREFERENCES);
+	preferences_button->SetToolTip("Configure editor preferences");
 	preferences_button->Bind(wxEVT_LEFT_UP, &WelcomeDialog::OnButtonClicked, dialog);
 
 	Bind(wxEVT_PAINT, &WelcomeDialogPanel::OnPaint, this);


### PR DESCRIPTION
This PR implements 10 micro-UX improvements as requested by the Palette agent instructions. It also fixes some build errors encountered during verification.

**UX Improvements:**
1.  **Standard Toolbar:** Dynamic tooltips for Undo/Redo/Cut/Copy/Save explaining disabled state.
2.  **Brush Toolbar:** Dynamic tooltips for disabled brushes.
3.  **Save Map:** Status bar success message "Map saved successfully".
4.  **About Window:** Fixed potential crash on unknown OpenGL version.
5.  **About Window:** Added "Copy Version Info" button.
6.  **Welcome Dialog:** Added tooltips to main buttons.
7.  **Result Window:** Added tooltips to Export/Clear.
8.  **Tileset Window:** Added tooltips to OK/Cancel.
9.  **Map Properties Window:** Added tooltips to fields/buttons.
10. **Minimap Window:** Added tooltip "Click to move camera".

**Build Fixes:**
- Removed `DECLARE_EVENT_TABLE()` from `source/palette/panels/brush_panel.h` and `source/ui/properties/properties_window.h` as the implementation files utilize `Bind()` and do not define the event table, causing linker errors.
- Updated `source/editor/operations/selection_operations.cpp` and `source/rendering/drawers/cursors/drag_shadow_drawer.cpp` to use `auto` for iterators, resolving a type mismatch between `std::vector` and `std::set` iterators (Selection type change).

---
*PR created automatically by Jules for task [7142207104876681066](https://jules.google.com/task/7142207104876681066) started by @karolak6612*