### PR TITLE
[TILE/WXWIDGETS] Fix legacy event tables and GDI management in UI windows

### DIFF
--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -29,16 +29,6 @@
 
 #include "rendering/drawers/minimap_drawer.h"
 
-BEGIN_EVENT_TABLE(MinimapWindow, wxPanel)
-EVT_LEFT_DOWN(MinimapWindow::OnMouseClick)
-EVT_SIZE(MinimapWindow::OnSize)
-EVT_PAINT(MinimapWindow::OnPaint)
-EVT_ERASE_BACKGROUND(MinimapWindow::OnEraseBackground)
-EVT_CLOSE(MinimapWindow::OnClose)
-EVT_TIMER(wxID_ANY, MinimapWindow::OnDelayedUpdate)
-EVT_KEY_DOWN(MinimapWindow::OnKey)
-END_EVENT_TABLE()
-
 // Helper to create attributes
 static wxGLAttributes& GetCoreProfileAttributes() {
 	static wxGLAttributes vAttrs = []() {
@@ -54,16 +44,23 @@ MinimapWindow::MinimapWindow(wxWindow* parent) :
 	update_timer(this),
 	context(nullptr) {
 	spdlog::info("MinimapWindow::MinimapWindow - Creating context");
-	context = new wxGLContext(this);
+	context = std::make_unique<wxGLContext>(this);
 	if (!context->IsOK()) {
 		spdlog::error("MinimapWindow::MinimapWindow - Context creation failed");
 	}
 	SetToolTip("Click to move camera");
 	drawer = std::make_unique<MinimapDrawer>();
+
+	Bind(wxEVT_LEFT_DOWN, &MinimapWindow::OnMouseClick, this);
+	Bind(wxEVT_SIZE, &MinimapWindow::OnSize, this);
+	Bind(wxEVT_PAINT, &MinimapWindow::OnPaint, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &MinimapWindow::OnEraseBackground, this);
+	Bind(wxEVT_CLOSE_WINDOW, &MinimapWindow::OnClose, this);
+	Bind(wxEVT_TIMER, &MinimapWindow::OnDelayedUpdate, this, wxID_ANY);
+	Bind(wxEVT_KEY_DOWN, &MinimapWindow::OnKey, this);
 }
 
 MinimapWindow::~MinimapWindow() {
-	delete context;
 }
 
 void MinimapWindow::OnSize(wxSizeEvent& event) {

--- a/source/rendering/ui/minimap_window.h
+++ b/source/rendering/ui/minimap_window.h
@@ -19,6 +19,7 @@
 #define RME_MINIMAP_WINDOW_H_
 
 #include <wx/glcanvas.h>
+#include <memory>
 
 class MinimapDrawer;
 class MinimapWindow : public wxGLCanvas {
@@ -39,9 +40,7 @@ public:
 protected:
 	std::unique_ptr<MinimapDrawer> drawer;
 	wxTimer update_timer;
-	wxGLContext* context;
-
-	DECLARE_EVENT_TABLE()
+	std::unique_ptr<wxGLContext> context;
 };
 
 #endif

--- a/source/ui/add_tileset_window.cpp
+++ b/source/ui/add_tileset_window.cpp
@@ -40,11 +40,6 @@
 // ============================================================================
 // Add Tileset Window
 
-BEGIN_EVENT_TABLE(AddTilesetWindow, wxDialog)
-EVT_BUTTON(wxID_OK, AddTilesetWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, AddTilesetWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
 AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType categoryType, wxPoint pos) :
@@ -55,6 +50,9 @@ AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType cat
 	tileset_name_field(nullptr),
 	item_id_field(nullptr),
 	item_button(nullptr) {
+	Bind(wxEVT_BUTTON, &AddTilesetWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &AddTilesetWindow::OnClickCancel, this, wxID_CANCEL);
+
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxString description = "Add a Tileset";
 
@@ -94,8 +92,8 @@ AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType cat
 	SetSizerAndFit(topsizer);
 	Centre(wxBOTH);
 
-	item_id_field->Connect(wxEVT_COMMAND_SPINCTRL_UPDATED, wxCommandEventHandler(AddTilesetWindow::OnChangeItemId), nullptr, this);
-	item_button->Connect(wxEVT_LEFT_DOWN, wxMouseEventHandler(AddTilesetWindow::OnItemClicked), nullptr, this);
+	item_id_field->Bind(wxEVT_SPINCTRL, &AddTilesetWindow::OnChangeItemId, this);
+	item_button->Bind(wxEVT_LEFT_DOWN, &AddTilesetWindow::OnItemClicked, this);
 }
 
 void AddTilesetWindow::OnChangeItemId(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/add_tileset_window.h
+++ b/source/ui/add_tileset_window.h
@@ -46,8 +46,6 @@ protected:
 
 	TilesetCategoryType category_type;
 	DCButton* item_button;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/ui/tileset_window.cpp
+++ b/source/ui/tileset_window.cpp
@@ -39,11 +39,6 @@
 // ============================================================================
 // Tileset Window
 
-BEGIN_EVENT_TABLE(TilesetWindow, wxDialog)
-EVT_BUTTON(wxID_OK, TilesetWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, TilesetWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
 TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
@@ -51,6 +46,9 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	palette_field(nullptr),
 	tileset_field(nullptr) {
 	ASSERT(edit_item);
+
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &TilesetWindow::OnClickCancel, this, wxID_CANCEL);
 
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxString description = "Move to Tileset";
@@ -74,7 +72,7 @@ TilesetWindow::TilesetWindow(wxWindow* win_parent, const Map* map, const Tile* t
 	palette_field->Append("Raw", newd int(TILESET_RAW));
 	palette_field->SetSelection(3);
 
-	palette_field->Connect(wxEVT_COMMAND_CHOICE_SELECTED, wxCommandEventHandler(TilesetWindow::OnChangePalette), nullptr, this);
+	palette_field->Bind(wxEVT_CHOICE, &TilesetWindow::OnChangePalette, this);
 	subsizer->Add(palette_field, wxSizerFlags(1).Expand());
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset"));

--- a/source/ui/tileset_window.h
+++ b/source/ui/tileset_window.h
@@ -39,8 +39,6 @@ protected:
 	// tileset
 	wxChoice* palette_field;
 	wxChoice* tileset_field;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif


### PR DESCRIPTION
ISSUE: Legacy wxWidgets event tables (BEGIN_EVENT_TABLE) and Connect() calls were used in TilesetWindow, MinimapWindow, and AddTilesetWindow, which are type-unsafe and deprecated. MinimapWindow also used raw pointers for wxGLContext management.
IMPACT: Potential type safety issues, harder maintenance, and risk of memory leaks (in MinimapWindow).
FIX:
1. Replaced BEGIN_EVENT_TABLE and Connect() with Bind() in TilesetWindow, MinimapWindow, and AddTilesetWindow.
2. Replaced wxGLContext* with std::unique_ptr<wxGLContext> in MinimapWindow to enforce RAII.
DOMAIN CONTEXT: Modernizing wxWidgets usage improves stability and safety of the editor UI.
TESTED: Verified code changes manually. Fixes follow standard wxWidgets modernization patterns.

---
*PR created automatically by Jules for task [17244742152392378992](https://jules.google.com/task/17244742152392378992) started by @karolak6612*