### PR TITLE
⚡ Throttle: Optimize Tooltip Generation & Render Loops

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -198,9 +198,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
-		TooltipData groundData = CreateItemTooltipData(tile->ground, location->getPosition(), tile->isHouseTile());
-		if (groundData.hasVisibleFields()) {
-			tooltip_drawer->addItemTooltip(groundData);
+		if (map_x == view.mouse_map_x && map_y == view.mouse_map_y) {
+			TooltipData groundData = CreateItemTooltipData(tile->ground, location->getPosition(), tile->isHouseTile());
+			if (groundData.hasVisibleFields()) {
+				tooltip_drawer->addItemTooltip(groundData);
+			}
 		}
 	}
 
@@ -239,23 +241,25 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 			}
 
 			// items on tile
-			for (ItemVector::iterator it = tile->items.begin(); it != tile->items.end(); it++) {
+			for (Item* item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData itemData = CreateItemTooltipData(*it, location->getPosition(), tile->isHouseTile());
-					if (itemData.hasVisibleFields()) {
-						tooltip_drawer->addItemTooltip(std::move(itemData));
+					if (map_x == view.mouse_map_x && map_y == view.mouse_map_y) {
+						TooltipData itemData = CreateItemTooltipData(item, location->getPosition(), tile->isHouseTile());
+						if (itemData.hasVisibleFields()) {
+							tooltip_drawer->addItemTooltip(std::move(itemData));
+						}
 					}
 				}
 
 				// item animation
 				if (options.show_preview && view.zoom <= 2.0) {
-					(*it)->animate();
+					item->animate();
 				}
 
 				// item sprite
-				if ((*it)->isBorder()) {
-					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, *it, options, false, r, g, b);
+				if (item->isBorder()) {
+					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item, options, false, r, g, b);
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
@@ -275,7 +279,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 							}
 						}
 					}
-					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, *it, options, false, ir, ig, ib);
+					item_drawer->BlitItem(sprite_batch, primitive_renderer, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item, options, false, ir, ig, ib);
 				}
 			}
 			// monster/npc on tile


### PR DESCRIPTION
Optimized `TileRenderer` performance by significantly reducing the number of tooltips generated per frame. Previously, tooltips were generated for every item on every visible tile if the option was enabled. Now, they are only generated for the tile under the mouse cursor.

Also refactored `TileRenderer::DrawTile` to use modern C++ range-based for loops instead of legacy iterators.


---
*PR created automatically by Jules for task [18018061357950234652](https://jules.google.com/task/18018061357950234652) started by @karolak6612*