### PR TITLE
[WXWIDGETS] Fix 42 wxWidgets violations across codebase

### DIFF
--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -8,26 +8,14 @@
 #include "editor/editor.h"
 #include "ui/gui.h"
 #include "rendering/ui/map_display.h"
+#include "app/main.h" // For FROM_DIP
 #include <wx/tglbtn.h>
 
 namespace IngamePreview {
 
-	enum {
-		ID_FOLLOW_SELECTION = 10001,
-		ID_ENABLE_LIGHTING,
-		ID_CHOOSE_OUTFIT,
-		ID_AMBIENT_SLIDER,
-		ID_INTENSITY_SLIDER,
-		ID_VIEWPORT_W_UP,
-		ID_VIEWPORT_W_DOWN,
-		ID_VIEWPORT_H_UP,
-		ID_VIEWPORT_H_DOWN,
-		ID_UPDATE_TIMER
-	};
-
 	IngamePreviewWindow::IngamePreviewWindow(wxWindow* parent) :
 		wxPanel(parent, wxID_ANY),
-		update_timer(this, ID_UPDATE_TIMER),
+		update_timer(this, wxID_ANY),
 		follow_selection(true) {
 
 		// Load initial preferences
@@ -36,87 +24,93 @@ namespace IngamePreview {
 		current_name = wxString::FromUTF8(g_preview_preferences.getName());
 		current_speed = g_preview_preferences.getSpeed();
 
-		// Bind Events
-		Bind(wxEVT_TIMER, &IngamePreviewWindow::OnUpdateTimer, this, ID_UPDATE_TIMER);
-		Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleFollow, this, ID_FOLLOW_SELECTION);
-		Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleLighting, this, ID_ENABLE_LIGHTING);
-		Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnAmbientSlider, this, ID_AMBIENT_SLIDER);
-		Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnIntensitySlider, this, ID_INTENSITY_SLIDER);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthUp, this, ID_VIEWPORT_W_UP);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthDown, this, ID_VIEWPORT_W_DOWN);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightUp, this, ID_VIEWPORT_H_UP);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightDown, this, ID_VIEWPORT_H_DOWN);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnChooseOutfit, this, ID_CHOOSE_OUTFIT);
-
 		wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
 
 		// Single Toolbar
 		wxBoxSizer* toolbar_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 		// Toggles
-		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, wxSize(28, 24));
-		follow_btn->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(76, 175, 80)));
+		follow_btn = new wxToggleButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		follow_btn->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(76, 175, 80))));
 		follow_btn->SetValue(true);
 		follow_btn->SetToolTip("Follow Selection / Camera");
-		toolbar_sizer->Add(follow_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		toolbar_sizer->Add(follow_btn, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, wxSize(28, 24));
-		lighting_btn->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_WB_SUNNY, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(255, 235, 59)));
+		follow_btn->Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleFollow, this);
+
+		lighting_btn = new wxToggleButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		lighting_btn->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_WB_SUNNY, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(255, 235, 59))));
 		lighting_btn->SetValue(true);
 		lighting_btn->SetToolTip("Toggle Lighting");
-		toolbar_sizer->Add(lighting_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		toolbar_sizer->Add(lighting_btn, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, wxSize(28, 24));
-		outfit_btn->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ACCOUNT_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(96, 125, 139)));
+		lighting_btn->Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleLighting, this);
+
+		outfit_btn = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		outfit_btn->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ACCOUNT_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(96, 125, 139))));
 		outfit_btn->SetToolTip("Change Preview Creature Outfit");
-		toolbar_sizer->Add(outfit_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		toolbar_sizer->Add(outfit_btn, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
+
+		outfit_btn->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnChooseOutfit, this);
 
 		// Sliders
-		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, wxSize(60, -1));
+		ambient_slider = new wxSlider(this, wxID_ANY, 128, 0, 255, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		ambient_slider->SetToolTip("Ambient Light");
-		toolbar_sizer->Add(ambient_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		toolbar_sizer->Add(ambient_slider, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, wxSize(60, -1));
+		ambient_slider->Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnAmbientSlider, this);
+
+		intensity_slider = new wxSlider(this, wxID_ANY, 100, 0, 200, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		intensity_slider->SetToolTip("Light Intensity");
-		toolbar_sizer->Add(intensity_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		toolbar_sizer->Add(intensity_slider, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
+
+		intensity_slider->Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnIntensitySlider, this);
 
 		// Spacer
-		toolbar_sizer->AddSpacer(4);
-		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "|"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-		toolbar_sizer->AddSpacer(4);
+		toolbar_sizer->AddSpacer(FromDIP(4));
+		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "|"), wxSizerFlags(0).Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
+		toolbar_sizer->AddSpacer(FromDIP(4));
 
 		// Viewport Controls
 		// Width
-		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_down->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_DO_NOT_DISTURB_ON, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_w_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_w_down = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_down->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_DO_NOT_DISTURB_ON, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136))));
+		toolbar_sizer->Add(viewport_w_down, wxSizerFlags(0).Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
-		toolbar_sizer->Add(viewport_x_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		viewport_w_down->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthDown, this);
 
-		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_up->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ADD_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_w_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
+		toolbar_sizer->Add(viewport_x_text, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+		viewport_w_up = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_up->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ADD_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136))));
+		toolbar_sizer->Add(viewport_w_up, wxSizerFlags(0).Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
+
+		viewport_w_up->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthUp, this);
+
+		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), wxSizerFlags(0).Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
 
 		// Height
