### PR TITLE
🎨 Palette: Add tooltips to dialog buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@ Action: Always audit property inspectors for missing tooltips on boolean flags.
 ## 2024-05-22 - Modal Dialog Overuse
 Learning: The application frequently uses modal dialogs for simple success feedback (e.g., "Item added to tileset", "Items removed"), which disrupts workflow.
 Action: Replace success-only modal dialogs with non-intrusive status bar updates (`g_gui.SetStatusText`) where possible.
+
+## 2024-05-23 - Dialog Buttons Lack Feedback
+Learning: Standard "OK/Cancel" buttons in dialogs often lack context. Users may hesitate if they are unsure if "OK" saves or just closes.
+Action: Add tooltips to "OK" and "Cancel" buttons in all custom dialogs to clarify the action (e.g., "Apply changes and close", "Discard changes").

--- a/source/app/application.cpp
+++ b/source/app/application.cpp
@@ -98,7 +98,9 @@ Application::~Application() {
 
 bool Application::OnInit() {
 	// Enable modern appearance handling (wxWidgets 3.3+)
+#if wxCHECK_VERSION(3, 3, 0)
 	SetAppearance(wxApp::Appearance::System);
+#endif
 
 #ifdef __WXMSW__
 	// Enable dark mode support for Windows

--- a/source/ui/about_window.cpp
+++ b/source/ui/about_window.cpp
@@ -75,7 +75,9 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	topsizer->Add(newd wxStaticText(this, wxID_ANY, about), 1, wxALL, 20);
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
-	choicesizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Close this window");
+	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 
 	wxButton* copyBtn = newd wxButton(this, wxID_COPY, "Copy Version Info");
 	copyBtn->Bind(wxEVT_BUTTON, [about](wxCommandEvent&) {

--- a/source/ui/add_item_window.cpp
+++ b/source/ui/add_item_window.cpp
@@ -87,8 +87,12 @@ AddItemWindow::AddItemWindow(wxWindow* win_parent, TilesetCategoryType categoryT
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 20));
 
 	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
-	subsizer_->Add(newd wxButton(this, wxID_OK, "Add"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	subsizer_->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "Add");
+	okBtn->SetToolTip("Add item to tileset");
+	subsizer_->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Close this window");
+	subsizer_->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -38,8 +38,12 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	sizer->Add(item_list, wxSizerFlags(1).Expand().Border());
 
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
-	stdsizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
-	stdsizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center());
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Jump to selected item/brush");
+	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Close this window");
+	stdsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
 
 	SetSizerAndFit(sizer);

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -31,8 +31,12 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 
 	// OK/Cancel buttons
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
-	tmpsizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center());
-	tmpsizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center());
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Go to position");
+	tmpsizer->Add(okBtn, wxSizerFlags(1).Center());
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Close this window");
+	tmpsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(tmpsizer, 0, wxALL | wxCENTER, 20); // Border to top too
 
 	SetSizerAndFit(sizer);

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -195,7 +195,9 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	bottom_sizer->AddStretchSpacer();
 
 	wxButton* ok_btn = new wxButton(this, wxID_OK, "OK", wxDefaultPosition, wxSize(90, 30));
+	ok_btn->SetToolTip("Confirm outfit selection");
 	wxButton* cancel_btn = new wxButton(this, wxID_CANCEL, "Cancel", wxDefaultPosition, wxSize(90, 30));
+	cancel_btn->SetToolTip("Cancel outfit selection");
 	bottom_sizer->Add(ok_btn, 0, wxALL, 8);
 	bottom_sizer->Add(cancel_btn, 0, wxALL, 8);
 

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -92,7 +92,9 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
 	export_button->SetToolTip("Not implemented yet");
 	export_button->Enable(false);
-	choicesizer->Add(newd wxButton(dg, wxID_CANCEL, "OK"), wxSizerFlags(1).Center());
+	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "OK");
+	okBtn->SetToolTip("Close this window");
+	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());
 	dg->SetSizerAndFit(topsizer);
 	dg->Centre(wxBOTH);

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -65,8 +65,12 @@ void PropertiesWindow::createUI() {
 	topSizer->Add(notebook, wxSizerFlags(1).DoubleBorder());
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
-	optSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(0).Center());
-	optSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(0).Center());
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Apply changes and close");
+	optSizer->Add(okBtn, wxSizerFlags(0).Center());
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Discard changes and close");
+	optSizer->Add(cancelBtn, wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
 
 	SetSizerAndFit(topSizer);


### PR DESCRIPTION
This PR adds descriptive tooltips to standard OK and Cancel buttons across several dialogs to improve user experience and accessibility. It also includes a fix for a build failure related to `wxApp::SetAppearance` availability on older wxWidgets versions.

---
*PR created automatically by Jules for task [4729446143607957869](https://jules.google.com/task/4729446143607957869) started by @karolak6612*