### PR TITLE
[REFACTOR] Deduplicate ItemDatabase OTB loaders

### DIFF
--- a/source/game/items.h
+++ b/source/game/items.h
@@ -459,6 +459,9 @@ protected:
 	bool loadFromOtbVer2(BinaryNode* itemNode, wxString& error, wxArrayString& warnings);
 	bool loadFromOtbVer3(BinaryNode* itemNode, wxString& error, wxArrayString& warnings);
 
+	void parseCommonFlags(uint32_t flags, ItemType* t);
+	int parseCommonAttribute(uint8_t attribute, uint16_t datalen, BinaryNode* itemNode, ItemType* t, wxString& error, wxArrayString& warnings);
+
 protected:
 	// Count of GameSprite types
 	uint16_t item_count;


### PR DESCRIPTION
CODE SMELL: Duplicate Code (CRITICAL) in `source/game/items.cpp`.
LOCATION: `ItemDatabase::loadFromOtbVer1`, `loadFromOtbVer2`, `loadFromOtbVer3`.
PROBLEM: Massive duplication of OTB parsing logic across three version loaders, making maintenance error-prone and code hard to read.
REFACTORING APPLIED: Extract Method.
CHANGES:
1.  Extracted `parseCommonFlags` to handle common item flags.
2.  Extracted `parseCommonAttribute` to handle common item attributes (returning tri-state result for control flow).
3.  Updated all 3 loaders to use these helpers.
4.  Replaced `newd` with `new`.
BEFORE: Loaders contained ~300 lines of duplicated switch statements and parsing logic.
AFTER: Loaders rely on shared helpers, reducing file size and complexity.
TESTED: Verified compilation of `items.cpp`. Fixed `items.o` binary leak.

---
*PR created automatically by Jules for task [9121467066311271614](https://jules.google.com/task/9121467066311271614) started by @karolak6612*