### PR TITLE
🗝️ Keeper: Modernize memory management in NetworkConnection, LiveSocket, and LiveAction

### DIFF
--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -294,15 +294,14 @@ Tile* LiveSocket::readTile(BinaryNode* node, Editor& editor, const Position* pos
 		pos.z = z;
 	}
 
-	Tile* tile = map.allocator(
+	std::unique_ptr<Tile> tile(map.allocator(
 		map.createTileL(pos)
-	);
+	));
 
 	if (tileType == OTBM_HOUSETILE) {
 		uint32_t houseId;
 		if (!node->getU32(houseId)) {
 			// warning("House tile without house data, discarding tile");
-			delete tile;
 			return nullptr;
 		}
 
@@ -348,7 +347,6 @@ Tile* LiveSocket::readTile(BinaryNode* node, Editor& editor, const Position* pos
 			uint8_t itemType;
 			if (!itemNode->getByte(itemType)) {
 				// warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
-				delete tile;
 				return nullptr;
 			}
 
@@ -367,7 +365,7 @@ Tile* LiveSocket::readTile(BinaryNode* node, Editor& editor, const Position* pos
 		} while (itemNode->advance());
 	}
 
-	return tile;
+	return tile.release();
 }
 
 LiveCursor LiveSocket::readCursor(NetworkMessage& message) {

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -95,7 +95,7 @@ bool NetworkConnection::start() {
 
 	stopped = false;
 	if (!service) {
-		service = new boost::asio::io_context;
+		service = std::make_unique<boost::asio::io_context>();
 	}
 
 	thread = std::thread([this]() -> void {
@@ -121,8 +121,7 @@ void NetworkConnection::stop() {
 	stopped = true;
 	thread.join();
 
-	delete service;
-	service = nullptr;
+	service.reset();
 }
 
 boost::asio::io_context& NetworkConnection::get_service() {

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <memory>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -78,7 +79,7 @@ public:
 	boost::asio::io_context& get_service();
 
 private:
-	boost::asio::io_context* service;
+	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
 	bool stopped;
 };


### PR DESCRIPTION
This PR modernizes memory management in `NetworkConnection` and `LiveSocket` by replacing raw pointers with `std::unique_ptr`. This improves exception safety and prevents potential memory leaks.

Changes:
- `source/net/net_connection.h`: Include `<memory>`, change `service` to `std::unique_ptr`.
- `source/net/net_connection.cpp`: Update `start` and `stop` to use smart pointer semantics.
- `source/live/live_socket.cpp`: Use `std::unique_ptr<Tile>` in `readTile` to automatically clean up allocated tiles on error paths, releasing ownership only on success.

Note: `LiveAction` changes were considered but reverted due to protected constructor access limitations preventing `std::make_unique`.


---
*PR created automatically by Jules for task [3951381369286863004](https://jules.google.com/task/3951381369286863004) started by @karolak6612*