### PR TITLE
Sentinel: Optimized LiveCursor loop and fixed compiler warnings

### DIFF
--- a/source/game/complexitem.h
+++ b/source/game/complexitem.h
@@ -180,7 +180,7 @@ public:
 		outfit = newOutfit;
 	}
 
-	const uint8_t getDirection() {
+	uint8_t getDirection() {
 		return direction;
 	}
 	void setDirection(uint8_t newDirection) {

--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -82,6 +82,10 @@ std::vector<LiveCursor> LiveSocket::getCursorList() const {
 	return cursorList;
 }
 
+const std::unordered_map<uint32_t, LiveCursor>& LiveSocket::getCursors() const {
+	return cursors;
+}
+
 void LiveSocket::logMessage(const wxString& message) {
 	wxTheApp->CallAfter([this, message]() {
 		if (log) {

--- a/source/live/live_socket.h
+++ b/source/live/live_socket.h
@@ -55,6 +55,7 @@ public:
 
 	std::string getHostName() const;
 	std::vector<LiveCursor> getCursorList() const;
+	const std::unordered_map<uint32_t, LiveCursor>& getCursors() const;
 
 	//
 	void logMessage(const wxString& message);

--- a/source/palette/palette_window.cpp
+++ b/source/palette/palette_window.cpp
@@ -259,6 +259,7 @@ bool PaletteWindow::OnSelectBrush(const Brush* whatbrush, PaletteType primary) {
 				SelectPage(TILESET_COLLECTION);
 				return true;
 			}
+			break;
 		}
 		case TILESET_ITEM: {
 			if (item_palette && item_palette->SelectBrush(whatbrush)) {

--- a/source/rendering/drawers/cursors/live_cursor_drawer.cpp
+++ b/source/rendering/drawers/cursors/live_cursor_drawer.cpp
@@ -16,7 +16,9 @@ void LiveCursorDrawer::draw(SpriteBatch& sprite_batch, const RenderView& view, E
 	}
 
 	LiveSocket& live = editor.live_manager.GetSocket();
-	for (LiveCursor& cursor : live.getCursorList()) {
+	for (const auto& pair : live.getCursors()) {
+		LiveCursor cursor = pair.second;
+
 		if (cursor.pos.z <= GROUND_LAYER && view.floor > GROUND_LAYER) {
 			continue;
 		}


### PR DESCRIPTION
This PR implements optimizations and cleanups identified during the Sentinel analysis.

1.  **Performance Optimization**: `LiveCursorDrawer` previously called `LiveSocket::getCursorList()` every frame, which returned a `std::vector` by value (copying all cursors). This has been refactored to expose the underlying `std::unordered_map` via a const reference getter `getCursors()`, avoiding memory allocation in the render loop.
2.  **Code Cleanup**: Fixed a compiler warning in `source/game/complexitem.h` where `const uint8_t` return type was redundant.
3.  **Bug Fix**: Added a missing `break` statement in `source/palette/palette_window.cpp` to prevent unintentional fallthrough from `TILESET_COLLECTION` to `TILESET_ITEM`.

The codebase was found to be already modernized regarding OpenGL usage (no legacy immediate mode calls found), so no further OpenGL refactoring was necessary.


---
*PR created automatically by Jules for task [2343753618028967891](https://jules.google.com/task/2343753618028967891) started by @karolak6612*