### PR TITLE
🧩 Fixer: Refactor Tile and Modernize Core Systems

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -114,6 +114,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/map/position.h
     ${CMAKE_CURRENT_LIST_DIR}/map/spatial_hash_grid.h
     ${CMAKE_CURRENT_LIST_DIR}/map/tile.h
+    ${CMAKE_CURRENT_LIST_DIR}/map/tile_operations.h
     ${CMAKE_CURRENT_LIST_DIR}/map/tileset.h
     ${CMAKE_CURRENT_LIST_DIR}/net/net_connection.h
     ${CMAKE_CURRENT_LIST_DIR}/net/process_com.h
@@ -428,6 +429,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/map/map_statistics.cpp
     ${CMAKE_CURRENT_LIST_DIR}/map/otml.cpp
     ${CMAKE_CURRENT_LIST_DIR}/map/tile.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/map/tile_operations.cpp
     ${CMAKE_CURRENT_LIST_DIR}/map/tileset.cpp
     ${CMAKE_CURRENT_LIST_DIR}/mkpch.cpp
     ${CMAKE_CURRENT_LIST_DIR}/net/net_connection.cpp

--- a/source/brushes/ground/ground_border_calculator.cpp
+++ b/source/brushes/ground/ground_border_calculator.cpp
@@ -7,6 +7,7 @@
 #include "brushes/ground/auto_border.h"
 #include "map/basemap.h"
 #include "map/tile.h"
+#include "map/tile_operations.h"
 #include "game/item.h"
 #include "game/items.h"
 #include <array>
@@ -296,7 +297,7 @@ void GroundBorderCalculator::calculate(BaseMap* map, Tile* tile) {
 	auto [first, last] = std::ranges::unique(specificList);
 	specificList.erase(first, last);
 
-	tile->cleanBorders();
+	TileOperations::cleanBorders(tile);
 
 	while (!borderList.empty()) {
 		GroundBrush::BorderCluster& borderCluster = borderList.back();
@@ -321,27 +322,27 @@ void GroundBorderCalculator::calculate(BaseMap* map, Tile* tile) {
 			}
 
 			if (borderCluster.border->tiles[direction] != 0) {
-				tile->addBorderItem(Item::Create(borderCluster.border->tiles[direction]));
+				TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[direction]));
 			} else {
 				if (direction == NORTHWEST_DIAGONAL) {
 					if (borderCluster.border->tiles[WEST_HORIZONTAL] != 0 && borderCluster.border->tiles[NORTH_HORIZONTAL] != 0) {
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[WEST_HORIZONTAL]));
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[NORTH_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[WEST_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[NORTH_HORIZONTAL]));
 					}
 				} else if (direction == NORTHEAST_DIAGONAL) {
 					if (borderCluster.border->tiles[EAST_HORIZONTAL] != 0 && borderCluster.border->tiles[NORTH_HORIZONTAL] != 0) {
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[EAST_HORIZONTAL]));
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[NORTH_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[EAST_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[NORTH_HORIZONTAL]));
 					}
 				} else if (direction == SOUTHWEST_DIAGONAL) {
 					if (borderCluster.border->tiles[SOUTH_HORIZONTAL] != 0 && borderCluster.border->tiles[WEST_HORIZONTAL] != 0) {
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[SOUTH_HORIZONTAL]));
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[WEST_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[SOUTH_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[WEST_HORIZONTAL]));
 					}
 				} else if (direction == SOUTHEAST_DIAGONAL) {
 					if (borderCluster.border->tiles[SOUTH_HORIZONTAL] != 0 && borderCluster.border->tiles[EAST_HORIZONTAL] != 0) {
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[SOUTH_HORIZONTAL]));
-						tile->addBorderItem(Item::Create(borderCluster.border->tiles[EAST_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[SOUTH_HORIZONTAL]));
+						TileOperations::addBorderItem(tile, Item::Create(borderCluster.border->tiles[EAST_HORIZONTAL]));
 					}
 				}
 			}

--- a/source/brushes/managers/autoborder_preview_manager.cpp
+++ b/source/brushes/managers/autoborder_preview_manager.cpp
@@ -8,6 +8,7 @@
 #include "brushes/managers/brush_manager.h"
 #include "map/map.h"
 #include "map/tile.h"
+#include "map/tile_operations.h"
 #include "ui/gui.h"
 #include "app/settings.h"
 #include "brushes/brush_utility.h"