-		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_down->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_DO_NOT_DISTURB_ON, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_h_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_h_down = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_down->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_DO_NOT_DISTURB_ON, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136))));
+		toolbar_sizer->Add(viewport_h_down, wxSizerFlags(0).Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
-		toolbar_sizer->Add(viewport_y_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		viewport_h_down->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightDown, this);
 
-		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_up->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ADD_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_h_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
+		toolbar_sizer->Add(viewport_y_text, wxSizerFlags(0).Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
+		viewport_h_up = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_up->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_ADD_CIRCLE, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136))));
+		toolbar_sizer->Add(viewport_h_up, wxSizerFlags(0).Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
+
+		viewport_h_up->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightUp, this);
+
+		main_sizer->Add(toolbar_sizer, wxSizerFlags(0).Expand().Border(wxALL, 2));
 
 		// Canvas
 		canvas = std::make_unique<IngamePreviewCanvas>(this);
-		main_sizer->Add(canvas.get(), 1, wxEXPAND);
+		main_sizer->Add(canvas.get(), wxSizerFlags(1).Expand());
 
 		// Sync UI State to Canvas
 		canvas->SetLightingEnabled(lighting_btn->GetValue());
@@ -128,6 +122,7 @@ namespace IngamePreview {
 
 		SetSizer(main_sizer);
 
+		Bind(wxEVT_TIMER, &IngamePreviewWindow::OnUpdateTimer, this, update_timer.GetId());
 		update_timer.Start(50);
 	}
 
@@ -176,9 +171,9 @@ namespace IngamePreview {
 	void IngamePreviewWindow::SetFollowSelection(bool follow) {
 		follow_selection = follow;
 		if (follow_selection) {
-			follow_btn->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(76, 175, 80)));
+			follow_btn->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(76, 175, 80))));
 		} else {
-			follow_btn->SetBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, wxSize(16, 16), wxColour(158, 158, 158)));
+			follow_btn->SetBitmap(wxBitmapBundle::FromBitmap(wxMaterialDesignArtProvider::GetBitmap(wxART_MY_LOCATION, wxART_CLIENT_MATERIAL_FILLED, FromDIP(wxSize(16, 16)), wxColour(158, 158, 158))));
 		}
 		follow_btn->SetValue(follow_selection);
 	}

