### PR TITLE
[REFACTOR] Fix code smells in items.cpp and iomap_otbm.cpp

### DIFF
--- a/source/game/items.h
+++ b/source/game/items.h
@@ -458,6 +458,13 @@ protected:
 	bool loadFromOtbVer2(BinaryNode* itemNode, wxString& error, wxArrayString& warnings);
 	bool loadFromOtbVer3(BinaryNode* itemNode, wxString& error, wxArrayString& warnings);
 
+	void parseItemGroup(ItemType* t, uint8_t group, wxArrayString& warnings);
+	void parseCommonFlags(ItemType* t, uint32_t flags);
+	bool parseCommonAttribute(ItemType* t, uint8_t attribute, uint16_t datalen, BinaryNode* itemNode, wxString& error, wxArrayString& warnings);
+
+	void parseItemTypeAttribute(ItemType& it, const std::string& value);
+	void parseItemGeneralAttribute(ItemType& it, const std::string& key, const std::string& value);
+
 protected:
 	// Count of GameSprite types
 	uint16_t item_count;

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -139,6 +139,7 @@ protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+	bool readTileArea(Map& map, BinaryNode* mapNode);
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
This PR addresses code smells identified by the 'Smeller' agent.
It refactors `source/game/items.cpp` to remove significant duplication in OTB loading methods and simplify the massive XML loading method.
It also refactors `source/io/iomap_otbm.cpp` to decompose the `loadMap` method.
These changes improve maintainability and readability without altering behavior.

---
*PR created automatically by Jules for task [18013366599394750173](https://jules.google.com/task/18013366599394750173) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal improvements to item parsing and map tile loading systems for enhanced code organization and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->