### PR TITLE
[WXWIDGETS] Fix 20+ wxWidgets violations across codebase

### DIFF
--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -40,10 +40,6 @@ public:
 
 IMPLEMENT_CLASS(myGrid, wxGrid)
 
-BEGIN_EVENT_TABLE(LiveLogTab, wxPanel)
-EVT_TEXT(LIVE_CHAT_TEXTBOX, LiveLogTab::OnChat)
-END_EVENT_TABLE()
-
 LiveLogTab::LiveLogTab(MapTabbook* aui, LiveSocket* server) :
 	EditorTab(),
 	wxPanel(aui),
@@ -81,15 +77,16 @@ LiveLogTab::LiveLogTab(MapTabbook* aui, LiveSocket* server) :
 	log->SetColMinimalWidth(2, 100);
 	log->SetColSize(2, 100);
 
-	log->Connect(wxEVT_SIZE, wxSizeEventHandler(LiveLogTab::OnResizeChat), nullptr, this);
+	log->Bind(wxEVT_SIZE, &LiveLogTab::OnResizeChat, this);
 
 	left_sizer->Add(log, 1, wxEXPAND);
 
 	input = newd wxTextCtrl(left_pane, LIVE_CHAT_TEXTBOX, wxEmptyString, wxDefaultPosition, wxDefaultSize);
 	left_sizer->Add(input, 0, wxEXPAND);
 
-	input->Connect(wxEVT_SET_FOCUS, wxFocusEventHandler(LiveLogTab::OnSelectChatbox), nullptr, this);
-	input->Connect(wxEVT_KILL_FOCUS, wxFocusEventHandler(LiveLogTab::OnDeselectChatbox), nullptr, this);
+	input->Bind(wxEVT_TEXT, &LiveLogTab::OnChat, this);
+	input->Bind(wxEVT_SET_FOCUS, &LiveLogTab::OnSelectChatbox, this);
+	input->Bind(wxEVT_KILL_FOCUS, &LiveLogTab::OnDeselectChatbox, this);
 
 	left_pane->SetSizerAndFit(left_sizer);
 

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -71,8 +71,6 @@ protected:
 	wxGrid* user_list;
 
 	std::mutex clients_mutex;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -15,12 +15,6 @@
 
 #include <sstream>
 
-BEGIN_EVENT_TABLE(EditHouseDialog, wxDialog)
-EVT_SET_FOCUS(EditHouseDialog::OnFocusChange)
-EVT_BUTTON(wxID_OK, EditHouseDialog::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, EditHouseDialog::OnClickCancel)
-END_EVENT_TABLE()
-
 EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	wxDialog(parent, wxID_ANY, "House Properties", wxDefaultPosition, wxSize(250, 160)),
 	map(map),
@@ -103,6 +97,10 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
+
+	Bind(wxEVT_SET_FOCUS, &EditHouseDialog::OnFocusChange, this);
+	Bind(wxEVT_BUTTON, &EditHouseDialog::OnClickOK, this, wxID_OK);
+	Bind(wxEVT_BUTTON, &EditHouseDialog::OnClickCancel, this, wxID_CANCEL);
 
 	SetSizerAndFit(topsizer);
 }

--- a/source/palette/house/edit_house_dialog.h
+++ b/source/palette/house/edit_house_dialog.h
@@ -39,8 +39,6 @@ protected:
 	wxCheckBox* guildhall_field;
 
 	std::vector<uint32_t> town_ids_;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -29,20 +29,6 @@ enum {
 	ID_EXIT_BRUSH
 };
 
-BEGIN_EVENT_TABLE(HousePalette, wxPanel)
-EVT_CHOICE(ID_TOWN_CHOICE, HousePalette::OnTownChange)
-EVT_TEXT(ID_SEARCH_CTRL, HousePalette::OnSearchChange)
-EVT_DATAVIEW_SELECTION_CHANGED(ID_HOUSE_LIST, HousePalette::OnHouseSelected)
-EVT_DATAVIEW_ITEM_ACTIVATED(ID_HOUSE_LIST, HousePalette::OnHouseActivated)
-
-EVT_BUTTON(ID_ADD_HOUSE, HousePalette::OnAddHouse)
-EVT_BUTTON(ID_EDIT_HOUSE, HousePalette::OnEditHouse)
-EVT_BUTTON(ID_REMOVE_HOUSE, HousePalette::OnRemoveHouse)
-
-EVT_TOGGLEBUTTON(ID_HOUSE_BRUSH, HousePalette::OnHouseBrushButton)
-EVT_TOGGLEBUTTON(ID_EXIT_BRUSH, HousePalette::OnSelectExitButton)
-END_EVENT_TABLE()
-
 HousePalette::HousePalette(wxWindow* parent) :
 	wxPanel(parent, wxID_ANY),
 	map(nullptr) {
@@ -117,6 +103,16 @@ HousePalette::HousePalette(wxWindow* parent) :
 	}
 
 	search_ctrl->Bind(wxEVT_CHAR_HOOK, &HousePalette::OnSearchCharHook, this);
