### PR TITLE
Modernize UI Lists and Grids with NanoVG

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -84,8 +84,10 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_window.h
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_chooser_dialog.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_color_grid.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_preview_panel.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_selection_grid.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/virtual_find_list.h
 
     ${CMAKE_CURRENT_LIST_DIR}/io/filehandle.h
     ${CMAKE_CURRENT_LIST_DIR}/io/loaders/dat_loader.h
@@ -127,6 +129,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/palette/palette_window.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/brush_button.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_grid.h
+    ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_list_box.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_palette_panel.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_panel.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/animator.h
@@ -404,8 +407,10 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_chooser_dialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_color_grid.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_preview_panel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_selection_grid.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/virtual_find_list.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/io/filehandle.cpp
     ${CMAKE_CURRENT_LIST_DIR}/io/loaders/dat_loader.cpp
@@ -443,6 +448,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/palette/palette_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/brush_button.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_grid.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_list_box.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_palette_panel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_panel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/animator.cpp

--- a/source/palette/controls/virtual_brush_list_box.cpp
+++ b/source/palette/controls/virtual_brush_list_box.cpp
@@ -1,0 +1,345 @@
+#include "palette/controls/virtual_brush_list_box.h"
+#include "ui/gui.h"
+#include "rendering/core/graphics.h"
+#include "palette/palette_window.h"
+#include "app/settings.h"
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+
+VirtualBrushListBox::VirtualBrushListBox(wxWindow* parent, const TilesetCategory* _tileset) :
+	NanoVGCanvas(parent, wxID_ANY, wxVSCROLL | wxWANTS_CHARS),
+	BrushBoxInterface(_tileset),
+	selected_index(-1),
+	hover_index(-1),
+	item_height(32) {
+
+	Bind(wxEVT_LEFT_DOWN, &VirtualBrushListBox::OnMouseDown, this);
+	Bind(wxEVT_MOTION, &VirtualBrushListBox::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &VirtualBrushListBox::OnLeave, this);
+	Bind(wxEVT_KEY_DOWN, &VirtualBrushListBox::OnKeyDown, this);
+	Bind(wxEVT_CHAR, &VirtualBrushListBox::OnChar, this);
+
+	UpdateScroll();
+}
+
+VirtualBrushListBox::~VirtualBrushListBox() {
+}
+
+void VirtualBrushListBox::UpdateScroll() {
+	if (tileset) {
+		UpdateScrollbar(static_cast<int>(tileset->size()) * item_height);
+	}
+}
+
+void VirtualBrushListBox::SelectFirstBrush() {
+	if (tileset && tileset->size() > 0) {
+		selected_index = 0;
+		EnsureVisible(0);
+		Refresh();
+	}
+}
+
+Brush* VirtualBrushListBox::GetSelectedBrush() const {
+	if (selected_index >= 0 && selected_index < static_cast<int>(tileset->size())) {
+		return tileset->brushlist[selected_index];
+	}
+	// Fallback to first if nothing selected but list not empty (mimic original behavior?)
+	// Original BrushListBox::GetSelectedBrush checks selection, if not found, returns index 0.
+	if (tileset && tileset->size() > 0) {
+		return tileset->brushlist[0];
+	}
+	return nullptr;
+}
+
+bool VirtualBrushListBox::SelectBrush(const Brush* brush) {
+	if (!tileset) return false;
+
+	for (size_t i = 0; i < tileset->size(); ++i) {
+		if (tileset->brushlist[i] == brush) {
+			selected_index = static_cast<int>(i);
+			EnsureVisible(selected_index);
+			Refresh();
+			return true;
+		}
+	}
+	return false;
+}
+
+void VirtualBrushListBox::EnsureVisible(int index) {
+	if (index < 0) return;
+
+	int top = index * item_height;
+	int bottom = top + item_height;
+	int scrollPos = GetScrollPosition();
+	int clientH = GetClientSize().y;
+
+	if (top < scrollPos) {
+		SetScrollPosition(top);
+	} else if (bottom > scrollPos + clientH) {
+		SetScrollPosition(bottom - clientH);
+	}
+}
+
+wxSize VirtualBrushListBox::DoGetBestClientSize() const {
+	return FromDIP(wxSize(200, 300));
+}
+
+void VirtualBrushListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	// Background
+	nvgBeginPath(vg);
+	nvgRect(vg, 0, 0, width, std::max(height, GetScrollPosition() + height));
+	nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	nvgFill(vg);
+
+	if (!tileset || tileset->size() == 0) return;
+
+	int scrollPos = GetScrollPosition();
+	int startIdx = scrollPos / item_height;
+	int endIdx = (scrollPos + height + item_height - 1) / item_height;
+
+	startIdx = std::max(0, startIdx);
+	endIdx = std::min((int)tileset->size(), endIdx);
+
+	for (int i = startIdx; i < endIdx; ++i) {
+		int y = i * item_height;
+
+		// Selection Background
+		if (i == selected_index) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, y, width, item_height);
+			if (HasFocus()) {
+				nvgFillColor(vg, nvgRGBA(0, 120, 215, 255));
+			} else {
+				nvgFillColor(vg, nvgRGBA(200, 200, 200, 255));
+			}
+			nvgFill(vg);
+		} else if (i == hover_index) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, y, width, item_height);
+			nvgFillColor(vg, nvgRGBA(240, 240, 240, 255));
+			nvgFill(vg);
+		}
+
+		Brush* brush = tileset->brushlist[i];
+
+		// Icon
+		int tex = GetOrCreateBrushTexture(vg, brush);
+		if (tex > 0) {
+			NVGpaint imgPaint = nvgImagePattern(vg, 4, y, 32, 32, 0, tex, 1.0f);
+			nvgBeginPath(vg);
+			nvgRect(vg, 4, y, 32, 32);
+			nvgFillPaint(vg, imgPaint);
+			nvgFill(vg);
+		}
+
+		// Text
+		if (i == selected_index && HasFocus()) {
+			nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+		} else {
+			nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+		}
+		nvgFontSize(vg, 14.0f);
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, 40, y + item_height / 2, wxstr(brush->getName()).ToUTF8().data(), nullptr);
+	}
+}
+
+int VirtualBrushListBox::GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush) {
+	if (!brush) return 0;
+
+	uint32_t brushId = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(brush) & 0xFFFFFFFF);
+	int existingTex = GetCachedImage(brushId);
+	if (existingTex > 0) return existingTex;
+
+	// Duplicated logic from VirtualBrushGrid/FindList to ensure self-containment
+	Sprite* spr = brush->getSprite();
+	if (!spr) spr = g_gui.gfx.getSprite(brush->getLookID());
+	if (!spr) return 0;
+
+	GameSprite* gs = dynamic_cast<GameSprite*>(spr);
+	if (!gs || gs->spriteList.empty()) return 0;
+
+	int w = gs->width * 32;
+	int h = gs->height * 32;
+	size_t bufferSize = w * h * 4;
+	std::vector<uint8_t> composite(bufferSize, 0);
+
+	int px = (gs->pattern_x >= 3) ? 2 : 0;
+	for (int l = 0; l < gs->layers; ++l) {
+		for (int sw = 0; sw < gs->width; ++sw) {
+			for (int sh = 0; sh < gs->height; ++sh) {
+				int idx = gs->getIndex(sw, sh, l, px, 0, 0, 0);
+				if (idx < 0 || (size_t)idx >= gs->spriteList.size()) continue;
+				auto data = gs->spriteList[idx]->getRGBAData();
+				if (!data) continue;
+
+				int part_x = (gs->width - sw - 1) * 32;
+				int part_y = (gs->height - sh - 1) * 32;
+
+				for (int sy = 0; sy < 32; ++sy) {
+					for (int sx = 0; sx < 32; ++sx) {
+						int dy = part_y + sy;
+						int dx = part_x + sx;
+						int di = (dy * w + dx) * 4;
+						int si = (sy * 32 + sx) * 4;
+
+						uint8_t sa = data[si + 3];
+						if (sa == 0) continue;
+
+						if (sa == 255) {
+							composite[di] = data[si];
+							composite[di+1] = data[si+1];
+							composite[di+2] = data[si+2];
+							composite[di+3] = 255;
+						} else {
+							float a = sa / 255.0f;
+							float ia = 1.0f - a;
+							composite[di] = (uint8_t)(data[si] * a + composite[di] * ia);
+							composite[di+1] = (uint8_t)(data[si+1] * a + composite[di+1] * ia);
+							composite[di+2] = (uint8_t)(data[si+2] * a + composite[di+2] * ia);
+							composite[di+3] = std::max(composite[di+3], sa);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return GetOrCreateImage(brushId, composite.data(), w, h);
+}
+
+int VirtualBrushListBox::HitTest(int x, int y) const {
+	int scrollPos = GetScrollPosition();
+	int realY = y + scrollPos;
+	int index = realY / item_height;
+
+	if (index >= 0 && index < static_cast<int>(tileset->size())) {
+		return index;
+	}
+	return -1;
+}
+
+void VirtualBrushListBox::OnMouseDown(wxMouseEvent& event) {
+	SetFocus();
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1 && index != selected_index) {
+		selected_index = index;
+		Refresh();
+
+		// Notify GUI
+		wxWindow* w = GetParent();
+		while (w) {
+			PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
+			if (pw) {
+				g_gui.ActivatePalette(pw);
+				break;
+			}
+			w = w->GetParent();
+		}
+		g_gui.SelectBrush(tileset->brushlist[selected_index], tileset->getType());
+	}
+}
+
+void VirtualBrushListBox::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != hover_index) {
+		hover_index = index;
+		Refresh();
+	}
+
+	if (index != -1) {
+		Brush* brush = tileset->brushlist[index];
+		if (brush) {
+			wxString tip = wxstr(brush->getName());
+			if (GetToolTipText() != tip) {
+				SetToolTip(tip);
+			}
+		}
+	} else {
+		UnsetToolTip();
+	}
+	event.Skip();
+}
+
+void VirtualBrushListBox::OnLeave(wxMouseEvent& event) {
+	hover_index = -1;
+	Refresh();
+	event.Skip();
+}
+
+void VirtualBrushListBox::OnKeyDown(wxKeyEvent& event) {
+	int key = event.GetKeyCode();
+	int count = (int)tileset->size();
+
+	if (count == 0) {
+		event.Skip();
+		return;
+	}
+
+	int nextSelection = selected_index;
+	int visibleRows = GetClientSize().y / item_height;
+	bool handled = false;
+
+	if (key == WXK_DOWN) {
+		nextSelection++;
+		handled = true;
+	} else if (key == WXK_UP) {
+		nextSelection--;
+		handled = true;
+	} else if (key == WXK_PAGEDOWN) {
+		nextSelection += visibleRows;
+		handled = true;
+	} else if (key == WXK_PAGEUP) {
+		nextSelection -= visibleRows;
+		handled = true;
+	} else if (key == WXK_HOME) {
+		nextSelection = 0;
+		handled = true;
+	} else if (key == WXK_END) {
+		nextSelection = count - 1;
+		handled = true;
+	}
+
+	if (handled) {
+		nextSelection = std::clamp(nextSelection, 0, count - 1);
+		if (nextSelection != selected_index) {
+			selected_index = nextSelection;
+			EnsureVisible(selected_index);
+			Refresh();
+
+			// Notify GUI
+			wxWindow* w = GetParent();
+			while (w) {
+				PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
+				if (pw) {
+					g_gui.ActivatePalette(pw);
+					break;
+				}
+				w = w->GetParent();
+			}
+			g_gui.SelectBrush(tileset->brushlist[selected_index], tileset->getType());
+		}
+	} else {
+		// Forward key events logic
+		if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
+			event.Skip(true);
+		} else {
+			if (g_gui.GetCurrentTab() != nullptr) {
+				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
+			}
+		}
+	}
+}
+
+void VirtualBrushListBox::OnChar(wxKeyEvent& event) {
+	if (g_gui.GetCurrentTab() != nullptr) {
+		g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
+	}
+}
+
+void VirtualBrushListBox::OnSize(wxSizeEvent& event) {
+	UpdateScroll();
+	Refresh();
+	event.Skip();
+}

--- a/source/palette/controls/virtual_brush_list_box.h
+++ b/source/palette/controls/virtual_brush_list_box.h
@@ -1,0 +1,47 @@
+#ifndef RME_PALETTE_CONTROLS_VIRTUAL_BRUSH_LIST_BOX_H_
+#define RME_PALETTE_CONTROLS_VIRTUAL_BRUSH_LIST_BOX_H_
+
+#include "app/main.h"
+#include "util/nanovg_canvas.h"
+#include "palette/panels/brush_panel.h"
+
+class VirtualBrushListBox : public NanoVGCanvas, public BrushBoxInterface {
+public:
+	VirtualBrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
+	virtual ~VirtualBrushListBox();
+
+	wxWindow* GetSelfWindow() override {
+		return this;
+	}
+
+	// BrushBoxInterface implementation
+	void SelectFirstBrush() override;
+	Brush* GetSelectedBrush() const override;
+	bool SelectBrush(const Brush* brush) override;
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Events
+	void OnMouseDown(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+	void OnSize(wxSizeEvent& event);
+	void OnChar(wxKeyEvent& event);
+
+	int HitTest(int x, int y) const;
+	void EnsureVisible(int index);
+	void UpdateScroll();
+
+	// Helpers
+	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
+
+private:
+	int selected_index;
+	int hover_index;
+	int item_height;
+};
+
+#endif

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -4,6 +4,7 @@
 #include "app/settings.h"
 #include "palette/palette_window.h" // For PaletteWindow dynamic_casts
 #include "palette/controls/virtual_brush_grid.h"
+#include "palette/controls/virtual_brush_list_box.h"
 #include <spdlog/spdlog.h>
 #include <wx/wrapsizer.h>
 
@@ -75,7 +76,7 @@ void BrushPanel::LoadContents() {
 			break;
 		case BRUSHLIST_LISTBOX:
 		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
+			brushbox = newd VirtualBrushListBox(this, tileset);
 			break;
 		default:
 			break;

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -32,7 +32,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	search_field->SetFocus();
 	sizer->Add(search_field, 0, wxEXPAND);
 
-	item_list = newd FindDialogListBox(this, JUMP_DIALOG_LIST);
+	item_list = newd VirtualFindList(this, JUMP_DIALOG_LIST);
 	item_list->SetMinSize(wxSize(470, 400));
 	item_list->SetToolTip("Double click to select.");
 	sizer->Add(item_list, wxSizerFlags(1).Expand().Border());
@@ -282,80 +282,3 @@ void FindBrushDialog::RefreshContentsInternal() {
 	item_list->Refresh();
 }
 
-// ============================================================================
-// Listbox in find item / brush stuff
-
-FindDialogListBox::FindDialogListBox(wxWindow* parent, wxWindowID id) :
-	wxVListBox(parent, id, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	cleared(false),
-	no_matches(false) {
-	Clear();
-}
-
-FindDialogListBox::~FindDialogListBox() {
-	////
-}
-
-void FindDialogListBox::Clear() {
-	cleared = true;
-	no_matches = false;
-	brushlist.clear();
-	SetItemCount(1);
-}
-
-void FindDialogListBox::SetNoMatches() {
-	cleared = false;
-	no_matches = true;
-	brushlist.clear();
-	SetItemCount(1);
-}
-
-void FindDialogListBox::AddBrush(Brush* brush) {
-	if (cleared || no_matches) {
-		SetItemCount(0);
-	}
-
-	cleared = false;
-	no_matches = false;
-
-	SetItemCount(GetItemCount() + 1);
-	brushlist.push_back(brush);
-}
-
-Brush* FindDialogListBox::GetSelectedBrush() {
-	ssize_t n = GetSelection();
-	if (n == wxNOT_FOUND || no_matches || cleared) {
-		return nullptr;
-	}
-	return brushlist[n];
-}
-
-void FindDialogListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	if (no_matches) {
-		dc.DrawText("No matches for your search.", rect.GetX() + 40, rect.GetY() + 6);
-	} else if (cleared) {
-		dc.DrawText("Please enter your search string.", rect.GetX() + 40, rect.GetY() + 6);
-	} else {
-		ASSERT(n < brushlist.size());
-		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());
-		if (spr) {
-			spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-		}
-
-		if (IsSelected(n)) {
-			if (HasFocus()) {
-				dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-			} else {
-				dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-			}
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-		}
-
-		dc.DrawText(wxstr(brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-	}
-}
-
-wxCoord FindDialogListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,8 +3,8 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
 #include <vector>
+#include "ui/dialogs/virtual_find_list.h"
 
 class Brush;
 
@@ -17,25 +17,6 @@ public:
 	~KeyForwardingTextCtrl() { }
 
 	void OnKeyDown(wxKeyEvent&);
-};
-
-class FindDialogListBox : public wxVListBox {
-public:
-	FindDialogListBox(wxWindow* parent, wxWindowID id);
-	~FindDialogListBox();
-
-	void Clear();
-	void SetNoMatches();
-	void AddBrush(Brush*);
-	Brush* GetSelectedBrush();
-
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
-
-protected:
-	bool cleared;
-	bool no_matches;
-	std::vector<Brush*> brushlist;
 };
 
 class FindDialog : public wxDialog {
@@ -63,7 +44,7 @@ protected:
 	virtual void OnClickListInternal(wxCommandEvent&) = 0;
 	virtual void OnClickOKInternal() = 0;
 
-	FindDialogListBox* item_list;
+	VirtualFindList* item_list;
 	KeyForwardingTextCtrl* search_field;
 	wxTimer idle_input_timer;
 	const Brush* result_brush;

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -31,59 +31,9 @@
 #include <nlohmann/json.hpp>
 
 namespace {
-	const int COLOR_COLUMNS = 19;
-	const int COLOR_ROWS = 7;
 	const int PREVIEW_SIZE = 192;
 	const int OUTFIT_TILE_WIDTH = 100;
 	const int OUTFIT_TILE_HEIGHT = 120;
-
-	class ColorSwatch : public wxWindow {
-	public:
-		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
-			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
-			color(color), selected(false) {
-			SetBackgroundStyle(wxBG_STYLE_PAINT);
-			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
-			Bind(wxEVT_LEFT_DOWN, &ColorSwatch::OnMouse, this);
-		}
-
-		void SetSelected(bool s) {
-			if (selected != s) {
-				selected = s;
-				Refresh();
-			}
-		}
-
-	private:
-		void OnPaint(wxPaintEvent&) {
-			wxAutoBufferedPaintDC dc(this);
-			dc.SetBackground(*wxBLACK_BRUSH);
-			dc.Clear();
-
-			wxRect rect = GetClientRect();
-			dc.SetPen(*wxTRANSPARENT_PEN);
-			dc.SetBrush(wxBrush(wxColor((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)));
-			dc.DrawRectangle(rect);
-
-			if (selected) {
-				dc.SetBrush(*wxTRANSPARENT_BRUSH);
-				dc.SetPen(wxPen(*wxWHITE, 2));
-				dc.DrawRectangle(rect.Inflate(-1, -1));
-			}
-		}
-
-		void OnMouse(wxMouseEvent&) {
-			wxCommandEvent evt(wxEVT_BUTTON, GetId());
-			evt.SetEventObject(this);
-			HandleWindowEvent(evt); // Ensure internal bindings (lambdas) are called
-			if (GetParent()) {
-				GetParent()->GetEventHandler()->ProcessEvent(evt); // Also send to parent just in case
-			}
-		}
-
-		uint32_t color;
-		bool selected;
-	};
 }
 
 // ============================================================================
@@ -171,18 +121,11 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
-	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
-		uint32_t color = TemplateOutfitLookupTable[i];
-		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
-		color_buttons.push_back(swatch);
-
-		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
-			SelectColor(i);
-		});
-	}
-	col1_sizer->Add(palette_sizer, 0, wxALL, 8);
+	color_grid = new OutfitColorGrid(this, wxID_ANY);
+	color_grid->Bind(wxEVT_BUTTON, [this](wxCommandEvent& event) {
+		SelectColor(event.GetInt());
+	});
+	col1_sizer->Add(color_grid, 0, wxALL, 8);
 
 	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);
@@ -331,10 +274,7 @@ void OutfitChooserDialog::UpdateColorSelection() {
 	} else if (selected_color_part == 3) {
 		currentColor = current_outfit.lookFeet;
 	}
-
-	for (size_t i = 0; i < color_buttons.size(); ++i) {
-		static_cast<ColorSwatch*>(color_buttons[i])->SetSelected(i == (size_t)currentColor);
-	}
+	color_grid->SetSelectedColor(currentColor);
 }
 
 void OutfitChooserDialog::SelectColor(int color_id) {

--- a/source/ui/dialogs/outfit_chooser_dialog.h
+++ b/source/ui/dialogs/outfit_chooser_dialog.h
@@ -10,6 +10,7 @@
 
 #include "ui/dialogs/outfit_preview_panel.h"
 #include "ui/dialogs/outfit_selection_grid.h"
+#include "ui/dialogs/outfit_color_grid.h"
 
 class OutfitChooserDialog : public wxDialog {
 public:
@@ -93,7 +94,7 @@ private:
 	wxButton* legs_btn;
 	wxButton* feet_btn;
 
-	std::vector<wxWindow*> color_buttons;
+	OutfitColorGrid* color_grid;
 };
 
 #endif

--- a/source/ui/dialogs/outfit_color_grid.cpp
+++ b/source/ui/dialogs/outfit_color_grid.cpp
@@ -1,0 +1,163 @@
+#include "ui/dialogs/outfit_color_grid.h"
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+#include <wx/event.h>
+
+OutfitColorGrid::OutfitColorGrid(wxWindow* parent, wxWindowID id) :
+	NanoVGCanvas(parent, id, wxBORDER_NONE),
+	selected_index(0),
+	hover_index(-1),
+	item_size(14), // Slightly smaller to fit 19 cols in similar space, or keep 16? Original was 16.
+	padding(2),
+	columns(19),
+	rows(7) {
+
+	item_size = 16;
+	padding = 2; // 1px gap in original, let's do 2 for NanoVG AA comfort
+
+	Bind(wxEVT_LEFT_DOWN, &OutfitColorGrid::OnMouseDown, this);
+	Bind(wxEVT_MOTION, &OutfitColorGrid::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &OutfitColorGrid::OnLeave, this);
+}
+
+OutfitColorGrid::~OutfitColorGrid() {
+}
+
+void OutfitColorGrid::SetSelectedColor(int index) {
+	if (index >= 0 && index < (int)TemplateOutfitLookupTableSize) {
+		selected_index = index;
+		Refresh();
+	}
+}
+
+wxSize OutfitColorGrid::DoGetBestClientSize() const {
+	int w = columns * item_size + (columns - 1) * padding + padding * 2;
+	int h = rows * item_size + (rows - 1) * padding + padding * 2;
+	return FromDIP(wxSize(w, h));
+}
+
+void OutfitColorGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int startX = padding;
+	int startY = padding;
+
+	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
+		int col = i % columns;
+		int row = i / columns;
+
+		float x = startX + col * (item_size + padding);
+		float y = startY + row * (item_size + padding);
+
+		uint32_t color = TemplateOutfitLookupTable[i];
+		int r = (color >> 16) & 0xFF;
+		int g = (color >> 8) & 0xFF;
+		int b = color & 0xFF;
+
+		// Hover effect
+		if ((int)i == hover_index) {
+			nvgBeginPath(vg);
+			nvgRoundedRect(vg, x - 1, y - 1, item_size + 2, item_size + 2, 3.0f);
+			nvgFillColor(vg, nvgRGBA(255, 255, 255, 100));
+			nvgFill(vg);
+		}
+
+		// Main color swatch
+		nvgBeginPath(vg);
+		nvgRoundedRect(vg, x, y, item_size, item_size, 2.0f);
+		nvgFillColor(vg, nvgRGBA(r, g, b, 255));
+		nvgFill(vg);
+
+		// Selection highlight
+		if ((int)i == selected_index) {
+			nvgBeginPath(vg);
+			nvgRoundedRect(vg, x - 1.5f, y - 1.5f, item_size + 3.0f, item_size + 3.0f, 3.0f);
+			nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 255));
+			nvgStrokeWidth(vg, 2.0f);
+			nvgStroke(vg);
+
+			// Inner stroke for contrast on white bg
+			nvgBeginPath(vg);
+			nvgRoundedRect(vg, x + 0.5f, y + 0.5f, item_size - 1.0f, item_size - 1.0f, 2.0f);
+			nvgStrokeColor(vg, nvgRGBA(0, 0, 0, 100));
+			nvgStrokeWidth(vg, 1.0f);
+			nvgStroke(vg);
+		} else {
+			// Subtle border
+			nvgBeginPath(vg);
+			nvgRoundedRect(vg, x + 0.5f, y + 0.5f, item_size - 1.0f, item_size - 1.0f, 2.0f);
+			nvgStrokeColor(vg, nvgRGBA(0, 0, 0, 40));
+			nvgStrokeWidth(vg, 1.0f);
+			nvgStroke(vg);
+		}
+	}
+}
+
+wxRect OutfitColorGrid::GetItemRect(int index) const {
+	int col = index % columns;
+	int row = index / columns;
+	int startX = padding;
+	int startY = padding;
+
+	return wxRect(
+		startX + col * (item_size + padding),
+		startY + row * (item_size + padding),
+		item_size,
+		item_size
+	);
+}
+
+int OutfitColorGrid::HitTest(int x, int y) const {
+	// Simple grid hit test
+	int startX = padding;
+	int startY = padding;
+
+	if (x < startX || y < startY) return -1;
+
+	int col = (x - startX) / (item_size + padding);
+	int row = (y - startY) / (item_size + padding);
+
+	if (col >= 0 && col < columns && row >= 0 && row < rows) {
+		// Check inside item rect (padding exclusion)
+		int itemX = startX + col * (item_size + padding);
+		int itemY = startY + row * (item_size + padding);
+		if (x >= itemX && x < itemX + item_size &&
+			y >= itemY && y < itemY + item_size) {
+
+			int index = row * columns + col;
+			if (index < (int)TemplateOutfitLookupTableSize) {
+				return index;
+			}
+		}
+	}
+	return -1;
+}
+
+void OutfitColorGrid::OnMouseDown(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1 && index != selected_index) {
+		selected_index = index;
+		Refresh();
+
+		wxCommandEvent evt(wxEVT_BUTTON, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(selected_index); // Pass index in event int data
+		ProcessEvent(evt);
+	}
+}
+
+void OutfitColorGrid::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != hover_index) {
+		hover_index = index;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void OutfitColorGrid::OnLeave(wxMouseEvent& event) {
+	if (hover_index != -1) {
+		hover_index = -1;
+		Refresh();
+	}
+	event.Skip();
+}

--- a/source/ui/dialogs/outfit_color_grid.h
+++ b/source/ui/dialogs/outfit_color_grid.h
@@ -1,0 +1,41 @@
+#ifndef RME_UI_DIALOGS_OUTFIT_COLOR_GRID_H_
+#define RME_UI_DIALOGS_OUTFIT_COLOR_GRID_H_
+
+#include "app/main.h"
+#include "util/nanovg_canvas.h"
+#include "rendering/core/outfit_colors.h"
+
+class OutfitColorGrid : public NanoVGCanvas {
+public:
+	OutfitColorGrid(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~OutfitColorGrid();
+
+	// Selection
+	void SetSelectedColor(int index);
+	int GetSelectedColor() const {
+		return selected_index;
+	}
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Events
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+
+	int HitTest(int x, int y) const;
+	wxRect GetItemRect(int index) const;
+
+private:
+	int selected_index;
+	int hover_index;
+
+	int item_size;
+	int padding;
+	int columns;
+	int rows;
+};
+
+#endif

--- a/source/ui/dialogs/virtual_find_list.cpp
+++ b/source/ui/dialogs/virtual_find_list.cpp
@@ -1,0 +1,339 @@
+#include "ui/dialogs/virtual_find_list.h"
+#include "ui/gui.h"
+#include "rendering/core/graphics.h"
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+#include <spdlog/spdlog.h>
+
+VirtualFindList::VirtualFindList(wxWindow* parent, wxWindowID id) :
+	NanoVGCanvas(parent, id, wxVSCROLL | wxWANTS_CHARS),
+	cleared(true),
+	no_matches(false),
+	selected_index(-1),
+	hover_index(-1),
+	item_height(32) {
+
+	Bind(wxEVT_LEFT_DOWN, &VirtualFindList::OnMouseDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &VirtualFindList::OnMouseDown, this); // Handle DClick
+	Bind(wxEVT_MOTION, &VirtualFindList::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &VirtualFindList::OnLeave, this);
+	Bind(wxEVT_KEY_DOWN, &VirtualFindList::OnKeyDown, this);
+	Bind(wxEVT_CHAR, &VirtualFindList::OnChar, this);
+}
+
+VirtualFindList::~VirtualFindList() {
+}
+
+void VirtualFindList::Clear() {
+	cleared = true;
+	no_matches = false;
+	brushlist.clear();
+	selected_index = -1;
+	hover_index = -1;
+	ClearImageCache();
+	UpdateScroll();
+	Refresh();
+}
+
+void VirtualFindList::SetNoMatches() {
+	cleared = false;
+	no_matches = true;
+	brushlist.clear();
+	selected_index = -1;
+	hover_index = -1;
+	UpdateScroll();
+	Refresh();
+}
+
+void VirtualFindList::AddBrush(Brush* brush) {
+	if (cleared || no_matches) {
+		cleared = false;
+		no_matches = false;
+		brushlist.clear();
+	}
+	brushlist.push_back(brush);
+	UpdateScroll();
+	Refresh();
+}
+
+Brush* VirtualFindList::GetSelectedBrush() const {
+	if (selected_index >= 0 && selected_index < (int)brushlist.size()) {
+		return brushlist[selected_index];
+	}
+	return nullptr;
+}
+
+void VirtualFindList::SetSelection(int index) {
+	if (index >= -1 && index < (int)brushlist.size()) {
+		selected_index = index;
+		EnsureVisible(index);
+		Refresh();
+
+		// Notify parent
+		wxCommandEvent event(wxEVT_LISTBOX, GetId());
+		event.SetEventObject(this);
+		event.SetInt(selected_index);
+		ProcessEvent(event);
+	}
+}
+
+wxSize VirtualFindList::DoGetBestClientSize() const {
+	return FromDIP(wxSize(300, 400));
+}
+
+void VirtualFindList::UpdateScroll() {
+	int count = (cleared || no_matches) ? 1 : (int)brushlist.size();
+	UpdateScrollbar(count * item_height);
+}
+
+void VirtualFindList::EnsureVisible(int index) {
+	if (index < 0) return;
+
+	int top = index * item_height;
+	int bottom = top + item_height;
+	int scrollPos = GetScrollPosition();
+	int clientH = GetClientSize().y;
+
+	if (top < scrollPos) {
+		SetScrollPosition(top);
+	} else if (bottom > scrollPos + clientH) {
+		SetScrollPosition(bottom - clientH);
+	}
+}
+
+void VirtualFindList::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	// Background
+	nvgBeginPath(vg);
+	nvgRect(vg, 0, 0, width, std::max(height, GetScrollPosition() + height));
+	nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	nvgFill(vg);
+
+	if (cleared) {
+		nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+		nvgFontSize(vg, 14.0f);
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, 40, item_height / 2, "Please enter your search string.", nullptr);
+		return;
+	}
+
+	if (no_matches) {
+		nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+		nvgFontSize(vg, 14.0f);
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, 40, item_height / 2, "No matches for your search.", nullptr);
+		return;
+	}
+
+	int scrollPos = GetScrollPosition();
+	int startIdx = scrollPos / item_height;
+	int endIdx = (scrollPos + height + item_height - 1) / item_height;
+
+	startIdx = std::max(0, startIdx);
+	endIdx = std::min((int)brushlist.size(), endIdx);
+
+	for (int i = startIdx; i < endIdx; ++i) {
+		int y = i * item_height;
+
+		// Selection Background
+		if (i == selected_index) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, y, width, item_height);
+			if (HasFocus()) {
+				nvgFillColor(vg, nvgRGBA(0, 120, 215, 255)); // Standard selection blue
+			} else {
+				nvgFillColor(vg, nvgRGBA(200, 200, 200, 255)); // Grey when inactive
+			}
+			nvgFill(vg);
+		} else if (i == hover_index) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, y, width, item_height);
+			nvgFillColor(vg, nvgRGBA(240, 240, 240, 255));
+			nvgFill(vg);
+		}
+
+		Brush* brush = brushlist[i];
+		if (!brush) continue;
+
+		// Icon
+		int tex = GetOrCreateBrushTexture(vg, brush);
+		if (tex > 0) {
+			NVGpaint imgPaint = nvgImagePattern(vg, 4, y, 32, 32, 0, tex, 1.0f);
+			nvgBeginPath(vg);
+			nvgRect(vg, 4, y, 32, 32);
+			nvgFillPaint(vg, imgPaint);
+			nvgFill(vg);
+		}
+
+		// Text
+		if (i == selected_index && HasFocus()) {
+			nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+		} else {
+			nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+		}
+		nvgFontSize(vg, 14.0f);
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, 40, y + item_height / 2, wxstr(brush->getName()).ToUTF8().data(), nullptr);
+	}
+}
+
+int VirtualFindList::GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush) {
+	if (!brush) return 0;
+
+	// Check cache
+	uint32_t brushId = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(brush) & 0xFFFFFFFF);
+	int existingTex = GetCachedImage(brushId);
+	if (existingTex > 0) return existingTex;
+
+	// Create texture logic (simplified from VirtualBrushGrid - assume basic sprite)
+	Sprite* spr = brush->getSprite();
+	if (!spr) spr = g_gui.gfx.getSprite(brush->getLookID());
+	if (!spr) return 0;
+
+	// Convert using wxImage if needed, or use GameSprite logic if sophisticated rendering needed
+	// For now, let's use the robust GameSprite logic from VirtualBrushGrid as it handles layers
+
+	GameSprite* gs = dynamic_cast<GameSprite*>(spr);
+	if (!gs || gs->spriteList.empty()) return 0;
+
+	int w = gs->width * 32;
+	int h = gs->height * 32;
+	size_t bufferSize = w * h * 4;
+	std::vector<uint8_t> composite(bufferSize, 0);
+
+	int px = (gs->pattern_x >= 3) ? 2 : 0;
+	for (int l = 0; l < gs->layers; ++l) {
+		for (int sw = 0; sw < gs->width; ++sw) {
+			for (int sh = 0; sh < gs->height; ++sh) {
+				int idx = gs->getIndex(sw, sh, l, px, 0, 0, 0);
+				if (idx < 0 || (size_t)idx >= gs->spriteList.size()) continue;
+				auto data = gs->spriteList[idx]->getRGBAData();
+				if (!data) continue;
+
+				int part_x = (gs->width - sw - 1) * 32;
+				int part_y = (gs->height - sh - 1) * 32;
+
+				for (int sy = 0; sy < 32; ++sy) {
+					for (int sx = 0; sx < 32; ++sx) {
+						int dy = part_y + sy;
+						int dx = part_x + sx;
+						int di = (dy * w + dx) * 4;
+						int si = (sy * 32 + sx) * 4;
+
+						uint8_t sa = data[si + 3];
+						if (sa == 0) continue;
+
+						if (sa == 255) {
+							composite[di] = data[si];
+							composite[di+1] = data[si+1];
+							composite[di+2] = data[si+2];
+							composite[di+3] = 255;
+						} else {
+							float a = sa / 255.0f;
+							float ia = 1.0f - a;
+							composite[di] = (uint8_t)(data[si] * a + composite[di] * ia);
+							composite[di+1] = (uint8_t)(data[si+1] * a + composite[di+1] * ia);
+							composite[di+2] = (uint8_t)(data[si+2] * a + composite[di+2] * ia);
+							composite[di+3] = std::max(composite[di+3], sa);
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return GetOrCreateImage(brushId, composite.data(), w, h);
+}
+
+int VirtualFindList::HitTest(int x, int y) const {
+	int scrollPos = GetScrollPosition();
+	int realY = y + scrollPos;
+	int index = realY / item_height;
+
+	if (index >= 0 && index < (int)brushlist.size()) {
+		return index;
+	}
+	return -1;
+}
+
+void VirtualFindList::OnMouseDown(wxMouseEvent& event) {
+	SetFocus();
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1) {
+		SetSelection(index);
+		if (event.LeftDClick()) {
+			wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+			evt.SetEventObject(this);
+			evt.SetInt(selected_index);
+			ProcessEvent(evt);
+		}
+	}
+}
+
+void VirtualFindList::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != hover_index) {
+		hover_index = index;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void VirtualFindList::OnLeave(wxMouseEvent& event) {
+	hover_index = -1;
+	Refresh();
+	event.Skip();
+}
+
+void VirtualFindList::OnKeyDown(wxKeyEvent& event) {
+	int key = event.GetKeyCode();
+	int count = (int)brushlist.size();
+
+	if (count == 0) {
+		event.Skip();
+		return;
+	}
+
+	int nextSelection = selected_index;
+	int visibleRows = GetClientSize().y / item_height;
+
+	if (key == WXK_DOWN) {
+		nextSelection++;
+	} else if (key == WXK_UP) {
+		nextSelection--;
+	} else if (key == WXK_PAGEDOWN) {
+		nextSelection += visibleRows;
+	} else if (key == WXK_PAGEUP) {
+		nextSelection -= visibleRows;
+	} else if (key == WXK_HOME) {
+		nextSelection = 0;
+	} else if (key == WXK_END) {
+		nextSelection = count - 1;
+	} else if (key == WXK_RETURN) {
+		wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId()); // Treat enter as dclick
+		evt.SetEventObject(this);
+		evt.SetInt(selected_index);
+		ProcessEvent(evt);
+		return;
+	} else {
+		event.Skip();
+		return;
+	}
+
+	nextSelection = std::clamp(nextSelection, 0, count - 1);
+	if (nextSelection != selected_index) {
+		SetSelection(nextSelection);
+	}
+}
+
+void VirtualFindList::OnChar(wxKeyEvent& event) {
+	// Forward to parent if needed for quick search?
+	// Existing behavior forwards keys to text box manually in FindDialog
+	event.Skip();
+}
+
+void VirtualFindList::OnSize(wxSizeEvent& event) {
+	UpdateScroll();
+	Refresh();
+	event.Skip();
+}

--- a/source/ui/dialogs/virtual_find_list.h
+++ b/source/ui/dialogs/virtual_find_list.h
@@ -1,0 +1,53 @@
+#ifndef RME_UI_DIALOGS_VIRTUAL_FIND_LIST_H_
+#define RME_UI_DIALOGS_VIRTUAL_FIND_LIST_H_
+
+#include "app/main.h"
+#include "util/nanovg_canvas.h"
+#include "brushes/brush.h"
+#include <vector>
+
+class VirtualFindList : public NanoVGCanvas {
+public:
+	VirtualFindList(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~VirtualFindList();
+
+	void Clear();
+	void SetNoMatches();
+	void AddBrush(Brush* brush);
+	Brush* GetSelectedBrush() const;
+
+	// List control methods
+	void SetSelection(int index);
+	int GetSelection() const { return selected_index; }
+	int GetItemCount() const { return static_cast<int>(brushlist.size()); }
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Events
+	void OnMouseDown(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+	void OnSize(wxSizeEvent& event);
+	void OnChar(wxKeyEvent& event); // For catching generic input if needed
+
+	int HitTest(int x, int y) const;
+	void EnsureVisible(int index);
+	void UpdateScroll();
+
+	// Drawing helpers
+	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
+
+private:
+	std::vector<Brush*> brushlist;
+	bool cleared;
+	bool no_matches;
+
+	int selected_index;
+	int hover_index;
+	int item_height;
+};
+
+#endif

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -18,7 +18,6 @@
 #include "app/main.h"
 #include "ui/find_item_window.h"
 #include "ui/dialogs/find_dialog.h"
-#include "ui/controls/sortable_list_box.h"
 #include "ui/gui.h"
 #include "game/items.h"
 #include "brushes/brush.h"
@@ -187,7 +186,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	// --------------- Items list ---------------
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
-	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
+	items_list = newd VirtualFindList(result_box_sizer->GetStaticBox(), wxID_ANY);
 	items_list->SetMinSize(wxSize(230, 512));
 	result_box_sizer->Add(items_list, 0, wxALL, 5);
 	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -26,8 +26,7 @@
 #include <wx/checkbox.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
-
-class FindDialogListBox;
+#include "ui/dialogs/virtual_find_list.h"
 
 class FindItemDialog : public wxDialog {
 public:
@@ -104,7 +103,7 @@ private:
 	wxCheckBox* floor_change;
 	wxCheckBox* invalid_item;
 
-	FindDialogListBox* items_list;
+	VirtualFindList* items_list;
 	wxStdDialogButtonSizer* buttons_box_sizer;
 	wxButton* ok_button;
 	wxButton* cancel_button;


### PR DESCRIPTION
Implemented `OutfitColorGrid`, `VirtualFindList`, and `VirtualBrushListBox` using `NanoVGCanvas` to replace legacy `wxWindow` grids and `wxVListBox` controls. This reduces GDI handle usage in `OutfitChooserDialog` and modernizes the look and feel of Find dialogs and Palette lists with hardware-accelerated rendering.

Key changes:
- Replaced 133 `ColorSwatch` windows in `OutfitChooserDialog` with a single `OutfitColorGrid`.
- Replaced `FindDialogListBox` with `VirtualFindList` in `FindDialog` and `FindItemDialog`.
- Replaced `BrushListBox` with `VirtualBrushListBox` in `BrushPanel`.
- Updated `CMakeLists.txt` to include new virtual control files.

---
*PR created automatically by Jules for task [6192778874640006711](https://jules.google.com/task/6192778874640006711) started by @karolak6612*