### PR TITLE
[REFACTOR] Fix Long Method smell in IOMapOTBM::loadMap

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -850,6 +850,37 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 		return false;
 	}
 
+	loadMapHeader(mapHeaderNode, map);
+
+	int nodes_loaded = 0;
+
+	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
+		++nodes_loaded;
+		if (nodes_loaded % 2048 == 0) {
+			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+		}
+
+		uint8_t node_type;
+		if (!mapNode->getByte(node_type)) {
+			warning("Invalid map node");
+			continue;
+		}
+		if (node_type == OTBM_TILE_AREA) {
+			loadTileArea(mapNode, map);
+		} else if (node_type == OTBM_TOWNS) {
+			loadTowns(mapNode, map);
+		} else if (node_type == OTBM_WAYPOINTS) {
+			loadWaypoints(mapNode, map);
+		}
+	}
+
+	if (!f.isOk()) {
+		warning(wxstr(f.getErrorMessage()).wc_str());
+	}
+	return true;
+}
+
+bool IOMapOTBM::loadMapHeader(BinaryNode* mapHeaderNode, Map& map) {
 	uint8_t attribute;
 	while (mapHeaderNode->getU8(attribute)) {
 		switch (attribute) {
@@ -885,211 +916,200 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 			}
 		}
 	}
+	return true;
+}
 
-	int nodes_loaded = 0;
+bool IOMapOTBM::loadTileArea(BinaryNode* mapNode, Map& map) {
+	uint16_t base_x, base_y;
+	uint8_t base_z;
+	if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
+		warning("Invalid map node, no base coordinate");
+		return false;
+	}
 
