### PR TITLE
[WXWIDGETS] Fix event bindings and GDI inefficiencies

### DIFF
--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -129,13 +129,6 @@ void BrowseTileListBox::UpdateItems() {
 // ============================================================================
 //
 
-BEGIN_EVENT_TABLE(BrowseTileWindow, wxDialog)
-EVT_BUTTON(wxID_REMOVE, BrowseTileWindow::OnClickDelete)
-EVT_BUTTON(wxID_FIND, BrowseTileWindow::OnClickSelectRaw)
-EVT_BUTTON(wxID_OK, BrowseTileWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, BrowseTileWindow::OnClickCancel)
-END_EVENT_TABLE()
-
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, "Browse Field", position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
@@ -181,12 +174,14 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	SetSizerAndFit(sizer);
 
 	// Connect Events
-	item_list->Connect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(BrowseTileWindow::OnItemSelected), nullptr, this);
+	item_list->Bind(wxEVT_LISTBOX, &BrowseTileWindow::OnItemSelected, this);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickDelete, this, wxID_REMOVE);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickSelectRaw, this, wxID_FIND);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickCancel, this, wxID_CANCEL);
 }
 
 BrowseTileWindow::~BrowseTileWindow() {
-	// Disconnect Events
-	item_list->Disconnect(wxEVT_COMMAND_LISTBOX_SELECTED, wxCommandEventHandler(BrowseTileWindow::OnItemSelected), nullptr, this);
 }
 
 void BrowseTileWindow::OnItemSelected(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/browse_tile_window.h
+++ b/source/ui/browse_tile_window.h
@@ -40,8 +40,6 @@ protected:
 	wxStaticText* item_count_txt;
 	wxButton* delete_button;
 	wxButton* select_raw_button;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/ui/controls/modern_button.cpp
+++ b/source/ui/controls/modern_button.cpp
@@ -1,12 +1,15 @@
 #include "ui/controls/modern_button.h"
 
-wxBEGIN_EVENT_TABLE(ModernButton, wxControl) EVT_PAINT(ModernButton::OnPaint) EVT_MOUSE_EVENTS(ModernButton::OnMouse) EVT_ERASE_BACKGROUND(ModernButton::OnEraseBackground) EVT_TIMER(wxID_ANY, ModernButton::OnTimer) wxEND_EVENT_TABLE()
-
-	ModernButton::ModernButton(wxWindow* parent, wxWindowID id, const wxString& label, const wxPoint& pos, const wxSize& size, long style) :
+ModernButton::ModernButton(wxWindow* parent, wxWindowID id, const wxString& label, const wxPoint& pos, const wxSize& size, long style) :
 	wxControl(parent, id, pos, size, style | wxBORDER_NONE),
 	m_animTimer(this) {
 	SetLabel(label);
 	SetBackgroundStyle(wxBG_STYLE_PAINT);
+
+	Bind(wxEVT_PAINT, &ModernButton::OnPaint, this);
+	Bind(wxEVT_MOUSE_EVENTS, &ModernButton::OnMouse, this);
+	Bind(wxEVT_ERASE_BACKGROUND, &ModernButton::OnEraseBackground, this);
+	Bind(wxEVT_TIMER, &ModernButton::OnTimer, this);
 }
 
 wxSize ModernButton::DoGetBestClientSize() const {
@@ -55,7 +58,7 @@ void ModernButton::OnPaint(wxPaintEvent& evt) {
 	// Focus indication (quiet)
 	if (HasFocus()) {
 		dc.SetBrush(*wxTRANSPARENT_BRUSH);
-		dc.SetPen(wxPen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT), 1, wxPENSTYLE_STIPPLE));
+		dc.SetPen(*wxThePenList->FindOrCreatePen(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT), 1, wxPENSTYLE_STIPPLE));
 		dc.DrawRectangle(GetClientSize());
 	}
 

--- a/source/ui/controls/modern_button.h
+++ b/source/ui/controls/modern_button.h
@@ -22,9 +22,6 @@ public:
 	float m_targetHover = 0.0f;
 	wxTimer m_animTimer;
 	void OnTimer(wxTimerEvent& evt);
-
-private:
-	wxDECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -62,12 +62,12 @@ namespace {
 
 			wxRect rect = GetClientRect();
 			dc.SetPen(*wxTRANSPARENT_PEN);
-			dc.SetBrush(wxBrush(wxColor((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)));
+			dc.SetBrush(*wxTheBrushList->FindOrCreateBrush(wxColor((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)));
 			dc.DrawRectangle(rect);
 
 			if (selected) {
 				dc.SetBrush(*wxTRANSPARENT_BRUSH);
-				dc.SetPen(wxPen(*wxWHITE, 2));
+				dc.SetPen(*wxThePenList->FindOrCreatePen(*wxWHITE, 2));
 				dc.DrawRectangle(rect.Inflate(-1, -1));
 			}
 		}

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -59,9 +59,6 @@
 #include "editor/operations/search_operations.h"
 #include "editor/operations/clean_operations.h"
 
-BEGIN_EVENT_TABLE(MainMenuBar, wxEvtHandler)
-END_EVENT_TABLE()
-
 MainMenuBar::MainMenuBar(MainFrame* frame) :
 	frame(frame) {
 	using namespace MenuBar;
@@ -98,10 +95,10 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	// Tie all events to this handler!
 
 	for (std::map<std::string, MenuBar::Action*>::iterator ai = actions.begin(); ai != actions.end(); ++ai) {
-		frame->Connect(MAIN_FRAME_MENU + ai->second->id, wxEVT_COMMAND_MENU_SELECTED, (wxObjectEventFunction)(wxEventFunction)(ai->second->handler), nullptr, this);
+		frame->Bind(wxEVT_MENU, ai->second->handler, this, MAIN_FRAME_MENU + ai->second->id);
 	}
 	for (size_t i = 0; i < 10; ++i) {
-		frame->Connect(recentFilesManager.GetBaseId() + i, wxEVT_COMMAND_MENU_SELECTED, wxCommandEventHandler(MainMenuBar::OnOpenRecent), nullptr, this);
+		frame->Bind(wxEVT_MENU, &MainMenuBar::OnOpenRecent, this, recentFilesManager.GetBaseId() + i);
 	}
 }
 

--- a/source/ui/main_menubar.h
+++ b/source/ui/main_menubar.h
@@ -316,8 +316,6 @@ protected:
 	FileMenuHandler* fileMenuHandler;
 	NavigationMenuHandler* navigationMenuHandler;
 	PaletteMenuHandler* paletteMenuHandler;
-
-	DECLARE_EVENT_TABLE();
 };
 
 namespace MenuBar {


### PR DESCRIPTION
This PR addresses three domain-specific issues identified in the codebase:
1.  **Legacy Event Bindings:** Replaced deprecated `Connect()` calls and static event tables with dynamic `Bind()` in `BrowseTileWindow`, `MainMenuBar`, and `ModernButton` to improve type safety and maintainability.
2.  **Inefficient GDI Usage:** Optimized `ColorSwatch::OnPaint` in `OutfitChooserDialog` and `ModernButton::OnPaint` to reuse cached `wxBrush` and `wxPen` objects, reducing GDI resource churn.
3.  **Modernization:** Removed `DECLARE_EVENT_TABLE` macros to align with modern wxWidgets practices.

---
*PR created automatically by Jules for task [4250589042093292627](https://jules.google.com/task/4250589042093292627) started by @karolak6612*