### PR TITLE
📊 Profiler: Fix CPU bottleneck in MapLayerDrawer::Draw

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -23,6 +23,7 @@
 #include "editor/editor.h"
 #include "live/live_client.h"
 #include "map/map.h"
+#include "map/map_region.h"
 #include "rendering/core/render_view.h"
 #include "rendering/core/drawing_options.h"
 #include "rendering/core/light_buffer.h"
@@ -70,23 +71,26 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					int node_draw_x = nd_map_x * TileSize + base_screen_x;
 					int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-					for (int map_x = 0; map_x < 4; ++map_x) {
-						for (int map_y = 0; map_y < 4; ++map_y) {
-							// Calculate draw coordinates directly
-							int draw_x = node_draw_x + (map_x * TileSize);
-							int draw_y = node_draw_y + (map_y * TileSize);
+					Floor* floor = nd->getFloor(map_z);
+					if (floor) {
+						for (int map_x = 0; map_x < 4; ++map_x) {
+							for (int map_y = 0; map_y < 4; ++map_y) {
+								// Calculate draw coordinates directly
+								int draw_x = node_draw_x + (map_x * TileSize);
+								int draw_y = node_draw_y + (map_y * TileSize);
 
-							// Culling: Skip tiles that are far outside the viewport.
-							if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
-								continue;
-							}
+								// Culling: Skip tiles that are far outside the viewport.
+								if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+									continue;
+								}
 
-							TileLocation* location = nd->getTile(map_x, map_y, map_z);
+								TileLocation* location = &floor->locs[map_x * 4 + map_y];
 
-							tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
-							// draw light, but only if not zoomed too far
-							if (location && options.isDrawLight() && view.zoom <= 10.0) {
-								tile_renderer->AddLight(location, view, options, light_buffer);
+								tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
+								// draw light, but only if not zoomed too far
+								if (location && options.isDrawLight() && view.zoom <= 10.0) {
+									tile_renderer->AddLight(location, view, options, light_buffer);
+								}
 							}
 						}
 					}
@@ -107,23 +111,26 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
-			for (int map_x = 0; map_x < 4; ++map_x) {
-				for (int map_y = 0; map_y < 4; ++map_y) {
-					// Calculate draw coordinates directly
-					int draw_x = node_draw_x + (map_x * TileSize);
-					int draw_y = node_draw_y + (map_y * TileSize);
+			Floor* floor = nd->getFloor(map_z);
+			if (floor) {
+				for (int map_x = 0; map_x < 4; ++map_x) {
+					for (int map_y = 0; map_y < 4; ++map_y) {
+						// Calculate draw coordinates directly
+						int draw_x = node_draw_x + (map_x * TileSize);
+						int draw_y = node_draw_y + (map_y * TileSize);
 
-					// Culling: Skip tiles that are far outside the viewport.
-					if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
-						continue;
-					}
+						// Culling: Skip tiles that are far outside the viewport.
+						if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+							continue;
+						}
 
-					TileLocation* location = nd->getTile(map_x, map_y, map_z);
+						TileLocation* location = &floor->locs[map_x * 4 + map_y];
 
-					tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
-					// draw light, but only if not zoomed too far
-					if (location && options.isDrawLight() && view.zoom <= 10.0) {
-						tile_renderer->AddLight(location, view, options, light_buffer);
+						tile_renderer->DrawTile(sprite_batch, primitive_renderer, location, view, options, options.current_house_id, draw_x, draw_y);
+						// draw light, but only if not zoomed too far
+						if (location && options.isDrawLight() && view.zoom <= 10.0) {
+							tile_renderer->AddLight(location, view, options, light_buffer);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
This PR optimizes `MapLayerDrawer::Draw` by hoisting the `Floor` lookup out of the inner 4x4 tile loop.

**Changes:**
- Included `map/map_region.h` in `source/rendering/drawers/map_layer_drawer.cpp` to access `MapNode` and `Floor` definitions.
- In `MapLayerDrawer::Draw`:
    - Retrieved `Floor* floor = nd->getFloor(map_z)` once per node.
    - Added a check `if (floor)` to skip the entire 4x4 loop if the floor doesn't exist (sparse map optimization).
    - Replaced `nd->getTile(map_x, map_y, map_z)` with direct array access `&floor->locs[...]` inside the loop, removing redundant function calls and checks.
- Applied this optimization to both the `live_client` loop and the local map `visitLeaves` lambda.

**Verification:**
- Verified that the logic preserves the Painter's Algorithm order (iteration order is unchanged).
- Confirmed that skipping null floors is behaviorally equivalent to the previous code (which would return null for each tile).
- Verified compilation with `ninja`.

---
*PR created automatically by Jules for task [7967478480352540042](https://jules.google.com/task/7967478480352540042) started by @karolak6612*