### PR TITLE
Sentinel: Modernize BrushPanel rendering

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -20,9 +20,9 @@ public:
 	 * @brief Constructs a VirtualBrushGrid.
 	 * @param parent Parent window
 	 * @param _tileset The tileset category containing brushes
-	 * @param rsz Icon render size (16x16 or 32x32)
+	 * @param type The list display type
 	 */
-	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz);
+	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, BrushListType type);
 	~VirtualBrushGrid() override;
 
 	wxWindow* GetSelfWindow() override {
@@ -48,6 +48,7 @@ protected:
 	// Event Handlers
 	void OnMouseDown(wxMouseEvent& event);
 	void OnMotion(wxMouseEvent& event);
+	void OnKey(wxKeyEvent& event);
 
 	// Internal helpers
 	void UpdateLayout();
@@ -56,6 +57,7 @@ protected:
 	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
 
+	BrushListType list_type;
 	RenderSize icon_size;
 	int selected_index;
 	int hover_index;

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -68,20 +68,8 @@ void BrushPanel::LoadContents() {
 
 	ASSERT(tileset != nullptr);
 
-	switch (list_type) {
-		case BRUSHLIST_LARGE_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
-			break;
-		case BRUSHLIST_SMALL_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16);
-			break;
-		case BRUSHLIST_LISTBOX:
-		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
-			break;
-		default:
-			break;
-	}
+	// Always use VirtualBrushGrid for all types
+	brushbox = newd VirtualBrushGrid(this, tileset, list_type);
 
 	if (!brushbox) {
 		return;
@@ -154,97 +142,4 @@ void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
 	}
 
 	g_gui.SelectBrush(tileset->brushlist[n], tileset->getType());
-}
-
-// ============================================================================
-// BrushListBox
-
-BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
-	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	BrushBoxInterface(tileset) {
-	SetItemCount(tileset->size());
-	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
-}
-
-BrushListBox::~BrushListBox() {
-	////
-}
-
-void BrushListBox::SelectFirstBrush() {
-	SetSelection(0);
-	wxWindow::ScrollLines(-1);
-}
-
-Brush* BrushListBox::GetSelectedBrush() const {
-	if (!tileset) {
-		return nullptr;
-	}
-
-	int n = GetSelection();
-	if (n != wxNOT_FOUND) {
-		return tileset->brushlist[n];
-	} else if (tileset->size() > 0) {
-		return tileset->brushlist[0];
-	}
-	return nullptr;
-}
-
-bool BrushListBox::SelectBrush(const Brush* whatbrush) {
-	auto it = std::ranges::find(tileset->brushlist, whatbrush);
-	if (it != tileset->brushlist.end()) {
-		SetSelection(std::distance(tileset->brushlist.begin(), it));
-		return true;
-	}
-	return false;
-}
-
-void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	ASSERT(n < tileset->size());
-	Sprite* spr = tileset->brushlist[n]->getSprite();
-	if (!spr) {
-		spr = g_gui.gfx.getSprite(tileset->brushlist[n]->getLookID());
-	}
-	if (spr) {
-		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord BrushListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
-
-void BrushListBox::OnKey(wxKeyEvent& event) {
-	switch (event.GetKeyCode()) {
-		case WXK_UP:
-		case WXK_DOWN:
-		case WXK_LEFT:
-		case WXK_RIGHT:
-		case WXK_PAGEUP:
-		case WXK_PAGEDOWN:
-		case WXK_HOME:
-		case WXK_END:
-			if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
-				event.Skip(true);
-			} else {
-				if (g_gui.GetCurrentTab() != nullptr) {
-					g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-				}
-			}
-			break;
-		default:
-			if (g_gui.GetCurrentTab() != nullptr) {
-				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-			}
-			break;
-	}
 }

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,30 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush();
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush);
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const;
-	virtual wxCoord OnMeasureItem(size_t n) const;
-
-	void OnKey(wxKeyEvent& event);
-};
-
-
 class BrushPanel : public wxPanel {
 public:
 	BrushPanel(wxWindow* parent);


### PR DESCRIPTION
Modernized the `BrushPanel` by removing the legacy `BrushListBox` class (which relied on software rendering via `wxDC`) and extending the GPU-accelerated `VirtualBrushGrid` to support list layouts and keyboard navigation. This unifies the rendering pipeline for brush selection.

---
*PR created automatically by Jules for task [17103115898961987276](https://jules.google.com/task/17103115898961987276) started by @karolak6612*