### PR TITLE
⚡ Bolt: Rendering and Memory Optimizations

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -169,12 +169,19 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 	// BatchRenderer::SetAtlasManager(g_gui.gfx.getAtlasManager());
 
 	int frame = item->getFrame();
-	for (int cx = 0; cx != spr->width; cx++) {
-		for (int cy = 0; cy != spr->height; cy++) {
-			for (int cf = 0; cf != spr->layers; cf++) {
-				const AtlasRegion* region = spr->getAtlasRegion(cx, cy, cf, subtype, pattern_x, pattern_y, pattern_z, frame);
-				if (region) {
-					sprite_drawer->glBlitAtlasQuad(sprite_batch, screenx - cx * TileSize, screeny - cy * TileSize, region, red, green, blue, alpha);
+	if (spr->width == 1 && spr->height == 1 && spr->layers == 1) {
+		const AtlasRegion* region = spr->getAtlasRegion(0, 0, 0, subtype, pattern_x, pattern_y, pattern_z, frame);
+		if (region) {
+			sprite_drawer->glBlitAtlasQuad(sprite_batch, screenx, screeny, region, red, green, blue, alpha);
+		}
+	} else {
+		for (int cx = 0; cx != spr->width; cx++) {
+			for (int cy = 0; cy != spr->height; cy++) {
+				for (int cf = 0; cf != spr->layers; cf++) {
+					const AtlasRegion* region = spr->getAtlasRegion(cx, cy, cf, subtype, pattern_x, pattern_y, pattern_z, frame);
+					if (region) {
+						sprite_drawer->glBlitAtlasQuad(sprite_batch, screenx - cx * TileSize, screeny - cy * TileSize, region, red, green, blue, alpha);
+					}
 				}
 			}
 		}

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -83,12 +83,23 @@ void TileColorCalculator::GetHouseColor(uint32_t house_id, uint8_t& r, uint8_t& 
 		uint8_t r, g, b;
 	};
 	static thread_local std::unordered_map<uint32_t, Color> color_cache;
+	static thread_local uint32_t last_house_id = 0xFFFFFFFF;
+	static thread_local Color last_color = { 255, 255, 255 };
+
+	if (house_id == last_house_id) {
+		r = last_color.r;
+		g = last_color.g;
+		b = last_color.b;
+		return;
+	}
 
 	auto it = color_cache.find(house_id);
 	if (it != color_cache.end()) {
 		r = it->second.r;
 		g = it->second.g;
 		b = it->second.b;
+		last_house_id = house_id;
+		last_color = it->second;
 		return;
 	}
 
@@ -111,7 +122,10 @@ void TileColorCalculator::GetHouseColor(uint32_t house_id, uint8_t& r, uint8_t& 
 		b += 100;
 	}
 
-	color_cache[house_id] = { r, g, b };
+	Color c = { r, g, b };
+	color_cache[house_id] = c;
+	last_house_id = house_id;
+	last_color = c;
 }
 
 void TileColorCalculator::GetMinimapColor(const Tile* tile, uint8_t& r, uint8_t& g, uint8_t& b) {

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -86,7 +86,7 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const Position& p
 
 	data.pos = pos;
 	data.itemId = id;
-	data.itemName = itemName; // Assign string_view to string (copy/allocation happens here)
+	data.itemName = itemName; // Assign string_view to string_view (no copy)
 
 	data.actionId = action;
 	data.uniqueId = unique;

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -75,7 +75,7 @@ void TooltipDrawer::addItemTooltip(TooltipData&& data) {
 	commitTooltip();
 }
 
-void TooltipDrawer::addWaypointTooltip(Position pos, const std::string& name) {
+void TooltipDrawer::addWaypointTooltip(Position pos, std::string_view name) {
 	if (name.empty()) {
 		return;
 	}
@@ -226,7 +226,7 @@ void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
 	std::vector<FieldLine>& fields = scratch_fields;
 
 	if (tooltip.category == TooltipCategory::WAYPOINT) {
-		fields.push_back({ "Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
+		fields.push_back({ "Waypoint", std::string(tooltip.waypointName), WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B, {} });
 	} else {
 		if (tooltip.actionId > 0) {
 			fields.push_back({ "Action ID", std::to_string(tooltip.actionId), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B, {} });
@@ -242,10 +242,10 @@ void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
 			fields.push_back({ "Destination", dest, TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B, {} });
 		}
 		if (!tooltip.description.empty()) {
-			fields.push_back({ "Description", tooltip.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
+			fields.push_back({ "Description", std::string(tooltip.description), BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, {} });
 		}
 		if (!tooltip.text.empty()) {
-			fields.push_back({ "Text", "\"" + tooltip.text + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
+			fields.push_back({ "Text", "\"" + std::string(tooltip.text) + "\"", TEXT_R, TEXT_G, TEXT_B, {} });
 		}
 	}
 }

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -24,6 +24,7 @@
 #include "rendering/core/render_view.h"
 #include <vector>
 #include <string>
+#include <string_view>
 #include <sstream>
 #include <unordered_map>
 
@@ -76,18 +77,18 @@ struct TooltipData {
 
 	// Header info
 	uint16_t itemId = 0;
-	std::string itemName;
+	std::string_view itemName;
 
 	// Optional fields (0 or empty = not shown)
 	uint16_t actionId = 0;
 	uint16_t uniqueId = 0;
 	uint8_t doorId = 0;
-	std::string text;
-	std::string description;
+	std::string_view text;
+	std::string_view description;
 	Position destination; // For teleports (check if valid via destination.x > 0)
 
 	// Waypoint-specific
-	std::string waypointName;
+	std::string_view waypointName;
 
 	// Container contents
 	std::vector<ContainerItem> containerItems;
@@ -96,11 +97,11 @@ struct TooltipData {
 	TooltipData() = default;
 
 	// Constructor for waypoint
-	TooltipData(Position p, const std::string& wpName) :
+	TooltipData(Position p, std::string_view wpName) :
 		pos(p), category(TooltipCategory::WAYPOINT), waypointName(wpName) { }
 
 	// Constructor for item
-	TooltipData(Position p, uint16_t id, const std::string& name) :
+	TooltipData(Position p, uint16_t id, std::string_view name) :
 		pos(p), category(TooltipCategory::ITEM), itemId(id), itemName(name) { }
 
 	// Determine category based on fields
@@ -128,15 +129,15 @@ struct TooltipData {
 		pos = Position();
 		category = TooltipCategory::ITEM;
 		itemId = 0;
-		// clear strings but keep capacity
-		itemName.clear();
+		// clear strings
+		itemName = {};
 		actionId = 0;
 		uniqueId = 0;
 		doorId = 0;
-		text.clear();
-		description.clear();
+		text = {};
+		description = {};
 		destination = Position();
-		waypointName.clear();
+		waypointName = {};
 		containerItems.clear();
 		containerCapacity = 0;
 	}
@@ -156,7 +157,7 @@ public:
 	void commitTooltip();
 
 	// Add a waypoint tooltip
-	void addWaypointTooltip(Position pos, const std::string& name);
+	void addWaypointTooltip(Position pos, std::string_view name);
 
 	// Draw all tooltips
 	void draw(NVGcontext* vg, const RenderView& view);


### PR DESCRIPTION
💡 What:
1. Implemented a fast path in `ItemDrawer::BlitItem` for 1x1x1 sprites.
2. Added a 1-element `thread_local` cache to `TileColorCalculator::GetHouseColor`.
3. Refactored `TooltipData` to use `std::string_view` for string members.

🎯 Why:
1. To avoid triple-loop overhead for the majority of items (single sprite).
2. To eliminate redundant `unordered_map` lookups for spatially adjacent tiles sharing the same house ID.
3. To reduce memory allocations and copying when generating tooltips for thousands of visible items per frame.

📊 Impact:
- Reduces branch prediction misses in sprite rendering.
- Reduces hash map overhead in tile rendering.
- Eliminates string allocations for tooltip generation in the hot loop.

🔬 Measurement:
- `ItemDrawer::BlitItem`: Verify correct rendering of single and multi-part sprites.
- `TileColorCalculator`: Verify house color consistency.
- `TooltipData`: Verify tooltip text correctness and absence of memory issues.

---
*PR created automatically by Jules for task [6759839934452033328](https://jules.google.com/task/6759839934452033328) started by @karolak6612*