### PR TITLE
⚡ Bolt: Optimize MapLayerDrawer::Draw loop

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -23,6 +23,7 @@
 #include "editor/editor.h"
 #include "live/live_client.h"
 #include "map/map.h"
+#include "map/map_region.h"
 #include "rendering/core/render_view.h"
 #include "rendering/core/drawing_options.h"
 #include "rendering/core/light_buffer.h"
@@ -67,26 +68,29 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 				}
 
 				if (nd->isVisible(map_z > GROUND_LAYER)) {
-					int node_draw_x = nd_map_x * TileSize + base_screen_x;
-					int node_draw_y = nd_map_y * TileSize + base_screen_y;
+					Floor* floor = nd->getFloor(map_z);
+					if (floor) {
+						int node_draw_x = nd_map_x * TileSize + base_screen_x;
+						int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-					for (int map_x = 0; map_x < 4; ++map_x) {
-						for (int map_y = 0; map_y < 4; ++map_y) {
-							// Calculate draw coordinates directly
-							int draw_x = node_draw_x + (map_x * TileSize);
-							int draw_y = node_draw_y + (map_y * TileSize);
+						for (int map_x = 0; map_x < 4; ++map_x) {
+							for (int map_y = 0; map_y < 4; ++map_y) {
+								// Calculate draw coordinates directly
+								int draw_x = node_draw_x + (map_x * TileSize);
+								int draw_y = node_draw_y + (map_y * TileSize);
 
-							// Culling: Skip tiles that are far outside the viewport.
-							if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
-								continue;
-							}
+								// Culling: Skip tiles that are far outside the viewport.
+								if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+									continue;
+								}
 
-							TileLocation* location = nd->getTile(map_x, map_y, map_z);
+								TileLocation* location = &floor->locs[(map_x * 4) + map_y];
 
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
-							// draw light, but only if not zoomed too far
-							if (location && options.isDrawLight() && view.zoom <= 10.0) {
-								tile_renderer->AddLight(location, view, options, light_buffer);
+								tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
+								// draw light, but only if not zoomed too far
+								if (location && options.isDrawLight() && view.zoom <= 10.0) {
+									tile_renderer->AddLight(location, view, options, light_buffer);
+								}
 							}
 						}
 					}
@@ -104,6 +108,11 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 		}
 	} else {
 		editor->map.visitLeaves(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
+			Floor* floor = nd->getFloor(map_z);
+			if (!floor) {
+				return;
+			}
+
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
@@ -118,7 +127,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 						continue;
 					}
 
-					TileLocation* location = nd->getTile(map_x, map_y, map_z);
+					TileLocation* location = &floor->locs[(map_x * 4) + map_y];
 
 					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
 					// draw light, but only if not zoomed too far


### PR DESCRIPTION
Optimized `MapLayerDrawer::Draw` by hoisting `MapNode::getFloor` and using direct access to `TileLocation` array.
Added include for `map/map_region.h` to access `Floor` internals.
Verified by compilation.


---
*PR created automatically by Jules for task [18417272061774057859](https://jules.google.com/task/18417272061774057859) started by @karolak6612*