### PR TITLE
[MODERNIZE] Use range-based for loops and static_cast

### DIFF
--- a/source/io/filehandle.cpp
+++ b/source/io/filehandle.cpp
@@ -234,8 +234,8 @@ DiskNodeFileReadHandle::DiskNodeFileReadHandle(const std::string& name, const st
 
 		if (ver[0] != 0 || ver[1] != 0 || ver[2] != 0 || ver[3] != 0) {
 			bool accepted = false;
-			for (std::vector<std::string>::const_iterator id_iter = acceptable_identifiers.begin(); id_iter != acceptable_identifiers.end(); ++id_iter) {
-				if (memcmp(ver, id_iter->c_str(), 4) == 0) {
+			for (const auto& id : acceptable_identifiers) {
+				if (memcmp(ver, id.c_str(), 4) == 0) {
 					accepted = true;
 					break;
 				}

--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -264,8 +264,8 @@ bool Container::serializeItemNode_OTMM(const IOMap& maphandle, NodeFileWriteHand
 	f.addU16(id);
 	serializeItemAttributes_OTMM(maphandle, f);
 
-	for (ItemVector::const_iterator it = contents.begin(); it != contents.end(); ++it) {
-		(*it)->serializeItemNode_OTMM(maphandle, f);
+	for (const auto& item : contents) {
+		item->serializeItemNode_OTMM(maphandle, f);
 	}
 	f.endNode();
 	return true;
@@ -837,8 +837,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 								f.addU16(0);
 							} else if (ground->hasBorderEquivalent()) {
 								bool found = false;
-								for (ItemVector::const_iterator it = save_tile->items.begin(); it != save_tile->items.end(); ++it) {
-									if ((*it)->getGroundEquivalent() == ground->getID()) {
+								for (const auto& item : save_tile->items) {
+									if (item->getGroundEquivalent() == ground->getID()) {
 										// Do nothing
 										// Found equivalent
 										found = true;
@@ -860,9 +860,9 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 							f.addU16(0);
 						}
 
-						for (ItemVector::const_iterator it = save_tile->items.begin(); it != save_tile->items.end(); ++it) {
-							if (!(*it)->isMetaItem()) {
-								(*it)->serializeItemNode_OTMM(*this, f);
+						for (const auto& item : save_tile->items) {
+							if (!item->isMetaItem()) {
+								item->serializeItemNode_OTMM(*this, f);
 							}
 						}
 					}
@@ -877,8 +877,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 			{
 				Spawns& spawns = map.spawns;
 				CreatureList creature_list;
-				for (SpawnPositionList::const_iterator piter = spawns.begin(); piter != spawns.end(); ++piter) {
-					const Tile* tile = map.getTile(*piter);
+				for (const auto& spawnPos : spawns) {
+					const Tile* tile = map.getTile(spawnPos);
 					ASSERT(tile);
 					const Spawn* spawn = tile->spawn;
 					ASSERT(spawn);
@@ -891,7 +891,7 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 						f.addU32(spawn->getSize());
 						for (int y = -tile->spawn->getSize(); y <= tile->spawn->getSize(); ++y) {
 							for (int x = -tile->spawn->getSize(); x <= tile->spawn->getSize(); ++x) {
-								Tile* creature_tile = map.getTile(*piter + Position(x, y, 0));
+								Tile* creature_tile = map.getTile(spawnPos + Position(x, y, 0));
 								if (creature_tile) {
 									Creature* c = creature_tile->creature;
 									if (c && c->isSaved() == false) {
@@ -926,8 +926,8 @@ bool IOMapOTMM::saveMap(Map& map, NodeFileWriteHandle& f, const FileName& identi
 					}
 					f.endNode(); // OTMM_SPAWN_AREA
 				}
-				for (CreatureList::iterator iter = creature_list.begin(); iter != creature_list.end(); ++iter) {
-					(*iter)->reset();
+				for (auto* creature : creature_list) {
+					creature->reset();
 				}
 			}
 			f.endNode(); // OTMM_SPAWN_DATA

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -113,8 +113,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	gpu_lights_.clear();
 	gpu_lights_.reserve(light_buffer.lights.size());
 
-	float map_draw_start_x = (float)(map_x * TileSize - view.view_scroll_x);
-	float map_draw_start_y = (float)(map_y * TileSize - view.view_scroll_y);
+	float map_draw_start_x = static_cast<float>(map_x * TileSize - view.view_scroll_x);
+	float map_draw_start_y = static_cast<float>(map_y * TileSize - view.view_scroll_y);
 
 	// Offset logic:
 	// The FBO represents the rectangle [map_x * 32, map_x * 32 + pixel_width] in map coordinates.
@@ -122,8 +122,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// Light Position in FBO = (LightMapX * 32 - FBO_StartX_In_Pixels, ...)
 	// FBO Start X in pure Map Pixel Coords = map_x * 32.
 
-	float fbo_origin_x = (float)(map_x * TileSize);
-	float fbo_origin_y = (float)(map_y * TileSize);
+	float fbo_origin_x = static_cast<float>(map_x * TileSize);
+	float fbo_origin_y = static_cast<float>(map_y * TileSize);
 
 	for (const auto& light : light_buffer.lights) {
 		// Cull lights that are definitely out of FBO range
@@ -189,9 +189,9 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 
 		// Setup Projection for FBO: Ortho 0..buffer_width, buffer_height..0 (Y-down)
 		// This matches screen coordinate system and avoids flips
-		glm::mat4 fbo_projection = glm::ortho(0.0f, (float)buffer_width, (float)buffer_height, 0.0f);
+		glm::mat4 fbo_projection = glm::ortho(0.0f, static_cast<float>(buffer_width), static_cast<float>(buffer_height), 0.0f);
 		shader->SetMat4("uProjection", fbo_projection);
-		shader->SetFloat("uTileSize", (float)TileSize);
+		shader->SetFloat("uTileSize", static_cast<float>(TileSize));
 
 		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, light_ssbo->GetID());
 		glBindVertexArray(vao->GetID());
@@ -201,7 +201,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 			ScopedGLCapability blendCap(GL_BLEND);
 			ScopedGLBlend blendState(GL_ONE, GL_ONE, GL_MAX); // Factors don't matter much for MAX, but usually 1,1 is safe
 
-			glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, (GLsizei)gpu_lights_.size());
+			glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(gpu_lights_.size()));
 		}
 
 		glBindVertexArray(0);
@@ -247,8 +247,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// Quad Transform for Screen
 	float draw_dest_x = map_draw_start_x;
 	float draw_dest_y = map_draw_start_y;
-	float draw_dest_w = (float)pixel_width;
-	float draw_dest_h = (float)pixel_height;
+	float draw_dest_w = static_cast<float>(pixel_width);
+	float draw_dest_h = static_cast<float>(pixel_height);
 
 	glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(draw_dest_x, draw_dest_y, 0.0f));
 	model = glm::scale(model, glm::vec3(draw_dest_w, draw_dest_h, 1.0f));
@@ -263,8 +263,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// If we use Y-down ortho: Y=0 -> V=1, Y=buffer_height -> V=0.
 	// Map Top (Y=0) -> V=1. Map Bottom (Y=pixel_height) -> V = 1.0 - (pixel_height / buffer_height).
 
-	float uv_w = (float)pixel_width / (float)buffer_width;
-	float uv_h = (float)pixel_height / (float)buffer_height;
+	float uv_w = static_cast<float>(pixel_width) / static_cast<float>(buffer_width);
+	float uv_h = static_cast<float>(pixel_height) / static_cast<float>(buffer_height);
 
 	// We pass UV range to shader. Shader should map aPos.y (0..1) to correct range.
 	// If screen aPos.y=0 is Top, it should get texture Map Top.


### PR DESCRIPTION
This PR modernizes several parts of the codebase by replacing outdated C++ patterns with modern alternatives.
Specifically:
1.  **Loop Refactoring**:
    -   In `source/io/iomap_otmm.cpp`, raw iterator loops iterating over `contents`, `save_tile->items`, `spawns`, and `creature_list` have been replaced with range-based for loops.
    -   In `source/io/filehandle.cpp`, a raw iterator loop over `acceptable_identifiers` has been replaced with a range-based for loop.
2.  **Cast Modernization**:
    -   In `source/rendering/utilities/light_drawer.cpp`, C-style casts (e.g., `(float)val`, `(GLsizei)val`) have been replaced with `static_cast<T>(val)` to improve type safety and code clarity.

These changes improve code quality and maintainability without altering functionality.

---
*PR created automatically by Jules for task [12659689749073439397](https://jules.google.com/task/12659689749073439397) started by @karolak6612*