+
+	Bind(wxEVT_CHOICE, &HousePalette::OnTownChange, this, ID_TOWN_CHOICE);
+	Bind(wxEVT_TEXT, &HousePalette::OnSearchChange, this, ID_SEARCH_CTRL);
+	Bind(wxEVT_DATAVIEW_SELECTION_CHANGED, &HousePalette::OnHouseSelected, this, ID_HOUSE_LIST);
+	Bind(wxEVT_DATAVIEW_ITEM_ACTIVATED, &HousePalette::OnHouseActivated, this, ID_HOUSE_LIST);
+	Bind(wxEVT_BUTTON, &HousePalette::OnAddHouse, this, ID_ADD_HOUSE);
+	Bind(wxEVT_BUTTON, &HousePalette::OnEditHouse, this, ID_EDIT_HOUSE);
+	Bind(wxEVT_BUTTON, &HousePalette::OnRemoveHouse, this, ID_REMOVE_HOUSE);
+	Bind(wxEVT_TOGGLEBUTTON, &HousePalette::OnHouseBrushButton, this, ID_HOUSE_BRUSH);
+	Bind(wxEVT_TOGGLEBUTTON, &HousePalette::OnSelectExitButton, this, ID_EXIT_BRUSH);
 }
 
 HousePalette::~HousePalette() {

--- a/source/palette/house/house_palette.h
+++ b/source/palette/house/house_palette.h
@@ -65,8 +65,6 @@ protected:
 
 	wxBitmap guild_icon;
 	wxBitmap no_guild_icon;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/palette/palette_common.cpp
+++ b/source/palette/palette_common.cpp
@@ -33,15 +33,12 @@
 // ============================================================================
 // Palette Panel
 
-BEGIN_EVENT_TABLE(PalettePanel, wxPanel)
-EVT_TIMER(PALETTE_DELAYED_REFRESH_TIMER, WaypointPalettePanel::OnRefreshTimer)
-END_EVENT_TABLE()
-
 PalettePanel::PalettePanel(wxWindow* parent, wxWindowID id, long style) :
 	wxPanel(parent, id, wxDefaultPosition, wxDefaultSize, style),
 	refresh_timer(this, PALETTE_DELAYED_REFRESH_TIMER),
 	last_brush_size(0) {
-	////
+
+	Bind(wxEVT_TIMER, &PalettePanel::OnRefreshTimer, this, PALETTE_DELAYED_REFRESH_TIMER);
 }
 
 PalettePanel::~PalettePanel() {

--- a/source/palette/palette_common.h
+++ b/source/palette/palette_common.h
@@ -84,8 +84,6 @@ protected:
 	ToolBarList tool_bars;
 	wxTimer refresh_timer;
 	int last_brush_size;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/palette/palette_creature.cpp
+++ b/source/palette/palette_creature.cpp
@@ -30,17 +30,6 @@
 // ============================================================================
 // Creature palette
 
-BEGIN_EVENT_TABLE(CreaturePalettePanel, PalettePanel)
-EVT_CHOICEBOOK_PAGE_CHANGING(wxID_ANY, CreaturePalettePanel::OnSwitchingPage)
-EVT_CHOICEBOOK_PAGE_CHANGED(wxID_ANY, CreaturePalettePanel::OnPageChanged)
-
-EVT_TOGGLEBUTTON(PALETTE_CREATURE_BRUSH_BUTTON, CreaturePalettePanel::OnClickCreatureBrushButton)
-EVT_TOGGLEBUTTON(PALETTE_SPAWN_BRUSH_BUTTON, CreaturePalettePanel::OnClickSpawnBrushButton)
-
-EVT_SPINCTRL(PALETTE_CREATURE_SPAWN_TIME, CreaturePalettePanel::OnChangeSpawnTime)
-EVT_SPINCTRL(PALETTE_CREATURE_SPAWN_SIZE, CreaturePalettePanel::OnChangeSpawnSize)
-END_EVENT_TABLE()
-
 CreaturePalettePanel::CreaturePalettePanel(wxWindow* parent, wxWindowID id) :
 	PalettePanel(parent, id),
 	handling_event(false) {
@@ -69,6 +58,13 @@ CreaturePalettePanel::CreaturePalettePanel(wxWindow* parent, wxWindowID id) :
 
 	sidesizer->Add(grid, 0, wxEXPAND);
 	topsizer->Add(sidesizer, 0, wxEXPAND);
+
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGING, &CreaturePalettePanel::OnSwitchingPage, this, wxID_ANY);
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &CreaturePalettePanel::OnPageChanged, this, wxID_ANY);
+	Bind(wxEVT_TOGGLEBUTTON, &CreaturePalettePanel::OnClickCreatureBrushButton, this, PALETTE_CREATURE_BRUSH_BUTTON);
+	Bind(wxEVT_TOGGLEBUTTON, &CreaturePalettePanel::OnClickSpawnBrushButton, this, PALETTE_SPAWN_BRUSH_BUTTON);
+	Bind(wxEVT_SPINCTRL, &CreaturePalettePanel::OnChangeSpawnTime, this, PALETTE_CREATURE_SPAWN_TIME);
+	Bind(wxEVT_SPINCTRL, &CreaturePalettePanel::OnChangeSpawnSize, this, PALETTE_CREATURE_SPAWN_SIZE);
 
 	SetSizerAndFit(topsizer);
 

--- a/source/palette/palette_creature.h
+++ b/source/palette/palette_creature.h
@@ -76,8 +76,6 @@ protected:
 	wxSpinCtrl* spawn_size_spin;
 
 	bool handling_event;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/palette/panels/brush_palette_panel.cpp
+++ b/source/palette/panels/brush_palette_panel.cpp
@@ -10,13 +10,6 @@
 // Brush Palette Panel
 // A common class for terrain/doodad/item/raw palette
 
-BEGIN_EVENT_TABLE(BrushPalettePanel, PalettePanel)
-EVT_BUTTON(wxID_ADD, BrushPalettePanel::OnClickAddItemToTileset)
-EVT_BUTTON(wxID_NEW, BrushPalettePanel::OnClickAddTileset)
-EVT_CHOICEBOOK_PAGE_CHANGING(wxID_ANY, BrushPalettePanel::OnSwitchingPage)
-EVT_CHOICEBOOK_PAGE_CHANGED(wxID_ANY, BrushPalettePanel::OnPageChanged)
-END_EVENT_TABLE()
-
 BrushPalettePanel::BrushPalettePanel(wxWindow* parent, const TilesetContainer& tilesets, TilesetCategoryType category, wxWindowID id) :
 	PalettePanel(parent, id),
 	palette_type(category),
@@ -54,6 +47,11 @@ BrushPalettePanel::BrushPalettePanel(wxWindow* parent, const TilesetContainer& t
 	SetSizerAndFit(topsizer);
 
 	choicebook = tmp_choicebook;
+
+	Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddItemToTileset, this, wxID_ADD);
+	Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddTileset, this, wxID_NEW);
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGING, &BrushPalettePanel::OnSwitchingPage, this, wxID_ANY);
+	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &BrushPalettePanel::OnPageChanged, this, wxID_ANY);
 }
 
 BrushPalettePanel::~BrushPalettePanel() {

--- a/source/palette/panels/brush_palette_panel.h
+++ b/source/palette/panels/brush_palette_panel.h
@@ -47,8 +47,6 @@ protected:
 	// No size_panel, it was unused
 
 	std::map<wxWindow*, Brush*> remembered_brushes;
-
-	DECLARE_EVENT_TABLE();
 };
 
 #endif

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -202,24 +202,24 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 
 	wxBoxSizer* buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-	add_button = new wxButton(this, wxID_ANY, wxT("Add"));
