### PR TITLE
[UB FIX] Fix strict aliasing violation in ItemAttribute

### DIFF
--- a/source/game/item_attributes.h
+++ b/source/game/item_attributes.h
@@ -23,6 +23,7 @@
 
 #include "io/filehandle.h"
 
+#include <variant>
 #include <boost/static_assert.hpp>
 
 class IOMap;
@@ -67,7 +68,7 @@ public:
 	const bool* getBoolean() const;
 
 private:
-	alignas(alignof(std::string) > alignof(double) ? alignof(std::string) : alignof(double)) char data[sizeof(std::string) > sizeof(double) ? sizeof(std::string) : sizeof(double)];
+	std::variant<std::monostate, std::string, int32_t, double, bool> m_value;
 };
 
 using ItemAttributeMap = std::map<std::string, ItemAttribute>;


### PR DESCRIPTION
Refactored ItemAttribute to use std::variant and fixed strict aliasing violations in serialization logic.

---
*PR created automatically by Jules for task [4191247422907235868](https://jules.google.com/task/4191247422907235868) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of item attribute data with enhanced type safety and more reliable value conversions across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->