### PR TITLE
[MODERNIZE] Use range-based for loops and std::ranges in UI panels

### DIFF
--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -117,8 +117,8 @@ bool BrushPanel::SelectBrush(const Brush* whatbrush) {
 		return brushbox->SelectBrush(whatbrush);
 	}
 
-	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
-		if (*iter == whatbrush) {
+	for (const auto* brush : tileset->brushlist) {
+		if (brush == whatbrush) {
 			LoadContents();
 			return brushbox->SelectBrush(whatbrush);
 		}
@@ -172,10 +172,10 @@ BrushIconBox::BrushIconBox(wxWindow* parent, const TilesetCategory* _tileset, Re
 
 	// Create buttons
 	wxSizer* sizer = newd wxWrapSizer(wxHORIZONTAL);
-	for (BrushVector::const_iterator iter = tileset->brushlist.begin(); iter != tileset->brushlist.end(); ++iter) {
-		ASSERT(*iter);
+	for (auto* brush : tileset->brushlist) {
+		ASSERT(brush);
 
-		BrushButton* bb = newd BrushButton(this, *iter, rsz);
+		BrushButton* bb = newd BrushButton(this, brush, rsz);
 		sizer->Add(bb);
 		brush_buttons.push_back(bb);
 	}
@@ -202,9 +202,9 @@ Brush* BrushIconBox::GetSelectedBrush() const {
 		return nullptr;
 	}
 
-	for (std::vector<BrushButton*>::const_iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		if ((*it)->GetValue()) {
-			return (*it)->brush;
+	for (const auto* btn : brush_buttons) {
+		if (btn->GetValue()) {
+			return btn->brush;
 		}
 	}
 	return nullptr;
@@ -212,10 +212,10 @@ Brush* BrushIconBox::GetSelectedBrush() const {
 
 bool BrushIconBox::SelectBrush(const Brush* whatbrush) {
 	DeselectAll();
-	for (std::vector<BrushButton*>::iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		if ((*it)->brush == whatbrush) {
-			(*it)->SetValue(true);
-			EnsureVisible(*it);
+	for (auto* btn : brush_buttons) {
+		if (btn->brush == whatbrush) {
+			btn->SetValue(true);
+			EnsureVisible(btn);
 			return true;
 		}
 	}
@@ -223,8 +223,8 @@ bool BrushIconBox::SelectBrush(const Brush* whatbrush) {
 }
 
 void BrushIconBox::DeselectAll() {
-	for (std::vector<BrushButton*>::iterator it = brush_buttons.begin(); it != brush_buttons.end(); ++it) {
-		(*it)->SetValue(false);
+	for (auto* btn : brush_buttons) {
+		btn->SetValue(false);
 	}
 }
 

--- a/source/rendering/ui/selection_controller.cpp
+++ b/source/rendering/ui/selection_controller.cpp
@@ -422,11 +422,11 @@ void SelectionController::ExecuteBoundboxSelection(const Position& start_pos, co
 	ASSERT(remainder == 0);
 
 	editor.selection.start(); // Start a selection session
-	for (std::vector<SelectionThread*>::iterator iter = threads.begin(); iter != threads.end(); ++iter) {
-		(*iter)->Execute();
+	for (auto* thread : threads) {
+		thread->Execute();
 	}
-	for (std::vector<SelectionThread*>::iterator iter = threads.begin(); iter != threads.end(); ++iter) {
-		editor.selection.join(*iter);
+	for (auto* thread : threads) {
+		editor.selection.join(thread);
 	}
 	editor.selection.finish(); // Finish the selection session
 	editor.selection.updateSelectionCount();

--- a/source/ui/map/towns_window.cpp
+++ b/source/ui/map/towns_window.cpp
@@ -7,6 +7,9 @@
 #include "ui/gui.h"
 #include "ui/dialog_util.h"
 
+#include <algorithm>
+#include <iterator>
+
 BEGIN_EVENT_TABLE(EditTownsDialog, wxDialog)
 EVT_LISTBOX(EDIT_TOWNS_LISTBOX, EditTownsDialog::OnListBoxChange)
 EVT_BUTTON(EDIT_TOWNS_SELECT_TEMPLE, EditTownsDialog::OnClickSelectTemplePosition)
@@ -25,8 +28,7 @@ EditTownsDialog::EditTownsDialog(wxWindow* parent, Editor& editor) :
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* tmpsizer;
 
-	for (TownMap::const_iterator town_iter = map.towns.begin(); town_iter != map.towns.end(); ++town_iter) {
-		Town* town = town_iter->second;
+	for (const auto& [id, town] : map.towns) {
 		town_list.push_back(newd Town(*town));
 		if (max_town_id < town->getID()) {
 			max_town_id = town->getID();
@@ -70,8 +72,8 @@ EditTownsDialog::EditTownsDialog(wxWindow* parent, Editor& editor) :
 }
 
 EditTownsDialog::~EditTownsDialog() {
-	for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-		delete *town_iter;
+	for (auto* town : town_list) {
+		delete town;
 	}
 }
 
@@ -84,16 +86,15 @@ void EditTownsDialog::BuildListBox(bool doselect) {
 	if (doselect && id_field->GetValue().ToLong(&tmplong)) {
 		uint32_t old_town_id = tmplong;
 
-		for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-			if (old_town_id == (*town_iter)->getID()) {
-				selection_before = (*town_iter)->getID();
+		for (const auto* town : town_list) {
+			if (old_town_id == town->getID()) {
+				selection_before = town->getID();
 				break;
 			}
 		}
 	}
 
-	for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-		Town* town = *town_iter;
+	for (const auto* town : town_list) {
 		town_name_list.Add(wxstr(town->getName()));
 		if (max_town_id < town->getID()) {
 			max_town_id = town->getID();
@@ -107,8 +108,8 @@ void EditTownsDialog::BuildListBox(bool doselect) {
 	if (doselect) {
 		if (selection_before) {
 			int i = 0;
-			for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-				if (selection_before == (*town_iter)->getID()) {
+			for (const auto* town : town_list) {
+				if (selection_before == town->getID()) {
 					town_listbox->SetSelection(i);
 					return;
 				}
@@ -129,9 +130,9 @@ void EditTownsDialog::UpdateSelection(int new_selection) {
 
 			Town* old_town = nullptr;
 
-			for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-				if (old_town_id == (*town_iter)->getID()) {
-					old_town = *town_iter;
+			for (auto* town : town_list) {
+				if (old_town_id == town->getID()) {
+					old_town = town;
 					break;
 				}
 			}
@@ -212,25 +213,23 @@ void EditTownsDialog::OnClickRemove(wxCommandEvent& WXUNUSED(event)) {
 		uint32_t old_town_id = tmplong;
 
 		Town* town = nullptr;
-
-		std::vector<Town*>::iterator town_iter = town_list.begin();
-
 		int selection_index = 0;
-		while (town_iter != town_list.end()) {
-			if (old_town_id == (*town_iter)->getID()) {
-				town = *town_iter;
-				break;
-			}
-			++selection_index;
-			++town_iter;
+
+		auto town_iter = std::ranges::find_if(town_list, [old_town_id](const Town* t) {
+			return t->getID() == old_town_id;
+		});
+
+		if (town_iter != town_list.end()) {
+			town = *town_iter;
+			selection_index = static_cast<int>(std::distance(town_list.begin(), town_iter));
 		}
+
 		if (!town) {
 			return;
 		}
 
 		Map& map = editor.map;
-		for (HouseMap::iterator house_iter = map.houses.begin(); house_iter != map.houses.end(); ++house_iter) {
-			House* house = house_iter->second;
+		for (const auto& [id, house] : map.houses) {
 			if (house->townid == town->getID()) {
 				DialogUtil::PopupDialog(this, "Error", "You cannot delete a town which still has houses associated with it.", wxOK);
 				return;
@@ -258,9 +257,9 @@ void EditTownsDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 
 			Town* old_town = nullptr;
 
-			for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-				if (old_town_id == (*town_iter)->getID()) {
-					old_town = *town_iter;
+			for (auto* town : town_list) {
+				if (old_town_id == town->getID()) {
+					old_town = town;
 					break;
 				}
 			}
@@ -288,8 +287,7 @@ void EditTownsDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 		Towns& towns = editor.map.towns;
 
 		// Verify the newd information
-		for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-			Town* town = *town_iter;
+		for (const auto* town : town_list) {
 			if (town->getName() == "") {
 				DialogUtil::PopupDialog(this, "Error", "You can't have a town with an empty name.", wxOK);
 				return;
@@ -306,8 +304,8 @@ void EditTownsDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 		towns.clear();
 
 		// Build the newd town map
-		for (std::vector<Town*>::iterator town_iter = town_list.begin(); town_iter != town_list.end(); ++town_iter) {
-			towns.addTown(*town_iter);
+		for (auto* town : town_list) {
+			towns.addTown(town);
 		}
 		town_list.clear();
 		editor.map.doChange();


### PR DESCRIPTION
Modernized loops in `BrushPanel`, `EditTownsDialog`, and `SelectionController` to use range-based for loops, structured bindings, and `std::ranges`. Verified compilation with C++20.

---
*PR created automatically by Jules for task [13991397493978392206](https://jules.google.com/task/13991397493978392206) started by @karolak6612*