### PR TITLE
Optimize MinimapRenderer with Instanced Rendering

### DIFF
--- a/source/rendering/drawers/minimap_renderer.h
+++ b/source/rendering/drawers/minimap_renderer.h
@@ -70,6 +70,7 @@ private:
 	std::unique_ptr<GLTextureResource> palette_texture_id_;
 	std::unique_ptr<GLVertexArray> vao_;
 	std::unique_ptr<GLBuffer> vbo_;
+	std::unique_ptr<GLBuffer> instance_vbo_;
 
 	int width_ = 0;
 	int height_ = 0;

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -217,7 +217,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 		float s = 32.0f; // Standard tile size
 
 		// Draw 1px solid border using geometry generation
-		primitive_renderer.drawBox(glm::vec4(x, y, s, s), border_color, 1.0f);
+		if (g_gui.gfx.hasAtlasManager()) {
+			sprite_batch.drawRectLines(x, y, s, s, border_color, *g_gui.gfx.getAtlasManager());
+		} else {
+			primitive_renderer.drawBox(glm::vec4(x, y, s, s), border_color, 1.0f);
+		}
 	}
 
 	if (!only_colors) {


### PR DESCRIPTION
This PR optimizes the `MinimapRenderer` by implementing Instanced Rendering, significantly reducing draw calls from N (number of chunks) to 1. It also optimizes `TileRenderer` to better utilize `SpriteBatch` for house borders.

Key Changes:
- `source/rendering/drawers/minimap_renderer.h`: Added `instance_vbo_`.
- `source/rendering/drawers/minimap_renderer.cpp`:
    - Updated shaders for instancing.
    - Updated `initialize` to setup VAO/VBO for instancing (DSA).
    - Updated `render` to collect instance data and draw instanced.
    - Added cap of 65536 instances with throttled warning.
- `source/rendering/drawers/tiles/tile_renderer.cpp`:
    - Switched to `sprite_batch.drawRectLines` for borders if possible.


---
*PR created automatically by Jules for task [2436314277087796504](https://jules.google.com/task/2436314277087796504) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized minimap rendering with instanced drawing for improved performance on large maps.

* **Improvements**
  * Enhanced tile border rendering with conditional atlas support for visual consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->