+	add_button = new wxButton(this, wxID_ANY, "Add");
 	add_button->SetToolTip("Add replacement rule to list");
 	add_button->Enable(false);
 	buttons_sizer->Add(add_button, 0, wxALL, 5);
 
-	remove_button = new wxButton(this, wxID_ANY, wxT("Remove"));
+	remove_button = new wxButton(this, wxID_ANY, "Remove");
 	remove_button->SetToolTip("Remove selected rule");
 	remove_button->Enable(false);
 	buttons_sizer->Add(remove_button, 0, wxALL, 5);
 
 	buttons_sizer->Add(0, 0, 1, wxEXPAND, 5);
 
-	execute_button = new wxButton(this, wxID_ANY, wxT("Execute"));
+	execute_button = new wxButton(this, wxID_ANY, "Execute");
 	execute_button->SetToolTip("Execute all replacement rules");
 	execute_button->Enable(false);
 	buttons_sizer->Add(execute_button, 0, wxALL, 5);
 
-	close_button = new wxButton(this, wxID_ANY, wxT("Close"));
+	close_button = new wxButton(this, wxID_ANY, "Close");
 	close_button->SetToolTip("Close this window");
 	buttons_sizer->Add(close_button, 0, wxALL, 5);
 


### PR DESCRIPTION
VIOLATIONS FIXED: 25+

BREAKDOWN BY CATEGORY:
- Feature 1 (Event Handling): 20+ violations fixed by replacing static event tables and `Connect()` with `Bind()`.
- Feature 4 (String Handling): 4 violations fixed by removing `wxT()` macros.

IMPACT:
- Improved UI stability by using type-safe event binding.
- Cleaner codebase compliant with modern wxWidgets standards.
- Reduced reliance on legacy macros.

---
*PR created automatically by Jules for task [4502902277836891099](https://jules.google.com/task/4502902277836891099) started by @karolak6612*