### PR TITLE
🧩 Fixer: Optimize core systems and harden network

### DIFF
--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -38,6 +38,9 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
+	if (position + length > buffer.size()) {
+		throw std::out_of_range("NetworkMessage::read<string>: buffer overflow");
+	}
 	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
 	position += length;
 	return std::string(strBuffer, length);

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -35,6 +36,9 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::out_of_range("NetworkMessage::read: buffer overflow");
+		}
 		T& value = *reinterpret_cast<T*>(&buffer[position]);
 		position += sizeof(T);
 		return value;


### PR DESCRIPTION
This PR addresses core system performance and security issues identified by the Fixer agent.

1.  **Map Conversion Optimization**: The original `Map::convert` used a nested loop with repeated `std::vector` key lookups in a map, resulting in O(N^2) complexity relative to the number of items on a tile. This has been replaced with a local `ConversionTrie` that allows finding the longest matching prefix in O(N) time.
2.  **Spatial Query Optimization**: Spawn management functions iterated over tile areas using global `getTile` calls, which incurred repeated `SpatialHashGrid` traversals. A local `MapNode` cache was introduced to bypass grid lookups for tiles within the same 4x4 node.
3.  **Network Hardening**: `NetworkMessage` reading methods lacked bounds checking. This PR adds explicit checks and throws `std::out_of_range` to prevent buffer overflows.

---
*PR created automatically by Jules for task [10953953999941490778](https://jules.google.com/task/10953953999941490778) started by @karolak6612*