### PR TITLE
👻 Phantom: Modernize event handling (Bind vs Event Tables)

### DIFF
--- a/source/app/application.cpp
+++ b/source/app/application.cpp
@@ -47,49 +47,6 @@
 
 #include "../brushes/icon/editor_icon.xpm"
 
-BEGIN_EVENT_TABLE(MainFrame, wxFrame)
-EVT_CLOSE(MainFrame::OnExit)
-
-// Update check complete
-#ifdef _USE_UPDATER_
-EVT_ON_UPDATE_CHECK_FINISHED(wxID_ANY, MainFrame::OnUpdateReceived)
-#endif
-EVT_ON_UPDATE_MENUS(wxID_ANY, MainFrame::OnUpdateMenus)
-
-// Idle event handler
-EVT_IDLE(MainFrame::OnIdle)
-END_EVENT_TABLE()
-
-BEGIN_EVENT_TABLE(MapWindow, wxPanel)
-EVT_SIZE(MapWindow::OnSize)
-
-EVT_COMMAND_SCROLL_TOP(MAP_WINDOW_HSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_BOTTOM(MAP_WINDOW_HSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_THUMBTRACK(MAP_WINDOW_HSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_LINEUP(MAP_WINDOW_HSCROLL, MapWindow::OnScrollLineUp)
-EVT_COMMAND_SCROLL_LINEDOWN(MAP_WINDOW_HSCROLL, MapWindow::OnScrollLineDown)
-EVT_COMMAND_SCROLL_PAGEUP(MAP_WINDOW_HSCROLL, MapWindow::OnScrollPageUp)
-EVT_COMMAND_SCROLL_PAGEDOWN(MAP_WINDOW_HSCROLL, MapWindow::OnScrollPageDown)
-
-EVT_COMMAND_SCROLL_TOP(MAP_WINDOW_VSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_BOTTOM(MAP_WINDOW_VSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_THUMBTRACK(MAP_WINDOW_VSCROLL, MapWindow::OnScroll)
-EVT_COMMAND_SCROLL_LINEUP(MAP_WINDOW_VSCROLL, MapWindow::OnScrollLineUp)
-EVT_COMMAND_SCROLL_LINEDOWN(MAP_WINDOW_VSCROLL, MapWindow::OnScrollLineDown)
-EVT_COMMAND_SCROLL_PAGEUP(MAP_WINDOW_VSCROLL, MapWindow::OnScrollPageUp)
-EVT_COMMAND_SCROLL_PAGEDOWN(MAP_WINDOW_VSCROLL, MapWindow::OnScrollPageDown)
-
-EVT_BUTTON(MAP_WINDOW_GEM, MapWindow::OnGem)
-END_EVENT_TABLE()
-
-BEGIN_EVENT_TABLE(MapScrollBar, wxScrollBar)
-EVT_KEY_DOWN(MapScrollBar::OnKey)
-EVT_KEY_UP(MapScrollBar::OnKey)
-EVT_CHAR(MapScrollBar::OnKey)
-EVT_SET_FOCUS(MapScrollBar::OnFocus)
-EVT_MOUSEWHEEL(MapScrollBar::OnWheel)
-END_EVENT_TABLE()
-
 wxIMPLEMENT_APP(Application);
 
 Application::~Application() {
@@ -380,6 +337,13 @@ bool Application::ParseCommandLineMap(wxString& fileName) {
 
 MainFrame::MainFrame(const wxString& title, const wxPoint& pos, const wxSize& size) :
 	wxFrame((wxFrame*)nullptr, -1, title, pos, size, wxDEFAULT_FRAME_STYLE) {
+	Bind(wxEVT_CLOSE_WINDOW, &MainFrame::OnExit, this);
+#ifdef _USE_UPDATER_
+	Bind(EVT_UPDATE_CHECK_FINISHED, &MainFrame::OnUpdateReceived, this);
+#endif
+	Bind(EVT_UPDATE_MENUS, &MainFrame::OnUpdateMenus, this);
+	Bind(wxEVT_IDLE, &MainFrame::OnIdle, this);
+
 	// Receive idle events
 	SetExtraStyle(wxWS_EX_PROCESS_IDLE);
 

--- a/source/app/application.h
+++ b/source/app/application.h
@@ -106,8 +106,6 @@ protected:
 
 	friend class Application;
 	friend class GUI;
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/palette/controls/brush_button.cpp
+++ b/source/palette/controls/brush_button.cpp
@@ -7,13 +7,10 @@
 // ============================================================================
 // Brush Button
 
-BEGIN_EVENT_TABLE(BrushButton, ItemToggleButton)
-EVT_KEY_DOWN(BrushButton::OnKey)
-END_EVENT_TABLE()
-
 BrushButton::BrushButton(wxWindow* parent, Brush* _brush, RenderSize sz, uint32_t id) :
 	ItemToggleButton(parent, sz, uint16_t(0), id),
 	brush(_brush) {
+	Bind(wxEVT_KEY_DOWN, &BrushButton::OnKey, this);
 	ASSERT(sz != RENDER_SIZE_64x64);
 	ASSERT(brush);
 	if (Sprite* s = brush->getSprite()) {
@@ -27,6 +24,7 @@ BrushButton::BrushButton(wxWindow* parent, Brush* _brush, RenderSize sz, uint32_
 BrushButton::BrushButton(wxWindow* parent, Brush* _brush, RenderSize sz, EditorSprite* espr, uint32_t id) :
 	ItemToggleButton(parent, sz, uint16_t(0), id),
 	brush(_brush) {
+	Bind(wxEVT_KEY_DOWN, &BrushButton::OnKey, this);
 	ASSERT(sz != RENDER_SIZE_64x64);
 	ASSERT(brush);
 	SetSprite(espr);

--- a/source/palette/controls/brush_button.h
+++ b/source/palette/controls/brush_button.h
@@ -13,8 +13,6 @@ public:
 	Brush* brush;
 
 	void OnKey(wxKeyEvent& event);
-
-	DECLARE_EVENT_TABLE()
 };
 
 #endif

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -77,36 +77,6 @@
 #include "brushes/carpet/carpet_brush.h"
 #include "brushes/table/table_brush.h"
 
-BEGIN_EVENT_TABLE(MapCanvas, wxGLCanvas)
-EVT_KEY_DOWN(MapCanvas::OnKeyDown)
-EVT_KEY_DOWN(MapCanvas::OnKeyUp)
-
-// Mouse events
-EVT_MOTION(MapCanvas::OnMouseMove)
-EVT_LEFT_UP(MapCanvas::OnMouseLeftRelease)
-EVT_LEFT_DOWN(MapCanvas::OnMouseLeftClick)
-EVT_LEFT_DCLICK(MapCanvas::OnMouseLeftDoubleClick)
-EVT_MIDDLE_DOWN(MapCanvas::OnMouseCenterClick)
-EVT_MIDDLE_UP(MapCanvas::OnMouseCenterRelease)
-EVT_RIGHT_DOWN(MapCanvas::OnMouseRightClick)
-EVT_RIGHT_UP(MapCanvas::OnMouseRightRelease)
-EVT_MOUSEWHEEL(MapCanvas::OnWheel)
-EVT_ENTER_WINDOW(MapCanvas::OnGainMouse)
-EVT_LEAVE_WINDOW(MapCanvas::OnLoseMouse)
-
-// Drawing events
-EVT_PAINT(MapCanvas::OnPaint)
-EVT_ERASE_BACKGROUND(MapCanvas::OnEraseBackground)
-
-// Menu events
-// Menu events
-//----
-// ----
-// ----
-// ----
-// ----
-END_EVENT_TABLE()
-
 bool MapCanvas::processed[] = { 0 };
 
 // Helper to create attributes
@@ -145,6 +115,22 @@ MapCanvas::MapCanvas(MapWindow* parent, Editor& editor, int* attriblist) :
 
 	last_mmb_click_x(-1),
 	last_mmb_click_y(-1) {
+	Bind(wxEVT_KEY_DOWN, &MapCanvas::OnKeyDown, this);
+	Bind(wxEVT_KEY_UP, &MapCanvas::OnKeyUp, this);
+	Bind(wxEVT_MOTION, &MapCanvas::OnMouseMove, this);
+	Bind(wxEVT_LEFT_UP, &MapCanvas::OnMouseLeftRelease, this);
+	Bind(wxEVT_LEFT_DOWN, &MapCanvas::OnMouseLeftClick, this);
+	Bind(wxEVT_LEFT_DCLICK, &MapCanvas::OnMouseLeftDoubleClick, this);
+	Bind(wxEVT_MIDDLE_DOWN, &MapCanvas::OnMouseCenterClick, this);
+	Bind(wxEVT_MIDDLE_UP, &MapCanvas::OnMouseCenterRelease, this);
+	Bind(wxEVT_RIGHT_DOWN, &MapCanvas::OnMouseRightClick, this);
+	Bind(wxEVT_RIGHT_UP, &MapCanvas::OnMouseRightRelease, this);
+	Bind(wxEVT_MOUSEWHEEL, &MapCanvas::OnWheel, this);
+	Bind(wxEVT_ENTER_WINDOW, &MapCanvas::OnGainMouse, this);
+	Bind(wxEVT_LEAVE_WINDOW, &MapCanvas::OnLoseMouse, this);
+	Bind(wxEVT_PAINT, &MapCanvas::OnPaint, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &MapCanvas::OnEraseBackground, this);
+
 	popup_menu = std::make_unique<MapPopupMenu>(editor);
 	animation_timer = std::make_unique<AnimationTimer>(this);
 	drawer = std::make_unique<MapDrawer>(this);

--- a/source/rendering/ui/map_display.h
+++ b/source/rendering/ui/map_display.h
@@ -162,8 +162,6 @@ public:
 	friend class SelectionController;
 	friend class DrawingController;
 
-	DECLARE_EVENT_TABLE()
-
 	std::unique_ptr<SelectionController> selection_controller;
 	std::unique_ptr<DrawingController> drawing_controller;
 	std::unique_ptr<MapMenuHandler> menu_handler;

--- a/source/ui/map_window.cpp
+++ b/source/ui/map_window.cpp
@@ -38,6 +38,27 @@ MapWindow::MapWindow(wxWindow* parent, Editor& editor) :
 	gem = newd DCButton(this, MAP_WINDOW_GEM, wxDefaultPosition, DC_BTN_NORMAL, RENDER_SIZE_16x16, EDITOR_SPRITE_SELECTION_GEM);
 	gem->SetToolTip("Switch between Drawing and Selection mode (Space)");
 
+	Bind(wxEVT_SIZE, &MapWindow::OnSize, this);
+	Bind(wxEVT_BUTTON, &MapWindow::OnGem, this, MAP_WINDOW_GEM);
+
+	// Scroll events for MAP_WINDOW_HSCROLL
+	Bind(wxEVT_SCROLL_TOP, &MapWindow::OnScroll, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_BOTTOM, &MapWindow::OnScroll, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_THUMBTRACK, &MapWindow::OnScroll, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_LINEUP, &MapWindow::OnScrollLineUp, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_LINEDOWN, &MapWindow::OnScrollLineDown, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_PAGEUP, &MapWindow::OnScrollPageUp, this, MAP_WINDOW_HSCROLL);
+	Bind(wxEVT_SCROLL_PAGEDOWN, &MapWindow::OnScrollPageDown, this, MAP_WINDOW_HSCROLL);
+
+	// Scroll events for MAP_WINDOW_VSCROLL
+	Bind(wxEVT_SCROLL_TOP, &MapWindow::OnScroll, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_BOTTOM, &MapWindow::OnScroll, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_THUMBTRACK, &MapWindow::OnScroll, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_LINEUP, &MapWindow::OnScrollLineUp, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_LINEDOWN, &MapWindow::OnScrollLineDown, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_PAGEUP, &MapWindow::OnScrollPageUp, this, MAP_WINDOW_VSCROLL);
+	Bind(wxEVT_SCROLL_PAGEDOWN, &MapWindow::OnScrollPageDown, this, MAP_WINDOW_VSCROLL);
+
 	wxFlexGridSizer* topsizer = newd wxFlexGridSizer(2, 0, 0);
 
 	topsizer->AddGrowableCol(0);

--- a/source/ui/map_window.h
+++ b/source/ui/map_window.h
@@ -97,8 +97,6 @@ private:
 
 	friend class MainFrame;
 	friend class MapCanvas;
-
-	DECLARE_EVENT_TABLE()
 };
 
 // MapScrollbar, a special scrollbar that relays alot of events
@@ -107,7 +105,13 @@ private:
 class MapScrollBar : public wxScrollBar {
 public:
 	MapScrollBar(MapWindow* parent, wxWindowID id, long style, wxWindow* canvas) :
-		wxScrollBar(parent, id, wxDefaultPosition, wxDefaultSize, style), canvas(canvas) { }
+		wxScrollBar(parent, id, wxDefaultPosition, wxDefaultSize, style), canvas(canvas) {
+		Bind(wxEVT_KEY_DOWN, &MapScrollBar::OnKey, this);
+		Bind(wxEVT_KEY_UP, &MapScrollBar::OnKey, this);
+		Bind(wxEVT_CHAR, &MapScrollBar::OnKey, this);
+		Bind(wxEVT_SET_FOCUS, &MapScrollBar::OnFocus, this);
+		Bind(wxEVT_MOUSEWHEEL, &MapScrollBar::OnWheel, this);
+	}
 	virtual ~MapScrollBar() { }
 
 	void OnKey(wxKeyEvent& event) {
@@ -121,7 +125,6 @@ public:
 	}
 
 	wxWindow* canvas;
-	DECLARE_EVENT_TABLE()
 };
 
 #endif


### PR DESCRIPTION
This PR addresses the "Event Handling Anti-Patterns" identified in the Phantom agent instructions. It replaces the legacy `BEGIN_EVENT_TABLE` macros with modern `Bind()` calls in `MainFrame`, `MapWindow`, `MapScrollBar`, `MapCanvas`, and `BrushButton`. This improves code maintainability and aligns with modern wxWidgets best practices. It also fixes a bug where `OnKeyUp` was incorrectly bound to `EVT_KEY_DOWN` in `MapCanvas`.

---
*PR created automatically by Jules for task [9239026530749452620](https://jules.google.com/task/9239026530749452620) started by @karolak6612*