### PR TITLE
🔒 Sentinel: Modernize MinimapRenderer with Instancing and DSA

### DIFF
--- a/source/rendering/drawers/minimap_renderer.h
+++ b/source/rendering/drawers/minimap_renderer.h
@@ -11,6 +11,11 @@
 
 class Map;
 
+struct InstanceData {
+	float x, y, w, h; // dest rect
+	float layer;      // layer index
+};
+
 class MinimapRenderer {
 public:
 	MinimapRenderer();
@@ -70,6 +75,9 @@ private:
 	std::unique_ptr<GLTextureResource> palette_texture_id_;
 	std::unique_ptr<GLVertexArray> vao_;
 	std::unique_ptr<GLBuffer> vbo_;
+	std::unique_ptr<GLBuffer> instance_vbo_;
+	std::vector<InstanceData> instance_data_;
+	size_t instance_vbo_capacity_ = 0;
 
 	int width_ = 0;
 	int height_ = 0;


### PR DESCRIPTION
- Refactored `MinimapRenderer` to use `glDrawArraysInstanced`.
- Implemented `InstanceData` struct and `instance_vbo_`.
- Updated `minimap_vert` and `minimap_frag` shaders.
- Replaced `glVertexAttribPointer` with DSA `glVertexArrayAttribFormat`.
- Removed legacy uniform updates from the render loop.

---
*PR created automatically by Jules for task [9577526468041367435](https://jules.google.com/task/9577526468041367435) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized minimap rendering pipeline for improved efficiency and performance when displaying multiple map elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->