### PR TITLE
Fix 23 wxWidgets violations (sizing, deletion, strings)

### DIFF
--- a/source/ui/dialog_util.cpp
+++ b/source/ui/dialog_util.cpp
@@ -59,7 +59,7 @@ void DialogUtil::ListDialog(wxWindow* parent, wxString title, const wxArrayStrin
 
 	// Show the window
 	dlg->ShowModal();
-	delete dlg;
+	dlg->Destroy();
 }
 
 void DialogUtil::ShowTextBox(wxWindow* parent, wxString title, wxString content) {

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -40,7 +40,7 @@ namespace {
 	class ColorSwatch : public wxWindow {
 	public:
 		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
-			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
+			wxWindow(parent, id, wxDefaultPosition, parent ? parent->FromDIP(wxSize(16, 16)) : wxSize(16, 16), wxBORDER_NONE),
 			color(color), selected(false) {
 			SetBackgroundStyle(wxBG_STYLE_PAINT);
 			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
@@ -91,7 +91,7 @@ namespace {
 // ============================================================================
 
 OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current_outfit) :
-	wxDialog(parent, wxID_ANY, "Customise Character", wxDefaultPosition, wxSize(1200, 850), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+	wxDialog(parent, wxID_ANY, "Customise Character", wxDefaultPosition, parent ? parent->FromDIP(wxSize(1200, 850)) : wxSize(1200, 850), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
 	current_outfit(current_outfit),
 	current_speed(220),
 	current_name("You"),
@@ -160,10 +160,10 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	col1_sizer->Add(CreateHeader("Appearance"), 0, wxLEFT | wxTOP, 8);
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
-	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
-	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
-	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
-	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
+	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, FromDIP(wxSize(50, -1)));
 
 	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
 	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);
@@ -196,7 +196,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	check_sizer->Add(addon1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 	check_sizer->Add(addon2, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
-	wxButton* rand_btn = new wxButton(this, ID_RANDOMIZE, "Random", wxDefaultPosition, wxSize(60, 22));
+	wxButton* rand_btn = new wxButton(this, ID_RANDOMIZE, "Random", wxDefaultPosition, FromDIP(wxSize(60, 22)));
 	rand_btn->SetToolTip("Randomize outfit colors");
 	check_sizer->Add(rand_btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 5);
 
@@ -220,7 +220,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* outfits_header_row = new wxBoxSizer(wxHORIZONTAL);
 	outfits_header_row->Add(CreateHeader("Available Outfits"), 1, wxALIGN_BOTTOM | wxLEFT, 4);
 
-	outfit_search = new wxSearchCtrl(this, ID_SEARCH, wxEmptyString, wxDefaultPosition, wxSize(180, -1));
+	outfit_search = new wxSearchCtrl(this, ID_SEARCH, wxEmptyString, wxDefaultPosition, FromDIP(wxSize(180, -1)));
 	outfit_search->SetDescriptiveText("Search...");
 	outfits_header_row->Add(outfit_search, 0, wxALIGN_BOTTOM | wxRIGHT, 4);
 
@@ -236,10 +236,10 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* favs_sizer = new wxBoxSizer(wxVERTICAL);
 	favs_sizer->Add(CreateHeader("Favorites"), 0, wxBOTTOM | wxLEFT, 4);
 
-	favorites_panel->SetMinSize(wxSize(430, -1)); // Force width for 4 columns of 100px
+	favorites_panel->SetMinSize(FromDIP(wxSize(430, -1))); // Force width for 4 columns of 100px
 	favs_sizer->Add(favorites_panel, 1, wxEXPAND);
 
-	wxButton* fav_btn = new wxButton(this, ID_ADD_FAVORITE, "Save Current Outfit as Favorite", wxDefaultPosition, wxSize(-1, 28));
+	wxButton* fav_btn = new wxButton(this, ID_ADD_FAVORITE, "Save Current Outfit as Favorite", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	favs_sizer->Add(fav_btn, 0, wxEXPAND | wxTOP, 8);
 
 	main_sizer->Add(favs_sizer, 0, wxEXPAND | wxLEFT, 5);
@@ -253,9 +253,9 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
 	bottom_sizer->AddStretchSpacer();
 
-	wxButton* ok_btn = new wxButton(this, wxID_OK, "OK", wxDefaultPosition, wxSize(90, 30));
+	wxButton* ok_btn = new wxButton(this, wxID_OK, "OK", wxDefaultPosition, FromDIP(wxSize(90, 30)));
 	ok_btn->SetToolTip("Confirm outfit selection");
-	wxButton* cancel_btn = new wxButton(this, wxID_CANCEL, "Cancel", wxDefaultPosition, wxSize(90, 30));
+	wxButton* cancel_btn = new wxButton(this, wxID_CANCEL, "Cancel", wxDefaultPosition, FromDIP(wxSize(90, 30)));
 	cancel_btn->SetToolTip("Cancel outfit selection");
 	bottom_sizer->Add(ok_btn, 0, wxALL, 8);
 	bottom_sizer->Add(cancel_btn, 0, wxALL, 8);

--- a/source/ui/menubar/navigation_menu_handler.cpp
+++ b/source/ui/menubar/navigation_menu_handler.cpp
@@ -64,7 +64,7 @@ void NavigationMenuHandler::OnJumpToBrush(wxCommandEvent& WXUNUSED(event)) {
 	if (brush) {
 		g_gui.SelectBrush(brush, TILESET_UNKNOWN);
 	}
-	delete dlg;
+	dlg->Destroy();
 }
 
 void NavigationMenuHandler::OnJumpToItemBrush(wxCommandEvent& WXUNUSED(event)) {
@@ -83,7 +83,6 @@ void NavigationMenuHandler::OnJumpToItemBrush(wxCommandEvent& WXUNUSED(event)) {
 		}
 		g_settings.setInteger(Config::JUMP_TO_ITEM_MODE, (int)dialog.getSearchMode());
 	}
-	dialog.Destroy();
 }
 
 void NavigationMenuHandler::OnChangeFloor(wxCommandEvent& event) {

--- a/source/ui/properties/object_properties_base.cpp
+++ b/source/ui/properties/object_properties_base.cpp
@@ -9,7 +9,7 @@
 // Object properties base
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, const Map* map, const Tile* tile, Item* item, wxPoint position /* = wxDefaultPosition */) :
-	wxDialog(parent, wxID_ANY, title, position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
+	wxDialog(parent, wxID_ANY, title, position, parent ? parent->FromDIP(wxSize(600, 400)) : wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
 	edit_map(map),
 	edit_tile(tile),
 	edit_item(item),
@@ -19,7 +19,7 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, const Map* map, const Tile* tile, Creature* creature, wxPoint position /* = wxDefaultPosition */) :
-	wxDialog(parent, wxID_ANY, title, position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
+	wxDialog(parent, wxID_ANY, title, position, parent ? parent->FromDIP(wxSize(600, 400)) : wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
 	edit_map(map),
 	edit_tile(tile),
 	edit_item(nullptr),
@@ -29,7 +29,7 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, const Map* map, const Tile* tile, Spawn* spawn, wxPoint position /* = wxDefaultPosition */) :
-	wxDialog(parent, wxID_ANY, title, position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
+	wxDialog(parent, wxID_ANY, title, position, parent ? parent->FromDIP(wxSize(600, 400)) : wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER),
 	edit_map(map),
 	edit_tile(tile),
 	edit_item(nullptr),
@@ -39,7 +39,7 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, wxPoint position /* = wxDefaultPosition */) :
-	wxDialog(parent, wxID_ANY, title, position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
+	wxDialog(parent, wxID_ANY, title, position, parent ? parent->FromDIP(wxSize(600, 400)) : wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
 	////
 }
 

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -162,7 +162,7 @@ wxCoord ReplaceItemsListBox::OnMeasureItem(size_t WXUNUSED(index)) const {
 // ReplaceItemsDialog
 
 ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
-	wxDialog(parent, wxID_ANY, (selectionOnly ? "Replace Items on Selection" : "Replace Items"), wxDefaultPosition, wxSize(500, 480), wxDEFAULT_DIALOG_STYLE),
+	wxDialog(parent, wxID_ANY, (selectionOnly ? "Replace Items on Selection" : "Replace Items"), wxDefaultPosition, parent ? parent->FromDIP(wxSize(500, 480)) : wxSize(500, 480), wxDEFAULT_DIALOG_STYLE),
 	selectionOnly(selectionOnly) {
 	SetSizeHints(wxDefaultSize, wxDefaultSize);
 
@@ -171,16 +171,16 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	wxFlexGridSizer* list_sizer = new wxFlexGridSizer(0, 2, 0, 0);
 	list_sizer->SetFlexibleDirection(wxBOTH);
 	list_sizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-	list_sizer->SetMinSize(wxSize(-1, 300));
+	list_sizer->SetMinSize(FromDIP(wxSize(-1, 300)));
 
 	list = new ReplaceItemsListBox(this);
-	list->SetMinSize(wxSize(480, 320));
+	list->SetMinSize(FromDIP(wxSize(480, 320)));
 
 	list_sizer->Add(list, 0, wxALL | wxEXPAND, 5);
 	sizer->Add(list_sizer, 1, wxALL | wxEXPAND, 5);
 
 	wxBoxSizer* items_sizer = new wxBoxSizer(wxHORIZONTAL);
-	items_sizer->SetMinSize(wxSize(-1, 40));
+	items_sizer->SetMinSize(FromDIP(wxSize(-1, 40)));
 
 	replace_button = new ReplaceItemsButton(this);
 	items_sizer->Add(replace_button, 0, wxALL, 5);
@@ -202,24 +202,24 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 
 	wxBoxSizer* buttons_sizer = new wxBoxSizer(wxHORIZONTAL);
 
-	add_button = new wxButton(this, wxID_ANY, wxT("Add"));
+	add_button = new wxButton(this, wxID_ANY, "Add");
 	add_button->SetToolTip("Add replacement rule to list");
 	add_button->Enable(false);
 	buttons_sizer->Add(add_button, 0, wxALL, 5);
 
-	remove_button = new wxButton(this, wxID_ANY, wxT("Remove"));
+	remove_button = new wxButton(this, wxID_ANY, "Remove");
 	remove_button->SetToolTip("Remove selected rule");
 	remove_button->Enable(false);
 	buttons_sizer->Add(remove_button, 0, wxALL, 5);
 
 	buttons_sizer->Add(0, 0, 1, wxEXPAND, 5);
 
-	execute_button = new wxButton(this, wxID_ANY, wxT("Execute"));
+	execute_button = new wxButton(this, wxID_ANY, "Execute");
 	execute_button->SetToolTip("Execute all replacement rules");
 	execute_button->Enable(false);
 	buttons_sizer->Add(execute_button, 0, wxALL, 5);
 
-	close_button = new wxButton(this, wxID_ANY, wxT("Close"));
+	close_button = new wxButton(this, wxID_ANY, "Close");
 	close_button->SetToolTip("Close this window");
 	buttons_sizer->Add(close_button, 0, wxALL, 5);
 
@@ -280,7 +280,6 @@ void ReplaceItemsDialog::OnReplaceItemClicked(wxMouseEvent& WXUNUSED(event)) {
 			UpdateWidgets();
 		}
 	}
-	dialog.Destroy();
 }
 
 void ReplaceItemsDialog::OnWithItemClicked(wxMouseEvent& WXUNUSED(event)) {
@@ -296,7 +295,6 @@ void ReplaceItemsDialog::OnWithItemClicked(wxMouseEvent& WXUNUSED(event)) {
 			UpdateWidgets();
 		}
 	}
-	dialog.Destroy();
 }
 
 void ReplaceItemsDialog::OnAddButtonClicked(wxCommandEvent& WXUNUSED(event)) {


### PR DESCRIPTION
Identified and fixed 23 wxWidgets violations following the WxFixer guidelines.

**Violations Fixed:**

**Feature 4: String Handling**
- `source/ui/replace_items_window.cpp`: 4 instances of `wxT("...")` replaced with `"..."`.

**Feature 2: Object Deletion**
- `source/ui/replace_items_window.cpp`: 2 instances of `dialog.Destroy()` on stack objects removed.
- `source/ui/dialog_util.cpp`: 1 instance of `delete dlg` replaced with `dlg->Destroy()`.
- `source/ui/menubar/navigation_menu_handler.cpp`: 1 instance of `delete dlg` replaced with `dlg->Destroy()`, 1 instance of stack `dialog.Destroy()` removed.

**Feature 6: Sizing (High DPI)**
- `source/ui/replace_items_window.cpp`: 4 instances of hardcoded `wxSize` wrapped with `FromDIP`.
- `source/ui/dialogs/outfit_chooser_dialog.cpp`: 9 instances of hardcoded `wxSize` wrapped with `FromDIP`.
- `source/ui/properties/object_properties_base.cpp`: 1 instance (in 4 constructors) of `wxSize(600, 400)` wrapped with `FromDIP`.

**Verification:**
- Verified compilation using `ninja` for all modified files.
- Code reviewed and approved.


---
*PR created automatically by Jules for task [9242670125525148445](https://jules.google.com/task/9242670125525148445) started by @karolak6612*