### PR TITLE
🗝️ Keeper: Refactor Live system memory management and ownership

### DIFF
--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -46,7 +46,7 @@
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::make_unique<ActionQueue>(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -57,7 +57,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName& fn) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::make_unique<ActionQueue>(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -67,9 +67,9 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName
 	EditorPersistence::loadMap(*this, fn);
 }
 
-Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* client) :
-	live_manager(*this, client),
-	actionQueue(newd NetworkedActionQueue(*this)),
+Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, std::unique_ptr<LiveClient> client) :
+	live_manager(*this, std::move(client)),
+	actionQueue(std::make_unique<NetworkedActionQueue>(*this)),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -85,7 +85,6 @@ Editor::~Editor() {
 
 	UnnamedRenderingLock();
 	selection.clear();
-	delete actionQueue;
 	spdlog::info("Editor destroyed [Editor={}]", (void*)this);
 }
 

--- a/source/editor/editor.h
+++ b/source/editor/editor.h
@@ -38,10 +38,11 @@ class LiveSocket;
 #include "live/live_manager.h"
 
 #include <functional>
+#include <memory>
 
 class Editor {
 public:
-	Editor(CopyBuffer& copybuffer, const MapVersion& version, LiveClient* client);
+	Editor(CopyBuffer& copybuffer, const MapVersion& version, std::unique_ptr<LiveClient> client);
 	Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName& fn);
 	Editor(CopyBuffer& copybuffer, const MapVersion& version);
 	~Editor();
@@ -51,7 +52,7 @@ public:
 
 public:
 	// Public members
-	ActionQueue* actionQueue;
+	std::unique_ptr<ActionQueue> actionQueue;
 	Selection selection;
 	CopyBuffer& copybuffer;
 	GroundBrush* replace_brush;

--- a/source/editor/editor_factory.cpp
+++ b/source/editor/editor_factory.cpp
@@ -7,6 +7,7 @@
 #include "ui/gui.h"
 #include "app/settings.h"
 #include "io/iomap.h"
