### PR TITLE
Integrate Boehm GC and Refactor Texture Cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ endif()
 find_package(glad CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(spdlog CONFIG REQUIRED)
+find_package(bdwgc CONFIG REQUIRED)
 
 # nanovg: try vcpkg/Conan first, fallback to ext/nanovg
 find_package(nanovg CONFIG QUIET)
@@ -122,3 +123,4 @@ target_link_libraries(rme PRIVATE glad::glad)
 target_link_libraries(rme PRIVATE glm::glm)
 target_link_libraries(rme PRIVATE nanovg::nanovg)
 target_link_libraries(rme PRIVATE spdlog::spdlog)
+target_link_libraries(rme PRIVATE bdwgc::bdwgc)

--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,7 @@ class RMERecipe(ConanFile):
             # Only dependencies NOT available via apt
             self.requires("glad/0.1.36")
             self.requires("opengl/system")
+            self.requires("bdwgc/8.2.14")
             # Note: nanovg is in ext/nanovg
         else:
             # Full dependency tree for Windows/macOS
@@ -30,6 +31,7 @@ class RMERecipe(ConanFile):
             self.requires("glad/0.1.36")
             self.requires("glm/1.0.1")
             self.requires("spdlog/1.15.0")
+            self.requires("bdwgc/8.2.14")
 
     
     def layout(self):

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -154,7 +154,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/text_renderer.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_array.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_atlas.h
-    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_garbage_collector.h
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_cache_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/brush_cursor_drawer.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/drag_shadow_drawer.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/live_cursor_drawer.h
@@ -322,6 +322,7 @@ set(rme_H
 
 set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/app/application.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/app/gc_memory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/app/client_version.cpp
     ${CMAKE_CURRENT_LIST_DIR}/app/extension.cpp
     ${CMAKE_CURRENT_LIST_DIR}/app/preferences.cpp
@@ -463,7 +464,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/text_renderer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_array.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_atlas.cpp
-    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_garbage_collector.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/rendering/core/texture_cache_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/brush_cursor_drawer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/drag_shadow_drawer.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/drawers/cursors/live_cursor_drawer.cpp

--- a/source/app/gc_memory.cpp
+++ b/source/app/gc_memory.cpp
@@ -1,0 +1,64 @@
+#include <gc.h>
+#include <new>
+#include <cstdlib>
+
+// Static initializer to ensure GC is initialized before main/wxEntry
+struct GCInitializer {
+    GCInitializer() {
+        GC_INIT();
+    }
+};
+
+static GCInitializer gc_init;
+
+// Global overrides
+void* operator new(size_t size) {
+    void* ptr = GC_MALLOC(size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+
+void* operator new[](size_t size) {
+    void* ptr = GC_MALLOC(size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+
+void operator delete(void* ptr) noexcept {
+    GC_FREE(ptr);
+}
+
+void operator delete[](void* ptr) noexcept {
+    GC_FREE(ptr);
+}
+
+// Sized delete (C++14)
+void operator delete(void* ptr, size_t size) noexcept {
+    GC_FREE(ptr);
+}
+
+void operator delete[](void* ptr, size_t size) noexcept {
+    GC_FREE(ptr);
+}
+
+// Debug new support (overloading the signature used by debug new macros)
+void* operator new(size_t size, const char* /*file*/, int /*line*/) {
+    void* ptr = GC_MALLOC(size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+
+void* operator new[](size_t size, const char* /*file*/, int /*line*/) {
+    void* ptr = GC_MALLOC(size);
+    if (!ptr) throw std::bad_alloc();
+    return ptr;
+}
+
+// Matching delete for placement new (called if constructor throws)
+void operator delete(void* ptr, const char* /*file*/, int /*line*/) noexcept {
+    GC_FREE(ptr);
+}
+
+void operator delete[](void* ptr, const char* /*file*/, int /*line*/) noexcept {
+    GC_FREE(ptr);
+}

--- a/source/app/main.h
+++ b/source/app/main.h
@@ -26,27 +26,7 @@
 	#define _WIN32_WINNT 0x0501
 #endif
 
-#ifdef DEBUG_MEM
-
-	#define _CRTDBG_MAP_ALLOC
-
-	#include <stdlib.h>
-	#include <crtdbg.h>
-
-	#pragma warning(disable : 4291)
-_Ret_bytecap_(_Size) inline void* __CRTDECL operator new(size_t _Size, const char* file, int line) {
-	return ::operator new(_Size, _NORMAL_BLOCK, file, line);
-}
-_Ret_bytecap_(_Size) inline void* __CRTDECL operator new[](size_t _Size, const char* file, int line) {
-	return ::operator new[](_Size, _NORMAL_BLOCK, file, line);
-}
-	#define newd new (__FILE__, __LINE__)
-
-#else
-
-	#define newd new
-
-#endif
+#define newd new
 
 // Boost libraries
 #include <boost/utility.hpp>

--- a/source/rendering/core/graphics.cpp
+++ b/source/rendering/core/graphics.cpp
@@ -200,8 +200,8 @@ void GraphicManager::addSpriteToCleanup(GameSprite* spr) {
 	collector.AddSpriteToCleanup(spr);
 }
 
-void GraphicManager::garbageCollection() {
-	collector.GarbageCollect(resident_game_sprites, resident_images, cached_time_);
+void GraphicManager::pruneTextureCache() {
+	collector.PruneCache(resident_game_sprites, resident_images, cached_time_);
 }
 
 CreatureSprite::CreatureSprite(GameSprite* parent, const Outfit& outfit) :

--- a/source/rendering/core/graphics.h
+++ b/source/rendering/core/graphics.h
@@ -45,7 +45,7 @@ class FileReadHandle;
 class Animator;
 
 #include "rendering/core/sprite_light.h"
-#include "rendering/core/texture_garbage_collector.h"
+#include "rendering/core/texture_cache_manager.h"
 #include "rendering/core/render_timer.h"
 #include "rendering/core/atlas_manager.h"
 
@@ -238,7 +238,7 @@ public:
 	friend class DatLoader;
 	friend class SprLoader;
 	friend class SpriteIconGenerator;
-	friend class TextureGarbageCollector;
+	friend class TextureCacheManager;
 	friend class TooltipDrawer;
 };
 
@@ -289,7 +289,7 @@ public:
 	friend class SprLoader;
 
 	// Cleans old & unused textures according to config settings
-	void garbageCollection();
+	void pruneTextureCache();
 	void addSpriteToCleanup(GameSprite* spr);
 
 	wxFileName getMetadataFileName() const {
@@ -348,7 +348,7 @@ private:
 	wxFileName metadata_file;
 	wxFileName sprites_file;
 
-	TextureGarbageCollector collector;
+	TextureCacheManager collector;
 
 	std::unique_ptr<RenderTimer> animation_timer;
 	time_t cached_time_ = 0;

--- a/source/rendering/core/texture_cache_manager.cpp
+++ b/source/rendering/core/texture_cache_manager.cpp
@@ -16,34 +16,34 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "app/main.h"
-#include "rendering/core/texture_garbage_collector.h"
+#include "rendering/core/texture_cache_manager.h"
 #include "rendering/core/graphics.h"
 #include "app/settings.h"
 #include <algorithm>
 
-TextureGarbageCollector::TextureGarbageCollector() :
+TextureCacheManager::TextureCacheManager() :
 	loaded_textures(0),
 	lastclean(0) {
 }
 
-TextureGarbageCollector::~TextureGarbageCollector() {
+TextureCacheManager::~TextureCacheManager() {
 }
 
-void TextureGarbageCollector::Clear() {
+void TextureCacheManager::Clear() {
 	loaded_textures = 0;
 	lastclean = time(nullptr);
 	cleanup_list.clear();
 }
 
-void TextureGarbageCollector::NotifyTextureLoaded() {
+void TextureCacheManager::NotifyTextureLoaded() {
 	loaded_textures++;
 }
 
-void TextureGarbageCollector::NotifyTextureUnloaded() {
+void TextureCacheManager::NotifyTextureUnloaded() {
 	loaded_textures--;
 }
 
-void TextureGarbageCollector::AddSpriteToCleanup(GameSprite* spr) {
+void TextureCacheManager::AddSpriteToCleanup(GameSprite* spr) {
 	cleanup_list.push_back(spr);
 	// Clean if needed
 	if (cleanup_list.size() > std::max<uint32_t>(100, g_settings.getInteger(Config::SOFTWARE_CLEAN_THRESHOLD))) {
@@ -54,7 +54,7 @@ void TextureGarbageCollector::AddSpriteToCleanup(GameSprite* spr) {
 	}
 }
 
-void TextureGarbageCollector::GarbageCollect(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time) {
+void TextureCacheManager::PruneCache(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time) {
 	if (g_settings.getInteger(Config::TEXTURE_MANAGEMENT)) {
 		if (loaded_textures > g_settings.getInteger(Config::TEXTURE_CLEAN_THRESHOLD) && current_time - lastclean > g_settings.getInteger(Config::TEXTURE_CLEAN_PULSE)) {
 
@@ -86,7 +86,7 @@ void TextureGarbageCollector::GarbageCollect(std::vector<GameSprite*>& resident_
 	}
 }
 
-void TextureGarbageCollector::CleanSoftwareSprites(std::vector<std::unique_ptr<Sprite>>& sprite_space) {
+void TextureCacheManager::CleanSoftwareSprites(std::vector<std::unique_ptr<Sprite>>& sprite_space) {
 	for (auto& sprite_ptr : sprite_space) {
 		if (sprite_ptr) {
 			sprite_ptr->unloadDC();

--- a/source/rendering/core/texture_cache_manager.h
+++ b/source/rendering/core/texture_cache_manager.h
@@ -15,8 +15,8 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //////////////////////////////////////////////////////////////////////
 
-#ifndef RME_TEXTURE_GARBAGE_COLLECTOR_H
-#define RME_TEXTURE_GARBAGE_COLLECTOR_H
+#ifndef RME_TEXTURE_CACHE_MANAGER_H
+#define RME_TEXTURE_CACHE_MANAGER_H
 
 #include <deque>
 #include <map>
@@ -27,12 +27,12 @@
 class GameSprite;
 class Sprite;
 
-class TextureGarbageCollector {
+class TextureCacheManager {
 public:
-	TextureGarbageCollector();
-	~TextureGarbageCollector();
+	TextureCacheManager();
+	~TextureCacheManager();
 
-	void GarbageCollect(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time);
+	void PruneCache(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time);
 	void AddSpriteToCleanup(GameSprite* spr);
 	void CleanSoftwareSprites(std::vector<std::unique_ptr<Sprite>>& sprite_space);
 	void Clear();

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -290,7 +290,7 @@ void MapCanvas::OnPaint(wxPaintEvent& event) {
 	static long last_gc_time = 0;
 	long current_time = wxGetLocalTime();
 	if (current_time - last_gc_time >= 1) {
-		g_gui.gfx.garbageCollection();
+		g_gui.gfx.pruneTextureCache();
 		last_gc_time = current_time;
 	}
 


### PR DESCRIPTION
- Replaced custom memory allocator (`newd`) with Boehm-Demers-Weiser Garbage Collector (`bdwgc`).
- Added `bdwgc` dependency to `conanfile.py` and `CMakeLists.txt`.
- Implemented global `operator new`/`delete` overrides using `GC_MALLOC` in `source/app/gc_memory.cpp`.
- Renamed `TextureGarbageCollector` to `TextureCacheManager` to disambiguate from the actual memory GC.
- Renamed `GarbageCollect` method to `PruneCache` and `GraphicManager::garbageCollection` to `pruneTextureCache`.
- Removed legacy debug memory macros in `source/app/main.h`.
- Initialized GC via static initializer to ensure early execution.

---
*PR created automatically by Jules for task [3736916221469721097](https://jules.google.com/task/3736916221469721097) started by @karolak6612*