### PR TITLE
👻 Phantom: Modernize Brush Panel and Buttons with NanoVG

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -34,6 +34,12 @@ public:
 	Brush* GetSelectedBrush() const override;
 	bool SelectBrush(const Brush* brush) override;
 
+	/**
+	 * @brief Sets the display mode (grid or list).
+	 * @param mode The desired display mode.
+	 */
+	void SetDisplayMode(BrushListType mode);
+
 protected:
 	/**
 	 * @brief Performs NanoVG rendering of the brush grid.
@@ -57,6 +63,7 @@ protected:
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
 
 	RenderSize icon_size;
+	BrushListType list_mode;
 	int selected_index;
 	int hover_index;
 	int columns;

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -21,8 +21,6 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	list_type(BRUSHLIST_LISTBOX) {
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
-
-	Bind(wxEVT_LISTBOX, &BrushPanel::OnClickListBoxRow, this, wxID_ANY);
 }
 
 BrushPanel::~BrushPanel() {
@@ -68,20 +66,14 @@ void BrushPanel::LoadContents() {
 
 	ASSERT(tileset != nullptr);
 
-	switch (list_type) {
-		case BRUSHLIST_LARGE_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
-			break;
-		case BRUSHLIST_SMALL_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16);
-			break;
-		case BRUSHLIST_LISTBOX:
-		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
-			break;
-		default:
-			break;
+	RenderSize rsz = RENDER_SIZE_32x32;
+	if (list_type == BRUSHLIST_SMALL_ICONS) {
+		rsz = RENDER_SIZE_16x16;
 	}
+
+	VirtualBrushGrid* vbg = newd VirtualBrushGrid(this, tileset, rsz);
+	vbg->SetDisplayMode(list_type);
+	brushbox = vbg;
 
 	if (!brushbox) {
 		return;
@@ -137,114 +129,3 @@ void BrushPanel::OnSwitchOut() {
 	////
 }
 
-void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
-	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	// We just notify the GUI of the action, it will take care of everything else
-	ASSERT(brushbox);
-	size_t n = event.GetSelection();
-
-	wxWindow* w = this->GetParent();
-	while (w) {
-		PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
-		if (pw) {
-			g_gui.ActivatePalette(pw);
-			break;
-		}
-		w = w->GetParent();
-	}
-
-	g_gui.SelectBrush(tileset->brushlist[n], tileset->getType());
-}
-
-// ============================================================================
-// BrushListBox
-
-BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
-	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	BrushBoxInterface(tileset) {
-	SetItemCount(tileset->size());
-	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
-}
-
-BrushListBox::~BrushListBox() {
-	////
-}
-
-void BrushListBox::SelectFirstBrush() {
-	SetSelection(0);
-	wxWindow::ScrollLines(-1);
-}
-
-Brush* BrushListBox::GetSelectedBrush() const {
-	if (!tileset) {
-		return nullptr;
-	}
-
-	int n = GetSelection();
-	if (n != wxNOT_FOUND) {
-		return tileset->brushlist[n];
-	} else if (tileset->size() > 0) {
-		return tileset->brushlist[0];
-	}
-	return nullptr;
-}
-
-bool BrushListBox::SelectBrush(const Brush* whatbrush) {
-	auto it = std::ranges::find(tileset->brushlist, whatbrush);
-	if (it != tileset->brushlist.end()) {
-		SetSelection(std::distance(tileset->brushlist.begin(), it));
-		return true;
-	}
-	return false;
-}
-
-void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	ASSERT(n < tileset->size());
-	Sprite* spr = tileset->brushlist[n]->getSprite();
-	if (!spr) {
-		spr = g_gui.gfx.getSprite(tileset->brushlist[n]->getLookID());
-	}
-	if (spr) {
-		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord BrushListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
-
-void BrushListBox::OnKey(wxKeyEvent& event) {
-	switch (event.GetKeyCode()) {
-		case WXK_UP:
-		case WXK_DOWN:
-		case WXK_LEFT:
-		case WXK_RIGHT:
-		case WXK_PAGEUP:
-		case WXK_PAGEDOWN:
-		case WXK_HOME:
-		case WXK_END:
-			if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
-				event.Skip(true);
-			} else {
-				if (g_gui.GetCurrentTab() != nullptr) {
-					g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-				}
-			}
-			break;
-		default:
-			if (g_gui.GetCurrentTab() != nullptr) {
-				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-			}
-			break;
-	}
-}

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,28 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() override {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush() override;
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const override;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush) override;
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;
-	virtual wxCoord OnMeasureItem(size_t n) const override;
-
-	void OnKey(wxKeyEvent& event);
-};
 
 class BrushPanel : public wxPanel {
 public:
@@ -86,9 +64,6 @@ public:
 	void OnSwitchIn();
 	// Called when this page is hidden
 	void OnSwitchOut();
-
-	// wxWidgets event handlers
-	void OnClickListBoxRow(wxCommandEvent& event);
 
 protected:
 	const TilesetCategory* tileset;

--- a/source/ui/dcbutton.cpp
+++ b/source/ui/dcbutton.cpp
@@ -23,29 +23,37 @@
 #include "game/sprites.h"
 #include "ui/gui.h"
 
-IMPLEMENT_DYNAMIC_CLASS(DCButton, wxPanel)
+#include <glad/glad.h>
+#include <nanovg.h>
 
 DCButton::DCButton() :
-	wxPanel(nullptr, wxID_ANY, wxDefaultPosition, wxSize(36, 36)),
+	NanoVGCanvas(nullptr, wxID_ANY, 0),
 	type(DC_BTN_NORMAL),
 	state(false),
 	size(RENDER_SIZE_16x16),
 	sprite(nullptr),
 	overlay(nullptr) {
-	Bind(wxEVT_PAINT, &DCButton::OnPaint, this);
+	SetSize(wxSize(36, 36));
 	Bind(wxEVT_LEFT_DOWN, &DCButton::OnClick, this);
 	SetSprite(0);
 }
 
 DCButton::DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, RenderSize sz, int sprite_id) :
-	wxPanel(parent, id, pos, (sz == RENDER_SIZE_64x64 ? wxSize(68, 68) : sz == RENDER_SIZE_32x32 ? wxSize(36, 36)
-																								 : wxSize(20, 20))),
+	NanoVGCanvas(parent, id, 0),
 	type(type),
 	state(false),
 	size(sz),
 	sprite(nullptr),
 	overlay(nullptr) {
-	Bind(wxEVT_PAINT, &DCButton::OnPaint, this);
+
+	wxSize winSize;
+	if (sz == RENDER_SIZE_64x64) winSize = wxSize(68, 68);
+	else if (sz == RENDER_SIZE_32x32) winSize = wxSize(36, 36);
+	else winSize = wxSize(20, 20);
+
+	SetSize(winSize);
+	if (pos != wxDefaultPosition) SetPosition(pos);
+
 	Bind(wxEVT_LEFT_DOWN, &DCButton::OnClick, this);
 	SetSprite(sprite_id);
 }
@@ -93,76 +101,162 @@ bool DCButton::GetValue() const {
 	return state;
 }
 
-void DCButton::OnPaint(wxPaintEvent& event) {
-	wxBufferedPaintDC pdc(this);
+void DCButton::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	nvgBeginPath(vg);
+	nvgRect(vg, 0, 0, width, height);
+	nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+	nvgFill(vg);
 
-	if (g_gui.gfx.isUnloaded()) {
-		return;
-	}
+	NVGcolor highlight = nvgRGBA(255, 255, 255, 255);
+	NVGcolor dark_highlight = nvgRGBA(212, 208, 200, 255);
+	NVGcolor light_shadow = nvgRGBA(128, 128, 128, 255);
+	NVGcolor shadow = nvgRGBA(64, 64, 64, 255);
 
-	wxPen* highlight_pen = wxThePenList->FindOrCreatePen(wxColor(0xFF, 0xFF, 0xFF), 1, wxSOLID);
-	wxPen* dark_highlight_pen = wxThePenList->FindOrCreatePen(wxColor(0xD4, 0xD0, 0xC8), 1, wxSOLID);
-	wxPen* light_shadow_pen = wxThePenList->FindOrCreatePen(wxColor(0x80, 0x80, 0x80), 1, wxSOLID);
-	wxPen* shadow_pen = wxThePenList->FindOrCreatePen(wxColor(0x40, 0x40, 0x40), 1, wxSOLID);
+	float w = static_cast<float>(width);
+	float h = static_cast<float>(height);
 
-	int size_x = 20, size_y = 20;
+	nvgStrokeWidth(vg, 1.0f);
 
-	if (size == RENDER_SIZE_16x16) {
-		size_x = 20;
-		size_y = 20;
-	} else if (size == RENDER_SIZE_32x32) {
-		size_x = 36;
-		size_y = 36;
-	}
-
-	pdc.SetBrush(*wxBLACK);
-	pdc.DrawRectangle(0, 0, size_x, size_y);
 	if (type == DC_BTN_TOGGLE && GetValue()) {
-		pdc.SetPen(*shadow_pen);
-		pdc.DrawLine(0, 0, size_x - 1, 0);
-		pdc.DrawLine(0, 1, 0, size_y - 1);
-		pdc.SetPen(*light_shadow_pen);
-		pdc.DrawLine(1, 1, size_x - 2, 1);
-		pdc.DrawLine(1, 2, 1, size_y - 2);
-		pdc.SetPen(*dark_highlight_pen);
-		pdc.DrawLine(size_x - 2, 1, size_x - 2, size_y - 2);
-		pdc.DrawLine(1, size_y - 2, size_x - 1, size_y - 2);
-		pdc.SetPen(*highlight_pen);
-		pdc.DrawLine(size_x - 1, 0, size_x - 1, size_y - 1);
-		pdc.DrawLine(0, size_y - 1, size_y, size_y - 1);
+		// Pressed state
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 0.5f, h - 0.5f);
+		nvgLineTo(vg, 0.5f, 0.5f);
+		nvgLineTo(vg, w - 0.5f, 0.5f);
+		nvgStrokeColor(vg, shadow);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 1.5f, h - 1.5f);
+		nvgLineTo(vg, 1.5f, 1.5f);
+		nvgLineTo(vg, w - 1.5f, 1.5f);
+		nvgStrokeColor(vg, light_shadow);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 1.5f, h - 1.5f);
+		nvgLineTo(vg, w - 1.5f, h - 1.5f);
+		nvgLineTo(vg, w - 1.5f, 1.5f);
+		nvgStrokeColor(vg, dark_highlight);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 0.5f, h - 0.5f);
+		nvgLineTo(vg, w - 0.5f, h - 0.5f);
+		nvgLineTo(vg, w - 0.5f, 0.5f);
+		nvgStrokeColor(vg, highlight);
+		nvgStroke(vg);
 	} else {
-		pdc.SetPen(*highlight_pen);
-		pdc.DrawLine(0, 0, size_x - 1, 0);
-		pdc.DrawLine(0, 1, 0, size_y - 1);
-		pdc.SetPen(*dark_highlight_pen);
-		pdc.DrawLine(1, 1, size_x - 2, 1);
-		pdc.DrawLine(1, 2, 1, size_y - 2);
-		pdc.SetPen(*light_shadow_pen);
-		pdc.DrawLine(size_x - 2, 1, size_x - 2, size_y - 2);
-		pdc.DrawLine(1, size_y - 2, size_x - 1, size_y - 2);
-		pdc.SetPen(*shadow_pen);
-		pdc.DrawLine(size_x - 1, 0, size_x - 1, size_y - 1);
-		pdc.DrawLine(0, size_y - 1, size_y, size_y - 1);
+		// Normal state
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 0.5f, h - 0.5f);
+		nvgLineTo(vg, 0.5f, 0.5f);
+		nvgLineTo(vg, w - 0.5f, 0.5f);
+		nvgStrokeColor(vg, highlight);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 1.5f, h - 1.5f);
+		nvgLineTo(vg, 1.5f, 1.5f);
+		nvgLineTo(vg, w - 1.5f, 1.5f);
+		nvgStrokeColor(vg, dark_highlight);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 1.5f, h - 1.5f);
+		nvgLineTo(vg, w - 1.5f, h - 1.5f);
+		nvgLineTo(vg, w - 1.5f, 1.5f);
+		nvgStrokeColor(vg, light_shadow);
+		nvgStroke(vg);
+
+		nvgBeginPath(vg);
+		nvgMoveTo(vg, 0.5f, h - 0.5f);
+		nvgLineTo(vg, w - 0.5f, h - 0.5f);
+		nvgLineTo(vg, w - 0.5f, 0.5f);
+		nvgStrokeColor(vg, shadow);
+		nvgStroke(vg);
 	}
 
-	if (sprite) {
-		if (size == RENDER_SIZE_16x16) {
-			// Draw the picture!
-			sprite->DrawTo(&pdc, SPRITE_SIZE_16x16, 2, 2);
+	auto drawSprite = [&](Sprite* spr) {
+		if (!spr) return;
 
-			if (overlay && type == DC_BTN_TOGGLE && GetValue()) {
-				overlay->DrawTo(&pdc, SPRITE_SIZE_16x16, 2, 2);
-			}
-		} else if (size == RENDER_SIZE_32x32) {
-			// Draw the picture!
-			sprite->DrawTo(&pdc, SPRITE_SIZE_32x32, 2, 2);
+		// Use sprite pointer address as unique ID (or look ID if dynamic casting fails)
+		uint32_t sprId = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(spr) & 0xFFFFFFFF);
+		int tex = GetCachedImage(sprId);
 
-			if (overlay && type == DC_BTN_TOGGLE && GetValue()) {
-				overlay->DrawTo(&pdc, SPRITE_SIZE_32x32, 2, 2);
+		if (tex <= 0) {
+			// Try to generate texture
+			GameSprite* gs = dynamic_cast<GameSprite*>(spr);
+			if (gs && !gs->spriteList.empty()) {
+				int texW = gs->width * 32;
+				int texH = gs->height * 32;
+				size_t bufferSize = static_cast<size_t>(texW) * texH * 4;
+				std::vector<uint8_t> composite(bufferSize, 0);
+
+				int px = (gs->pattern_x >= 3) ? 2 : 0;
+				for (int l = 0; l < gs->layers; ++l) {
+					for (int sw = 0; sw < gs->width; ++sw) {
+						for (int sh = 0; sh < gs->height; ++sh) {
+							int idx = gs->getIndex(sw, sh, l, px, 0, 0, 0);
+							if (idx < 0 || static_cast<size_t>(idx) >= gs->spriteList.size()) continue;
+
+							auto data = gs->spriteList[idx]->getRGBAData();
+							if (!data) continue;
+
+							int part_x = (gs->width - sw - 1) * 32;
+							int part_y = (gs->height - sh - 1) * 32;
+
+							for (int sy = 0; sy < 32; ++sy) {
+								for (int sx = 0; sx < 32; ++sx) {
+									int dy = part_y + sy;
+									int dx = part_x + sx;
+									int di = (dy * texW + dx) * 4;
+									int si = (sy * 32 + sx) * 4;
+
+									uint8_t sa = data[si + 3];
+									if (sa == 0) continue;
+
+									if (sa == 255) {
+										composite[di + 0] = data[si + 0];
+										composite[di + 1] = data[si + 1];
+										composite[di + 2] = data[si + 2];
+										composite[di + 3] = 255;
+									} else {
+										float a = sa / 255.0f;
+										float ia = 1.0f - a;
+										composite[di + 0] = static_cast<uint8_t>(data[si + 0] * a + composite[di + 0] * ia);
+										composite[di + 1] = static_cast<uint8_t>(data[si + 1] * a + composite[di + 1] * ia);
+										composite[di + 2] = static_cast<uint8_t>(data[si + 2] * a + composite[di + 2] * ia);
+										composite[di + 3] = std::max(composite[di + 3], sa);
+									}
+								}
+							}
+						}
+					}
+				}
+				tex = GetOrCreateImage(sprId, composite.data(), texW, texH);
 			}
-		} else if (size == RENDER_SIZE_64x64) {
-			////
 		}
+
+		if (tex > 0) {
+			float iconSize = 32.0f;
+			if (size == RENDER_SIZE_16x16) iconSize = 16.0f;
+
+			// Center the image
+			float ix = (width - iconSize) / 2.0f;
+			float iy = (height - iconSize) / 2.0f;
+
+			NVGpaint imgPaint = nvgImagePattern(vg, ix, iy, iconSize, iconSize, 0.0f, tex, 1.0f);
+			nvgBeginPath(vg);
+			nvgRect(vg, ix, iy, iconSize, iconSize);
+			nvgFillPaint(vg, imgPaint);
+			nvgFill(vg);
+		}
+	};
+
+	drawSprite(sprite);
+	if (overlay && type == DC_BTN_TOGGLE && GetValue()) {
+		drawSprite(overlay);
 	}
 }
 
@@ -172,6 +266,9 @@ void DCButton::OnClick(wxMouseEvent& WXUNUSED(evt)) {
 
 	if (type == DC_BTN_TOGGLE) {
 		SetValue(!GetValue());
+	} else {
+		// Normal button might want visual feedback
+		Refresh();
 	}
 	SetFocus();
 

--- a/source/ui/dcbutton.h
+++ b/source/ui/dcbutton.h
@@ -18,6 +18,8 @@
 #ifndef RME_DC_BUTTON_H
 #define RME_DC_BUTTON_H
 
+#include "util/nanovg_canvas.h"
+
 class Sprite;
 class GameSprite;
 class EditorSprite;
@@ -33,7 +35,7 @@ enum RenderSize {
 	RENDER_SIZE_64x64,
 };
 
-class DCButton : public wxPanel {
+class DCButton : public NanoVGCanvas {
 public:
 	DCButton();
 	DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, RenderSize sz, int sprite_id);
@@ -45,10 +47,10 @@ public:
 	void SetSprite(int id);
 	void SetSprite(Sprite* sprite);
 
-	void OnPaint(wxPaintEvent&);
 	void OnClick(wxMouseEvent&);
 
 protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
 	void SetOverlay(Sprite* espr);
 
 	int type;
@@ -56,8 +58,6 @@ protected:
 	RenderSize size;
 	Sprite* sprite;
 	Sprite* overlay;
-
-	DECLARE_DYNAMIC_CLASS(DCButton)
 };
 
 #endif


### PR DESCRIPTION
This PR modernizes the Brush Panel and DCButton components by migrating them to use NanoVG for rendering.

1.  **VirtualBrushGrid Enhancements**:
    -   Added `SetDisplayMode` to support list and text-list views.
    -   Implemented list rendering logic (icon + text) in `OnNanoVGPaint`.
    -   Updated layout and hit-testing to support single-column list modes.

2.  **BrushPanel Refactoring**:
    -   Removed `BrushListBox` usage and class definition.
    -   Now uses `VirtualBrushGrid` for all display modes (Large Icons, Small Icons, List, Text List).
    -   Removed legacy `wxEVT_LISTBOX` event handling.

3.  **DCButton Migration**:
    -   Changed inheritance from `wxPanel` to `NanoVGCanvas`.
    -   Reimplemented drawing logic using NanoVG paths to replicate the original 3D button look.
    -   Implemented sprite texture generation and caching using NanoVG.


---
*PR created automatically by Jules for task [1652549002261447721](https://jules.google.com/task/1652549002261447721) started by @karolak6612*