### PR TITLE
[UB FIX] Fix buffer over-read in NetworkMessage

### DIFF
--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -38,6 +38,9 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
+	if (position + length > buffer.size()) {
+		throw std::out_of_range("NetworkMessage::read<string>: Buffer underflow");
+	}
 	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
 	position += length;
 	return std::string(strBuffer, length);

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -35,6 +36,9 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::out_of_range("NetworkMessage::read: Buffer underflow");
+		}
 		T& value = *reinterpret_cast<T*>(&buffer[position]);
 		position += sizeof(T);
 		return value;


### PR DESCRIPTION
This PR fixes a critical undefined behavior and potential security vulnerability in `NetworkMessage` packet parsing.

The `read<T>` and `read<std::string>` methods previously accessed the internal buffer using `reinterpret_cast` and pointer arithmetic without verifying that the requested data was within the buffer bounds. This allowed malformed packets (e.g., claiming a large string length) to cause a heap-buffer-overflow.

The fix introduces explicit bounds checks:
- In `read<T>`, it checks `position + sizeof(T) > buffer.size()`.
- In `read<std::string>`, it checks `position + length > buffer.size()` before accessing the buffer.

If a check fails, a `std::out_of_range` exception is thrown, which safely aborts the packet processing (caught by the application loop or causing termination, preventing RCE/memory corruption).

---
*PR created automatically by Jules for task [7204966355002091019](https://jules.google.com/task/7204966355002091019) started by @karolak6612*