### PR TITLE
[WXWIDGETS] Refactor property windows: Fix sizer layout and remove legacy event tables

### DIFF
--- a/source/ui/properties/creature_properties_window.cpp
+++ b/source/ui/properties/creature_properties_window.cpp
@@ -8,13 +8,6 @@
 #include "game/creature.h"
 #include "ui/gui.h"
 
-/*
-BEGIN_EVENT_TABLE(CreaturePropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, CreaturePropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, CreaturePropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 CreaturePropertiesWindow::CreaturePropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Creature* creature, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Creature Properties", map, tile_parent, creature, pos),
 	count_field(nullptr),

--- a/source/ui/properties/depot_properties_window.cpp
+++ b/source/ui/properties/depot_properties_window.cpp
@@ -15,13 +15,6 @@
 // ============================================================================
 // Depot Properties Window
 
-/*
-BEGIN_EVENT_TABLE(DepotPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, DepotPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, DepotPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 DepotPropertiesWindow::DepotPropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Depot Properties", map, tile, item, pos),
 	depot_id_field(nullptr) {

--- a/source/ui/properties/podium_properties_window.cpp
+++ b/source/ui/properties/podium_properties_window.cpp
@@ -14,13 +14,6 @@
 
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
-/*
-BEGIN_EVENT_TABLE(PodiumPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, PodiumPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, PodiumPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 PodiumPropertiesWindow::PodiumPropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Podium Properties", map, tile_parent, item, pos) {
 	ASSERT(edit_item);

--- a/source/ui/properties/spawn_properties_window.cpp
+++ b/source/ui/properties/spawn_properties_window.cpp
@@ -8,13 +8,6 @@
 #include "map/map.h"
 #include "app/application.h"
 
-/*
-BEGIN_EVENT_TABLE(SpawnPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, SpawnPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, SpawnPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Spawn* spawn, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Spawn Properties", map, tile_parent, spawn, pos),
 	count_field(nullptr) {

--- a/source/ui/properties/splash_properties_window.cpp
+++ b/source/ui/properties/splash_properties_window.cpp
@@ -13,13 +13,6 @@
 // ============================================================================
 // Splash Properties Window
 
-/*
-BEGIN_EVENT_TABLE(SplashPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, SplashPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, SplashPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 SplashPropertiesWindow::SplashPropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Splash Properties", map, tile, item, pos),
 	action_id_field(nullptr),

--- a/source/ui/properties/writable_properties_window.cpp
+++ b/source/ui/properties/writable_properties_window.cpp
@@ -13,13 +13,6 @@
 // ============================================================================
 // Writable Properties Window
 
-/*
-BEGIN_EVENT_TABLE(WritablePropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, WritablePropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, WritablePropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
-
 WritablePropertiesWindow::WritablePropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Writable Properties", map, tile, item, pos),
 	action_id_field(nullptr),
@@ -51,9 +44,9 @@ WritablePropertiesWindow::WritablePropertiesWindow(wxWindow* parent, const Map* 
 	boxsizer->Add(subsizer, wxSizerFlags(1).Expand());
 
 	wxSizer* textsizer = newd wxBoxSizer(wxVERTICAL);
-	textsizer->Add(newd wxStaticText(this, wxID_ANY, "Text"), wxSizerFlags(1).Center());
+	textsizer->Add(newd wxStaticText(this, wxID_ANY, "Text"), wxSizerFlags(0).Center());
 	text_field = newd wxTextCtrl(this, wxID_ANY, wxstr(item->getText()), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
-	textsizer->Add(text_field, wxSizerFlags(7).Expand());
+	textsizer->Add(text_field, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(textsizer, wxSizerFlags(2).Expand());
 


### PR DESCRIPTION
ISSUE: Legacy event table comments were cluttering the code, and `WritablePropertiesWindow` had a layout bug where the label expanded unnecessarily.
IMPACT: Improved code readability and correct UI layout for writable item properties.
FIX: Removed `BEGIN_EVENT_TABLE` comments and adjusted sizer proportions in `WritablePropertiesWindow`.
DOMAIN CONTEXT: wxWidgets sizer management and event handling modernization.
TESTED: Verified compilation with `ninja` on Linux.

---
*PR created automatically by Jules for task [2124078115677684136](https://jules.google.com/task/2124078115677684136) started by @karolak6612*