### PR TITLE
[REFACTOR] Fix Long Methods in IOMapOTBM

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -605,121 +605,149 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 #ifdef OTGZ_SUPPORT
 	if (filename.GetExt() == "otgz") {
-		// Open the archive
-		std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
-		archive_read_support_filter_all(a.get());
-		archive_read_support_format_all(a.get());
-		if (archive_read_open_filename(a.get(), nstr(filename.GetFullPath()).c_str(), 10240) != ARCHIVE_OK) {
-			return false;
-		}
-
-		// Memory buffers for the houses & spawns
-		std::vector<uint8_t> house_buffer;
-		std::vector<uint8_t> spawn_buffer;
-
-		// See if the otbm file has been loaded
-		bool otbm_loaded = false;
-
-		// Loop over the archive entries until we find the otbm file
-		g_gui.SetLoadDone(0, "Decompressing archive...");
-		struct archive_entry* entry;
-		while (archive_read_next_header(a.get(), &entry) == ARCHIVE_OK) {
-			std::string entryName = archive_entry_pathname(entry);
-
-			if (entryName == "world/map.otbm") {
-				// Read the entire OTBM file into a memory region
-				size_t otbm_size = archive_entry_size(entry);
-				std::vector<uint8_t> otbm_buffer(otbm_size);
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), otbm_buffer.data(), otbm_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < 4) {
-					return false;
-				}
-
-				if (read_bytes < otbm_size) {
-					error("Could not read file.");
-					return false;
-				}
-
-				g_gui.SetLoadDone(0, "Loading OTBM map...");
-
-				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(
-					new MemoryNodeFileReadHandle(otbm_buffer.data() + 4, otbm_size - 4)
-				);
-
-				// Read the version info
-				if (!loadMap(map, *f.get())) {
-					error("Could not load OTBM file inside archive");
-					return false;
-				}
-
-				otbm_loaded = true;
-			} else if (entryName == "world/houses.xml") {
-				size_t house_buffer_size = archive_entry_size(entry);
-				house_buffer.resize(house_buffer_size);
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), house_buffer.data(), house_buffer_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < house_buffer_size) {
-					house_buffer.clear();
-					warning("Failed to decompress houses.");
-				}
-			} else if (entryName == "world/spawns.xml") {
-				size_t spawn_buffer_size = archive_entry_size(entry);
-				spawn_buffer.resize(spawn_buffer_size);
-
-				// Read from the archive
-				size_t read_bytes = archive_read_data(a.get(), spawn_buffer.data(), spawn_buffer_size);
-
-				// Check so it at least contains the 4-byte file id
-				if (read_bytes < spawn_buffer_size) {
-					spawn_buffer.clear();
-					warning("Failed to decompress spawns.");
-				}
-			}
-		}
-
-		if (!otbm_loaded) {
-			error("OTBM file not found inside archive.");
-			return false;
-		}
-
-		// Load the houses from the stored buffer
-		if (!house_buffer.empty()) {
-			pugi::xml_document doc;
-			pugi::xml_parse_result result = doc.load_buffer(house_buffer.data(), house_buffer.size());
-			if (result) {
-				if (!loadHouses(map, doc)) {
-					warning("Failed to load houses.");
-				}
-			} else {
-				warning("Failed to load houses due to XML parse error.");
-			}
-		}
-
-		// Load the spawns from the stored buffer
-		if (!spawn_buffer.empty()) {
-			pugi::xml_document doc;
-			pugi::xml_parse_result result = doc.load_buffer(spawn_buffer.data(), spawn_buffer.size());
-			if (result) {
-				if (!loadSpawns(map, doc)) {
-					warning("Failed to load spawns.");
-				}
-			} else {
-				warning("Failed to load spawns due to XML parse error.");
-			}
-		}
-
-		return true;
+		return loadMapFromArchive(map, filename);
 	}
 #endif
 
