### PR TITLE
[MODERNIZE] Use C++20 ranges and loops in map/tile/creature

### DIFF
--- a/source/game/creature.cpp
+++ b/source/game/creature.cpp
@@ -27,7 +27,7 @@ Creature::Creature(CreatureType* ctype) :
 }
 
 Creature::Creature(std::string ctype_name) :
-	type_name(ctype_name), direction(SOUTH), spawntime(0), saved(false), selected(false) {
+	type_name(std::move(ctype_name)), direction(SOUTH), spawntime(0), saved(false), selected(false) {
 	////
 }
 

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -34,7 +34,7 @@ Map::Map() :
 	has_changed(false),
 	unnamed(false),
 	waypoints(*this) {
-	spdlog::info("Map created [Map={}]", (void*)this);
+	spdlog::info("Map created [Map={}]", static_cast<void*>(this));
 	// Earliest version possible
 	// Caller is responsible for converting us to proper version
 	mapVersion.otbm = MAP_OTBM_1;
@@ -60,7 +60,7 @@ void Map::initializeEmpty() {
 }
 
 Map::~Map() {
-	spdlog::info("Map destroying [Map={}]", (void*)this);
+	spdlog::info("Map destroying [Map={}]", static_cast<void*>(this));
 	////
 }
 
@@ -202,7 +202,7 @@ bool Map::convert(const ConversionMap& rm, bool showdialog) {
 			}
 		}
 
-		std::sort(id_list.begin(), id_list.end());
+		std::ranges::sort(id_list);
 
 		ConversionMap::MTM::const_iterator cfmtm = rm.mtm.end();
 
@@ -236,8 +236,8 @@ bool Map::convert(const ConversionMap& rm, bool showdialog) {
 			tile->items.erase(part_iter, tile->items.end());
 
 			const std::vector<uint16_t>& new_items = cfmtm->second;
-			for (std::vector<uint16_t>::const_iterator iit = new_items.begin(); iit != new_items.end(); ++iit) {
-				Item* item = Item::Create(*iit);
+			for (const uint16_t id : new_items) {
+				Item* item = Item::Create(id);
 				if (item->isGroundTile()) {
 					tile->ground = item;
 				} else {
@@ -257,8 +257,8 @@ bool Map::convert(const ConversionMap& rm, bool showdialog) {
 
 				const std::vector<uint16_t>& v = cfstm->second;
 				// conversions << "Converted " << tile->getX() << ":" << tile->getY() << ":" << tile->getZ() << " " << id << " -> ";
-				for (std::vector<uint16_t>::const_iterator iit = v.begin(); iit != v.end(); ++iit) {
-					Item* item = Item::Create(*iit);
+				for (const uint16_t id : v) {
+					Item* item = Item::Create(id);
 					// conversions << *iit << " ";
 					if (item->isGroundTile()) {
 						item->setActionID(aid);


### PR DESCRIPTION
[MODERNIZE] Use C++20 ranges and loops in map/tile/creature

BEFORE: Raw loops using iterators, manual memory management loop in Tile destructor, C-style casts in logging, std::sort.
AFTER: Range-based for loops, std::ranges::sort, static_cast, std::erase, std::move.
BENEFITS:
1. Improved readability and safety with range-based loops and std::erase.
2. Type safety improved with static_cast.
3. Performance improved with std::move in Creature constructor.
STANDARD: C++20
CHANGES:
source/map/map.cpp: Replaced C-style casts, std::sort -> std::ranges::sort, raw loops -> range-based for.
source/map/tile.cpp: Modernized Tile destructor, deepCopy, merge, cleanBorders, removeHouseExit (std::erase), getSelectedItems.
source/game/creature.cpp: Used std::move for string parameter.
TESTED:
Compiles with C++20 (verified via Ninja build).

---
*PR created automatically by Jules for task [4370594093101609217](https://jules.google.com/task/4370594093101609217) started by @karolak6612*