### PR TITLE
Fix locked door highlighting artifact by initializing ItemType::isLocked

### DIFF
--- a/source/game/items.cpp
+++ b/source/game/items.cpp
@@ -79,6 +79,7 @@ ItemType::ItemType() :
 	isWall(false),
 	isBrushDoor(false),
 	isOpen(false),
+	isLocked(false),
 	isTable(false),
 	isCarpet(false),
 

--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -39,14 +39,10 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
-	// FIXME: This logic causes the map to turn black when zooming out with a house brush selected.
-	// Disabled until a proper fix is found.
-	/*
 	if (!options.ingame && options.highlight_locked_doors && it.isDoor() && it.isLocked) {
 		blue /= 2;
 		green /= 2;
 	}
-	*/
 
 	if (!options.ingame && !ephemeral && item->isSelected()) {
 		red /= 2;


### PR DESCRIPTION
Fixed a bug where `ItemType::isLocked` was uninitialized, causing undefined behavior and rendering artifacts when highlighting locked doors. Re-enabled the highlighting feature.

---
*PR created automatically by Jules for task [1860098843212162911](https://jules.google.com/task/1860098843212162911) started by @karolak6612*