@@ -102,9 +103,9 @@ void AutoborderPreviewManager::SimulateBrush(Editor& editor, const Position& pos
 		}
 
 		if (is_wall) {
-			tile->cleanWalls(false);
+			TileOperations::cleanWalls(tile, false);
 		} else if (is_ground) {
-			tile->cleanBorders();
+			TileOperations::cleanBorders(tile);
 		}
 
 		// Draw the brush
@@ -138,19 +139,19 @@ void AutoborderPreviewManager::ApplyBorders(const std::vector<Position>& tilesto
 		Tile* tile = preview_buffer_map->getTile(p);
 		if (tile) {
 			if (is_eraser) {
-				tile->wallize(preview_buffer_map.get());
-				tile->tableize(preview_buffer_map.get());
-				tile->carpetize(preview_buffer_map.get());
-				tile->borderize(preview_buffer_map.get());
+				TileOperations::wallize(preview_buffer_map.get(), tile);
+				TileOperations::tableize(preview_buffer_map.get(), tile);
+				TileOperations::carpetize(preview_buffer_map.get(), tile);
+				TileOperations::borderize(preview_buffer_map.get(), tile);
 			} else if (is_wall) {
-				tile->wallize(preview_buffer_map.get());
+				TileOperations::wallize(preview_buffer_map.get(), tile);
 			} else if (is_table) {
-				tile->tableize(preview_buffer_map.get());
+				TileOperations::tableize(preview_buffer_map.get(), tile);
 			} else if (is_carpet) {
-				tile->carpetize(preview_buffer_map.get());
+				TileOperations::carpetize(preview_buffer_map.get(), tile);
 			} else {
 				// Default/Ground
-				tile->borderize(preview_buffer_map.get());
+				TileOperations::borderize(preview_buffer_map.get(), tile);
 			}
 		}
 	};

--- a/source/brushes/wall/wall_border_calculator.cpp
+++ b/source/brushes/wall/wall_border_calculator.cpp
@@ -6,6 +6,7 @@
 #include "brushes/wall/wall_brush.h"
 #include "brushes/wall/wall_brush_items.h"
 #include "map/basemap.h"
+#include "map/tile_operations.h"
 #include "game/items.h"
 #include "app/main.h" // ASSERT, etc
 
@@ -188,8 +189,8 @@ void WallBorderCalculator::doWalls(BaseMap* map, Tile* tile) {
 			}
 		}
 	}
-	tile->cleanWalls();
+	TileOperations::cleanWalls(tile);
 	for (Item* item : items_to_add) {
-		tile->addWallItem(item);
+		TileOperations::addWallItem(tile, item);
 	}
 }

--- a/source/brushes/wall/wall_brush.cpp
+++ b/source/brushes/wall/wall_brush.cpp
@@ -8,6 +8,7 @@
 #include "brushes/wall/wall_brush_loader.h"
 #include "brushes/wall/wall_border_calculator.h"
 
+#include "map/tile_operations.h"
 #include "ui/gui.h"
 #include "game/items.h"
 #include "map/basemap.h"
@@ -29,7 +30,7 @@ bool WallBrush::load(pugi::xml_node node, std::vector<std::string>& warnings) {
 }
 
 void WallBrush::undraw(BaseMap* map, Tile* tile) {
-	tile->cleanWalls(this);
+	TileOperations::cleanWalls(tile, this);
 }
 
 void WallBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
@@ -77,7 +78,7 @@ void WallBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 		}
 	}
 
-	tile->cleanWalls(this);
+	TileOperations::cleanWalls(tile, this);
 
 	// Just find a valid item and place it, the bordering algorithm will change it to the proper shape.
 	uint16_t id = 0;
@@ -104,7 +105,7 @@ void WallBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 		}
 	}
 
