### PR TITLE
👻 Phantom: NanoVG UI Migration & Event Cleanup

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -20,9 +20,9 @@ public:
 	 * @brief Constructs a VirtualBrushGrid.
 	 * @param parent Parent window
 	 * @param _tileset The tileset category containing brushes
-	 * @param rsz Icon render size (16x16 or 32x32)
+	 * @param ltype Brush list display type
 	 */
-	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz);
+	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, BrushListType ltype);
 	~VirtualBrushGrid() override;
 
 	wxWindow* GetSelfWindow() override {
@@ -57,6 +57,7 @@ protected:
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
 
 	RenderSize icon_size;
+	BrushListType list_type;
 	int selected_index;
 	int hover_index;
 	int columns;

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -22,7 +22,6 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
 
-	Bind(wxEVT_LISTBOX, &BrushPanel::OnClickListBoxRow, this, wxID_ANY);
 }
 
 BrushPanel::~BrushPanel() {
@@ -68,20 +67,7 @@ void BrushPanel::LoadContents() {
 
 	ASSERT(tileset != nullptr);
 
-	switch (list_type) {
-		case BRUSHLIST_LARGE_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
-			break;
-		case BRUSHLIST_SMALL_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16);
-			break;
-		case BRUSHLIST_LISTBOX:
-		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
-			break;
-		default:
-			break;
-	}
+	brushbox = newd VirtualBrushGrid(this, tileset, list_type);
 
 	if (!brushbox) {
 		return;
@@ -135,116 +121,4 @@ void BrushPanel::OnSwitchIn() {
 
 void BrushPanel::OnSwitchOut() {
 	////
-}
-
-void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
-	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	// We just notify the GUI of the action, it will take care of everything else
-	ASSERT(brushbox);
-	size_t n = event.GetSelection();
-
-	wxWindow* w = this->GetParent();
-	while (w) {
-		PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
-		if (pw) {
-			g_gui.ActivatePalette(pw);
-			break;
-		}
-		w = w->GetParent();
-	}
-
-	g_gui.SelectBrush(tileset->brushlist[n], tileset->getType());
-}
-
-// ============================================================================
-// BrushListBox
-
-BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
-	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	BrushBoxInterface(tileset) {
-	SetItemCount(tileset->size());
-	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
-}
-
-BrushListBox::~BrushListBox() {
-	////
-}
-
-void BrushListBox::SelectFirstBrush() {
-	SetSelection(0);
-	wxWindow::ScrollLines(-1);
-}
-
-Brush* BrushListBox::GetSelectedBrush() const {
-	if (!tileset) {
-		return nullptr;
-	}
-
-	int n = GetSelection();
-	if (n != wxNOT_FOUND) {
-		return tileset->brushlist[n];
-	} else if (tileset->size() > 0) {
-		return tileset->brushlist[0];
-	}
-	return nullptr;
-}
-
-bool BrushListBox::SelectBrush(const Brush* whatbrush) {
-	auto it = std::ranges::find(tileset->brushlist, whatbrush);
-	if (it != tileset->brushlist.end()) {
-		SetSelection(std::distance(tileset->brushlist.begin(), it));
-		return true;
-	}
-	return false;
-}
-
-void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	ASSERT(n < tileset->size());
-	Sprite* spr = tileset->brushlist[n]->getSprite();
-	if (!spr) {
-		spr = g_gui.gfx.getSprite(tileset->brushlist[n]->getLookID());
-	}
-	if (spr) {
-		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord BrushListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
-
-void BrushListBox::OnKey(wxKeyEvent& event) {
-	switch (event.GetKeyCode()) {
-		case WXK_UP:
-		case WXK_DOWN:
-		case WXK_LEFT:
-		case WXK_RIGHT:
-		case WXK_PAGEUP:
-		case WXK_PAGEDOWN:
-		case WXK_HOME:
-		case WXK_END:
-			if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
-				event.Skip(true);
-			} else {
-				if (g_gui.GetCurrentTab() != nullptr) {
-					g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-				}
-			}
-			break;
-		default:
-			if (g_gui.GetCurrentTab() != nullptr) {
-				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-			}
-			break;
-	}
 }

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,29 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() override {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush() override;
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const override;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush) override;
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;
-	virtual wxCoord OnMeasureItem(size_t n) const override;
-
-	void OnKey(wxKeyEvent& event);
-};
-
 class BrushPanel : public wxPanel {
 public:
 	BrushPanel(wxWindow* parent);
@@ -86,9 +63,6 @@ public:
 	void OnSwitchIn();
 	// Called when this page is hidden
 	void OnSwitchOut();
-
-	// wxWidgets event handlers
-	void OnClickListBoxRow(wxCommandEvent& event);
 
 protected:
 	const TilesetCategory* tileset;

--- a/source/ui/dcbutton.h
+++ b/source/ui/dcbutton.h
@@ -18,6 +18,8 @@
 #ifndef RME_DC_BUTTON_H
 #define RME_DC_BUTTON_H
 
+#include "util/nanovg_canvas.h"
+
 class Sprite;
 class GameSprite;
 class EditorSprite;
@@ -33,9 +35,8 @@ enum RenderSize {
 	RENDER_SIZE_64x64,
 };
 
-class DCButton : public wxPanel {
+class DCButton : public NanoVGCanvas {
 public:
-	DCButton();
 	DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, RenderSize sz, int sprite_id);
 	virtual ~DCButton();
 
@@ -45,10 +46,12 @@ public:
 	void SetSprite(int id);
 	void SetSprite(Sprite* sprite);
 
-	void OnPaint(wxPaintEvent&);
 	void OnClick(wxMouseEvent&);
 
 protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	int GetOrCreateSpriteTexture(NVGcontext* vg, Sprite* sprite);
+
 	void SetOverlay(Sprite* espr);
 
 	int type;
@@ -56,8 +59,6 @@ protected:
 	RenderSize size;
 	Sprite* sprite;
 	Sprite* overlay;
-
-	DECLARE_DYNAMIC_CLASS(DCButton)
 };
 
 #endif

--- a/source/ui/properties/creature_properties_window.cpp
+++ b/source/ui/properties/creature_properties_window.cpp
@@ -8,12 +8,7 @@
 #include "game/creature.h"
 #include "ui/gui.h"
 
-/*
-BEGIN_EVENT_TABLE(CreaturePropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, CreaturePropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, CreaturePropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 CreaturePropertiesWindow::CreaturePropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Creature* creature, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Creature Properties", map, tile_parent, creature, pos),

--- a/source/ui/properties/depot_properties_window.cpp
+++ b/source/ui/properties/depot_properties_window.cpp
@@ -15,12 +15,7 @@
 // ============================================================================
 // Depot Properties Window
 
-/*
-BEGIN_EVENT_TABLE(DepotPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, DepotPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, DepotPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 DepotPropertiesWindow::DepotPropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Depot Properties", map, tile, item, pos),

--- a/source/ui/properties/podium_properties_window.cpp
+++ b/source/ui/properties/podium_properties_window.cpp
@@ -14,12 +14,7 @@
 
 static constexpr int OUTFIT_COLOR_MAX = 133;
 
-/*
-BEGIN_EVENT_TABLE(PodiumPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, PodiumPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, PodiumPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 PodiumPropertiesWindow::PodiumPropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Podium Properties", map, tile_parent, item, pos) {

--- a/source/ui/properties/spawn_properties_window.cpp
+++ b/source/ui/properties/spawn_properties_window.cpp
@@ -8,12 +8,7 @@
 #include "map/map.h"
 #include "app/application.h"
 
-/*
-BEGIN_EVENT_TABLE(SpawnPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, SpawnPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, SpawnPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Spawn* spawn, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Spawn Properties", map, tile_parent, spawn, pos),

--- a/source/ui/properties/splash_properties_window.cpp
+++ b/source/ui/properties/splash_properties_window.cpp
@@ -13,12 +13,7 @@
 // ============================================================================
 // Splash Properties Window
 
-/*
-BEGIN_EVENT_TABLE(SplashPropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, SplashPropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, SplashPropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 SplashPropertiesWindow::SplashPropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Splash Properties", map, tile, item, pos),

--- a/source/ui/properties/writable_properties_window.cpp
+++ b/source/ui/properties/writable_properties_window.cpp
@@ -13,12 +13,7 @@
 // ============================================================================
 // Writable Properties Window
 
-/*
-BEGIN_EVENT_TABLE(WritablePropertiesWindow, wxDialog)
-EVT_BUTTON(wxID_OK, WritablePropertiesWindow::OnClickOK)
-EVT_BUTTON(wxID_CANCEL, WritablePropertiesWindow::OnClickCancel)
-END_EVENT_TABLE()
-*/
+
 
 WritablePropertiesWindow::WritablePropertiesWindow(wxWindow* parent, const Map* map, const Tile* tile, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(parent, "Writable Properties", map, tile, item, pos),


### PR DESCRIPTION
This PR addresses UI modernization tasks assigned to the Phantom agent. 

Key changes:
1.  **Unified Brush Grid**: `VirtualBrushGrid` now supports both grid (icons only) and list (icon + label) layouts. This allowed the removal of the legacy `BrushListBox` control which used `wxVListBox` and GDI+ rendering. `BrushPanel` now exclusively uses `VirtualBrushGrid`.
2.  **NanoVG Buttons**: `DCButton` has been ported from `wxPanel` (using `wxBufferedPaintDC`) to `NanoVGCanvas`. It now uses hardware-accelerated rendering for button states (borders, gradients) and sprite content. A helper method `GetOrCreateSpriteTexture` was implemented to handle sprite-to-texture conversion for `GameSprite` (optimized) and other sprite types (fallback via `wxMemoryDC`).
3.  **Event Table Cleanup**: Removed commented-out `BEGIN_EVENT_TABLE` blocks from 6 property window files (`writable_properties_window.cpp`, etc.) as they have been fully migrated to `Bind()`.

These changes improve UI performance (GPU acceleration) and code maintainability (unified controls, modern event handling).

---
*PR created automatically by Jules for task [12730623593164654399](https://jules.google.com/task/12730623593164654399) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Brush list view now displays brush names as text alongside icons in list modes.

* **Refactor**
  * Simplified brush panel implementation for improved maintainability.
  * Migrated button rendering to modern graphics engine for enhanced visual quality.
  * Modernized UI event handling by removing deprecated event table patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->