### PR TITLE
🗝️ Keeper: Modernize LiveServer and LiveManager memory management

### DIFF
--- a/source/app/application.cpp
+++ b/source/app/application.cpp
@@ -98,7 +98,9 @@ Application::~Application() {
 
 bool Application::OnInit() {
 	// Enable modern appearance handling (wxWidgets 3.3+)
+#if wxCHECK_VERSION(3, 3, 0)
 	SetAppearance(wxApp::Appearance::System);
+#endif
 
 #ifdef __WXMSW__
 	// Enable dark mode support for Windows

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -244,7 +244,7 @@ MapTab* LiveClient::createEditorWindow() {
 	MapTabbook* mtb = dynamic_cast<MapTabbook*>(g_gui.tabbook);
 	ASSERT(mtb);
 
-	MapTab* edit = newd MapTab(mtb, editor.get());
+	MapTab* edit = newd MapTab(mtb, editor);
 	edit->OnSwitchEditorMode(g_gui.IsSelectionMode() ? SELECTION_MODE : DRAWING_MODE);
 
 	return edit;
@@ -372,7 +372,7 @@ void LiveClient::parsePacket(NetworkMessage message) {
 
 void LiveClient::parseHello(NetworkMessage& message) {
 	ASSERT(editor == nullptr);
-	editor = EditorFactory::JoinLive(g_gui.copybuffer, this);
+	editor = EditorFactory::JoinLive(g_gui.copybuffer, this).release();
 
 	Map& map = editor->map;
 	map.setName("Live Map - " + message.read<std::string>());

--- a/source/live/live_client.h
+++ b/source/live/live_client.h
@@ -85,7 +85,8 @@ protected:
 	std::shared_ptr<boost::asio::ip::tcp::resolver> resolver;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;
 
-	std::unique_ptr<Editor> editor;
+	// Owned by MapTab/Editor (LiveClient is owned by Editor via LiveManager)
+	Editor* editor;
 
 	bool stopped;
 };

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -47,11 +47,11 @@ bool LiveManager::IsLocal() const {
 }
 
 LiveClient* LiveManager::GetClient() const {
-	return live_client;
+	return live_client.get();
 }
 
 LiveServer* LiveManager::GetServer() const {
-	return live_server;
+	return live_server.get();
 }
 
 LiveSocket& LiveManager::GetSocket() const {
@@ -63,25 +63,23 @@ LiveSocket& LiveManager::GetSocket() const {
 
 LiveServer* LiveManager::StartServer() {
 	ASSERT(IsLocal());
-	live_server = newd LiveServer(editor);
+	live_server = std::make_unique<LiveServer>(editor);
 
 	delete editor.actionQueue;
 	editor.actionQueue = newd NetworkedActionQueue(editor);
 
-	return live_server;
+	return live_server.get();
 }
 
 void LiveManager::CloseServer() {
 	if (live_server) {
 		live_server->close();
-		delete live_server;
-		live_server = nullptr;
+		live_server.reset();
 	}
 
 	if (live_client) {
 		live_client->close();
-		delete live_client;
-		live_client = nullptr;
+		live_client.reset();
 	}
 
 	delete editor.actionQueue;

--- a/source/live/live_manager.h
+++ b/source/live/live_manager.h
@@ -2,6 +2,7 @@
 #define RME_LIVE_LIVE_MANAGER_H
 
 #include "app/rme_forward_declarations.h"
+#include <memory>
 
 class Editor;
 class LiveServer;
@@ -31,8 +32,8 @@ public:
 
 private:
 	Editor& editor;
-	LiveServer* live_server;
-	LiveClient* live_client;
+	std::unique_ptr<LiveServer> live_server;
+	std::unique_ptr<LiveClient> live_client;
 };
 
 #endif

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -70,7 +70,7 @@ public:
 	void updateOperation(int32_t percent);
 
 protected:
-	std::unordered_map<uint32_t, LivePeer*> clients;
+	std::unordered_map<uint32_t, std::unique_ptr<LivePeer>> clients;
 
 	std::shared_ptr<boost::asio::ip::tcp::acceptor> acceptor;
 	std::shared_ptr<boost::asio::ip::tcp::socket> socket;

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -196,18 +196,17 @@ void LiveLogTab::OnDeselectChatbox(wxFocusEvent& evt) {
 	g_hotkeys.EnableHotkeys();
 }
 
-void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients) {
+void LiveLogTab::UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients) {
 	// Delete old rows
 	if (user_list->GetNumberRows() > 0) {
 		user_list->DeleteRows(0, user_list->GetNumberRows());
 	}
 
-	clients = updatedClients;
-	user_list->AppendRows(clients.size());
+	user_list->AppendRows(updatedClients.size());
 
 	int32_t i = 0;
-	for (auto& clientEntry : clients) {
-		LivePeer* peer = clientEntry.second;
+	for (auto& clientEntry : updatedClients) {
+		LivePeer* peer = clientEntry.second.get();
 		user_list->SetCellBackgroundColour(i, 0, peer->getUsedColor());
 		user_list->SetCellValue(i, 1, i2ws((peer->getClientId() >> 1) + 1));
 		user_list->SetCellValue(i, 2, peer->getName());

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -52,7 +52,7 @@ public:
 		return socket;
 	}
 
-	void UpdateClientList(const std::unordered_map<uint32_t, LivePeer*>& updatedClients);
+	void UpdateClientList(const std::unordered_map<uint32_t, std::unique_ptr<LivePeer>>& updatedClients);
 
 	void OnSelectChatbox(wxFocusEvent& evt);
 	void OnDeselectChatbox(wxFocusEvent& evt);
@@ -67,8 +67,6 @@ protected:
 	wxGrid* log;
 	wxTextCtrl* input;
 	wxGrid* user_list;
-
-	std::unordered_map<uint32_t, LivePeer*> clients;
 
 	DECLARE_EVENT_TABLE();
 };


### PR DESCRIPTION
This PR modernizes the memory management of the Live subsystem, addressing raw pointer ownership issues and memory leaks identified by the Keeper agent.

### Changes
- **LiveServer**: Converted `clients` map to hold `std::unique_ptr<LivePeer>`, ensuring proper cleanup when clients disconnect or the server closes.
- **LiveManager**: Converted `live_server` and `live_client` members to `std::unique_ptr`, removing manual `delete` calls and improving exception safety.
- **LiveClient**: Changed `editor` member from `std::unique_ptr` to raw pointer. This clarifies that `LiveClient` does not own the `Editor` (ownership is transferred to `MapTab` upon creation), preventing potential double-free errors.
- **LiveLogTab**: Removed the member `clients` map which stored raw pointers, updated `UpdateClientList` to work directly with the `LiveServer`'s `unique_ptr` map.
- **Application**: Added `#if wxCHECK_VERSION(3, 3, 0)` guard around `SetAppearance` call to fix compilation on systems with wxWidgets < 3.3.

### Verification
- `build_linux.sh` passes successfully.
- Code review feedback addressed (removed accidental build artifact, documented ownership model).

---
*PR created automatically by Jules for task [16970781272486236872](https://jules.google.com/task/16970781272486236872) started by @karolak6612*