### PR TITLE
📜 Auditor: Modernize Casts & Fix IOMapOTMM Overrides

### DIFF
--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -307,6 +307,10 @@ ClientVersionID IOMapOTMM::getVersionInfo(const FileName& filename) {
 	return CLIENT_VERSION_NONE;
 }
 
+bool IOMapOTMM::loadMap(Map& map, const FileName& identifier) {
+	return loadMap(map, identifier, true);
+}
+
 bool IOMapOTMM::loadMap(Map& map, const FileName& identifier, bool showdialog) {
 	if (showdialog) {
 		g_gui.CreateLoadBar("Loading OTMM map...");
@@ -738,6 +742,10 @@ bool IOMapOTMM::loadMap(Map& map, NodeFileReadHandle& f, const FileName& identif
 		} while (mapNode->advance());
 	}
 	return true;
+}
+
+bool IOMapOTMM::saveMap(Map& map, const FileName& identifier) {
+	return saveMap(map, identifier, true);
 }
 
 bool IOMapOTMM::saveMap(Map& map, const FileName& identifier, bool showdialog) {

--- a/source/io/iomap_otmm.h
+++ b/source/io/iomap_otmm.h
@@ -77,9 +77,11 @@ public:
 
 	virtual bool loadMap(Map& map, NodeFileReadHandle& handle, const FileName& identifier, bool showdialog);
 	virtual bool loadMap(Map& map, const FileName& identifier, bool showdialog);
+	bool loadMap(Map& map, const FileName& identifier) override;
 
 	virtual bool saveMap(Map& map, NodeFileWriteHandle& handle, const FileName& identifier, bool showdialog);
 	virtual bool saveMap(Map& map, const FileName& identifier, bool showdialog);
+	bool saveMap(Map& map, const FileName& identifier) override;
 };
 
 #endif

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -273,15 +273,15 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 	}
 
 	// Constants
-	float scale_x = (float)w / map_w;
-	float scale_y = (float)h / map_h;
+	float scale_x = static_cast<float>(w) / map_w;
+	float scale_y = static_cast<float>(h) / map_h;
 
 	// Determine visible tiles
 	// Clamp to integer grid
-	int start_col = (int)std::floor(map_x / TILE_SIZE);
-	int end_col = (int)std::floor((map_x + map_w) / TILE_SIZE);
-	int start_row = (int)std::floor(map_y / TILE_SIZE);
-	int end_row = (int)std::floor((map_y + map_h) / TILE_SIZE);
+	int start_col = static_cast<int>(std::floor(map_x / TILE_SIZE));
+	int end_col = static_cast<int>(std::floor((map_x + map_w) / TILE_SIZE));
+	int start_row = static_cast<int>(std::floor(map_y / TILE_SIZE));
+	int end_row = static_cast<int>(std::floor((map_y + map_h) / TILE_SIZE));
 
 	start_col = std::max(0, start_col);
 	start_row = std::max(0, start_row);
@@ -305,7 +305,7 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 
 			int layer = r * cols_ + c;
 
-			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = (float)layer });
+			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = static_cast<float>(layer) });
 		}
 	}
 

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -113,8 +113,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	gpu_lights_.clear();
 	gpu_lights_.reserve(light_buffer.lights.size());
 
-	float map_draw_start_x = (float)(map_x * TileSize - view.view_scroll_x);
-	float map_draw_start_y = (float)(map_y * TileSize - view.view_scroll_y);
+	float map_draw_start_x = static_cast<float>(map_x * TileSize - view.view_scroll_x);
+	float map_draw_start_y = static_cast<float>(map_y * TileSize - view.view_scroll_y);
 
 	// Offset logic:
 	// The FBO represents the rectangle [map_x * 32, map_x * 32 + pixel_width] in map coordinates.
@@ -122,8 +122,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// Light Position in FBO = (LightMapX * 32 - FBO_StartX_In_Pixels, ...)
 	// FBO Start X in pure Map Pixel Coords = map_x * 32.
 
-	float fbo_origin_x = (float)(map_x * TileSize);
-	float fbo_origin_y = (float)(map_y * TileSize);
+	float fbo_origin_x = static_cast<float>(map_x * TileSize);
+	float fbo_origin_y = static_cast<float>(map_y * TileSize);
 
 	for (const auto& light : light_buffer.lights) {
 		// Cull lights that are definitely out of FBO range
@@ -189,9 +189,9 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 
 		// Setup Projection for FBO: Ortho 0..buffer_width, buffer_height..0 (Y-down)
 		// This matches screen coordinate system and avoids flips
-		glm::mat4 fbo_projection = glm::ortho(0.0f, (float)buffer_width, (float)buffer_height, 0.0f);
+		glm::mat4 fbo_projection = glm::ortho(0.0f, static_cast<float>(buffer_width), static_cast<float>(buffer_height), 0.0f);
 		shader->SetMat4("uProjection", fbo_projection);
-		shader->SetFloat("uTileSize", (float)TileSize);
+		shader->SetFloat("uTileSize", static_cast<float>(TileSize));
 
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, light_ssbo->GetID());
 		glBindVertexArray(vao->GetID());
@@ -201,7 +201,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 			ScopedGLCapability blendCap(GL_BLEND);
 			ScopedGLBlend blendState(GL_ONE, GL_ONE, GL_MAX); // Factors don't matter much for MAX, but usually 1,1 is safe
 
-			glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, (GLsizei)gpu_lights_.size());
+			glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(gpu_lights_.size()));
 		}
 
 		glBindVertexArray(0);
@@ -247,8 +247,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// Quad Transform for Screen
 	float draw_dest_x = map_draw_start_x;
 	float draw_dest_y = map_draw_start_y;
-	float draw_dest_w = (float)pixel_width;
-	float draw_dest_h = (float)pixel_height;
+	float draw_dest_w = static_cast<float>(pixel_width);
+	float draw_dest_h = static_cast<float>(pixel_height);
 
 	glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(draw_dest_x, draw_dest_y, 0.0f));
 	model = glm::scale(model, glm::vec3(draw_dest_w, draw_dest_h, 1.0f));
@@ -263,8 +263,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// If we use Y-down ortho: Y=0 -> V=1, Y=buffer_height -> V=0.
 	// Map Top (Y=0) -> V=1. Map Bottom (Y=pixel_height) -> V = 1.0 - (pixel_height / buffer_height).
 
-	float uv_w = (float)pixel_width / (float)buffer_width;
-	float uv_h = (float)pixel_height / (float)buffer_height;
+	float uv_w = static_cast<float>(pixel_width) / static_cast<float>(buffer_width);
+	float uv_h = static_cast<float>(pixel_height) / static_cast<float>(buffer_height);
 
 	// We pass UV range to shader. Shader should map aPos.y (0..1) to correct range.
 	// If screen aPos.y=0 is Top, it should get texture Map Top.


### PR DESCRIPTION
Auditor applied fixes for legacy C++ patterns:
- Replaced C-style casts `(int)`, `(float)` with `static_cast` in `source/rendering/drawers/minimap_renderer.cpp` and `source/rendering/utilities/light_drawer.cpp`.
- Fixed `IOMapOTMM` inheritance by adding `override` keyword and implementing missing `loadMap`/`saveMap` overrides that delegate to internal methods.

---
*PR created automatically by Jules for task [13952324353014978124](https://jules.google.com/task/13952324353014978124) started by @karolak6612*