### PR TITLE
[UB FIX] Fix Division by Zero and LiveServer Visibility Logic

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1544,7 +1544,7 @@ bool IOMapOTBM::saveMap(Map& map, NodeFileWriteHandle& f) {
 			while (map_iterator != map.end()) {
 				// Update progressbar
 				++tiles_saved;
-				if (tiles_saved % 8192 == 0) {
+				if (tiles_saved % 8192 == 0 && map.getTileCount() > 0) {
 					g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
 				}
 

--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -801,7 +801,7 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 				while (map_iterator != map.end()) {
 					// Update progressbar
 					++tiles_saved;
-					if (showdialog && tiles_saved % 8192 == 0) {
+					if (showdialog && tiles_saved % 8192 == 0 && map.getTileCount() > 0) {
 						g_gui.SetLoadDone(int(tiles_saved / double(map.getTileCount()) * 100.0));
 					}
 

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -158,7 +158,7 @@ bool LiveServer::setPort(int32_t newPort) {
 }
 
 uint32_t LiveServer::getFreeClientId() {
-	for (int32_t bit = 1; bit < (1 << 16); bit <<= 1) {
+	for (int32_t bit = 16; bit < (1 << 16); bit <<= 1) {
 		if (!testFlags(clientIds, bit)) {
 			clientIds |= bit;
 			return bit;

--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -158,23 +158,23 @@ bool QTreeNode::isRequested(bool underground) {
 	}
 }
 
-void QTreeNode::clearVisible(uint32_t u) {
+void QTreeNode::clearVisible(uint32_t clientMask) {
 	if (isLeaf) {
-		visible &= u;
+		visible &= clientMask;
 	} else {
 		for (int i = 0; i < MAP_LAYERS; ++i) {
 			if (child[i]) {
-				child[i]->clearVisible(u);
+				child[i]->clearVisible(clientMask);
 			}
 		}
 	}
 }
 
-bool QTreeNode::isVisible(uint32_t client, bool underground) {
+bool QTreeNode::isVisible(uint32_t clientMask, bool underground) {
 	if (underground) {
-		return testFlags(visible >> MAP_LAYERS, static_cast<uint64_t>(1) << client);
+		return testFlags(visible >> MAP_LAYERS, static_cast<uint64_t>(clientMask));
 	} else {
-		return testFlags(visible, static_cast<uint64_t>(1) << client);
+		return testFlags(visible, static_cast<uint64_t>(clientMask));
 	}
 }
 
@@ -202,11 +202,11 @@ void QTreeNode::setRequested(bool underground, bool r) {
 	}
 }
 
-void QTreeNode::setVisible(uint32_t client, bool underground, bool value) {
+void QTreeNode::setVisible(uint32_t clientMask, bool underground, bool value) {
 	if (value) {
-		visible |= (1 << client << (underground ? MAP_LAYERS : 0));
+		visible |= (clientMask << (underground ? MAP_LAYERS : 0));
 	} else {
-		visible &= ~(1 << client << (underground ? MAP_LAYERS : 0));
+		visible &= ~(clientMask << (underground ? MAP_LAYERS : 0));
 	}
 }
 

--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -177,9 +177,9 @@ public:
 	}
 
 	void setVisible(bool overground, bool underground);
-	void setVisible(uint32_t client, bool underground, bool value);
-	bool isVisible(uint32_t client, bool underground);
-	void clearVisible(uint32_t client);
+	void setVisible(uint32_t clientMask, bool underground, bool value);
+	bool isVisible(uint32_t clientMask, bool underground);
+	void clearVisible(uint32_t clientMask);
 
 	void setRequested(bool underground, bool r);
 	bool isVisible(bool underground);


### PR DESCRIPTION
This PR addresses critical bugs identified during the weekly deep scan by the Phantom agent:

1.  **Division by Zero**: Fixed potential division by zero errors in `IOMapOTBM::saveMap` and `IOMapOTMM::saveMap` when saving maps with zero tiles.
2.  **LiveServer/QTreeNode Logic Bug**: Fixed a critical mismatch between `LiveServer` (which generates bitmasks for client IDs) and `QTreeNode` (which interpreted them as indices and double-shifted them). This caused incorrect visibility flags and potential undefined behavior (shifts >= 32).
    *   `LiveServer::getFreeClientId` now starts allocating at bit 4 (value 16) to avoid conflicts with reserved visibility flags (bits 0-3).
    *   `QTreeNode` methods now accept `clientMask` and apply it directly without shifting.

Note: `source/io/iomap_otmm.cpp` is currently excluded from the build in `CMakeLists.txt`, but the fix was applied for correctness and future-proofing.

---
*PR created automatically by Jules for task [10237185503437059951](https://jules.google.com/task/10237185503437059951) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential crashes when saving empty maps
  * Improved stability in progress reporting during map save operations by preventing division-by-zero errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->