### PR TITLE
Optimize waypoint lookup by position

### DIFF
--- a/source/game/waypoints.h
+++ b/source/game/waypoints.h
@@ -20,6 +20,9 @@
 
 #include "map/position.h"
 
+#include <functional>
+#include <unordered_map>
+
 class Waypoint {
 public:
 	std::string name;
@@ -30,6 +33,16 @@ using WaypointMap = std::map<std::string, Waypoint*>;
 
 class Waypoints {
 	Map& map;
+
+	struct PositionHasher {
+		std::size_t operator()(const Position& p) const {
+			std::size_t h = 0;
+			h ^= std::hash<int>{}(p.x) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(p.y) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			h ^= std::hash<int>{}(p.z) + 0x9e3779b9 + (h << 6) + (h >> 2);
+			return h;
+		}
+	};
 
 public:
 	Waypoints(Map& map) :
@@ -46,6 +59,8 @@ public:
 	void removeWaypoint(std::string name);
 
 	WaypointMap waypoints;
+	using WaypointByPosMap = std::unordered_multimap<Position, Waypoint*, PositionHasher>;
+	WaypointByPosMap waypoints_by_pos;
 
 	WaypointMap::iterator begin() {
 		return waypoints.begin();


### PR DESCRIPTION
This change optimizes the `Waypoints::getWaypoint(TileLocation*)` function, which was previously performing a linear search over all waypoints. This could be a performance bottleneck in large maps or when rendering many tiles.

I introduced a secondary index `waypoints_by_pos` using `std::unordered_multimap` and a custom `PositionHasher`. This index allows for O(1) average time complexity lookups by position.

The index is automatically maintained in `addWaypoint` and `removeWaypoint`. I also added a check in `addWaypoint` to ensure consistency.

Verified that the changes compile and integrate correctly with the rest of the codebase (e.g., `TileRenderer`, `WaypointBrush`).

---
*PR created automatically by Jules for task [7839808194906854559](https://jules.google.com/task/7839808194906854559) started by @karolak6612*