### PR TITLE
Save changes when switching notebook pages in PropertiesWindow

### DIFF
--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -50,6 +50,7 @@ protected:
 	// Simple pane
 	wxWindow* createGeneralPanel(wxWindow* parent);
 	void saveGeneralPanel();
+	void updateGeneralPanel();
 
 	// Container pane
 	std::vector<ContainerItemButton*> container_items;
@@ -60,6 +61,7 @@ protected:
 	wxGrid* attributesGrid;
 	wxWindow* createAttributesPanel(wxWindow* parent);
 	void saveAttributesPanel();
+	void updateAttributesPanel();
 	void SetGridValue(wxGrid* grid, int rowIndex, std::string name, const ItemAttribute& attr);
 
 protected:


### PR DESCRIPTION
This change ensures that when a user switches tabs in the Item Properties window (PropertiesWindow), any changes made in the current tab are saved to the underlying item, and the new tab is updated to reflect the current state of the item. This addresses the issue where changes in one tab (e.g., Action ID in General tab) were not reflected or persisted when switching to another tab (e.g., Advanced tab), potentially leading to data loss or inconsistency.

Specific changes:
- Refactored `OnNotebookPageChanged` to handle saving of old page and updating of new page.
- Added `updateGeneralPanel` to sync General tab fields with `edit_item`.
- Added `updateAttributesPanel` to sync Advanced tab grid with `edit_item`.
- Corrected the ID of the Advanced tab panel to `ITEM_PROPERTIES_ADVANCED_TAB`.

---
*PR created automatically by Jules for task [9048970049958784236](https://jules.google.com/task/9048970049958784236) started by @karolak6612*