+	if (!loadMapFromDisk(map, filename)) {
+		return false;
+	}
+
+	// Read auxilliary files
+	if (!loadHouses(map, filename)) {
+		warning("Failed to load houses.");
+		map.housefile = nstr(filename.GetName()) + "-house.xml";
+	}
+	if (!loadSpawns(map, filename)) {
+		warning("Failed to load spawns.");
+		map.spawnfile = nstr(filename.GetName()) + "-spawn.xml";
+	}
+	if (!loadWaypoints(map, filename)) {
+		// just assume the map did not have this file before
+		// warning("Failed to load waypoints.");
+		map.waypointfile = nstr(filename.GetName()) + "-waypoint.xml";
+	}
+	return true;
+}
+
+bool IOMapOTBM::loadMapFromArchive(Map& map, const FileName& filename) {
+#ifdef OTGZ_SUPPORT
+	// Open the archive
+	std::shared_ptr<struct archive> a(archive_read_new(), archive_read_free);
+	archive_read_support_filter_all(a.get());
+	archive_read_support_format_all(a.get());
+	if (archive_read_open_filename(a.get(), nstr(filename.GetFullPath()).c_str(), 10240) != ARCHIVE_OK) {
+		return false;
+	}
+
+	// Memory buffers for the houses & spawns
+	std::vector<uint8_t> house_buffer;
+	std::vector<uint8_t> spawn_buffer;
+
+	// See if the otbm file has been loaded
+	bool otbm_loaded = false;
+
+	// Loop over the archive entries until we find the otbm file
+	g_gui.SetLoadDone(0, "Decompressing archive...");
+	struct archive_entry* entry;
+	while (archive_read_next_header(a.get(), &entry) == ARCHIVE_OK) {
+		std::string entryName = archive_entry_pathname(entry);
+
+		if (entryName == "world/map.otbm") {
+			// Read the entire OTBM file into a memory region
+			size_t otbm_size = archive_entry_size(entry);
+			std::vector<uint8_t> otbm_buffer(otbm_size);
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), otbm_buffer.data(), otbm_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < 4) {
+				return false;
+			}
+
+			if (read_bytes < otbm_size) {
+				error("Could not read file.");
+				return false;
+			}
+
+			g_gui.SetLoadDone(0, "Loading OTBM map...");
+
+			// Create a read handle on it
+			std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(otbm_buffer.data() + 4, otbm_size - 4));
+
+			// Read the version info
+			if (!loadMap(map, *f.get())) {
+				error("Could not load OTBM file inside archive");
+				return false;
+			}
+
+			otbm_loaded = true;
+		} else if (entryName == "world/houses.xml") {
+			size_t house_buffer_size = archive_entry_size(entry);
+			house_buffer.resize(house_buffer_size);
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), house_buffer.data(), house_buffer_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < house_buffer_size) {
+				house_buffer.clear();
+				warning("Failed to decompress houses.");
+			}
+		} else if (entryName == "world/spawns.xml") {
+			size_t spawn_buffer_size = archive_entry_size(entry);
+			spawn_buffer.resize(spawn_buffer_size);
+
+			// Read from the archive
+			size_t read_bytes = archive_read_data(a.get(), spawn_buffer.data(), spawn_buffer_size);
+
+			// Check so it at least contains the 4-byte file id
+			if (read_bytes < spawn_buffer_size) {
+				spawn_buffer.clear();
+				warning("Failed to decompress spawns.");
+			}
+		}
+	}
+
+	if (!otbm_loaded) {
+		error("OTBM file not found inside archive.");
+		return false;
+	}
+
+	// Load the houses from the stored buffer
+	if (!house_buffer.empty()) {
+		pugi::xml_document doc;
+		pugi::xml_parse_result result = doc.load_buffer(house_buffer.data(), house_buffer.size());
+		if (result) {
+			if (!loadHouses(map, doc)) {
+				warning("Failed to load houses.");
+			}
+		} else {
+			warning("Failed to load houses due to XML parse error.");
+		}
+	}
+
+	// Load the spawns from the stored buffer
+	if (!spawn_buffer.empty()) {
+		pugi::xml_document doc;
+		pugi::xml_parse_result result = doc.load_buffer(spawn_buffer.data(), spawn_buffer.size());
+		if (result) {
+			if (!loadSpawns(map, doc)) {
+				warning("Failed to load spawns.");
+			}
+		} else {
+			warning("Failed to load spawns due to XML parse error.");
+		}
+	}
+
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool IOMapOTBM::loadMapFromDisk(Map& map, const FileName& filename) {
 	std::ifstream file(nstr(filename.GetFullPath()), std::ios::binary | std::ios::ate);
 	if (!file.is_open()) {
 		std::string err = std::format("Couldn't open file for reading: {}", filename.GetFullPath().ToStdString());
@@ -766,21 +794,6 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 		if (!loadMap(map, f)) {
 			return false;
 		}
-	}
-
-	// Read auxilliary files
-	if (!loadHouses(map, filename)) {
-		warning("Failed to load houses.");
-		map.housefile = nstr(filename.GetName()) + "-house.xml";
-	}
-	if (!loadSpawns(map, filename)) {
-		warning("Failed to load spawns.");
-		map.spawnfile = nstr(filename.GetName()) + "-spawn.xml";
-	}
-	if (!loadWaypoints(map, filename)) {
-		// just assume the map did not have this file before
-		// warning("Failed to load waypoints.");
-		map.waypointfile = nstr(filename.GetName()) + "-waypoint.xml";
 	}
 	return true;
 }
