### PR TITLE
🗝️ Keeper: Modernize ownership with unique_ptr

### DIFF
--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -46,7 +46,7 @@
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::unique_ptr<ActionQueue>(newd ActionQueue(*this))),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -57,7 +57,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version) :
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName& fn) :
 	live_manager(*this),
-	actionQueue(newd ActionQueue(*this)),
+	actionQueue(std::unique_ptr<ActionQueue>(newd ActionQueue(*this))),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -69,7 +69,7 @@ Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, const FileName
 
 Editor::Editor(CopyBuffer& copybuffer, const MapVersion& version, std::unique_ptr<LiveClient> client) :
 	live_manager(*this, std::move(client)),
-	actionQueue(newd NetworkedActionQueue(*this)),
+	actionQueue(std::unique_ptr<NetworkedActionQueue>(newd NetworkedActionQueue(*this))),
 	selection(*this),
 	copybuffer(copybuffer),
 	replace_brush(nullptr) {
@@ -85,7 +85,6 @@ Editor::~Editor() {
 
 	UnnamedRenderingLock();
 	selection.clear();
-	delete actionQueue;
 	spdlog::info("Editor destroyed [Editor={}]", (void*)this);
 }
 

--- a/source/editor/editor.h
+++ b/source/editor/editor.h
@@ -38,6 +38,7 @@ class LiveSocket;
 #include "live/live_manager.h"
 
 #include <functional>
+#include <memory>
 
 class Editor {
 public:
@@ -51,7 +52,7 @@ public:
 
 public:
 	// Public members
-	ActionQueue* actionQueue;
+	std::unique_ptr<ActionQueue> actionQueue;
 	Selection selection;
 	CopyBuffer& copybuffer;
 	GroundBrush* replace_brush;

--- a/source/live/live_manager.cpp
+++ b/source/live/live_manager.cpp
@@ -66,8 +66,7 @@ LiveServer* LiveManager::StartServer() {
 	ASSERT(IsLocal());
 	live_server = std::make_unique<LiveServer>(editor);
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd NetworkedActionQueue(editor);
+	editor.actionQueue = std::unique_ptr<NetworkedActionQueue>(newd NetworkedActionQueue(editor));
 
 	return live_server.get();
 }
@@ -95,8 +94,7 @@ void LiveManager::CloseServer() {
 		live_client.reset();
 	}
 
-	delete editor.actionQueue;
-	editor.actionQueue = newd ActionQueue(editor);
+	editor.actionQueue = std::unique_ptr<ActionQueue>(newd ActionQueue(editor));
 
 	NetworkConnection& connection = NetworkConnection::getInstance();
 	connection.stop();

--- a/source/live/live_peer.cpp
+++ b/source/live/live_peer.cpp
@@ -278,9 +278,9 @@ void LivePeer::parseReceiveChanges(NetworkMessage& message) {
 
 	if (tileNode) {
 		do {
-			Tile* tile = readTile(tileNode, editor, nullptr);
+			std::unique_ptr<Tile> tile = readTile(tileNode, editor, nullptr);
 			if (tile) {
-				action->addChange(std::make_unique<Change>(tile));
+				action->addChange(std::make_unique<Change>(tile.release()));
 			}
 		} while (tileNode->advance());
 	}

--- a/source/live/live_socket.h
+++ b/source/live/live_socket.h
@@ -78,7 +78,7 @@ protected:
 	void sendTile(MemoryNodeFileWriteHandle& writer, Tile* tile, const Position* position);
 
 	// read / write types
-	Tile* readTile(BinaryNode* node, Editor& editor, const Position* position);
+	std::unique_ptr<Tile> readTile(BinaryNode* node, Editor& editor, const Position* position);
 
 	LiveCursor readCursor(NetworkMessage& message);
 	void writeCursor(NetworkMessage& message, const LiveCursor& cursor);

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -72,7 +72,7 @@ void NetworkMessage::write<Position>(const Position& value) {
 
 // NetworkConnection
 NetworkConnection::NetworkConnection() :
-	service(nullptr), thread(), stopped(false) {
+	thread(), stopped(false) {
 	//
 }
 
@@ -95,7 +95,7 @@ bool NetworkConnection::start() {
 
 	stopped = false;
 	if (!service) {
-		service = new boost::asio::io_context;
+		service = std::make_unique<boost::asio::io_context>();
 	}
 
 	thread = std::thread([this]() -> void {
@@ -119,10 +119,11 @@ void NetworkConnection::stop() {
 
 	service->stop();
 	stopped = true;
-	thread.join();
+	if (thread.joinable()) {
+		thread.join();
+	}
 
-	delete service;
-	service = nullptr;
+	service.reset();
 }
 
 boost::asio::io_context& NetworkConnection::get_service() {

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,13 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <memory>
+
+namespace boost {
+namespace asio {
+class io_context;
+}
+}
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -78,7 +85,7 @@ public:
 	boost::asio::io_context& get_service();
 
 private:
-	boost::asio::io_context* service;
+	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
 	bool stopped;
 };


### PR DESCRIPTION
Refactored manual memory management to use `std::unique_ptr` in key areas:
- `LiveSocket::readTile`: Now returns `std::unique_ptr<Tile>` to ensure automatic cleanup on error paths, preventing memory leaks during tile parsing.
- `NetworkConnection`: Managed `boost::asio::io_context` with `std::unique_ptr`, removing manual `new`/`delete` and improving thread safety in `stop()`.
- `Editor`: Managed `ActionQueue` with `std::unique_ptr`, simplifying constructors and `LiveManager` logic.

---
*PR created automatically by Jules for task [7481221665264082988](https://jules.google.com/task/7481221665264082988) started by @karolak6612*