### PR TITLE
⚡ Throttle: Optimize MapLayerDrawer::Draw loop

### DIFF
--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -77,6 +77,16 @@ bool RenderView::IsPixelVisible(int draw_x, int draw_y, int margin) const {
 	return true;
 }
 
+bool RenderView::IsRectFullyInside(int x, int y, int w, int h, int margin) const {
+	float logical_width = screensize_x * zoom;
+	float logical_height = screensize_y * zoom;
+
+	return (x >= -margin) &&
+	       (x + w <= logical_width + margin) &&
+	       (y >= -margin) &&
+	       (y + h <= logical_height + margin);
+}
+
 void RenderView::getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const {
 	int offset = (map_z <= GROUND_LAYER)
 		? (GROUND_LAYER - map_z) * TileSize

--- a/source/rendering/core/render_view.h
+++ b/source/rendering/core/render_view.h
@@ -34,6 +34,7 @@ struct RenderView {
 	int getFloorAdjustment() const;
 	bool IsTileVisible(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 	bool IsPixelVisible(int draw_x, int draw_y, int margin = PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS) const;
+	bool IsRectFullyInside(int x, int y, int w, int h, int margin = PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS) const;
 	void getScreenPosition(int map_x, int map_y, int map_z, int& out_x, int& out_y) const;
 };
 


### PR DESCRIPTION
Optimize MapLayerDrawer::Draw loop by hoisting floor lookups, using pointer arithmetic, and skipping visibility checks for fully visible nodes.

---
*PR created automatically by Jules for task [7877994314943887773](https://jules.google.com/task/7877994314943887773) started by @karolak6612*