### PR TITLE
⚡ Bolt: Tooltip Pooling & Minimap Optimization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -5,3 +5,11 @@ Action: Future optimizations for tooltips should focus on caching the generated 
 ## 2025-02-18 - Tooltip Allocations
 Learning: `TooltipDrawer::draw` was allocating `std::vector<FieldLine>` inside a loop for every tooltip, causing allocator churn. Also `TileRenderer` was deep-copying `TooltipData` (containing strings/vectors) every frame.
 Action: Use persistent scratch buffers (member variables) for immediate-mode rendering loops to avoid allocation. Use `std::move` for passing heavy transient data like tooltips.
+
+## 2025-02-18 - Tooltip String Allocations
+Learning: `CreateItemTooltipData` was allocating thousands of `std::string` objects (from `std::string_view`) every frame for item names. By pooling `TooltipData` objects and clearing them (which keeps `std::string` capacity), we eliminate these allocations entirely after warmup.
+Action: Prefer modifying pooled objects in-place (`FillItemTooltipData`) over returning new objects by value in hot paths.
+
+## 2025-02-18 - Minimap Color Caching
+Learning: `Tile::update` failed to reset `minimapColor` when no color was found, leading to stale colors if items were removed. Also `deepCopy` produced `INVALID_MINIMAP_COLOR` tiles, forcing `getMiniMapColor` to scan items every time.
+Action: Always initialize/reset cached values in `update()` methods to ensure state validity. Use `minimapColor = 0` (or valid "empty" value) instead of `INVALID` to enable unconditional fast-path access.

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -72,6 +72,7 @@ Tile::~Tile() {
 Tile* Tile::deepCopy(BaseMap& map) {
 	Tile* copy = map.allocator.allocateTile(location);
 	copy->flags = flags;
+	copy->minimapColor = minimapColor;
 	copy->house_id = house_id;
 	if (spawn) {
 		copy->spawn = spawn->deepCopy();
@@ -449,6 +450,8 @@ void Tile::update() {
 	if (creature && creature->isSelected()) {
 		statflags |= TILESTATE_SELECTED;
 	}
+
+	minimapColor = 0; // Reset to "no color" (valid)
 
 	if (ground) {
 		if (ground->isSelected()) {

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -38,7 +38,7 @@ MapLayerDrawer::MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_dra
 MapLayerDrawer::~MapLayerDrawer() {
 }
 
-void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, std::ostringstream& tooltip) {
+void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {
 	int nd_start_x = view.start_x & ~3;
 	int nd_start_y = view.start_y & ~3;
 	int nd_end_x = (view.end_x & ~3) + 4;
@@ -64,7 +64,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 							}
 							TileLocation* location = nd->getTile(map_x, map_y, map_z);
 
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip, draw_x, draw_y);
+							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
 							// draw light, but only if not zoomed too far
 							if (location && options.isDrawLight() && view.zoom <= 10.0) {
 								tile_renderer->AddLight(location, view, options, light_buffer);
@@ -93,7 +93,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					}
 					TileLocation* location = nd->getTile(map_x, map_y, map_z);
 
-					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, tooltip, draw_x, draw_y);
+					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
 					// draw light, but only if not zoomed too far
 					if (location && options.isDrawLight() && view.zoom <= 10.0) {
 						tile_renderer->AddLight(location, view, options, light_buffer);

--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -34,7 +34,7 @@ public:
 	MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_drawer, Editor* editor);
 	~MapLayerDrawer();
 
-	void Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, std::ostringstream& tooltip);
+	void Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
 	TileRenderer* tile_renderer;

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -24,7 +24,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, std::ostringstream& tooltip_stream, int in_draw_x = -1, int in_draw_y = -1);
+	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -251,7 +251,7 @@ void MapDrawer::DrawCreatureNames() {
 }
 
 void MapDrawer::DrawMapLayer(int map_z, bool live_client) {
-	map_layer_drawer->Draw(*sprite_batch, *primitive_renderer, map_z, live_client, view, options, light_buffer, tooltip);
+	map_layer_drawer->Draw(*sprite_batch, *primitive_renderer, map_z, live_client, view, options, light_buffer);
 }
 
 void MapDrawer::DrawLight() {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -81,8 +81,6 @@ class MapDrawer {
 	std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 
 protected:
-	std::ostringstream tooltip;
-
 	friend class BrushOverlayDrawer;
 	friend class DragShadowDrawer;
 	friend class FloorDrawer;

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -122,6 +122,24 @@ struct TooltipData {
 	bool hasVisibleFields() const {
 		return !waypointName.empty() || actionId > 0 || uniqueId > 0 || doorId > 0 || !text.empty() || !description.empty() || destination.x > 0 || !containerItems.empty();
 	}
+
+	void clear() {
+		// Reset scalars
+		pos = Position();
+		category = TooltipCategory::ITEM;
+		itemId = 0;
+		// clear strings but keep capacity
+		itemName.clear();
+		actionId = 0;
+		uniqueId = 0;
+		doorId = 0;
+		text.clear();
+		description.clear();
+		destination = Position();
+		waypointName.clear();
+		containerItems.clear();
+		containerCapacity = 0;
+	}
 };
 
 class TooltipDrawer {
@@ -132,6 +150,10 @@ public:
 	// Add a structured tooltip for an item
 	void addItemTooltip(const TooltipData& data);
 	void addItemTooltip(TooltipData&& data);
+
+	// Request a tooltip object from the pool. Call commitTooltip() to finalize.
+	TooltipData& requestTooltipData();
+	void commitTooltip();
 
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, const std::string& name);
@@ -152,6 +174,8 @@ protected:
 	std::vector<FieldLine> scratch_fields;
 
 	std::vector<TooltipData> tooltips;
+	size_t active_count = 0;
+
 	std::map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
 	NVGcontext* lastContext = nullptr;
 


### PR DESCRIPTION
Implemented object pooling for tooltips to eliminate per-frame allocations.
Optimized `Tile::getMiniMapColor` by fixing cache invalidation in `Tile::update` and preserving it in `deepCopy`.
Removed unused `tooltip_stream` parameter from `TileRenderer`, `MapLayerDrawer`, and `MapDrawer`.

---
*PR created automatically by Jules for task [8004047550188515080](https://jules.google.com/task/8004047550188515080) started by @karolak6612*