### PR TITLE
[TILE/WXWIDGETS] Fix inefficient tile lookup and High DPI sizing

### DIFF
--- a/source/ui/extension_window.cpp
+++ b/source/ui/extension_window.cpp
@@ -26,10 +26,12 @@
 extern Materials g_materials;
 
 ExtensionsDialog::ExtensionsDialog(wxWindow* parent) :
-	wxDialog(parent, wxID_ANY, "Extensions", wxDefaultPosition, wxSize(600, 500), wxRESIZE_BORDER | wxCAPTION) {
+	wxDialog(parent, wxID_ANY, "Extensions", wxDefaultPosition, wxDefaultSize, wxRESIZE_BORDER | wxCAPTION) {
+	SetSize(FromDIP(wxSize(600, 500)));
+
 	wxBoxSizer* topSizer = new wxBoxSizer(wxVERTICAL);
 
-	wxHtmlWindow* htmlWindow = new wxHtmlWindow(this, wxID_ANY, wxDefaultPosition, wxSize(550, 400));
+	wxHtmlWindow* htmlWindow = new wxHtmlWindow(this, wxID_ANY, wxDefaultPosition, FromDIP(wxSize(550, 400)));
 	htmlWindow->SetPage(HTML());
 	topSizer->Add(htmlWindow, wxSizerFlags(1).DoubleBorder().Expand());
 


### PR DESCRIPTION
Optimized `MapLayerDrawer::Draw` for performance and fixed High DPI sizing in `ExtensionsDialog`.

---
*PR created automatically by Jules for task [12287327054573966172](https://jules.google.com/task/12287327054573966172) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI window and dialog sizing on high-DPI displays to scale properly.

* **Refactor**
  * Optimized map rendering logic with improved floor handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->