--- a/source/ui/dialog_util.cpp
+++ b/source/ui/dialog_util.cpp
@@ -35,7 +35,7 @@ void DialogUtil::ListDialog(wxWindow* parent, wxString title, const std::vector<
 
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 	wxListBox* item_list = newd wxListBox(dlg, wxID_ANY, wxDefaultPosition, wxDefaultSize, 0, nullptr, wxLB_SINGLE);
-	item_list->SetMinSize(wxSize(500, 300));
+	item_list->SetMinSize(FROM_DIP(dlg, wxSize(500, 300)));
 
 	for (size_t i = 0; i != list_items.size();) {
 		wxString str = list_items[i];
@@ -49,7 +49,7 @@ void DialogUtil::ListDialog(wxWindow* parent, wxString title, const std::vector<
 		item_list->Append(list_items[i]);
 		++i;
 	}
-	sizer->Add(item_list, 1, wxEXPAND);
+	sizer->Add(item_list, wxSizerFlags(1).Expand());
 
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
 	stdsizer->Add(newd wxButton(dlg, wxID_OK, "OK"), wxSizerFlags(1).Center());
@@ -66,7 +66,7 @@ void DialogUtil::ShowTextBox(wxWindow* parent, wxString title, wxString content)
 	wxDialog* dlg = newd wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, wxRESIZE_BORDER | wxCAPTION | wxCLOSE_BOX);
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxTextCtrl* text_field = newd wxTextCtrl(dlg, wxID_ANY, content, wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
-	text_field->SetMinSize(wxSize(400, 550));
+	text_field->SetMinSize(FROM_DIP(dlg, wxSize(400, 550)));
 	topsizer->Add(text_field, wxSizerFlags(5).Expand());
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/ui/map/towns_window.cpp
+++ b/source/ui/map/towns_window.cpp
@@ -28,35 +28,35 @@ EditTownsDialog::EditTownsDialog(wxWindow* parent, Editor& editor) :
 
 	// Town list
 	town_listbox = newd wxListBox(this, EDIT_TOWNS_LISTBOX, wxDefaultPosition, FROM_DIP(this, wxSize(240, 100)));
-	sizer->Add(town_listbox, 1, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 10);
+	sizer->Add(town_listbox, wxSizerFlags(1).Expand().Border(wxTOP | wxLEFT | wxRIGHT, 10));
 
 	tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 	auto addBtn = newd wxButton(this, EDIT_TOWNS_ADD, "Add");
 	addBtn->SetToolTip("Add a new town");
-	tmpsizer->Add(addBtn, 0, wxTOP, 5);
+	tmpsizer->Add(addBtn, wxSizerFlags(0).Border(wxTOP, 5));
 	remove_button = newd wxButton(this, EDIT_TOWNS_REMOVE, "Remove");
 	remove_button->SetToolTip("Remove selected town");
-	tmpsizer->Add(remove_button, 0, wxRIGHT | wxTOP, 5);
-	sizer->Add(tmpsizer, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+	tmpsizer->Add(remove_button, wxSizerFlags(0).Border(wxRIGHT | wxTOP, 5));
+	sizer->Add(tmpsizer, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 10));
 
 	// House options
 	tmpsizer = newd wxStaticBoxSizer(wxHORIZONTAL, this, "Name / ID");
 	name_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, FROM_DIP(this, wxSize(190, 20)), 0, wxTextValidator(wxFILTER_ASCII, &town_name));
 	name_field->SetToolTip("Town name");
-	tmpsizer->Add(name_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
+	tmpsizer->Add(name_field, wxSizerFlags(2).Expand().Border(wxLEFT | wxBOTTOM, 5));
 
 	id_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, FROM_DIP(this, wxSize(40, 20)), 0, wxTextValidator(wxFILTER_NUMERIC, &town_id));
 	id_field->SetToolTip("Town ID");
 	id_field->Enable(false);
-	tmpsizer->Add(id_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
-	sizer->Add(tmpsizer, 0, wxEXPAND | wxALL, 10);
+	tmpsizer->Add(id_field, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, 5));
+	sizer->Add(tmpsizer, wxSizerFlags(0).Expand().Border(wxALL, 10));
 
 	// Temple position
 	temple_position = newd PositionCtrl(this, "Temple Position", 0, 0, 0, map.getWidth(), map.getHeight());
 	select_position_button = newd wxButton(this, EDIT_TOWNS_SELECT_TEMPLE, "Go To");
 	select_position_button->SetToolTip("Jump to temple position");
-	temple_position->Add(select_position_button, 0, wxLEFT | wxRIGHT | wxBOTTOM, 5);
-	sizer->Add(temple_position, 0, wxEXPAND | wxLEFT | wxRIGHT, 10);
+	temple_position->Add(select_position_button, wxSizerFlags(0).Border(wxLEFT | wxRIGHT | wxBOTTOM, 5));
+	sizer->Add(temple_position, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT, 10));
 
 	// OK/Cancel buttons
 	tmpsizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/ui/replace_tool/card_panel.cpp
+++ b/source/ui/replace_tool/card_panel.cpp
@@ -1,8 +1,10 @@
+#include "app/main.h" // For FROM_DIP and others
 #include "ui/replace_tool/card_panel.h"
 #include "ui/theme.h"
 #include <wx/dcclient.h>
 #include <wx/graphics.h>
 #include <wx/settings.h>
