### PR TITLE
OpenGL Rendering Optimizations: Minimap Batching and View Culling

### DIFF
--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -77,6 +77,18 @@ bool RenderView::IsPixelVisible(int draw_x, int draw_y, int margin) const {
 	return true;
 }
 
+bool RenderView::IsRectFullyInside(int draw_x, int draw_y, int w, int h) const {
+	// Checks if the rectangle [draw_x, draw_y, w, h] is fully inside the viewport [0, logical_width] x [0, logical_height]
+	// Note: zoom is inverse scale (zoom > 1.0 means minified/zoomed out), so logical dimensions increase with zoom.
+	float logical_width = screensize_x * zoom;
+	float logical_height = screensize_y * zoom;
+
+	if (draw_x >= 0 && draw_x + w <= logical_width && draw_y >= 0 && draw_y + h <= logical_height) {
+		return true;
+	}
+	return false;
+}
+
 void RenderView::getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const {
 	int offset = (map_z <= GROUND_LAYER)
 		? (GROUND_LAYER - map_z) * TileSize

--- a/source/rendering/core/render_view.h
+++ b/source/rendering/core/render_view.h
@@ -34,6 +34,7 @@ struct RenderView {
 	int getFloorAdjustment() const;
 	bool IsTileVisible(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 	bool IsPixelVisible(int draw_x, int draw_y, int margin = PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS) const;
+	bool IsRectFullyInside(int draw_x, int draw_y, int w, int h) const;
 	void getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 };
 

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -69,6 +69,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 				if (nd->isVisible(map_z > GROUND_LAYER)) {
 					int node_draw_x = nd_map_x * TileSize + base_screen_x;
 					int node_draw_y = nd_map_y * TileSize + base_screen_y;
+					bool fully_visible = view.IsRectFullyInside(node_draw_x, node_draw_y, 4 * TileSize, 4 * TileSize);
 
 					for (int map_x = 0; map_x < 4; ++map_x) {
 						for (int map_y = 0; map_y < 4; ++map_y) {
@@ -77,7 +78,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 							int draw_y = node_draw_y + (map_y * TileSize);
 
 							// Culling: Skip tiles that are far outside the viewport.
-							if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+							if (!fully_visible && !view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
 								continue;
 							}
 
@@ -106,6 +107,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 		editor->map.visitLeaves(nd_start_x, nd_start_y, nd_end_x, nd_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
+			bool fully_visible = view.IsRectFullyInside(node_draw_x, node_draw_y, 4 * TileSize, 4 * TileSize);
 
 			for (int map_x = 0; map_x < 4; ++map_x) {
 				for (int map_y = 0; map_y < 4; ++map_y) {
@@ -114,7 +116,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					int draw_y = node_draw_y + (map_y * TileSize);
 
 					// Culling: Skip tiles that are far outside the viewport.
-					if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+					if (!fully_visible && !view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
 						continue;
 					}
 

--- a/source/rendering/drawers/minimap_renderer.h
+++ b/source/rendering/drawers/minimap_renderer.h
@@ -2,7 +2,7 @@
 #define RME_RENDERING_DRAWERS_MINIMAP_RENDERER_H_
 
 #include "app/main.h"
-#include "rendering/core/pixel_buffer_object.h"
+#include "rendering/core/ring_buffer.h"
 #include "rendering/core/shader_program.h"
 #include "rendering/core/gl_resources.h"
 #include <vector>
@@ -83,10 +83,7 @@ private:
 	int height_ = 0;
 
 	std::unique_ptr<ShaderProgram> shader_;
-	std::unique_ptr<PixelBufferObject> pbo_;
-
-	// Temporary staging buffer for PBO uploads
-	std::vector<uint8_t> stage_buffer_;
+	RingBuffer pbo_;
 
 	// Tiled configuration
 	static constexpr int TILE_SIZE = 2048;


### PR DESCRIPTION
Optimized rendering pipeline by batching minimap texture updates and implementing efficient culling for map layers.

- Replaced `PixelBufferObject` with `RingBuffer` in `MinimapRenderer` to enable batched, triple-buffered updates, eliminating per-chunk GPU stalls.
- Implemented `IsRectFullyInside` in `RenderView` to skip redundant visibility checks for fully visible map nodes in `MapLayerDrawer`.
- Verified `RingBuffer` implementation supports triple buffering and correct fencing.

---
*PR created automatically by Jules for task [17734472034789150534](https://jules.google.com/task/17734472034789150534) started by @karolak6612*