@@ -850,6 +863,39 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 		return false;
 	}
 
+	if (!loadMapHeader(mapHeaderNode, map)) {
+		return false;
+	}
+
+	int nodes_loaded = 0;
+
+	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
+		++nodes_loaded;
+		if (nodes_loaded % 2048 == 0) {
+			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+		}
+
+		uint8_t node_type;
+		if (!mapNode->getByte(node_type)) {
+			warning("Invalid map node");
+			continue;
+		}
+		if (node_type == OTBM_TILE_AREA) {
+			loadTileArea(mapNode, map);
+		} else if (node_type == OTBM_TOWNS) {
+			loadTowns(mapNode, map);
+		} else if (node_type == OTBM_WAYPOINTS) {
+			loadWaypoints(mapNode, map);
+		}
+	}
+
+	if (!f.isOk()) {
+		warning(wxstr(f.getErrorMessage()).wc_str());
+	}
+	return true;
+}
+
+bool IOMapOTBM::loadMapHeader(BinaryNode* mapHeaderNode, Map& map) {
 	uint8_t attribute;
 	while (mapHeaderNode->getU8(attribute)) {
 		switch (attribute) {
@@ -885,211 +931,200 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 			}
 		}
 	}
+	return true;
+}
 
-	int nodes_loaded = 0;
+bool IOMapOTBM::loadTileArea(BinaryNode* mapNode, Map& map) {
+	uint16_t base_x, base_y;
+	uint8_t base_z;
+	if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
+		warning("Invalid map node, no base coordinate");
+		return false;
+	}
 