+#include "live/live_client.h"
 
 void SetupCallbacks(Editor* editor) {
 	editor->onStateChange = []() {
@@ -63,12 +64,12 @@ std::unique_ptr<Editor> EditorFactory::LoadFromFile(CopyBuffer& copybuffer, cons
 	return editor;
 }
 
-std::unique_ptr<Editor> EditorFactory::JoinLive(CopyBuffer& copybuffer, LiveClient* client) {
+std::unique_ptr<Editor> EditorFactory::JoinLive(CopyBuffer& copybuffer, std::unique_ptr<LiveClient> client) {
 	MapVersion mapVersion;
 	mapVersion.otbm = g_version.GetCurrentVersion().getPrefferedMapVersionID();
 	mapVersion.client = g_version.GetCurrentVersionID();
 
-	std::unique_ptr<Editor> editor = std::make_unique<Editor>(copybuffer, mapVersion, client);
+	std::unique_ptr<Editor> editor = std::make_unique<Editor>(copybuffer, mapVersion, std::move(client));
 	SetupCallbacks(editor.get());
 	return editor;
 }

--- a/source/editor/editor_factory.h
+++ b/source/editor/editor_factory.h
@@ -17,7 +17,7 @@ public:
 	static std::unique_ptr<Editor> LoadFromFile(CopyBuffer& copybuffer, const FileName& fn);
 
 	// Joins a live session
-	static std::unique_ptr<Editor> JoinLive(CopyBuffer& copybuffer, LiveClient* client);
+	static std::unique_ptr<Editor> JoinLive(CopyBuffer& copybuffer, std::unique_ptr<LiveClient> client);
 
 private:
 	// Helper to ensure the correct version is loaded in g_gui

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -214,7 +214,7 @@ bool EditorManager::NewMap() {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 	mapTab->GetMap()->clearChanges();
 
@@ -305,7 +305,7 @@ bool EditorManager::LoadMap(const FileName& fileName) {
 		return false;
 	}
 
-	auto* mapTab = newd MapTab(g_gui.tabbook, editor.release());
+	auto* mapTab = newd MapTab(g_gui.tabbook, std::move(editor));
 	mapTab->OnSwitchEditorMode(g_gui.mode);
 
 	g_gui.root->AddRecentFile(fileName);

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -240,11 +240,11 @@ LiveLogTab* LiveClient::createLogWindow(wxWindow* parent) {
 	return log;
 }
 
-MapTab* LiveClient::createEditorWindow() {
+MapTab* LiveClient::createEditorWindow(std::shared_ptr<Editor> editor) {
 	MapTabbook* mtb = dynamic_cast<MapTabbook*>(g_gui.tabbook);
 	ASSERT(mtb);
 
-	MapTab* edit = newd MapTab(mtb, editor.get());
+	MapTab* edit = newd MapTab(mtb, editor);
 	edit->OnSwitchEditorMode(g_gui.IsSelectionMode() ? SELECTION_MODE : DRAWING_MODE);
 
 	return edit;
@@ -372,14 +372,15 @@ void LiveClient::parsePacket(NetworkMessage message) {
 
 void LiveClient::parseHello(NetworkMessage& message) {
 	ASSERT(editor == nullptr);
-	editor = EditorFactory::JoinLive(g_gui.copybuffer, this);
+	std::shared_ptr<Editor> sharedEditor = EditorFactory::JoinLive(g_gui.copybuffer, std::unique_ptr<LiveClient>(this));
+	editor = sharedEditor.get();
 
 	Map& map = editor->map;
 	map.setName("Live Map - " + message.read<std::string>());
 	map.setWidth(message.read<uint16_t>());
 	map.setHeight(message.read<uint16_t>());
 
-	createEditorWindow();
+	createEditorWindow(sharedEditor);
 }
 
 void LiveClient::parseKick(NetworkMessage& message) {

--- a/source/live/live_client.h
+++ b/source/live/live_client.h
@@ -50,7 +50,7 @@ public:
 	void updateCursor(const Position& position);
 
 	LiveLogTab* createLogWindow(wxWindow* parent);
-	MapTab* createEditorWindow();
+	MapTab* createEditorWindow(std::shared_ptr<Editor> editor);
 
 	// send packets
 	void sendHello();
@@ -85,7 +85,7 @@ protected:
 	std::shared_ptr<boost::asio::ip::tcp::resolver> resolver;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;
 
-	std::unique_ptr<Editor> editor;
+	Editor* editor;
 
 	bool stopped;
 };

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -18,10 +18,10 @@ LiveManager::LiveManager(Editor& editor) :
 	live_client(nullptr) {
 }
 
-LiveManager::LiveManager(Editor& editor, LiveClient* client) :
+LiveManager::LiveManager(Editor& editor, std::unique_ptr<LiveClient> client) :
 	editor(editor),
 	live_server(nullptr),
-	live_client(client) {
+	live_client(std::move(client)) {
 }
 
 LiveManager::~LiveManager() {
@@ -47,11 +47,11 @@ bool LiveManager::IsLocal() const {
 }
 
 LiveClient* LiveManager::GetClient() const {
-	return live_client;
+	return live_client.get();
 }
 
 LiveServer* LiveManager::GetServer() const {
-	return live_server;
+	return live_server.get();
 }
 
 LiveSocket& LiveManager::GetSocket() const {
@@ -63,29 +63,25 @@ LiveSocket& LiveManager::GetSocket() const {
 
 LiveServer* LiveManager::StartServer() {
 	ASSERT(IsLocal());
-	live_server = newd LiveServer(editor);
+	live_server = std::make_unique<LiveServer>(editor);
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd NetworkedActionQueue(editor);
+	editor.actionQueue = std::make_unique<NetworkedActionQueue>(editor);
 
-	return live_server;
+	return live_server.get();
 }
 
 void LiveManager::CloseServer() {
 	if (live_server) {
 		live_server->close();
-		delete live_server;
-		live_server = nullptr;
+		live_server.reset();
 	}
 
 	if (live_client) {
 		live_client->close();
-		delete live_client;
-		live_client = nullptr;
+		live_client.reset();
 	}
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd ActionQueue(editor);
+	editor.actionQueue = std::make_unique<ActionQueue>(editor);
 
 	NetworkConnection& connection = NetworkConnection::getInstance();
 	connection.stop();

--- a/source/live/live_manager.h
+++ b/source/live/live_manager.h
@@ -3,6 +3,8 @@
 
 #include "app/rme_forward_declarations.h"
 
+#include <memory>
+
 class Editor;
 class LiveServer;
 class LiveClient;
@@ -12,7 +14,7 @@ class DirtyList;
 class LiveManager {
 public:
 	LiveManager(Editor& editor);
-	LiveManager(Editor& editor, LiveClient* client);
+	LiveManager(Editor& editor, std::unique_ptr<LiveClient> client);
 	~LiveManager();
 
 	LiveServer* StartServer();
@@ -31,8 +33,8 @@ public:
 
 private:
 	Editor& editor;
-	LiveServer* live_server;
-	LiveClient* live_client;
+	std::unique_ptr<LiveServer> live_server;
+	std::unique_ptr<LiveClient> live_client;
 };
 
 #endif

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -64,9 +64,6 @@ bool LiveServer::bind() {
 }
 
 void LiveServer::close() {
-	for (auto& clientEntry : clients) {
-		delete clientEntry.second;
-	}
 	clients.clear();
 
 	if (log) {
@@ -105,7 +102,7 @@ void LiveServer::acceptClient() {
 			peer->log = log;
 			peer->receiveHeader();
 
-			clients.insert(std::make_pair(id++, peer));
+			clients.insert(std::make_pair(id++, std::unique_ptr<LivePeer>(peer)));
 		}
 		acceptClient();
 	});
@@ -191,7 +188,7 @@ void LiveServer::broadcastNodes(DirtyList& dirtyList) {
 		}
 
 		for (auto& clientEntry : clients) {
-			LivePeer* peer = clientEntry.second;
+			LivePeer* peer = clientEntry.second.get();
 
 			const uint32_t clientId = peer->getClientId();
 			if (dirtyList.owner != 0 && dirtyList.owner == clientId) {
@@ -223,7 +220,7 @@ void LiveServer::broadcastCursor(const LiveCursor& cursor) {
 	writeCursor(message, cursor);
 
 	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+		LivePeer* peer = clientEntry.second.get();
 		if (peer->getClientId() != cursor.id) {
 			peer->send(message);
 		}

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -22,6 +22,9 @@
 #include "net/net_connection.h"
 #include "editor/action.h"
 
+#include <memory>
+#include <unordered_map>
+
 class LivePeer;
 class LiveLogTab;
 class QTreeNode;
@@ -70,7 +73,7 @@ public:
 	void updateOperation(int32_t percent);
 
 protected:
-	std::unordered_map<uint32_t, LivePeer*> clients;
+	std::unordered_map<uint32_t, std::unique_ptr<LivePeer>> clients;
 
 	std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -196,13 +196,17 @@ void LiveLogTab::OnDeselectChatbox(wxFocusEvent& evt) {
 	g_hotkeys.EnableHotkeys();
 }
 
-void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients) {
+void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients) {
 	// Delete old rows
 	if (user_list->GetNumberRows() > 0) {
 		user_list->DeleteRows(0, user_list->GetNumberRows());
 	}
 
-	clients = updatedClients;
+	clients.clear();
+	for (const auto& entry : updatedClients) {
+		clients[entry.first] = entry.second.get();
+	}
+
 	user_list->AppendRows(clients.size());
 
 	int32_t i = 0;

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -52,7 +52,7 @@ public:
 		return socket;
 	}
 
-	void UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients);
+	void UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients);
 
 	void OnSelectChatbox(wxFocusEvent& evt);
 	void OnDeselectChatbox(wxFocusEvent& evt);

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -357,7 +357,7 @@ protected:
 	int disabled_counter;
 
 	friend class RenderingLock;
-	friend MapTab::MapTab(MapTabbook*, Editor*);
+	friend MapTab::MapTab(MapTabbook*, std::shared_ptr<Editor>);
 	friend MapTab::MapTab(const MapTab*);
 };
 

--- a/source/ui/map_tab.cpp
+++ b/source/ui/map_tab.cpp
@@ -27,14 +27,11 @@
 
 #include <spdlog/spdlog.h>
 
-MapTab::MapTab(MapTabbook* aui, Editor* editor) :
+MapTab::MapTab(MapTabbook* aui, std::shared_ptr<Editor> editor) :
 	EditorTab(),
 	MapWindow(aui, *editor),
-	aui(aui) {
-	iref = newd InternalReference;
-	iref->editor = editor;
-	iref->owner_count = 1;
-
+	aui(aui),
+	editor_ptr(editor) {
 	spdlog::info("MapTab created (New Editor) [Tab={}]", (void*)this);
 
 	aui->AddTab(this, true);
@@ -43,10 +40,9 @@ MapTab::MapTab(MapTabbook* aui, Editor* editor) :
 
 MapTab::MapTab(const MapTab* other) :
 	EditorTab(),
-	MapWindow(other->aui, *other->iref->editor),
+	MapWindow(other->aui, *other->editor_ptr),
 	aui(other->aui),
-	iref(other->iref) {
-	iref->owner_count++;
+	editor_ptr(other->editor_ptr) {
 	spdlog::info("MapTab created (Shared Editor) [Tab={}]", (void*)this);
 	aui->AddTab(this, true);
 	FitToMap();
@@ -56,17 +52,11 @@ MapTab::MapTab(const MapTab* other) :
 }
 
 MapTab::~MapTab() {
-	spdlog::info("MapTab destroying [Tab={}] (Owner count: {})", (void*)this, iref->owner_count);
-	iref->owner_count--;
-	if (iref->owner_count <= 0) {
-		spdlog::info("MapTab destroying editor [Editor={}]", (void*)iref->editor);
-		delete iref->editor;
-		delete iref;
-	}
+	spdlog::info("MapTab destroying [Tab={}] (Owner count: {})", (void*)this, editor_ptr.use_count());
 }
 
 bool MapTab::IsUniqueReference() const {
-	return iref->owner_count == 1;
+	return editor_ptr.unique();
 }
 
 wxWindow* MapTab::GetWindow() const {
@@ -83,16 +73,16 @@ MapWindow* MapTab::GetView() const {
 
 wxString MapTab::GetTitle() const {
 	wxString ss;
-	ss << wxstr(iref->editor->map.getName()) << (iref->editor->map.hasChanged() ? "*" : "");
+	ss << wxstr(editor_ptr->map.getName()) << (editor_ptr->map.hasChanged() ? "*" : "");
 	return ss;
 }
 
 Editor* MapTab::GetEditor() const {
-	return &editor;
+	return editor_ptr.get();
 }
 
 Map* MapTab::GetMap() const {
-	return &editor.map;
+	return &editor_ptr->map;
 }
 
 void MapTab::VisibilityCheck() {

--- a/source/ui/map_tab.h
+++ b/source/ui/map_tab.h
@@ -22,9 +22,11 @@
 #include "app/application.h"
 #include "ui/map_window.h"
 
+#include <memory>
+
 class MapTab : public EditorTab, public MapWindow {
 public:
-	MapTab(MapTabbook* aui, Editor* editor);
+	MapTab(MapTabbook* aui, std::shared_ptr<Editor> editor);
 	// Constructs a newd window, but it uses the same internal editor as 'other'
 	// AND the same parent, aui_notebook etc.
 	MapTab(const MapTab* other);
@@ -47,16 +49,12 @@ public:
 	void OnSwitchEditorMode(EditorMode mode);
 
 protected:
-	struct InternalReference {
-		Editor* editor;
-		int owner_count;
-	};
 	MapTabbook* aui;
-	InternalReference* iref;
+	std::shared_ptr<Editor> editor_ptr;
 };
 
 inline bool MapTab::HasSameReference(MapTab* other) const {
-	return other->iref == iref;
+	return other->editor_ptr == editor_ptr;
 }
 
 #endif


### PR DESCRIPTION
This PR addresses memory management issues and ownership cycles in the Live editing system.

**Key Changes:**
1.  **`LiveServer`**: `clients` map now stores `std::unique_ptr<LivePeer>`, eliminating memory leaks when clients disconnect or server closes.
2.  **`LiveManager`**: Now owns `LiveServer` and `LiveClient` via `std::unique_ptr`. `StartServer` and `CloseServer` use `make_unique` and `reset`.
3.  **`Editor`**: `actionQueue` is now `std::unique_ptr`. `Editor` takes ownership of `LiveClient` via `std::unique_ptr` in constructor.
4.  **`LiveClient`**: Broken the circular dependency. `LiveClient` no longer owns `Editor`. Instead, it transfers ownership of itself (`this`) to `Editor` (via `EditorFactory::JoinLive`). It retains a raw back-pointer to `Editor`.
5.  **`MapTab`**: Now holds `std::shared_ptr<Editor>`, replacing manual reference counting (`InternalReference`). This ensures `Editor` (and thus `LiveManager` and `LiveClient`) stays alive as long as a tab is open.
6.  **`EditorFactory`**: Updated `JoinLive` to accept `std::unique_ptr<LiveClient>`.

**Verification:**
- Compiled with `./build_linux.sh` (compilation passed up to timeout with no errors).
- Verified logic for ownership transfer and cycle breaking.


---
*PR created automatically by Jules for task [8989637174308436615](https://jules.google.com/task/8989637174308436615) started by @karolak6612*