### PR TITLE
⚡ Throttle: Optimize TileRenderer and TooltipDrawer hot paths

### DIFF
--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -51,6 +51,13 @@ void TooltipDrawer::addItemTooltip(const TooltipData& data) {
 	tooltips.push_back(data);
 }
 
+void TooltipDrawer::addItemTooltip(TooltipData&& data) {
+	if (!data.hasVisibleFields()) {
+		return;
+	}
+	tooltips.push_back(std::move(data));
+}
+
 void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
 	if (name.empty()) {
 		return;

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -131,6 +131,7 @@ public:
 
 	// Add a structured tooltip for an item
 	void addItemTooltip(const TooltipData& data);
+	void addItemTooltip(TooltipData&& data);
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);


### PR DESCRIPTION
This PR implements several performance optimizations identified by the Throttle agent:
1.  **TileRenderer::DrawTile**: Hoisted `GetHouseColor` calculation out of the loop over items.
2.  **TileRenderer::DrawTile**: Restricted tooltip generation to only the tile under the mouse cursor (`view.mouse_map_x`, `view.mouse_map_y`), preventing generation of tooltips for all visible tiles.
3.  **CreateItemTooltipData**: Added `reserve()` for `containerItems` vector.
4.  **TooltipDrawer**: Added `addItemTooltip(TooltipData&&)` to support move semantics, reducing string and vector copies.

These changes significantly reduce memory allocations and CPU usage during the rendering loop, especially when tooltips are enabled.

---
*PR created automatically by Jules for task [237392963039582633](https://jules.google.com/task/237392963039582633) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized tooltip display to show exclusively for tiles directly beneath the cursor, reducing on-screen clutter and improving overall responsiveness, fluidity, and application performance
  * Improved tile rendering efficiency through optimized house color processing and calculations during various rendering operations
  * Enhanced tooltip data processing with improved memory management for better overall performance, efficiency, and responsiveness

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->