-	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
-		++nodes_loaded;
-		if (nodes_loaded % 2048 == 0) {
-			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
-		}
-
-		uint8_t node_type;
-		if (!mapNode->getByte(node_type)) {
-			warning("Invalid map node");
+	for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
+		Tile* tile = nullptr;
+		uint8_t tile_type;
+		if (!tileNode->getByte(tile_type)) {
+			warning("Invalid tile type");
 			continue;
 		}
-		if (node_type == OTBM_TILE_AREA) {
-			uint16_t base_x, base_y;
-			uint8_t base_z;
-			if (!mapNode->getU16(base_x) || !mapNode->getU16(base_y) || !mapNode->getU8(base_z)) {
-				warning("Invalid map node, no base coordinate");
+		if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
+			uint8_t x_offset, y_offset;
+			if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
+				warning("Could not read position of tile");
+				continue;
+			}
+			const Position pos(base_x + x_offset, base_y + y_offset, base_z);
+
+			if (map.getTile(pos)) {
+				warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
 				continue;
 			}
 
-			for (BinaryNode* tileNode = mapNode->getChild(); tileNode != nullptr; tileNode = tileNode->advance()) {
-				Tile* tile = nullptr;
-				uint8_t tile_type;
-				if (!tileNode->getByte(tile_type)) {
-					warning("Invalid tile type");
+			tile = map.allocator(map.createTileL(pos));
+			House* house = nullptr;
+			if (tile_type == OTBM_HOUSETILE) {
+				uint32_t house_id;
+				if (!tileNode->getU32(house_id)) {
+					warning("House tile without house data, discarding tile");
 					continue;
 				}
-				if (tile_type == OTBM_TILE || tile_type == OTBM_HOUSETILE) {
-					uint8_t x_offset, y_offset;
-					if (!tileNode->getU8(x_offset) || !tileNode->getU8(y_offset)) {
-						warning("Could not read position of tile");
-						continue;
+				if (house_id) {
+					house = map.houses.getHouse(house_id);
+					if (!house) {
+						auto new_house = std::make_unique<House>(map);
+						house = new_house.get();
+						new_house->setID(house_id);
+						map.houses.addHouse(std::move(new_house));
 					}
-					const Position pos(base_x + x_offset, base_y + y_offset, base_z);
-
-					if (map.getTile(pos)) {
-						warning("Duplicate tile at %d:%d:%d, discarding duplicate", pos.x, pos.y, pos.z);
-						continue;
-					}
-
-					tile = map.allocator(map.createTileL(pos));
-					House* house = nullptr;
-					if (tile_type == OTBM_HOUSETILE) {
-						uint32_t house_id;
-						if (!tileNode->getU32(house_id)) {
-							warning("House tile without house data, discarding tile");
-							continue;
-						}
-						if (house_id) {
-							house = map.houses.getHouse(house_id);
-							if (!house) {
-								auto new_house = std::make_unique<House>(map);
-								house = new_house.get();
-								new_house->setID(house_id);
-								map.houses.addHouse(std::move(new_house));
-							}
-						} else {
-							warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
-						}
-					}
-
-					uint8_t attribute;
-					while (tileNode->getU8(attribute)) {
-						switch (attribute) {
-							case OTBM_ATTR_TILE_FLAGS: {
-								uint32_t flags = 0;
-								if (!tileNode->getU32(flags)) {
-									warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->setMapFlags(flags);
-								break;
-							}
-							case OTBM_ATTR_ITEM: {
-								Item* item = Item::Create_OTBM(*this, tileNode);
-								if (item == nullptr) {
-									warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								tile->addItem(item);
-								break;
-							}
-							default: {
-								warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
-								break;
-							}
-						}
-					}
-
-					for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
-						Item* item = nullptr;
-						uint8_t item_type;
-						if (!itemNode->getByte(item_type)) {
-							warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
-							continue;
-						}
-						if (item_type == OTBM_ITEM) {
-							item = Item::Create_OTBM(*this, itemNode);
-							if (item) {
-								if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
-									warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
-								}
-								// reform(&map, tile, item);
-								tile->addItem(item);
-							}
-						} else {
-							warning("Unknown type of tile child node");
-						}
-					}
-
-					tile->update();
-					if (house) {
-						house->addTile(tile);
-					}
-
-					map.setTile(pos.x, pos.y, pos.z, tile);
 				} else {
-					warning("Unknown type of tile node");
+					warning("Invalid house id from tile %d:%d:%d", pos.x, pos.y, pos.z);
 				}
 			}
-		} else if (node_type == OTBM_TOWNS) {
-			for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
-				Town* town = nullptr;
-				uint8_t town_type;
-				if (!townNode->getByte(town_type)) {
-					warning("Invalid town type (1)");
-					continue;
-				}
-				if (town_type != OTBM_TOWN) {
-					warning("Invalid town type (2)");
-					continue;
-				}
-				uint32_t town_id;
-				if (!townNode->getU32(town_id)) {
-					warning("Invalid town id");
-					continue;
-				}
 
-				town = map.towns.getTown(town_id);
-				if (town) {
-					warning("Duplicate town id %d, discarding duplicate", town_id);
-					continue;
-				} else {
-					auto new_town = std::make_unique<Town>(town_id);
-					town = new_town.get();
-					if (!map.towns.addTown(std::move(new_town))) {
-						continue;
+			uint8_t attribute;
+			while (tileNode->getU8(attribute)) {
+				switch (attribute) {
+					case OTBM_ATTR_TILE_FLAGS: {
+						uint32_t flags = 0;
+						if (!tileNode->getU32(flags)) {
+							warning("Invalid tile flags of tile on %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->setMapFlags(flags);
+						break;
+					}
+					case OTBM_ATTR_ITEM: {
+						Item* item = Item::Create_OTBM(*this, tileNode);
+						if (item == nullptr) {
+							warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						tile->addItem(item);
+						break;
+					}
+					default: {
+						warning("Unknown tile attribute at %d:%d:%d", pos.x, pos.y, pos.z);
+						break;
 					}
 				}
-				std::string town_name;
-				if (!townNode->getString(town_name)) {
-					warning("Invalid town name");
-					continue;
-				}
-				town->setName(town_name);
-				Position pos;
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
-					warning("Invalid town temple position");
-					continue;
-				}
-				pos.x = x;
-				pos.y = y;
-				pos.z = z;
-				town->setTemplePosition(pos);
-				map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
 			}
-		} else if (node_type == OTBM_WAYPOINTS) {
-			for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
-				uint8_t waypoint_type;
-				if (!waypointNode->getByte(waypoint_type)) {
-					warning("Invalid waypoint type (1)");
-					continue;
-				}
-				if (waypoint_type != OTBM_WAYPOINT) {
-					warning("Invalid waypoint type (2)");
-					continue;
-				}
 
-				Waypoint wp;
-
-				if (!waypointNode->getString(wp.name)) {
-					warning("Invalid waypoint name");
+			for (BinaryNode* itemNode = tileNode->getChild(); itemNode != nullptr; itemNode = itemNode->advance()) {
+				Item* item = nullptr;
+				uint8_t item_type;
+				if (!itemNode->getByte(item_type)) {
+					warning("Unknown item type %d:%d:%d", pos.x, pos.y, pos.z);
 					continue;
 				}
-				uint16_t x;
-				uint16_t y;
-				uint8_t z;
-				if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
-					warning("Invalid waypoint position");
-					continue;
+				if (item_type == OTBM_ITEM) {
+					item = Item::Create_OTBM(*this, itemNode);
+					if (item) {
+						if (!item->unserializeItemNode_OTBM(*this, itemNode)) {
+							warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
+						}
+						// reform(&map, tile, item);
+						tile->addItem(item);
+					}
+				} else {
+					warning("Unknown type of tile child node");
 				}
-				wp.pos.x = x;
-				wp.pos.y = y;
-				wp.pos.z = z;
-
-				map.waypoints.addWaypoint(newd Waypoint(wp));
 			}
+
+			tile->update();
+			if (house) {
+				house->addTile(tile);
+			}
+
+			map.setTile(pos.x, pos.y, pos.z, tile);
+		} else {
+			warning("Unknown type of tile node");
 		}
 	}
+	return true;
+}
 
-	if (!f.isOk()) {
-		warning(wxstr(f.getErrorMessage()).wc_str());
+bool IOMapOTBM::loadTowns(BinaryNode* mapNode, Map& map) {
+	for (BinaryNode* townNode = mapNode->getChild(); townNode != nullptr; townNode = townNode->advance()) {
+		Town* town = nullptr;
+		uint8_t town_type;
+		if (!townNode->getByte(town_type)) {
+			warning("Invalid town type (1)");
+			continue;
+		}
+		if (town_type != OTBM_TOWN) {
+			warning("Invalid town type (2)");
+			continue;
+		}
+		uint32_t town_id;
+		if (!townNode->getU32(town_id)) {
+			warning("Invalid town id");
+			continue;
+		}
+
+		town = map.towns.getTown(town_id);
+		if (town) {
+			warning("Duplicate town id %d, discarding duplicate", town_id);
+			continue;
+		} else {
+			auto new_town = std::make_unique<Town>(town_id);
+			town = new_town.get();
+			if (!map.towns.addTown(std::move(new_town))) {
+				continue;
+			}
+		}
+		std::string town_name;
+		if (!townNode->getString(town_name)) {
+			warning("Invalid town name");
+			continue;
+		}
+		town->setName(town_name);
+		Position pos;
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!townNode->getU16(x) || !townNode->getU16(y) || !townNode->getU8(z)) {
+			warning("Invalid town temple position");
+			continue;
+		}
+		pos.x = x;
+		pos.y = y;
+		pos.z = z;
+		town->setTemplePosition(pos);
+		map.getOrCreateTile(pos)->getLocation()->increaseTownCount();
+	}
+	return true;
+}
+
+bool IOMapOTBM::loadWaypoints(BinaryNode* mapNode, Map& map) {
+	for (BinaryNode* waypointNode = mapNode->getChild(); waypointNode != nullptr; waypointNode = waypointNode->advance()) {
+		uint8_t waypoint_type;
+		if (!waypointNode->getByte(waypoint_type)) {
+			warning("Invalid waypoint type (1)");
+			continue;
+		}
+		if (waypoint_type != OTBM_WAYPOINT) {
+			warning("Invalid waypoint type (2)");
+			continue;
+		}
+
+		Waypoint wp;
+
+		if (!waypointNode->getString(wp.name)) {
+			warning("Invalid waypoint name");
+			continue;
+		}
+		uint16_t x;
+		uint16_t y;
+		uint8_t z;
+		if (!waypointNode->getU16(x) || !waypointNode->getU16(y) || !waypointNode->getU8(z)) {
+			warning("Invalid waypoint position");
+			continue;
+		}
+		wp.pos.x = x;
+		wp.pos.y = y;
+		wp.pos.z = z;
+
+		map.waypoints.addWaypoint(newd Waypoint(wp));
 	}
 	return true;
 }
@@ -1346,124 +1381,132 @@ bool IOMapOTBM::loadWaypoints(Map& map, pugi::xml_document& doc) {
 bool IOMapOTBM::saveMap(Map& map, const FileName& identifier) {
 #ifdef OTGZ_SUPPORT
 	if (identifier.GetExt() == "otgz") {
-		// Create the archive
-		struct archive* a = archive_write_new();
-		struct archive_entry* entry = nullptr;
-		std::ostringstream streamData;
-
-		archive_write_set_compression_gzip(a);
-		archive_write_set_format_pax_restricted(a);
-		archive_write_open_filename(a, nstr(identifier.GetFullPath()).c_str());
-
-		g_gui.SetLoadDone(0, "Saving spawns...");
-
-		pugi::xml_document spawnDoc;
-		if (saveSpawns(map, spawnDoc)) {
-			// Write the data
-			spawnDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
-			std::string xmlData = streamData.str();
-
-			// Write to the arhive
-			entry = archive_entry_new();
-			archive_entry_set_pathname(entry, "world/spawns.xml");
-			archive_entry_set_size(entry, xmlData.size());
-			archive_entry_set_filetype(entry, AE_IFREG);
-			archive_entry_set_perm(entry, 0644);
-
-			// Write to the archive
-			archive_write_header(a, entry);
-			archive_write_data(a, xmlData.data(), xmlData.size());
-
-			// Free the entry
-			archive_entry_free(entry);
-			streamData.str("");
-		}
-
-		g_gui.SetLoadDone(0, "Saving houses...");
-
-		pugi::xml_document houseDoc;
-		if (saveHouses(map, houseDoc)) {
-			// Write the data
-			houseDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
-			std::string xmlData = streamData.str();
-
-			// Write to the arhive
-			entry = archive_entry_new();
-			archive_entry_set_pathname(entry, "world/houses.xml");
-			archive_entry_set_size(entry, xmlData.size());
-			archive_entry_set_filetype(entry, AE_IFREG);
-			archive_entry_set_perm(entry, 0644);
-
-			// Write to the archive
-			archive_write_header(a, entry);
-			archive_write_data(a, xmlData.data(), xmlData.size());
-
-			// Free the entry
-			archive_entry_free(entry);
-			streamData.str("");
-		}
-		// to do
-		/*
-		g_gui.SetLoadDone(0, "Saving waypoints...");
-
-		pugi::xml_document wpDoc;
-		if (saveWaypoints(map, wpDoc)) {
-			// Write the data
-			wpDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
-			std::string xmlData = streamData.str();
-
-			// Write to the arhive
-			entry = archive_entry_new();
-			archive_entry_set_pathname(entry, "world/waypoints.xml");
-			archive_entry_set_size(entry, xmlData.size());
-			archive_entry_set_filetype(entry, AE_IFREG);
-			archive_entry_set_perm(entry, 0644);
-
-			// Write to the archive
-			archive_write_header(a, entry);
-			archive_write_data(a, xmlData.data(), xmlData.size());
-
-			// Free the entry
-			archive_entry_free(entry);
-			streamData.str("");
-		}
-		*/
-		g_gui.SetLoadDone(0, "Saving OTBM map...");
-
-		MemoryNodeFileWriteHandle otbmWriter;
-		saveMap(map, otbmWriter);
-
-		g_gui.SetLoadDone(75, "Compressing...");
-
-		// Create an archive entry for the otbm file
-		entry = archive_entry_new();
-		archive_entry_set_pathname(entry, "world/map.otbm");
-		archive_entry_set_size(entry, otbmWriter.getSize() + 4); // 4 bytes extra for header
-		archive_entry_set_filetype(entry, AE_IFREG);
-		archive_entry_set_perm(entry, 0644);
-		archive_write_header(a, entry);
-
-		// Write the version header
-		char otbm_identifier[] = "OTBM";
-		archive_write_data(a, otbm_identifier, 4);
-
-		// Write the OTBM data
-		archive_write_data(a, otbmWriter.getMemory(), otbmWriter.getSize());
-		archive_entry_free(entry);
-
-		// Free / close the archive
-		archive_write_close(a);
-		archive_write_free(a);
-
-		g_gui.DestroyLoadBar();
-		return true;
+		return saveMapToArchive(map, identifier);
 	}
 #endif
+	return saveMapToDisk(map, identifier);
+}
 
-	DiskNodeFileWriteHandle f(
-		nstr(identifier.GetFullPath()),
-		(g_settings.getInteger(Config::SAVE_WITH_OTB_MAGIC_NUMBER) ? "OTBM" : std::string(4, '\0'))
-	);
+bool IOMapOTBM::saveMapToArchive(Map& map, const FileName& identifier) {
+#ifdef OTGZ_SUPPORT
+	// Create the archive
+	struct archive* a = archive_write_new();
+	struct archive_entry* entry = nullptr;
+	std::ostringstream streamData;
+
+	archive_write_set_compression_gzip(a);
+	archive_write_set_format_pax_restricted(a);
+	archive_write_open_filename(a, nstr(identifier.GetFullPath()).c_str());
+
+	g_gui.SetLoadDone(0, "Saving spawns...");
+
+	pugi::xml_document spawnDoc;
+	if (saveSpawns(map, spawnDoc)) {
+		// Write the data
+		spawnDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
+		std::string xmlData = streamData.str();
+
+		// Write to the arhive
+		entry = archive_entry_new();
+		archive_entry_set_pathname(entry, "world/spawns.xml");
+		archive_entry_set_size(entry, xmlData.size());
+		archive_entry_set_filetype(entry, AE_IFREG);
+		archive_entry_set_perm(entry, 0644);
+
+		// Write to the archive
+		archive_write_header(a, entry);
+		archive_write_data(a, xmlData.data(), xmlData.size());
+
+		// Free the entry
+		archive_entry_free(entry);
+		streamData.str("");
+	}
+
+	g_gui.SetLoadDone(0, "Saving houses...");
+
+	pugi::xml_document houseDoc;
+	if (saveHouses(map, houseDoc)) {
+		// Write the data
+		houseDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
+		std::string xmlData = streamData.str();
+
+		// Write to the arhive
+		entry = archive_entry_new();
+		archive_entry_set_pathname(entry, "world/houses.xml");
+		archive_entry_set_size(entry, xmlData.size());
+		archive_entry_set_filetype(entry, AE_IFREG);
+		archive_entry_set_perm(entry, 0644);
+
+		// Write to the archive
+		archive_write_header(a, entry);
+		archive_write_data(a, xmlData.data(), xmlData.size());
+
+		// Free the entry
+		archive_entry_free(entry);
+		streamData.str("");
+	}
+	// to do
+	/*
+	g_gui.SetLoadDone(0, "Saving waypoints...");
+
+	pugi::xml_document wpDoc;
+	if (saveWaypoints(map, wpDoc)) {
+		// Write the data
+		wpDoc.save(streamData, "", pugi::format_raw, pugi::encoding_utf8);
+		std::string xmlData = streamData.str();
+
+		// Write to the arhive
+		entry = archive_entry_new();
+		archive_entry_set_pathname(entry, "world/waypoints.xml");
+		archive_entry_set_size(entry, xmlData.size());
+		archive_entry_set_filetype(entry, AE_IFREG);
+		archive_entry_set_perm(entry, 0644);
+
+		// Write to the archive
+		archive_write_header(a, entry);
+		archive_write_data(a, xmlData.data(), xmlData.size());
+
+		// Free the entry
+		archive_entry_free(entry);
+		streamData.str("");
+	}
+	*/
+	g_gui.SetLoadDone(0, "Saving OTBM map...");
+
+	MemoryNodeFileWriteHandle otbmWriter;
+	saveMap(map, otbmWriter);
+
+	g_gui.SetLoadDone(75, "Compressing...");
+
+	// Create an archive entry for the otbm file
+	entry = archive_entry_new();
+	archive_entry_set_pathname(entry, "world/map.otbm");
+	archive_entry_set_size(entry, otbmWriter.getSize() + 4); // 4 bytes extra for header
+	archive_entry_set_filetype(entry, AE_IFREG);
+	archive_entry_set_perm(entry, 0644);
+	archive_write_header(a, entry);
+
+	// Write the version header
+	char otbm_identifier[] = "OTBM";
+	archive_write_data(a, otbm_identifier, 4);
+
+	// Write the OTBM data
+	archive_write_data(a, otbmWriter.getMemory(), otbmWriter.getSize());
+	archive_entry_free(entry);
+
+	// Free / close the archive
+	archive_write_close(a);
+	archive_write_free(a);
+
+	g_gui.DestroyLoadBar();
+	return true;
+#else
+	return false;
+#endif
+}
+
+bool IOMapOTBM::saveMapToDisk(Map& map, const FileName& identifier) {
+	DiskNodeFileWriteHandle f(nstr(identifier.GetFullPath()), (g_settings.getInteger(Config::SAVE_WITH_OTB_MAGIC_NUMBER) ? "OTBM" : std::string(4, '\0')));
 
 	if (!f.isOk()) {
 		error("Can not open file %s for writing", (const char*)identifier.GetFullPath().mb_str(wxConvUTF8));

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -139,6 +139,15 @@ protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+
+	bool loadMapFromArchive(Map& map, const FileName& filename);
+	bool loadMapFromDisk(Map& map, const FileName& filename);
+
+	bool loadMapHeader(BinaryNode* mapHeaderNode, Map& map);
+	bool loadTileArea(BinaryNode* mapNode, Map& map);
+	bool loadTowns(BinaryNode* mapNode, Map& map);
+	bool loadWaypoints(BinaryNode* mapNode, Map& map);
+
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);
@@ -147,6 +156,10 @@ protected:
 	bool loadWaypoints(Map& map, pugi::xml_document& doc);
 
 	virtual bool saveMap(Map& map, NodeFileWriteHandle& handle);
+
+	bool saveMapToArchive(Map& map, const FileName& identifier);
+	bool saveMapToDisk(Map& map, const FileName& identifier);
+
 	bool saveSpawns(Map& map, const FileName& dir);
 	bool saveSpawns(Map& map, pugi::xml_document& doc);
 	bool saveHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
Extracted methods from loadMap and saveMap in source/io/iomap_otbm.cpp to address "Long Method" code smells. Created helpers for archive handling, map header, tile area, towns, and waypoints. Validated via compilation.

---
*PR created automatically by Jules for task [4703261082720305939](https://jules.google.com/task/4703261082720305939) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * OTBM map I/O infrastructure refactored to improve efficiency and stability. Introduced optimized loading and saving pathways with enhanced memory management for large files. Added robust fallback mechanisms and error handling for auxiliary map data with informative warnings during operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->