### PR TITLE
[UB FIX] Fix Undefined Behavior in Network/IO and Div-by-Zero in Map Loader

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <stack>
 #include <stdio.h>
+#include <cstring>
 
 #ifndef FORCEINLINE
 	#ifdef _MSV_VER
@@ -174,7 +175,7 @@ protected:
 			read_offset = data.size();
 			return false;
 		}
-		ref = *(T*)(data.data() + read_offset);
+		memcpy(&ref, data.data() + read_offset, sizeof(T));
 
 		read_offset += sizeof(ref);
 		return true;

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -891,7 +891,9 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
 		++nodes_loaded;
 		if (nodes_loaded % 2048 == 0) {
-			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			if (f.size() > 0) {
+				g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			}
 		}
 
 		uint8_t node_type;

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,8 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <cstring>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -35,7 +37,11 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::out_of_range("NetworkMessage::read: buffer overflow");
+		}
+		T value;
+		memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}


### PR DESCRIPTION
This PR addresses three critical issues identified during a deep scan for undefined behavior and subtle bugs:

1.  **Strict Aliasing & Alignment Violation in Network Message Parsing**: `NetworkMessage::read` previously cast a byte buffer pointer directly to `T*`. This violates strict aliasing rules and causes undefined behavior (and potential crashes on strict-alignment architectures). It also lacked bounds checking.
    *   **Fix**: Replaced the cast with `memcpy` to safely copy bytes into a local variable. Added a check to ensure the read does not exceed the buffer size, throwing `std::out_of_range` if it does.

2.  **Strict Aliasing Violation in Binary File Reading**: `BinaryNode::getType` similarly used an unsafe cast from `char*` (internal buffer) to `T*`.
    *   **Fix**: Replaced with `memcpy` to strictly adhere to C++ aliasing rules.

3.  **Division by Zero in Map Loading**: The OTBM loader calculated progress percentage using `file_size` as a divisor without checking if it was zero, leading to a crash on empty files.
    *   **Fix**: Added a guard check `if (f.size() > 0)` before the calculation.

These changes improve the robustness and stability of the application, preventing potential security vulnerabilities and runtime crashes.

---
*PR created automatically by Jules for task [16799913562190787917](https://jules.google.com/task/16799913562190787917) started by @karolak6612*