-	tile->addWallItem(Item::Create(id));
+	TileOperations::addWallItem(tile, Item::Create(id));
 }
 
 void WallBrush::doWalls(BaseMap* map, Tile* tile) {
@@ -152,7 +153,7 @@ void WallDecorationBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 
 	bool prefLocked = g_gui.HasDoorLocked();
 
-	tile->cleanWalls(this);
+	TileOperations::cleanWalls(tile, this);
 	while (iter != tile->items.end()) {
 		Item* item = *iter;
 		if (item->isBorder()) {

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -10,6 +10,7 @@
 #include "game/creature.h"
 #include "game/spawn.h"
 #include "map/map.h"
+#include "map/tile_operations.h"
 #include "editor/action.h"
 #include "editor/action_queue.h"
 #include "app/settings.h"
@@ -150,12 +151,12 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 			TileLocation* location = editor.map.createTileL(pos);
 			if (location->get()) {
 				std::unique_ptr<Tile> new_tile = location->get()->deepCopy(editor.map);
-				new_tile->borderize(&editor.map);
-				new_tile->wallize(&editor.map);
+				TileOperations::borderize(&editor.map, new_tile.get());
+				TileOperations::wallize(&editor.map, new_tile.get());
 				action->addChange(std::make_unique<Change>(new_tile.release()));
 			} else {
 				std::unique_ptr<Tile> new_tile(editor.map.allocator(location));
-				new_tile->borderize(&editor.map);
+				TileOperations::borderize(&editor.map, new_tile.get());
 				if (new_tile->size()) {
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}
@@ -284,13 +285,13 @@ void CopyOperations::paste(Editor& editor, CopyBuffer& buffer, const Position& t
 		for (Tile* tile : borderize_tiles) {
 			if (tile) {
 				std::unique_ptr<Tile> newTile = tile->deepCopy(editor.map);
-				newTile->borderize(&map);
+				TileOperations::borderize(&map, newTile.get());
 
 				if (tile->ground && tile->ground->isSelected()) {
 					newTile->selectGround();
 				}
 
-				newTile->wallize(&map);
+				TileOperations::wallize(&map, newTile.get());
 				action->addChange(std::make_unique<Change>(newTile.release()));
 			}
 		}

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -22,6 +22,7 @@
 #include "map/map.h"
 #include "map/map.h"
 #include "map/tile.h"
+#include "map/tile_operations.h"
 #include "app/settings.h"
 
 void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw) {
@@ -108,8 +109,8 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 				Tile* tile = editor.map.getTile(*it);
 				if (tile) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-					new_tile->borderize(&editor.map);
-					new_tile->wallize(&editor.map);
+					TileOperations::borderize(&editor.map, new_tile.get());
+					TileOperations::wallize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}
 			}
@@ -219,18 +220,18 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, boo
 				if (dodraw) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 					brush->draw(&editor.map, new_tile.get());
-					new_tile->borderize(&editor.map);
+					TileOperations::borderize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				} else if (!dodraw && tile->hasOptionalBorder()) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 					brush->undraw(&editor.map, new_tile.get());
-					new_tile->borderize(&editor.map);
+					TileOperations::borderize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}
 			} else if (dodraw) {
 				std::unique_ptr<Tile> new_tile(editor.map.allocator(location));
 				brush->draw(&editor.map, new_tile.get());
-				new_tile->borderize(&editor.map);
+				TileOperations::borderize(&editor.map, new_tile.get());
 				if (new_tile->empty()) {
 					continue;
 				}
@@ -276,7 +277,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 			if (tile) {
 				std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 				if (g_settings.getInteger(Config::USE_AUTOMAGIC)) {
-					new_tile->cleanBorders();
+					TileOperations::cleanBorders(new_tile.get());
 				}
 				if (dodraw) {
 					if (brush->isGround() && alt) {
@@ -328,21 +329,21 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				if (tile) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 					if (brush->isEraser()) {
-						new_tile->wallize(&editor.map);
-						new_tile->tableize(&editor.map);
-						new_tile->carpetize(&editor.map);
+						TileOperations::wallize(&editor.map, new_tile.get());
+						TileOperations::tableize(&editor.map, new_tile.get());
+						TileOperations::carpetize(&editor.map, new_tile.get());
 					}
-					new_tile->borderize(&editor.map);
+					TileOperations::borderize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				} else {
 					std::unique_ptr<Tile> new_tile(editor.map.allocator(location));
 					if (brush->isEraser()) {
 						// There are no carpets/tables/walls on empty tiles...
-						// new_tile->wallize(map);
-						// new_tile->tableize(map);
-						// new_tile->carpetize(map);
+						// TileOperations::wallize(map, new_tile.get());
+						// TileOperations::tableize(map, new_tile.get());
+						// TileOperations::carpetize(map, new_tile.get());
 					}
-					new_tile->borderize(&editor.map);
+					TileOperations::borderize(&editor.map, new_tile.get());
 					if (!new_tile->empty()) {
 						action->addChange(std::make_unique<Change>(new_tile.release()));
 					}
@@ -384,13 +385,13 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 			if (brush->isTable()) {
 				if (tile && tile->hasTable()) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-					new_tile->tableize(&editor.map);
+					TileOperations::tableize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}
 			} else if (brush->isCarpet()) {
 				if (tile && tile->hasCarpet()) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-					new_tile->carpetize(&editor.map);
+					TileOperations::carpetize(&editor.map, new_tile.get());
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}
 			}
@@ -412,7 +413,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				Tile* tile = location->get();
 				if (tile) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-					new_tile->cleanWalls(brush->isWall());
+					TileOperations::cleanWalls(new_tile.get(), brush->isWall());
 					g_gui.GetCurrentBrush()->draw(draw_map, new_tile.get());
 					draw_map->setTile(*it, new_tile.release(), true);
 				} else if (dodraw) {
@@ -425,7 +426,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				// Get the correct tiles from the draw map instead of the editor map
 				Tile* tile = draw_map->getTile(*it);
 				if (tile) {
-					tile->wallize(draw_map);
+					TileOperations::wallize(draw_map, tile);
 					action->addChange(std::make_unique<Change>(tile));
 				}
 			}
@@ -439,7 +440,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				if (tile) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 					// Wall cleaning is exempt from automagic
-					new_tile->cleanWalls(brush->isWall());
+					TileOperations::cleanWalls(new_tile.get(), brush->isWall());
 					if (dodraw) {
 						g_gui.GetCurrentBrush()->draw(&editor.map, new_tile.get());
 					} else {
@@ -463,7 +464,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 					Tile* tile = editor.map.getTile(*it);
 					if (tile) {
 						std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-						new_tile->wallize(&editor.map);
+						TileOperations::wallize(&editor.map, new_tile.get());
 						// if(*tile == *new_tile) delete new_tile;
 						action->addChange(std::make_unique<Change>(new_tile.release()));
 					}
@@ -486,7 +487,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
 				// Wall cleaning is exempt from automagic
 				if (brush->isWall()) {
-					new_tile->cleanWalls(brush->asWall());
+					TileOperations::cleanWalls(new_tile.get(), brush->asWall());
 				}
 				if (dodraw) {
 					door_brush->draw(&editor.map, new_tile.get(), &alt);
@@ -511,7 +512,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 				Tile* tile = editor.map.getTile(*it);
 				if (tile) {
 					std::unique_ptr<Tile> new_tile = tile->deepCopy(editor.map);
-					new_tile->wallize(&editor.map);
+					TileOperations::wallize(&editor.map, new_tile.get());
 					// if(*tile == *new_tile) delete new_tile;
 					action->addChange(std::make_unique<Change>(new_tile.release()));
 				}

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -240,29 +240,29 @@ void Selection::flush() {
 	}
 	if (!pending_removes.empty()) {
 		bounds_dirty = true;
-		std::sort(pending_removes.begin(), pending_removes.end(), tilePositionLessThan);
-		auto last = std::unique(pending_removes.begin(), pending_removes.end(), [](Tile* a, Tile* b) {
+		std::ranges::sort(pending_removes, tilePositionLessThan);
+		auto [first, last] = std::ranges::unique(pending_removes, [](Tile* a, Tile* b) {
 			return a->getPosition() == b->getPosition();
 		});
-		pending_removes.erase(last, pending_removes.end());
+		pending_removes.erase(first, last);
 
 		std::vector<Tile*> result;
 		result.reserve(tiles.size());
-		std::set_difference(tiles.begin(), tiles.end(), pending_removes.begin(), pending_removes.end(), std::back_inserter(result), tilePositionLessThan);
+		std::ranges::set_difference(tiles, pending_removes, std::back_inserter(result), tilePositionLessThan);
 		tiles = std::move(result);
 	}
 
 	if (!pending_adds.empty()) {
 		bounds_dirty = true;
-		std::sort(pending_adds.begin(), pending_adds.end(), tilePositionLessThan);
-		auto last = std::unique(pending_adds.begin(), pending_adds.end(), [](Tile* a, Tile* b) {
+		std::ranges::sort(pending_adds, tilePositionLessThan);
+		auto [first, last] = std::ranges::unique(pending_adds, [](Tile* a, Tile* b) {
 			return a->getPosition() == b->getPosition();
 		});
-		pending_adds.erase(last, pending_adds.end());
+		pending_adds.erase(first, last);
 
 		std::vector<Tile*> merged;
 		merged.reserve(tiles.size() + pending_adds.size());
-		std::set_union(tiles.begin(), tiles.end(), pending_adds.begin(), pending_adds.end(), std::back_inserter(merged), tilePositionLessThan);
+		std::ranges::set_union(tiles, pending_adds, std::back_inserter(merged), tilePositionLessThan);
 		tiles = std::move(merged);
 	}
 

--- a/source/map/basemap.h
+++ b/source/map/basemap.h
@@ -27,6 +27,7 @@
 #include <unordered_map>
 #include <memory>
 #include <iterator>
+#include <ranges>
 
 // Class declarations
 class SpatialHashGrid;
@@ -84,6 +85,11 @@ public:
 	void clear(bool del = true);
 	MapIterator begin();
 	MapIterator end();
+
+	auto tiles() {
+		return std::ranges::subrange(begin(), end());
+	}
+
 	uint64_t size() const {
 		return tilecount;
 	}

--- a/source/map/map.h
+++ b/source/map/map.h
@@ -223,13 +223,9 @@ inline void foreach_ItemOnMap(Map& map, ForeachType& foreach, bool selectedTiles
 
 template <typename ForeachType>
 inline void foreach_TileOnMap(Map& map, ForeachType& foreach) {
-	MapIterator tileiter = map.begin();
-	MapIterator end = map.end();
 	long long done = 0;
-
-	while (tileiter != end) {
-		foreach (map, (tileiter++)->get(), ++done)
-			;
+	for (TileLocation& loc : map.tiles()) {
+		foreach(map, loc.get(), ++done);
 	}
 }
 

--- a/source/map/operations/map_processor.cpp
+++ b/source/map/operations/map_processor.cpp
@@ -7,6 +7,7 @@
 #include "map/operations/map_processor.h"
 #include "editor/editor.h"
 #include "map/map.h"
+#include "map/tile_operations.h"
 #include "ui/gui.h"
 #include "brushes/ground/ground_brush.h"
 
@@ -24,7 +25,7 @@ void MapProcessor::borderizeMap(Editor& editor, bool showdialog) {
 		Tile* tile = tileLocation.get();
 		ASSERT(tile);
 
-		tile->borderize(&editor.map);
+		TileOperations::borderize(&editor.map, tile);
 		++tiles_done;
 	}
 
@@ -47,7 +48,7 @@ void MapProcessor::randomizeMap(Editor& editor, bool showdialog) {
 		Tile* tile = tileLocation.get();
 		ASSERT(tile);
 
-		GroundBrush* groundBrush = tile->getGroundBrush();
+		GroundBrush* groundBrush = tile->ground ? tile->ground->getGroundBrush() : nullptr;
 		if (groundBrush) {
 			Item* oldGround = tile->ground;
 

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -25,10 +25,6 @@
 #include "map/basemap.h"
 #include "map/map_region.h"
 #include "game/spawn.h"
-#include "brushes/ground/ground_brush.h"
-#include "brushes/wall/wall_brush.h"
-#include "brushes/carpet/carpet_brush.h"
-#include "brushes/table/table_brush.h"
 #include "game/town.h"
 #include "map/map.h"
 
@@ -531,18 +527,6 @@ void Tile::update() {
 	}
 }
 
-void Tile::borderize(BaseMap* parent) {
-	GroundBrush::doBorders(parent, this);
-}
-
-void Tile::addBorderItem(Item* item) {
-	if (!item) {
-		return;
-	}
-	ASSERT(item->isBorder());
-	items.insert(items.begin(), item);
-}
-
 GroundBrush* Tile::getGroundBrush() const {
 	if (ground) {
 		if (ground->getGroundBrush()) {
@@ -550,21 +534,6 @@ GroundBrush* Tile::getGroundBrush() const {
 		}
 	}
 	return nullptr;
-}
-
-void Tile::cleanBorders() {
-	auto first_to_remove = std::stable_partition(items.begin(), items.end(), [](Item* item) {
-		return !item->isBorder();
-	});
-
-	for (auto it = first_to_remove; it != items.end(); ++it) {
-		delete *it;
-	}
-	items.erase(first_to_remove, items.end());
-}
-
-void Tile::wallize(BaseMap* parent) {
-	WallBrush::doWalls(parent, this);
 }
 
 Item* Tile::getWall() const {
@@ -586,60 +555,6 @@ Item* Tile::getTable() const {
 		return i->isTable();
 	});
 	return (it != items.end()) ? *it : nullptr;
-}
-
-void Tile::addWallItem(Item* item) {
-	if (!item) {
-		return;
-	}
-	ASSERT(item->isWall());
-
-	addItem(item);
-}
-
-void Tile::cleanWalls(bool dontdelete) {
-	auto first_to_remove = std::stable_partition(items.begin(), items.end(), [](Item* item) {
-		return !item->isWall();
-	});
-
-	if (!dontdelete) {
-		for (auto it = first_to_remove; it != items.end(); ++it) {
-			delete *it;
-		}
-	}
-	items.erase(first_to_remove, items.end());
-}
-
-void Tile::cleanWalls(WallBrush* wb) {
-	auto first_to_remove = std::stable_partition(items.begin(), items.end(), [wb](Item* item) {
-		return !(item->isWall() && wb->hasWall(item));
-	});
-
-	for (auto it = first_to_remove; it != items.end(); ++it) {
-		delete *it;
-	}
-	items.erase(first_to_remove, items.end());
-}
-
-void Tile::cleanTables(bool dontdelete) {
-	auto first_to_remove = std::stable_partition(items.begin(), items.end(), [](Item* item) {
-		return !item->isTable();
-	});
-
-	if (!dontdelete) {
-		for (auto it = first_to_remove; it != items.end(); ++it) {
-			delete *it;
-		}
-	}
-	items.erase(first_to_remove, items.end());
-}
-
-void Tile::tableize(BaseMap* parent) {
-	TableBrush::doTables(parent, this);
-}
-
-void Tile::carpetize(BaseMap* parent) {
-	CarpetBrush::doCarpets(parent, this);
 }
 
 void Tile::selectGround() {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -173,15 +173,6 @@ public: // Functions
 	// Get the border brush of this tile
 	GroundBrush* getGroundBrush() const;
 
-	// Remove all borders (for autoborder)
-	void cleanBorders();
-
-	// Add a border item (added at the bottom of all items)
-	void addBorderItem(Item* item);
-
-	// Borderize this tile
-	void borderize(BaseMap* parent);
-
 	bool hasTable() const {
 		return testFlags(statflags, TILESTATE_HAS_TABLE);
 	}
@@ -206,21 +197,6 @@ public: // Functions
 	// Get the (first) wall of this tile
 	Item* getWall() const;
 	bool hasWall() const;
-	// Remove all walls from the tile (for autowall) (only of those belonging to the specified brush
-	void cleanWalls(WallBrush* wb);
-	// Remove all walls from the tile
-	void cleanWalls(bool dontdelete = false);
-	// Add a wall item (same as just addItem, but an additional check to verify that it is a wall)
-	void addWallItem(Item* item);
-	// Wallize (name sucks, I know) this tile
-	void wallize(BaseMap* parent);
-	// Remove all tables from this tile
-	void cleanTables(bool dontdelete = false);
-	// Tableize (name sucks even worse, I know) this tile
-	void tableize(BaseMap* parent);
-	// Carpetize (name sucks even worse than last one, I know) this tile
-	void carpetize(BaseMap* parent);
-
 	// Has to do with houses
 	bool isHouseTile() const;
 	uint32_t getHouseID() const;

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -1,0 +1,98 @@
+#include "app/main.h"
+#include "map/tile_operations.h"
+#include "map/tile.h"
+#include "game/item.h"
+#include "brushes/ground/ground_brush.h"
+#include "brushes/wall/wall_brush.h"
+#include "brushes/carpet/carpet_brush.h"
+#include "brushes/table/table_brush.h"
+
+#include <algorithm>
+
+namespace TileOperations {
+
+void borderize(BaseMap* map, Tile* tile) {
+	if (!tile) return;
+	GroundBrush::doBorders(map, tile);
+}
+
+void cleanBorders(Tile* tile) {
+	if (!tile) return;
+	auto first_to_remove = std::stable_partition(tile->items.begin(), tile->items.end(), [](Item* item) {
+		return !item->isBorder();
+	});
+
+	for (auto it = first_to_remove; it != tile->items.end(); ++it) {
+		delete *it;
+	}
+	tile->items.erase(first_to_remove, tile->items.end());
+}
+
+void addBorderItem(Tile* tile, Item* item) {
+	if (!tile || !item) return;
+	ASSERT(item->isBorder());
+	tile->items.insert(tile->items.begin(), item);
+}
+
+void wallize(BaseMap* map, Tile* tile) {
+	if (!tile) return;
+	WallBrush::doWalls(map, tile);
+}
+
+void cleanWalls(Tile* tile, bool dontdelete) {
+	if (!tile) return;
+	auto first_to_remove = std::stable_partition(tile->items.begin(), tile->items.end(), [](Item* item) {
+		return !item->isWall();
+	});
+
+	if (!dontdelete) {
+		for (auto it = first_to_remove; it != tile->items.end(); ++it) {
+			delete *it;
+		}
+	}
+	tile->items.erase(first_to_remove, tile->items.end());
+}
+
+void cleanWalls(Tile* tile, WallBrush* wb) {
+	if (!tile || !wb) return;
+	auto first_to_remove = std::stable_partition(tile->items.begin(), tile->items.end(), [wb](Item* item) {
+		return !(item->isWall() && wb->hasWall(item));
+	});
+
+	for (auto it = first_to_remove; it != tile->items.end(); ++it) {
+		delete *it;
+	}
+	tile->items.erase(first_to_remove, tile->items.end());
+}
+
+void addWallItem(Tile* tile, Item* item) {
+	if (!tile || !item) return;
+	ASSERT(item->isWall());
+	tile->addItem(item);
+}
+
+void tableize(BaseMap* map, Tile* tile) {
+	if (!tile) return;
+	TableBrush::doTables(map, tile);
+}
+
+void cleanTables(Tile* tile, bool dontdelete) {
+	if (!tile) return;
+	auto first_to_remove = std::stable_partition(tile->items.begin(), tile->items.end(), [](Item* item) {
+		return !item->isTable();
+	});
+
+	if (!dontdelete) {
+		for (auto it = first_to_remove; it != tile->items.end(); ++it) {
+			delete *it;
+		}
+	}
+	tile->items.erase(first_to_remove, tile->items.end());
+}
+
+void carpetize(BaseMap* map, Tile* tile) {
+	if (!tile) return;
+	CarpetBrush::doCarpets(map, tile);
+}
+
+} // namespace TileOperations

--- a/source/map/tile_operations.h
+++ b/source/map/tile_operations.h
@@ -1,0 +1,27 @@
+#ifndef RME_MAP_TILE_OPERATIONS_H_
+#define RME_MAP_TILE_OPERATIONS_H_
+
+class BaseMap;
+class Tile;
+class Item;
+class WallBrush;
+
+namespace TileOperations {
+
+void borderize(BaseMap* map, Tile* tile);
+void cleanBorders(Tile* tile);
+void addBorderItem(Tile* tile, Item* item);
+
+void wallize(BaseMap* map, Tile* tile);
+void cleanWalls(Tile* tile, bool dontdelete = false);
+void cleanWalls(Tile* tile, WallBrush* wb);
+void addWallItem(Tile* tile, Item* item);
+
+void tableize(BaseMap* map, Tile* tile);
+void cleanTables(Tile* tile, bool dontdelete = false);
+
+void carpetize(BaseMap* map, Tile* tile);
+
+} // namespace TileOperations
+
+#endif


### PR DESCRIPTION
This PR addresses core system issues identified by the Fixer agent. It refactors the `Tile` class to reduce responsibilities and coupling with brushes, modernizes the `Selection` system using C++20 ranges, and introduces modern iteration patterns for the Map system.

Key changes:
1.  **Tile Refactor**: Moved logic that modifies tile content based on brushes (e.g., auto-bordering, wall placement) out of `Tile` and into `TileOperations` namespace. This simplifies `Tile` and breaks circular dependencies.
2.  **Selection Modernization**: Rewrote `Selection::flush` to use `std::ranges` for cleaner and potentially more efficient set operations.
3.  **Map Iteration**: Added a `tiles()` view to `BaseMap` to allow range-based iteration over tiles, replacing some legacy macro-like template usage.

This work aligns with the goal of modernizing the codebase and improving maintainability.

---
*PR created automatically by Jules for task [13005835877837576315](https://jules.google.com/task/13005835877837576315) started by @karolak6612*