### PR TITLE
⚡ Bolt: Rendering and Tooltip Optimizations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -13,3 +13,11 @@ Action: Prefer modifying pooled objects in-place (`FillItemTooltipData`) over re
 ## 2025-02-18 - Minimap Color Caching
 Learning: `Tile::update` failed to reset `minimapColor` when no color was found, leading to stale colors if items were removed. Also `deepCopy` produced `INVALID_MINIMAP_COLOR` tiles, forcing `getMiniMapColor` to scan items every time.
 Action: Always initialize/reset cached values in `update()` methods to ensure state validity. Use `minimapColor = 0` (or valid "empty" value) instead of `INVALID` to enable unconditional fast-path access.
+
+## 2024-05-22 - Map Loop Bounds & Parallax
+Learning: `MapLayerDrawer` was using loop bounds derived from the camera's floor (z=7) for all layers. Due to parallax offset `(GROUND_LAYER - map_z) * TileSize`, this caused iteration over off-screen areas for other layers.
+Action: Always calculate loop bounds specifically for the current `map_z` layer, accounting for the layer-specific offset. This allows removing per-tile visibility checks inside the loop.
+
+## 2024-05-22 - Zero-Copy Tooltip Data
+Learning: `TooltipData` used `std::string` members to store names from `ItemType` (static) and `Map` (long-lived). This caused unnecessary copies in the hot path of `FillItemTooltipData` which runs for every item.
+Action: Use `std::string_view` in transient rendering structures when data source lifetime is guaranteed to outlive the frame (e.g. static assets).

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -39,10 +39,32 @@ MapLayerDrawer::~MapLayerDrawer() {
 }
 
 void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {
-	int nd_start_x = view.start_x & ~3;
-	int nd_start_y = view.start_y & ~3;
-	int nd_end_x = (view.end_x & ~3) + 4;
-	int nd_end_y = (view.end_y & ~3) + 4;
+	// Optimization: Calculate exact visible bounds for this layer
+	// This accounts for the parallax/depth offset relative to the floor layer
+	const int TileSize = 32;
+	int offset = (map_z <= GROUND_LAYER)
+		? (GROUND_LAYER - map_z) * TileSize
+		: TileSize * (view.floor - map_z);
+
+	// Calculate visible map coordinates based on viewport and offset
+	// view_scroll_x + offset <= map_x * TileSize <= view_scroll_x + screensize + offset
+	// Add 2 tiles margin to be safe (matching RenderView::Setup logic)
+	int margin_tiles = 2;
+	int start_map_x = (view.view_scroll_x + offset) / TileSize - margin_tiles;
+	int start_map_y = (view.view_scroll_y + offset) / TileSize - margin_tiles;
+
+	int end_map_x = (view.view_scroll_x + (int)(view.screensize_x / view.zoom) + offset) / TileSize + margin_tiles;
+	int end_map_y = (view.view_scroll_y + (int)(view.screensize_y / view.zoom) + offset) / TileSize + margin_tiles;
+
+	// Align to node boundaries (4 tiles per node)
+	int nd_start_x = start_map_x & ~3;
+	int nd_start_y = start_map_y & ~3;
+	int nd_end_x = (end_map_x & ~3) + 4;
+	int nd_end_y = (end_map_y & ~3) + 4;
+
+	// Precompute draw base position to avoid recomputing in loop
+	int draw_x_base = -view.view_scroll_x - offset;
+	int draw_y_base = -view.view_scroll_y - offset;
 
 	// ND visibility
 
@@ -58,10 +80,14 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 				if (nd->isVisible(map_z > GROUND_LAYER)) {
 					for (int map_x = 0; map_x < 4; ++map_x) {
 						for (int map_y = 0; map_y < 4; ++map_y) {
-							int draw_x, draw_y;
-							if (!view.IsTileVisible(nd_map_x + map_x, nd_map_y + map_y, map_z, draw_x, draw_y)) {
-								continue;
-							}
+							// Optimization: Skip IsTileVisible call, rely on calculated bounds
+							// Manually calculate draw position
+							int tile_map_x = nd_map_x + map_x;
+							int tile_map_y = nd_map_y + map_y;
+
+							int draw_x = tile_map_x * TileSize + draw_x_base;
+							int draw_y = tile_map_y * TileSize + draw_y_base;
+
 							TileLocation* location = nd->getTile(map_x, map_y, map_z);
 
 							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
@@ -87,10 +113,14 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 		editor->map.visitLeaves(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
 			for (int map_x = 0; map_x < 4; ++map_x) {
 				for (int map_y = 0; map_y < 4; ++map_y) {
-					int draw_x, draw_y;
-					if (!view.IsTileVisible(nd_map_x + map_x, nd_map_y + map_y, map_z, draw_x, draw_y)) {
-						continue;
-					}
+					// Optimization: Skip IsTileVisible call, rely on calculated bounds
+					// Manually calculate draw position
+					int tile_map_x = nd_map_x + map_x;
+					int tile_map_y = nd_map_y + map_y;
+
+					int draw_x = tile_map_x * TileSize + draw_x_base;
+					int draw_y = tile_map_y * TileSize + draw_y_base;
+
 					TileLocation* location = nd->getTile(map_x, map_y, map_z);
 
 					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -226,7 +226,7 @@ void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
 	std::vector<FieldLine>& fields = scratch_fields;
 
 	if (tooltip.category == TooltipCategory::WAYPOINT) {
-		fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
+		fields.push_back({ "Waypoint", std::string(tooltip.waypointName), WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
 	} else {
 		if (tooltip.actionId > 0) {
 			fields.push_back({ "Action ID", std::to_string(tooltip.actionId), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B, {} });
@@ -242,10 +242,10 @@ void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
 			fields.push_back({ "Destination", dest, TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B, {} });
 		}
 		if (!tooltip.description.empty()) {
-			fields.push_back({ "Description", tooltip.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
+			fields.push_back({ "Description", std::string(tooltip.description), BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
 		}
 		if (!tooltip.text.empty()) {
-			fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+			fields.push_back({ "Text", "\"" + std::string(tooltip.text) + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
 		}
 	}
 }

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -24,6 +24,7 @@
 #include "rendering/core/render_view.h"
 #include <vector>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <unordered_map>
 
@@ -76,18 +77,18 @@ struct TooltipData {
 
 	// Header info
 	uint16_t itemId = 0;
-	std::string itemName;
+	std::string_view itemName;
 
 	// Optional fields (0 or empty = not shown)
 	uint16_t actionId = 0;
 	uint16_t uniqueId = 0;
 	uint8_t doorId = 0;
-	std::string text;
-	std::string description;
+	std::string_view text;
+	std::string_view description;
 	Position destination; // For teleports (check if valid via destination.x > 0)
 
 	// Waypoint-specific
-	std::string waypointName;
+	std::string_view waypointName;
 
 	// Container contents
 	std::vector<ContainerItem> containerItems;
@@ -96,11 +97,11 @@ struct TooltipData {
 	TooltipData() = default;
 
 	// Constructor for waypoint
-	TooltipData(Position p, const std::string& wpName) :
+	TooltipData(Position p, std::string_view wpName) :
 		pos(p), category(TooltipCategory::WAYPOINT), waypointName(wpName) { }
 
 	// Constructor for item
-	TooltipData(Position p, uint16_t id, const std::string& name) :
+	TooltipData(Position p, uint16_t id, std::string_view name) :
 		pos(p), category(TooltipCategory::ITEM), itemId(id), itemName(name) { }
 
 	// Determine category based on fields
@@ -128,15 +129,15 @@ struct TooltipData {
 		pos = Position();
 		category = TooltipCategory::ITEM;
 		itemId = 0;
-		// clear strings but keep capacity
-		itemName.clear();
+		// clear string_views
+		itemName = {};
 		actionId = 0;
 		uniqueId = 0;
 		doorId = 0;
-		text.clear();
-		description.clear();
+		text = {};
+		description = {};
 		destination = Position();
-		waypointName.clear();
+		waypointName = {};
 		containerItems.clear();
 		containerCapacity = 0;
 	}


### PR DESCRIPTION
💡 What:
1.  **Map Rendering**: Optimized `MapLayerDrawer::Draw` to calculate exact visible tile bounds for each Z-layer, accounting for parallax offset. Removed per-tile `IsTileVisible` check inside the rendering loop.
2.  **Tooltips**: Changed `TooltipData` to use `std::string_view` for static fields (`itemName`, `text`, `description`, `waypointName`), reducing allocations in the hot path.

🎯 Why:
1.  **Map Rendering**: Previous logic used floor-layer bounds for all layers, causing over-draw (off-screen tiles) or under-draw (missing tiles) due to parallax shift on other layers. Per-tile visibility check was redundant with correct bounds.
2.  **Tooltips**: `FillItemTooltipData` runs for every visible item frame. Copying static strings into `std::string` was expensive and unnecessary.

📊 Impact:
*   Reduced CPU overhead in main rendering loop by skipping redundant visibility checks.
*   Reduced memory allocations/deallocations per frame when tooltips are enabled.

🔬 Measurement:
*   Verify frame time consistency when changing layers.
*   Verify tooltip text rendering remains correct (explicit string conversion added).
*   Verify no visual artifacts at viewport edges (margin maintained).

---
*PR created automatically by Jules for task [7323887716888387891](https://jules.google.com/task/7323887716888387891) started by @karolak6612*