### PR TITLE
📜 Auditor: Fix virtual overrides and destructors

### DIFF
--- a/source/io/iomap.h
+++ b/source/io/iomap.h
@@ -43,7 +43,7 @@ public:
 		version.otbm = MAP_OTBM_1;
 		version.client = CLIENT_VERSION_NONE;
 	}
-	virtual ~IOMap() { }
+	virtual ~IOMap() = default;
 
 	MapVersion version;
 

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -128,7 +128,7 @@ public:
 	IOMapOTBM(MapVersion ver) {
 		version = ver;
 	}
-	~IOMapOTBM() { }
+	~IOMapOTBM() override = default;
 
 	static bool getVersionInfo(const FileName& identifier, MapVersion& out_ver);
 
@@ -138,7 +138,7 @@ public:
 protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
-	virtual bool loadMap(Map& map, NodeFileReadHandle& handle);
+	bool loadMap(Map& map, NodeFileReadHandle& handle);
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);
@@ -146,7 +146,7 @@ protected:
 	bool loadWaypoints(Map& map, const FileName& dir);
 	bool loadWaypoints(Map& map, pugi::xml_document& doc);
 
-	virtual bool saveMap(Map& map, NodeFileWriteHandle& handle);
+	bool saveMap(Map& map, NodeFileWriteHandle& handle);
 	bool saveSpawns(Map& map, const FileName& dir);
 	bool saveSpawns(Map& map, pugi::xml_document& doc);
 	bool saveHouses(Map& map, const FileName& dir);

--- a/source/map/basemap.cpp
+++ b/source/map/basemap.cpp
@@ -28,10 +28,6 @@ BaseMap::BaseMap() :
 	////
 }
 