+#include <wx/dcbuffer.h>
 #include <numbers>
 
 CardPanel::CardPanel(wxWindow* parent, wxWindowID id) : wxPanel(parent, id) {
@@ -11,13 +13,13 @@ CardPanel::CardPanel(wxWindow* parent, wxWindowID id) : wxPanel(parent, id) {
 	Bind(wxEVT_SIZE, &CardPanel::OnSize, this);
 
 	m_mainSizer = new wxBoxSizer(wxVERTICAL);
-	m_mainSizer->AddSpacer(HEADER_HEIGHT);
+	m_mainSizer->AddSpacer(FromDIP(HEADER_HEIGHT));
 
 	m_contentSizer = new wxBoxSizer(wxVERTICAL);
-	m_mainSizer->Add(m_contentSizer, 1, wxEXPAND);
+	m_mainSizer->Add(m_contentSizer, wxSizerFlags(1).Expand());
 
 	m_footerSizer = new wxBoxSizer(wxVERTICAL);
-	m_mainSizer->Add(m_footerSizer, 0, wxEXPAND);
+	m_mainSizer->Add(m_footerSizer, wxSizerFlags(0).Expand());
 
 	SetSizer(m_mainSizer);
 }
@@ -25,7 +27,7 @@ CardPanel::CardPanel(wxWindow* parent, wxWindowID id) : wxPanel(parent, id) {
 void CardPanel::SetShowFooter(bool show) {
 	m_showFooter = show;
 	if (m_showFooter) {
-		m_mainSizer->SetItemMinSize(m_footerSizer, wxSize(-1, FOOTER_HEIGHT));
+		m_mainSizer->SetItemMinSize(m_footerSizer, FromDIP(wxSize(-1, FOOTER_HEIGHT)));
 	} else {
 		m_mainSizer->SetItemMinSize(m_footerSizer, wxSize(-1, 0));
 	}
@@ -46,7 +48,7 @@ void CardPanel::OnSize(wxSizeEvent& event) {
 }
 
 void CardPanel::OnPaint(wxPaintEvent& event) {
-	wxPaintDC dc(this);
+	wxAutoBufferedPaintDC dc(this);
 	std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
 
 	if (!gc) {
@@ -71,13 +73,13 @@ void CardPanel::OnPaint(wxPaintEvent& event) {
 	gc->DrawRectangle(0, 0, w, h);
 
 	// Padding for "shadow"
-	double margin = 2.0;
-	double r = 6.0; // Radius
+	double margin = (double)FromDIP(2);
+	double r = (double)FromDIP(6); // Radius
 
 	// Draw Shadow (simulated with offset rect)
 	gc->SetBrush(wxBrush(wxColour(0, 0, 0, 40)));
 	gc->SetPen(*wxTRANSPARENT_PEN);
-	gc->DrawRoundedRectangle(margin + 2, margin + 2, w - 2 * margin, h - 2 * margin, r);
+	gc->DrawRoundedRectangle(margin + FromDIP(2), margin + FromDIP(2), w - 2 * margin, h - 2 * margin, r);
 
 	// Draw Card Body
 	wxGraphicsPath path = gc->CreatePath();
@@ -91,9 +93,8 @@ void CardPanel::OnPaint(wxPaintEvent& event) {
 	gc->StrokePath(path);
 
 	// Draw Header if Title exists
-	// Draw Header if Title exists
 	if (!m_title.IsEmpty()) {
-		double headerH = (double)HEADER_HEIGHT;
+		double headerH = (double)FromDIP(HEADER_HEIGHT);
 		double x = margin;
 		double y = margin;
 		double cw = w - 2 * margin;
@@ -150,7 +151,7 @@ void CardPanel::OnPaint(wxPaintEvent& event) {
 
 	// Draw Footer if requested
 	if (m_showFooter) {
-		double footerH = (double)FOOTER_HEIGHT;
+		double footerH = (double)FromDIP(FOOTER_HEIGHT);
 		double x = margin;
 		double y = h - margin - footerH;
 		double cw = w - 2 * margin;


### PR DESCRIPTION
VIOLATIONS FIXED: 42

BREAKDOWN BY CATEGORY:
- Feature 6 (Sizing): 11 violations (Hardcoded sizes -> FromDIP)
- Feature 8 (High DPI): 7 violations (wxBitmap -> wxBitmapBundle)
- Feature 7 (Sizer Syntax): 22 violations (Bitwise flags -> wxSizerFlags)
- Feature 20 (IDs): 1 violation (Magic enum IDs -> wxID_ANY)
- Feature 13 (Paint Events): 1 violation (wxPaintDC -> wxAutoBufferedPaintDC)

IMPACT:
- Improved UI stability (buffered painting in CardPanel)
- Better High DPI support (DIP scaling, bitmap bundles)
- Cleaner codebase (modern sizer syntax, removal of magic IDs)
- Modern wxWidgets compliance (3.x standards)


---
*PR created automatically by Jules for task [8812228326953241276](https://jules.google.com/task/8812228326953241276) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved DPI-aware scaling across UI components to ensure proper display on high-resolution screens.
  * Modernized event binding and layout handling throughout the interface.
  * Enhanced rendering performance with double buffering for smoother visual updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->