### PR TITLE
⚡ Throttle: Rendering & Map Logic Optimizations

### DIFF
--- a/source/map/spatial_hash_grid.h
+++ b/source/map/spatial_hash_grid.h
@@ -101,6 +101,10 @@ protected:
 	BaseMap& map;
 	std::unordered_map<uint64_t, std::unique_ptr<GridCell>> cells;
 
+	// Simple MRU cache for getLeaf
+	mutable uint64_t cached_key = 0;
+	mutable GridCell* cached_cell = nullptr;
+
 	static uint64_t makeKeyFromCell(int cx, int cy) {
 		// Assumption: cell coordinates fit in 32 bits (covering +/- 2 billion tiles).
 		// Tibia maps are typically limited to 65k x 65k.

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -70,23 +70,29 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					int node_draw_x = nd_map_x * TileSize + base_screen_x;
 					int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-					for (int map_x = 0; map_x < 4; ++map_x) {
-						for (int map_y = 0; map_y < 4; ++map_y) {
-							// Calculate draw coordinates directly
-							int draw_x = node_draw_x + (map_x * TileSize);
-							int draw_y = node_draw_y + (map_y * TileSize);
+					Floor* floor = nd->getFloor(map_z);
+					if (floor) {
+						int idx = 0;
+						for (int map_x = 0; map_x < 4; ++map_x) {
+							for (int map_y = 0; map_y < 4; ++map_y) {
+								// Calculate draw coordinates directly
+								int draw_x = node_draw_x + (map_x * TileSize);
+								int draw_y = node_draw_y + (map_y * TileSize);
 
-							// Culling: Skip tiles that are far outside the viewport.
-							if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
-								continue;
-							}
+								// Culling: Skip tiles that are far outside the viewport.
+								if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+									idx++;
+									continue;
+								}
 
-							TileLocation* location = nd->getTile(map_x, map_y, map_z);
+								TileLocation* location = &floor->locs[idx];
 
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
-							// draw light, but only if not zoomed too far
-							if (location && options.isDrawLight() && view.zoom <= 10.0) {
-								tile_renderer->AddLight(location, view, options, light_buffer);
+								tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
+								// draw light, but only if not zoomed too far
+								if (options.isDrawLight() && view.zoom <= 10.0) {
+									tile_renderer->AddLight(location, view, options, light_buffer);
+								}
+								idx++;
 							}
 						}
 					}
@@ -107,23 +113,29 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-			for (int map_x = 0; map_x < 4; ++map_x) {
-				for (int map_y = 0; map_y < 4; ++map_y) {
-					// Calculate draw coordinates directly
-					int draw_x = node_draw_x + (map_x * TileSize);
-					int draw_y = node_draw_y + (map_y * TileSize);
+			Floor* floor = nd->getFloor(map_z);
+			if (floor) {
+				int idx = 0;
+				for (int map_x = 0; map_x < 4; ++map_x) {
+					for (int map_y = 0; map_y < 4; ++map_y) {
+						// Calculate draw coordinates directly
+						int draw_x = node_draw_x + (map_x * TileSize);
+						int draw_y = node_draw_y + (map_y * TileSize);
 
-					// Culling: Skip tiles that are far outside the viewport.
-					if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
-						continue;
-					}
+						// Culling: Skip tiles that are far outside the viewport.
+						if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+							idx++;
+							continue;
+						}
 
-					TileLocation* location = nd->getTile(map_x, map_y, map_z);
+						TileLocation* location = &floor->locs[idx];
 
-					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
-					// draw light, but only if not zoomed too far
-					if (location && options.isDrawLight() && view.zoom <= 10.0) {
-						tile_renderer->AddLight(location, view, options, light_buffer);
+						tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
+						// draw light, but only if not zoomed too far
+						if (options.isDrawLight() && view.zoom <= 10.0) {
+							tile_renderer->AddLight(location, view, options, light_buffer);
+						}
+						idx++;
 					}
 				}
 			}


### PR DESCRIPTION
- **MapLayerDrawer**: Optimized rendering loop to bypass repeated `getTile` lookups and bounds checking. It now retrieves `Floor*` once per node and iterates `TileLocation` array directly.
- **SpatialHashGrid**: Added a 1-entry MRU cache to `getLeaf`. This reduces `std::unordered_map` lookups for sequential access to the same grid cell (common in brushes and logic).
- **Map::convert**: Implemented `ConversionTrie` to replace the quadratic "longest prefix match" search loop with a linear Trie traversal during map conversion.

---
*PR created automatically by Jules for task [1830946940774152842](https://jules.google.com/task/1830946940774152842) started by @karolak6612*