### PR TITLE
⚡ Bolt: Rendering optimizations for tooltips and tile colors

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,7 @@
 ## 2025-02-18 - Rendering Bottleneck: Per-Tile Logic
 Learning: `TileRenderer::DrawTile` executes per visible tile every frame. Tooltips are currently drawn for all items, which is intentional (labels), but this design choice inherently limits performance on large views due to string operations.
 Action: Future optimizations for tooltips should focus on caching the generated strings or using a more efficient font renderer, rather than culling them, as culling contradicts the "label" behavior.
+
+## 2025-02-18 - Tooltip Allocations
+Learning: `TooltipDrawer::draw` was allocating `std::vector<FieldLine>` inside a loop for every tooltip, causing allocator churn. Also `TileRenderer` was deep-copying `TooltipData` (containing strings/vectors) every frame.
+Action: Use persistent scratch buffers (member variables) for immediate-mode rendering loops to avoid allocation. Use `std::move` for passing heavy transient data like tooltips.

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -102,6 +102,7 @@ static TooltipData CreateItemTooltipData(Item* item, const Position& pos, bool i
 			// but getItem(i) is safer if available, or just iterating vector.
 			// Container::getVector() returns ItemVector& (std::vector<Item*>)
 			const ItemVector& items = container->getVector();
+			data.containerItems.reserve(items.size());
 			for (Item* subItem : items) {
 				if (subItem) {
 					ContainerItem ci;
@@ -222,13 +223,20 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	if (!only_colors) {
 		if (view.zoom < 10.0 || !options.hide_items_when_zoomed) {
+			// Hoist house color calculation out of item loop
+			uint8_t house_r = 255, house_g = 255, house_b = 255;
+			bool calculate_house_color = options.extended_house_shader && options.show_houses && tile->isHouseTile();
+			if (calculate_house_color) {
+				TileColorCalculator::GetHouseColor(tile->getHouseID(), house_r, house_g, house_b);
+			}
+
 			// items on tile
 			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
 					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
 					if (itemData.hasVisibleFields()) {
-						tooltip_drawer->addItemTooltip(itemData);
+						tooltip_drawer->addItemTooltip(std::move(itemData));
 					}
 				}
 
@@ -243,17 +251,13 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
-					if (options.extended_house_shader && options.show_houses && tile->isHouseTile()) {
-						uint32_t house_id = tile->getHouseID();
-						uint8_t hr = 255, hg = 255, hb = 255;
-						TileColorCalculator::GetHouseColor(house_id, hr, hg, hb);
-
+					if (calculate_house_color) {
 						// Apply house color tint
-						ir = (uint8_t)((int)ir * hr / 255);
-						ig = (uint8_t)((int)ig * hg / 255);
-						ib = (uint8_t)((int)ib * hb / 255);
+						ir = (uint8_t)((int)ir * house_r / 255);
+						ig = (uint8_t)((int)ig * house_g / 255);
+						ib = (uint8_t)((int)ib * house_b / 255);
 
-						if ((int)house_id == current_house_id) {
+						if ((int)tile->getHouseID() == current_house_id) {
 							// Pulse effect matching the tile pulse
 							if (options.highlight_pulse > 0.0f) {
 								float boost = options.highlight_pulse * 0.6f;

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -51,6 +51,13 @@ void TooltipDrawer::addItemTooltip(const TooltipData& data) {
 	tooltips.push_back(data);
 }
 
+void TooltipDrawer::addItemTooltip(TooltipData&& data) {
+	if (!data.hasVisibleFields()) {
+		return;
+	}
+	tooltips.push_back(std::move(data));
+}
+
 void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
 	if (name.empty()) {
 		return;
@@ -228,13 +235,8 @@ void TooltipDrawer::draw(const RenderView& view) {
 		float maxWidth = 220.0f; // Max content width for wrapping
 
 		// Build content lines with word wrapping support
-		struct FieldLine {
-			std::string label;
-			std::string value;
-			uint8_t r, g, b;
-			std::vector<std::string> wrappedLines; // For multi-line values
-		};
-		std::vector<FieldLine> fields;
+		scratch_fields.clear();
+		std::vector<FieldLine>& fields = scratch_fields;
 
 		if (tooltip.category == TooltipCategory::WAYPOINT) {
 			fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -131,6 +131,7 @@ public:
 
 	// Add a structured tooltip for an item
 	void addItemTooltip(const TooltipData& data);
+	void addItemTooltip(TooltipData&& data);
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);
@@ -142,6 +143,14 @@ public:
 	void clear();
 
 protected:
+	struct FieldLine {
+		std::string label;
+		std::string value;
+		uint8_t r, g, b;
+		std::vector<std::string> wrappedLines; // For multi-line values
+	};
+	std::vector<FieldLine> scratch_fields;
+
 	std::vector<TooltipData> tooltips;
 	std::map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
 	NVGcontext* lastContext = nullptr;


### PR DESCRIPTION
💡 **What**: Implemented three performance optimizations:
1. Hoisted house color calculation in `TileRenderer::DrawTile`.
2. Used move semantics (`std::move`) for passing `TooltipData`.
3. Added a persistent `scratch_fields` buffer in `TooltipDrawer` for text wrapping.

🎯 **Why**:
- **House Color**: Previously calculated for *every item* on a house tile. Now calculated once per tile.
- **Move Semantics**: `TooltipData` contains strings and vectors. Passing by value (copy) was expensive.
- **Scratch Buffer**: `TooltipDrawer::draw` was allocating a `std::vector<FieldLine>` for *every tooltip, every frame*. This eliminates that allocation churn.

📊 **Impact**: Reduces CPU overhead on house tiles and significantly reduces memory allocation/deallocation frequency during the rendering pass.

🔬 **Measurement**: Verified compilation of modified files. Optimizations follow standard zero-overhead principles.

---
*PR created automatically by Jules for task [13152006104067747793](https://jules.google.com/task/13152006104067747793) started by @karolak6612*