-	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
-		++nodes_loaded;
-		if (nodes_loaded % 2048 == 0) {
-			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
-		}
-
-		uint8_t node_type;
-		if (!mapNode->getByte(node_type)) {
-			warning("Invalid map node");
+	for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
+		Tile* tile = nullptr;
+		uint8_t tile_type;
+		if (!tileNode->getByte(tile_type)) {
+			warning("Invalid tile type");
 			continue;
 		}
-		if (node_type == OTBM_TILE_AREA) {
-			uint16_t base_x, base_y;
-			uint8_t base_z;
-			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
+		if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
+			uint8_t x_offset, y_offset;
+			if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
+				warning("Could not read position of tile");
+				continue;
+			}
+			const Position pos(base_x + x_offset, base_y + y_offset, base_z);
+
+			if (map.getTile(pos)) {
+				warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
 				continue;
 			}
 
-			for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
-				Tile* tile = nullptr;
-				uint8_t tile_type;
-				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
+			tile = map.allocator(map.createTileL(pos));
+			House* house = nullptr;
+			if (tile_type == OTBM_HOUSETILE) {
+				uint32_t house_id;
+				if (!tileNode->getU32(house_id)) {
+					warning("House tile without house data, discarding tile");
 					continue;
 				}
-				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
-					uint8_t x_offset, y_offset;
-					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
-						continue;
+				if (house_id) {
+					house = map.houses.getHouse(house_id);
+					if (!house) {
+						auto new_house = std::make_unique<House>(map);
+						house = new_house.get();
+						new_house->setID(house_id);
+						map.houses.addHouse(std::move(new_house));
 					}
-					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
-
-					if (map.getTile(pos)) {
-						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
-						continue;
-					}
-
-					tile = map.allocator(map.createTileL(pos));
-					House* house = nullptr;
-					if (tile_type == OTBM_HOUSETILE) {
-						uint32_t house_id;
-						if (!tileNode->getU32(house_id)) {
-							warning("House tile without house data, discarding tile");
-							continue;
-						}
-						if (house_id) {
-							house = map.houses.getHouse(house_id);
-							if (!house) {
-								auto new_house = std::make_unique<House>(map);
-								house = new_house.get();
-								new_house->setID(house_id);
-								map.houses.addHouse(std::move(new_house));
-							}
-						} else {
-							warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
-						}
-					}
-
-					uint8_t attribute;
-					while (tileNode->getU8(attribute)) {
-						switch (attribute) {
-							case OTBM_ATTR_TILE_FLAGS: {
-								uint32_t flags = 0;
-								if (!tileNode->getU32(flags)) {
-									warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->setMapFlags(flags);
-								break;
-							}
-							case OTBM_ATTR_ITEM: {
-								Item* item = Item::Create_OTBM(*this, tileNode);
-								if (item == nullptr) {
-									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->addItem(item);
-								break;
-							}
-							default: {
-								warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
-								break;
-							}
-						}
-					}
-
-					for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
-						Item* item = nullptr;
-						uint8_t item_type;
-						if (!itemNode->getByte(item_type)) {
-							warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
-							continue;
-						}
-						if (item_type == OTBM_ITEM) {
-							item = Item::Create_OTBM(*this, itemNode);
-							if (item) {
-								if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
-									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								// reform(&map, tile, item);
-								tile->addItem(item);
-							}
-						} else {
-							warning("Unknown type of tile child node");
-						}
-					}
-
-					tile->update();
-					if (house) {
-						house->addTile(tile);
-					}
-
-					map.setTile(pos.x, pos.y, pos.z, tile);
 				} else {
-					warning("Unknown type of tile node");
+					warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
 				}
 			}
-		} else if (node_type == OTBM_TOWNS) {
-			for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
-				Town* town = nullptr;
-				uint8_t town_type;
-				if (!townNode->getByte(town_type)) {
-					warning("Invalid town type (1)");
-					continue;
-				}
-				if (town_type != OTBM_TOWN) {
-					warning("Invalid town type (2)");
-					continue;
-				}
-				uint32_t town_id;
-				if (!townNode->getU32(town_id)) {
-					warning("Invalid town id");
-					continue;
-				}
 
-				town = map.towns.getTown(town_id);
-				if (town) {
-					warning("Duplicate town id %d, discarding duplicate", town_id);
-					continue;
-				} else {
-					auto new_town = std::make_unique<Town>(town_id);
-					town = new_town.get();
-					if (!map.towns.addTown(std::move(new_town))) {
-						continue;
+			uint8_t attribute;
+			while (tileNode->getU8(attribute)) {
+				switch (attribute) {
+					case OTBM_ATTR_TILE_FLAGS: {
+						uint32_t flags = 0;
+						if (!tileNode->getU32(flags)) {
+							warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->setMapFlags(flags);
+						break;
+					}
+					case OTBM_ATTR_ITEM: {
+						Item* item = Item::Create_OTBM(*this, tileNode);
+						if (item == nullptr) {
+							warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->addItem(item);
+						break;
+					}
+					default: {
+						warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
+						break;
 					}
 				}
-				std::string town_name;
-				if (!townNode->getString(town_name)) {
-					warning("Invalid town name");
-					continue;
-				}
-				town->setName(town_name);
-				Position pos;
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
-					warning("Invalid town temple position");
-					continue;
-				}
-				pos.x = x;
-				pos.y = y;
-				pos.z = z;
-				town->setTemplePosition(pos);
-				map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
 			}
-		} else if (node_type == OTBM_WAYPOINTS) {
-			for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
-				uint8_t waypoint_type;
-				if (!waypointNode->getByte(waypoint_type)) {
-					warning("Invalid waypoint type (1)");
-					continue;
-				}
-				if (waypoint_type != OTBM_WAYPOINT) {
-					warning("Invalid waypoint type (2)");
-					continue;
-				}
 
-				Waypoint wp;
-
-				if (!waypointNode->getString(wp.name)) {
-					warning("Invalid waypoint name");
+			for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
+				Item* item = nullptr;
+				uint8_t item_type;
+				if (!itemNode->getByte(item_type)) {
+					warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
 					continue;
 				}
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
-					warning("Invalid waypoint position");
-					continue;
+				if (item_type == OTBM_ITEM) {
+					item = Item::Create_OTBM(*this, itemNode);
+					if (item) {
+						if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
+							warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						// reform(&map, tile, item);
+						tile->addItem(item);
+					}
+				} else {
+					warning("Unknown type of tile child node");
 				}
-				wp.pos.x = x;
-				wp.pos.y = y;
-				wp.pos.z = z;
-
-				map.waypoints.addWaypoint(newd Waypoint(wp));
 			}
+
+			tile->update();
+			if (house) {
+				house->addTile(tile);
+			}
+
+			map.setTile(pos.x, pos.y, pos.z, tile);
+		} else {
+			warning("Unknown type of tile node");
 		}
 	}
+	return true;
+}
 
-	if (!f.isOk()) {
-		warning(wxstr(f.getErrorMessage()).wc_str());
+bool IOMapOTBM::loadTowns(BinaryNode* mapNode, Map& map) {
+	for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
+		Town* town = nullptr;
+		uint8_t town_type;
+		if (!townNode->getByte(town_type)) {
+			warning("Invalid town type (1)");
+			continue;
+		}
+		if (town_type != OTBM_TOWN) {
+			warning("Invalid town type (2)");
+			continue;
+		}
+		uint32_t town_id;
+		if (!townNode->getU32(town_id)) {
+			warning("Invalid town id");
+			continue;
+		}
+
+		town = map.towns.getTown(town_id);
+		if (town) {
+			warning("Duplicate town id %d, discarding duplicate", town_id);
+			continue;
+		} else {
+			auto new_town = std::make_unique<Town>(town_id);
+			town = new_town.get();
+			if (!map.towns.addTown(std::move(new_town))) {
+				continue;
+			}
+		}
+		std::string town_name;
+		if (!townNode->getString(town_name)) {
+			warning("Invalid town name");
+			continue;
+		}
+		town->setName(town_name);
+		Position pos;
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
+			warning("Invalid town temple position");
+			continue;
+		}
+		pos.x = x;
+		pos.y = y;
+		pos.z = z;
+		town->setTemplePosition(pos);
+		map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
+	}
+	return true;
+}
+
+bool IOMapOTBM::loadWaypoints(BinaryNode* mapNode, Map& map) {
+	for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
+		uint8_t waypoint_type;
+		if (!waypointNode->getByte(waypoint_type)) {
+			warning("Invalid waypoint type (1)");
+			continue;
+		}
+		if (waypoint_type != OTBM_WAYPOINT) {
+			warning("Invalid waypoint type (2)");
+			continue;
+		}
+
+		Waypoint wp;
+
+		if (!waypointNode->getString(wp.name)) {
+			warning("Invalid waypoint name");
+			continue;
+		}
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
+			warning("Invalid waypoint position");
+			continue;
+		}
+		wp.pos.x = x;
+		wp.pos.y = y;
+		wp.pos.z = z;
+
+		map.waypoints.addWaypoint(newd Waypoint(wp));
 	}
 	return true;
 }

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -139,6 +139,12 @@ protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+
+	bool loadMapHeader(BinaryNode* mapHeaderNode, Map& map);
+	bool loadTileArea(BinaryNode* mapNode, Map& map);
+	bool loadTowns(BinaryNode* mapNode, Map& map);
+	bool loadWaypoints(BinaryNode* mapNode, Map& map);
+
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
Extracted methods from `IOMapOTBM::loadMap` to handle specific map node types (Header, Tile Area, Towns, Waypoints) in order to resolve a "Long Method" code smell and deep nesting. This improves readability and maintainability of the map loading logic.

---
*PR created automatically by Jules for task [10768010184261264793](https://jules.google.com/task/10768010184261264793) started by @karolak6612*