-BaseMap::~BaseMap() {
-	////
-}
-
 void BaseMap::clear(bool del) {
 	PositionVector pos_vec;
 	for (MapIterator map_iter = begin(); map_iter != end(); ++map_iter) {
@@ -146,10 +142,6 @@ MapIterator::MapIterator(BaseMap* _map) :
 	if (map) {
 		cell_it = map->grid.cells.begin();
 	}
-}
-
-MapIterator::~MapIterator() {
-	////
 }
 
 // Copy constructor for flat iterator design - copies all stateful members

--- a/source/map/basemap.h
+++ b/source/map/basemap.h
@@ -45,7 +45,7 @@ public:
 	using reference = TileLocation&;
 
 	MapIterator(BaseMap* _map = nullptr);
-	~MapIterator();
+	~MapIterator() = default;
 	MapIterator(const MapIterator& other);
 
 	TileLocation& operator*() noexcept;
@@ -78,7 +78,7 @@ private:
 class BaseMap {
 public:
 	BaseMap();
-	virtual ~BaseMap();
+	virtual ~BaseMap() = default;
 
 	// This doesn't destroy the map structure, just clears it, if param is true, delete all tiles too.
 	void clear(bool del = true);

--- a/source/map/map.h
+++ b/source/map/map.h
@@ -31,7 +31,7 @@ class Map : public BaseMap {
 public:
 	// ctor and dtor
 	Map();
-	virtual ~Map();
+	~Map() override;
 
 	// Operations on the entire map
 	void cleanInvalidTiles(bool showdialog = false);

--- a/source/map/otml.h
+++ b/source/map/otml.h
@@ -159,7 +159,7 @@ class OTMLNode : public OTMLNodeEnableSharedFromThis {
 public:
 	OTMLNode() :
 		m_unique(false), m_null(false) { }
-	virtual ~OTMLNode() { }
+	virtual ~OTMLNode() = default;
 
 	static OTMLNodePtr create(std::string tag = "", bool unique = false);
 	static OTMLNodePtr create(std::string tag, std::string value);
@@ -269,11 +269,11 @@ protected:
 class OTMLDocument : public OTMLNode {
 public:
 	OTMLDocument() { }
-	virtual ~OTMLDocument() { }
+	~OTMLDocument() override = default;
 	static OTMLDocumentPtr create();
 	static OTMLDocumentPtr parse(const wxString& fileName);
 	static OTMLDocumentPtr parse(std::istream& in, const wxString& source);
-	std::string emit();
+	std::string emit() override;
 	bool save(const wxString& fileName);
 };
 

--- a/source/rendering/core/editor_sprite.h
+++ b/source/rendering/core/editor_sprite.h
@@ -11,9 +11,9 @@
 class EditorSprite : public Sprite {
 public:
 	EditorSprite(std::unique_ptr<wxBitmap> b16x16, std::unique_ptr<wxBitmap> b32x32);
-	virtual ~EditorSprite();
+	~EditorSprite() override;
 
-	virtual void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
+	void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
 	virtual void unloadDC() override;
 
 protected:

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -36,7 +36,7 @@ class GraphicManager;
 class Sprite {
 public:
 	Sprite() { }
-	virtual ~Sprite() { }
+	virtual ~Sprite() = default;
 
 	virtual void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) = 0;
 	virtual void unloadDC() = 0;
@@ -50,9 +50,9 @@ class GameSprite;
 class CreatureSprite : public Sprite {
 public:
 	CreatureSprite(GameSprite* parent, const Outfit& outfit);
-	virtual ~CreatureSprite();
+	~CreatureSprite() override;
 
-	virtual void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
+	void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
 	virtual void unloadDC() override;
 
 	GameSprite* parent;
@@ -62,7 +62,7 @@ public:
 class GameSprite : public Sprite {
 public:
 	GameSprite();
-	~GameSprite();
+	~GameSprite() override;
 
 	int getIndex(int width, int height, int layer, int pattern_x, int pattern_y, int pattern_z, int frame) const;
 
@@ -70,10 +70,10 @@ public:
 	const AtlasRegion* getAtlasRegion(int _x, int _y, int _layer, int _subtype, int _pattern_x, int _pattern_y, int _pattern_z, int _frame);
 	const AtlasRegion* getAtlasRegion(int _x, int _y, int _dir, int _addon, int _pattern_z, const Outfit& _outfit, int _frame);
 
-	virtual void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
+	void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
 	virtual void DrawTo(wxDC* dc, SpriteSize sz, const Outfit& outfit, int start_x, int start_y, int width = -1, int height = -1);
 
-	virtual void unloadDC() override;
+	void unloadDC() override;
 
 	void clean(time_t time);
 
@@ -100,7 +100,7 @@ protected:
 	class Image {
 	public:
 		Image();
-		virtual ~Image();
+		virtual ~Image() = default;
 
 		bool isGLLoaded;
 		time_t lastaccess;
@@ -119,7 +119,7 @@ protected:
 	class NormalImage : public Image {
 	public:
 		NormalImage();
-		virtual ~NormalImage();
+		~NormalImage() override;
 
 		// We use the sprite id as key
 		uint32_t id;
@@ -143,9 +143,9 @@ protected:
 	class TemplateImage : public Image {
 	public:
 		TemplateImage(GameSprite* parent, int v, const Outfit& outfit);
-		virtual ~TemplateImage();
+		~TemplateImage() override;
 
-		virtual void clean(time_t time) override;
+		void clean(time_t time) override;
 
 		virtual std::unique_ptr<uint8_t[]> getRGBData() override;
 		virtual std::unique_ptr<uint8_t[]> getRGBAData() override;

--- a/source/rendering/ui/map_display.h
+++ b/source/rendering/ui/map_display.h
@@ -45,7 +45,7 @@ class MapMenuHandler;
 class MapCanvas : public wxGLCanvas {
 public:
 	MapCanvas(MapWindow* parent, Editor& editor, int* attriblist);
-	virtual ~MapCanvas();
+	~MapCanvas() override;
 	void Reset();
 
 	// All events

--- a/source/rendering/ui/minimap_window.h
+++ b/source/rendering/ui/minimap_window.h
@@ -27,7 +27,7 @@ class MinimapDrawer;
 class MinimapWindow : public wxGLCanvas {
 public:
 	MinimapWindow(wxWindow* parent);
-	virtual ~MinimapWindow();
+	~MinimapWindow() override;
 
 	void OnPaint(wxPaintEvent&);
 	void OnEraseBackground(wxEraseEvent&) { }


### PR DESCRIPTION
This PR modernizes the codebase by ensuring that virtual functions that override base class methods are explicitly marked with `override`, and destructors are defaulted or overridden correctly. This improves code safety and readability, and helps the compiler catch signature mismatches.

Specific changes:
- `source/io/iomap.h`: `virtual ~IOMap() = default;`
- `source/io/iomap_otbm.h`: `~IOMapOTBM() override = default;`, removed `virtual` from `loadMap`/`saveMap` overloads.
- `source/map/basemap.h`: `virtual ~BaseMap() = default;`, `~MapIterator() = default;`.
- `source/map/basemap.cpp`: Removed empty destructors.
- `source/map/map.h`: `~Map() override;`.
- `source/map/otml.h`: defaulted `~OTMLNode`, `~OTMLDocument` (override), added `override` to `emit()`.
- `source/rendering/core/editor_sprite.h`: `~EditorSprite() override;`.
- `source/rendering/core/game_sprite.h`: Defaulted `~Sprite`, `~Image`. Added `override` to `~CreatureSprite`, `~GameSprite`, `~NormalImage`, `~TemplateImage`.
- `source/rendering/ui/minimap_window.h`: `~MinimapWindow() override;`.
- `source/rendering/ui/map_display.h`: `~MapCanvas() override;`.

---
*PR created automatically by Jules for task [10865743623271162127](https://jules.google.com/task/10865743623271162127) started by @karolak6612*