### PR TITLE
⚡ Bolt: Rendering Optimizations

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -99,23 +99,29 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 		}
 	} else {
 		editor->map.visitLeaves(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
+			Floor* floor = nd->getFloor(map_z);
+			if (!floor) {
+				return;
+			}
+
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-			for (int map_x = 0; map_x < 4; ++map_x) {
-				for (int map_y = 0; map_y < 4; ++map_y) {
-					// Calculate draw coordinates directly
-					int draw_x = node_draw_x + (map_x * TileSize);
-					int draw_y = node_draw_y + (map_y * TileSize);
+			int draw_x = node_draw_x;
 
-					TileLocation* location = nd->getTile(map_x, map_y, map_z);
+			for (int map_x = 0; map_x < 4; ++map_x) {
+				int draw_y = node_draw_y;
+				for (int map_y = 0; map_y < 4; ++map_y) {
+					TileLocation* location = &floor->locs[(map_x << 2) + map_y];
 
 					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
 					// draw light, but only if not zoomed too far
-					if (location && options.isDrawLight() && view.zoom <= 10.0) {
+					if (options.isDrawLight() && view.zoom <= 10.0) {
 						tile_renderer->AddLight(location, view, options, light_buffer);
 					}
+					draw_y += TileSize;
 				}
+				draw_x += TileSize;
 			}
 		});
 	}

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -77,6 +77,17 @@ void TileColorCalculator::Calculate(const Tile* tile, const DrawingOptions& opti
 }
 
 void TileColorCalculator::GetHouseColor(uint32_t house_id, uint8_t& r, uint8_t& g, uint8_t& b) {
+	// 1-element cache to speed up consecutive lookups for the same house (common in spatial rendering)
+	static thread_local uint32_t last_house_id = 0xFFFFFFFF;
+	static thread_local uint8_t last_r = 0, last_g = 0, last_b = 0;
+
+	if (house_id == last_house_id) {
+		r = last_r;
+		g = last_g;
+		b = last_b;
+		return;
+	}
+
 	// Use a simple seeded random to get consistent colors
 	// Simple hash
 	// (Cache removed as calculation is faster than hash map lookup)
@@ -96,6 +107,11 @@ void TileColorCalculator::GetHouseColor(uint32_t house_id, uint8_t& r, uint8_t& 
 		g += 100;
 		b += 100;
 	}
+
+	last_house_id = house_id;
+	last_r = r;
+	last_g = g;
+	last_b = b;
 }
 
 void TileColorCalculator::GetMinimapColor(const Tile* tile, uint8_t& r, uint8_t& g, uint8_t& b) {

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -131,7 +131,7 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const Position& p
 	return true;
 }
 
-void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y) {
+void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int draw_x, int draw_y) {
 	if (!location) {
 		return;
 	}
@@ -148,17 +148,6 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	int map_x = location->getX();
 	int map_y = location->getY();
 	int map_z = location->getZ();
-
-	int draw_x, draw_y;
-	if (in_draw_x != -1 && in_draw_y != -1) {
-		draw_x = in_draw_x;
-		draw_y = in_draw_y;
-	} else {
-		// Early viewport culling - skip tiles that are completely off-screen
-		if (!view.IsTileVisible(map_x, map_y, map_z, draw_x, draw_y)) {
-			return;
-		}
-	}
 
 	Waypoint* waypoint = editor->map.waypoints.getWaypoint(location);
 
@@ -198,7 +187,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground) {
+	if (options.show_tooltips && map_z == view.floor && tile->ground && tile->ground->getID() >= 100) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground, location->getPosition(), tile->isHouseTile())) {
 			if (groundData.hasVisibleFields()) {
@@ -244,7 +233,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primit
 			// items on tile
 			for (auto* item : tile->items) {
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (options.show_tooltips && map_z == view.floor && item->getID() >= 100) {
 					TooltipData& itemData = tooltip_drawer->requestTooltipData();
 					if (FillItemTooltipData(itemData, item, location->getPosition(), tile->isHouseTile())) {
 						if (itemData.hasVisibleFields()) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -24,7 +24,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
+	void DrawTile(SpriteBatch& sprite_batch, PrimitiveRenderer& primitive_renderer, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int draw_x, int draw_y);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:


### PR DESCRIPTION
💡 What:
1. Implemented `thread_local` cache in `TileColorCalculator::GetHouseColor`.
2. Optimized `MapLayerDrawer` loop to lift `Floor` lookup and use direct `locs` access, and skip empty floors.
3. Updated `TileRenderer::DrawTile` to accept explicit coordinates and hoisted tooltip ID check (`id >= 100`).

🎯 Why:
- `GetHouseColor` was re-hashing for every tile, but house IDs are spatially coherent.
- `MapLayerDrawer` was doing 16 `getTile` calls (16 pointer checks + 16 array lookups) per node, even for empty floors.
- `DrawTile` was doing redundant visibility checks and allocating tooltip data for invalid items (void tiles/trash).

📊 Impact:
- Reduces function call overhead in the main rendering loop (3000+ tiles).
- Skips processing entirely for empty Z-levels in visible nodes.
- Eliminates arithmetic overhead for house coloring.

---
*PR created automatically by Jules for task [17320414338803403969](https://jules.google.com/task/17320414338803403969) started by @karolak6612*