### PR TITLE
Profiler: Optimize MapLayerDrawer with node-level culling

### DIFF
--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -77,6 +77,22 @@ bool RenderView::IsPixelVisible(int draw_x, int draw_y, int margin) const {
 	return true;
 }
 
+bool RenderView::IsRectFullyInside(int draw_x, int draw_y, int width, int height, int margin) const {
+	// Logic matches IsPixelVisible but checks containment.
+	// screensize_x * zoom gives the logical viewport size (since TileSize is constant 32).
+	float logical_width = screensize_x * zoom;
+	float logical_height = screensize_y * zoom;
+
+	// Check if the rectangle is fully within the visible bounds (expanded by margin)
+	if (draw_x >= -margin &&
+		draw_x + width <= logical_width + margin &&
+		draw_y >= -margin &&
+		draw_y + height <= logical_height + margin) {
+		return true;
+	}
+	return false;
+}
+
 void RenderView::getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const {
 	int offset = (map_z <= GROUND_LAYER)
 		? (GROUND_LAYER - map_z) * TileSize

--- a/source/rendering/core/render_view.h
+++ b/source/rendering/core/render_view.h
@@ -34,6 +34,7 @@ struct RenderView {
 	int getFloorAdjustment() const;
 	bool IsTileVisible(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 	bool IsPixelVisible(int draw_x, int draw_y, int margin = PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS) const;
+	bool IsRectFullyInside(int draw_x, int draw_y, int width, int height, int margin = PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS) const;
 	void getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 };
 

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -70,6 +70,9 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					int node_draw_x = nd_map_x * TileSize + base_screen_x;
 					int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
+					// Optimization: Check if the whole node (4x4 tiles) is fully visible
+					bool node_fully_visible = view.IsRectFullyInside(node_draw_x, node_draw_y, 4 * TileSize, 4 * TileSize, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS);
+
 					for (int map_x = 0; map_x < 4; ++map_x) {
 						for (int map_y = 0; map_y < 4; ++map_y) {
 							// Calculate draw coordinates directly
@@ -77,7 +80,8 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 							int draw_y = node_draw_y + (map_y * TileSize);
 
 							// Culling: Skip tiles that are far outside the viewport.
-							if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+							// Only perform this check if the node is NOT fully visible
+							if (!node_fully_visible && !view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
 								continue;
 							}
 
@@ -107,6 +111,9 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 			int node_draw_x = nd_map_x * TileSize + base_screen_x;
 			int node_draw_y = nd_map_y * TileSize + base_screen_y;
 
+			// Optimization: Check if the whole node (4x4 tiles) is fully visible
+			bool node_fully_visible = view.IsRectFullyInside(node_draw_x, node_draw_y, 4 * TileSize, 4 * TileSize, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS);
+
 			for (int map_x = 0; map_x < 4; ++map_x) {
 				for (int map_y = 0; map_y < 4; ++map_y) {
 					// Calculate draw coordinates directly
@@ -114,7 +121,8 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, PrimitiveRenderer& primitiv
 					int draw_y = node_draw_y + (map_y * TileSize);
 
 					// Culling: Skip tiles that are far outside the viewport.
-					if (!view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
+					// Only perform this check if the node is NOT fully visible
+					if (!node_fully_visible && !view.IsPixelVisible(draw_x, draw_y, PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS)) {
 						continue;
 					}
 


### PR DESCRIPTION
Identified a CPU bottleneck in `MapLayerDrawer::Draw` where `IsPixelVisible` was called for every tile (approx. 2000 times per frame at 1080p).
Implemented node-level culling (4x4 tiles) using a new `IsRectFullyInside` method in `RenderView`.
This optimization reduces the number of visibility checks significantly for fully visible nodes, which constitute the majority of the viewport.
Also identified other bottlenecks in Tooltip system for future optimization.

---
*PR created automatically by Jules for task [4308672550369366458](https://jules.google.com/task/4308672550369366458) started by @karolak6612*