### PR TITLE
✨ Designer: NanoVG Tileset Palette & Glass Minimap

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -16,6 +16,11 @@
  */
 class VirtualBrushGrid : public NanoVGCanvas, public BrushBoxInterface {
 public:
+	enum class DisplayMode {
+		GRID,
+		LIST
+	};
+
 	/**
 	 * @brief Constructs a VirtualBrushGrid.
 	 * @param parent Parent window
@@ -28,6 +33,8 @@ public:
 	wxWindow* GetSelfWindow() override {
 		return this;
 	}
+
+	void SetDisplayMode(DisplayMode mode);
 
 	// BrushBoxInterface
 	void SelectFirstBrush() override;
@@ -55,12 +62,15 @@ protected:
 	wxRect GetItemRect(int index) const;
 	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
+	void DrawListItem(NVGcontext* vg, int index, const wxRect& rect);
 
 	RenderSize icon_size;
+	DisplayMode display_mode;
 	int selected_index;
 	int hover_index;
 	int columns;
 	int item_size;
+	int item_height; // Used for list mode
 	int padding;
 
 	// Animation state

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -21,8 +21,6 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	list_type(BRUSHLIST_LISTBOX) {
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
-
-	Bind(wxEVT_LISTBOX, &BrushPanel::OnClickListBoxRow, this, wxID_ANY);
 }
 
 BrushPanel::~BrushPanel() {
@@ -69,16 +67,21 @@ void BrushPanel::LoadContents() {
 	ASSERT(tileset != nullptr);
 
 	switch (list_type) {
-		case BRUSHLIST_LARGE_ICONS:
+		case BRUSHLIST_LARGE_ICONS: {
 			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
 			break;
-		case BRUSHLIST_SMALL_ICONS:
+		}
+		case BRUSHLIST_SMALL_ICONS: {
 			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16);
 			break;
+		}
 		case BRUSHLIST_LISTBOX:
-		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
+		case BRUSHLIST_TEXT_LISTBOX: {
+			auto* vbg = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
+			vbg->SetDisplayMode(VirtualBrushGrid::DisplayMode::LIST);
+			brushbox = vbg;
 			break;
+		}
 		default:
 			break;
 	}
@@ -135,116 +138,4 @@ void BrushPanel::OnSwitchIn() {
 
 void BrushPanel::OnSwitchOut() {
 	////
-}
-
-void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
-	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	// We just notify the GUI of the action, it will take care of everything else
-	ASSERT(brushbox);
-	size_t n = event.GetSelection();
-
-	wxWindow* w = this->GetParent();
-	while (w) {
-		PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
-		if (pw) {
-			g_gui.ActivatePalette(pw);
-			break;
-		}
-		w = w->GetParent();
-	}
-
-	g_gui.SelectBrush(tileset->brushlist[n], tileset->getType());
-}
-
-// ============================================================================
-// BrushListBox
-
-BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
-	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	BrushBoxInterface(tileset) {
-	SetItemCount(tileset->size());
-	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
-}
-
-BrushListBox::~BrushListBox() {
-	////
-}
-
-void BrushListBox::SelectFirstBrush() {
-	SetSelection(0);
-	wxWindow::ScrollLines(-1);
-}
-
-Brush* BrushListBox::GetSelectedBrush() const {
-	if (!tileset) {
-		return nullptr;
-	}
-
-	int n = GetSelection();
-	if (n != wxNOT_FOUND) {
-		return tileset->brushlist[n];
-	} else if (tileset->size() > 0) {
-		return tileset->brushlist[0];
-	}
-	return nullptr;
-}
-
-bool BrushListBox::SelectBrush(const Brush* whatbrush) {
-	auto it = std::ranges::find(tileset->brushlist, whatbrush);
-	if (it != tileset->brushlist.end()) {
-		SetSelection(std::distance(tileset->brushlist.begin(), it));
-		return true;
-	}
-	return false;
-}
-
-void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	ASSERT(n < tileset->size());
-	Sprite* spr = tileset->brushlist[n]->getSprite();
-	if (!spr) {
-		spr = g_gui.gfx.getSprite(tileset->brushlist[n]->getLookID());
-	}
-	if (spr) {
-		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord BrushListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
-
-void BrushListBox::OnKey(wxKeyEvent& event) {
-	switch (event.GetKeyCode()) {
-		case WXK_UP:
-		case WXK_DOWN:
-		case WXK_LEFT:
-		case WXK_RIGHT:
-		case WXK_PAGEUP:
-		case WXK_PAGEDOWN:
-		case WXK_HOME:
-		case WXK_END:
-			if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
-				event.Skip(true);
-			} else {
-				if (g_gui.GetCurrentTab() != nullptr) {
-					g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-				}
-			}
-			break;
-		default:
-			if (g_gui.GetCurrentTab() != nullptr) {
-				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-			}
-			break;
-	}
 }

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,29 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() override {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush() override;
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const override;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush) override;
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;
-	virtual wxCoord OnMeasureItem(size_t n) const override;
-
-	void OnKey(wxKeyEvent& event);
-};
-
 class BrushPanel : public wxPanel {
 public:
 	BrushPanel(wxWindow* parent);
@@ -86,9 +63,6 @@ public:
 	void OnSwitchIn();
 	// Called when this page is hidden
 	void OnSwitchOut();
-
-	// wxWidgets event handlers
-	void OnClickListBoxRow(wxCommandEvent& event);
 
 protected:
 	const TilesetCategory* tileset;

--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -28,8 +28,8 @@
 #include "rendering/ui/minimap_window.h"
 
 #include "rendering/drawers/minimap_drawer.h"
+#include "rendering/core/text_renderer.h"
 
-#define NANOVG_GL3
 #include <nanovg.h>
 #include <nanovg_gl.h>
 
@@ -117,6 +117,9 @@ void MinimapWindow::OnPaint(wxPaintEvent& event) {
 		// Minimap uses a separate NanoVG context to avoid state interference with the main
 		// TextRenderer, as the minimap window has its own GL context and lifecycle.
 		nvg.reset(nvgCreateGL3(NVG_ANTIALIAS | NVG_STENCIL_STROKES));
+		if (nvg) {
+			TextRenderer::LoadFont(nvg.get());
+		}
 	}
 
 	if (!g_gui.IsEditorOpen()) {
@@ -151,6 +154,17 @@ void MinimapWindow::OnPaint(wxPaintEvent& event) {
 		nvgRoundedRect(vg, 0, 0, w, h, 4.0f);
 		nvgFillPaint(vg, glow);
 		nvgFill(vg);
+
+		// "MINIMAP" Label
+		nvgFontSize(vg, 12.0f);
+		nvgFontFace(vg, "sans-bold");
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
+
+		nvgFillColor(vg, nvgRGBA(0, 0, 0, 200)); // Shadow
+		nvgText(vg, 9.0f, 9.0f, "MINIMAP", nullptr);
+
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 180));
+		nvgText(vg, 8.0f, 8.0f, "MINIMAP", nullptr);
 
 		nvgEndFrame(vg);
 	}


### PR DESCRIPTION
- Enhanced `VirtualBrushGrid` to support `DisplayMode::LIST` (icon + text) and `DisplayMode::GRID` (icons).
- Implemented "WOW" visual effects (glow, hover states) in `VirtualBrushGrid` using NanoVG.
- Refactored `BrushPanel` to use `VirtualBrushGrid` for all view modes, replacing and removing the legacy `BrushListBox`.
- Enhanced `MinimapWindow` with a "Glass" overlay and "MINIMAP" label using NanoVG for a modern HUD feel.
- Verified compilation with `ninja`.

---
*PR created automatically by Jules for task [6713645911017026636](https://jules.google.com/task/6713645911017026636) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added display mode options for the brush grid (grid or list view)
  * Added "MINIMAP" label to the minimap overlay for improved visibility

* **Refactor**
  * Unified text list box functionality with the brush grid control for improved consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->