### PR TITLE
👻 Phantom: Migrate lists and grids to NanoVG

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -16,13 +16,19 @@
  */
 class VirtualBrushGrid : public NanoVGCanvas, public BrushBoxInterface {
 public:
+	enum ViewMode {
+		VIEW_GRID,
+		VIEW_LIST
+	};
+
 	/**
 	 * @brief Constructs a VirtualBrushGrid.
 	 * @param parent Parent window
 	 * @param _tileset The tileset category containing brushes
 	 * @param rsz Icon render size (16x16 or 32x32)
+	 * @param mode View mode (Grid or List)
 	 */
-	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz);
+	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz, ViewMode mode = VIEW_GRID);
 	~VirtualBrushGrid() override;
 
 	wxWindow* GetSelfWindow() override {
@@ -48,6 +54,7 @@ protected:
 	// Event Handlers
 	void OnMouseDown(wxMouseEvent& event);
 	void OnMotion(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
 
 	// Internal helpers
 	void UpdateLayout();
@@ -55,8 +62,10 @@ protected:
 	wxRect GetItemRect(int index) const;
 	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
+	void UpdateSelection(); // Helper to notify GUI and ensure visible
 
 	RenderSize icon_size;
+	ViewMode view_mode;
 	int selected_index;
 	int hover_index;
 	int columns;

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,30 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush();
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush);
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const;
-	virtual wxCoord OnMeasureItem(size_t n) const;
-
-	void OnKey(wxKeyEvent& event);
-};
-
-
 class BrushPanel : public wxPanel {
 public:
 	BrushPanel(wxWindow* parent);
@@ -87,9 +63,6 @@ public:
 	void OnSwitchIn();
 	// Called when this page is hidden
 	void OnSwitchOut();
-
-	// wxWidgets event handlers
-	void OnClickListBoxRow(wxCommandEvent& event);
 
 protected:
 	const TilesetCategory* tileset;

--- a/source/ui/dialogs/outfit_chooser_dialog.h
+++ b/source/ui/dialogs/outfit_chooser_dialog.h
@@ -11,6 +11,8 @@
 #include "ui/dialogs/outfit_preview_panel.h"
 #include "ui/dialogs/outfit_selection_grid.h"
 
+class ColorPaletteView; // Forward declaration
+
 class OutfitChooserDialog : public wxDialog {
 public:
 	enum {
@@ -54,11 +56,7 @@ public:
 	void OnFavoriteEdit(wxCommandEvent& event);
 	void OnFavoriteDelete(wxCommandEvent& event);
 
-	Outfit current_outfit; // Made public or keep friend? Friend is messy with circular includes. Let's make it public for now or add getter/setter.
-	// Actually, OutfitSelectionGrid accesses current_outfit. Let's use getter/setter in the grid.
-	// But current_outfit is used extensively. Let's keep it private and add friends or accessors.
-	// Wait, I already added GetOutfit/SetOutfit. I'll make members public/accessors as needed.
-	// For now, I'll keep the private section but moving specific handlers to public so Grid can bind them.
+	Outfit current_outfit;
 
 private:
 	void OnColorPartChange(wxCommandEvent& event);
@@ -80,6 +78,7 @@ private:
 	wxSearchCtrl* outfit_search;
 	OutfitSelectionGrid* selection_panel;
 	OutfitSelectionGrid* favorites_panel;
+	ColorPaletteView* palette_view;
 
 	wxCheckBox* addon1;
 	wxCheckBox* addon2;
@@ -92,8 +91,6 @@ private:
 	wxButton* body_btn;
 	wxButton* legs_btn;
 	wxButton* feet_btn;
-
-	std::vector<wxWindow*> color_buttons;
 };
 
 #endif


### PR DESCRIPTION
This PR addresses critical wxWidgets violations by migrating legacy list and grid implementations to hardware-accelerated `NanoVGCanvas` components.

**Key Changes:**
1.  **Welcome Dialog:** Replaced the inefficient `wxScrolledWindow` containing individual `wxPanel` items for recent files with a single `RecentFilesView` canvas.
2.  **Brush Panel:** Removed the `BrushListBox` class (which used `wxDC` on `wxVListBox`) and repurposed the existing `VirtualBrushGrid` to support a "List Mode", ensuring consistent rendering and behavior.
3.  **Outfit Chooser:** Replaced the grid of ~133 `ColorSwatch` windows (which caused high GDI usage) with a single `ColorPaletteView` canvas.
4.  **VirtualBrushGrid:** Added keyboard navigation support to restore functionality lost from `BrushListBox`.

**Verification:**
- Verified compilation of all modified files (`welcome_dialog.cpp`, `brush_panel.cpp`, `virtual_brush_grid.cpp`, `outfit_chooser_dialog.cpp`).
- Checked for removed dependencies (grepped for `BrushListBox`).


---
*PR created automatically by Jules for task [13267745313534643739](https://jules.google.com/task/13267745313534643739) started by @karolak6612*