### PR TITLE
Auditor: Fix C-style casts and modernize ToolOptionsSurface to NanoVG

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -216,8 +216,8 @@ namespace IngamePreview {
 				// Total elevation offset was calculated above.
 				// For the label to stay synced, we should probably fetch it again or store it.
 				// Since we are at the center of the screen, we can just use screen-relative coords.
-				float screenCenterX = (float)viewport_width / 2.0f;
-				float screenCenterY = (float)viewport_height / 2.0f;
+				float screenCenterX = static_cast<float>(viewport_width) / 2.0f;
+				float screenCenterY = static_cast<float>(viewport_height) / 2.0f;
 
 				// Fetch elevation again to be precise
 				int elevation_offset = GetTileElevationOffset(map.getTile(camera_pos));

--- a/source/ui/tool_options_surface.h
+++ b/source/ui/tool_options_surface.h
@@ -6,12 +6,13 @@
 #include <wx/timer.h>
 #include <vector>
 #include "palette/palette_common.h"
+#include "util/nanovg_canvas.h"
 
 class Brush;
 
 // A custom-drawn, high-density surface for tool options.
 // Replaces the old panel-based layout with a unified, paint-optimized control.
-class ToolOptionsSurface : public wxControl {
+class ToolOptionsSurface : public NanoVGCanvas {
 public:
 	ToolOptionsSurface(wxWindow* parent);
 	~ToolOptionsSurface();
@@ -21,8 +22,7 @@ public:
 	void DoSetSizeHints(int minW, int minH, int maxW, int maxH, int incW, int incH) override;
 
 	// Event Handlers
-	void OnPaint(wxPaintEvent& evt);
-	void OnEraseBackground(wxEraseEvent& evt); // No-op
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
 	void OnMouse(wxMouseEvent& evt);
 	void OnLeave(wxMouseEvent& evt);
 	void OnSize(wxSizeEvent& evt);
@@ -82,9 +82,10 @@ private:
 
 	// Internal Helpers
 	void RebuildLayout();
-	void DrawToolIcon(wxDC& dc, const ToolRect& tr);
-	void DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
-	void DrawCheckbox(wxDC& dc, const wxRect& rect, const wxString& label, bool value, bool hover);
+	void DrawToolIcon(NVGcontext* vg, const ToolRect& tr);
+	void DrawSlider(NVGcontext* vg, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
+	void DrawCheckbox(NVGcontext* vg, const wxRect& rect, const wxString& label, bool value, bool hover);
+	int GetOrCreateSpriteTexture(Sprite* s, uint32_t key);
 
 	Brush* GetBrushAt(const wxPoint& pt);
 	void HandleClick(const wxPoint& pt);

--- a/source/util/nvg_utils.h
+++ b/source/util/nvg_utils.h
@@ -36,7 +36,7 @@ namespace NvgUtils {
 			for (int w = 0; w < gs.width; ++w) {
 				for (int h = 0; h < gs.height; ++h) {
 					int spriteIdx = gs.getIndex(w, h, l, pattern_x, pattern_y, pattern_z, frame);
-					if (spriteIdx < 0 || (size_t)spriteIdx >= gs.spriteList.size()) {
+					if (spriteIdx < 0 || static_cast<size_t>(spriteIdx) >= gs.spriteList.size()) {
 						continue;
 					}
 
@@ -74,9 +74,9 @@ namespace NvgUtils {
 							} else {
 								float a = sa / 255.0f;
 								float inv_a = 1.0f - a;
-								composite[dst_idx + 0] = (uint8_t)(spriteData[src_idx + 0] * a + composite[dst_idx + 0] * inv_a);
-								composite[dst_idx + 1] = (uint8_t)(spriteData[src_idx + 1] * a + composite[dst_idx + 1] * inv_a);
-								composite[dst_idx + 2] = (uint8_t)(spriteData[src_idx + 2] * a + composite[dst_idx + 2] * inv_a);
+								composite[dst_idx + 0] = static_cast<uint8_t>(spriteData[src_idx + 0] * a + composite[dst_idx + 0] * inv_a);
+								composite[dst_idx + 1] = static_cast<uint8_t>(spriteData[src_idx + 1] * a + composite[dst_idx + 1] * inv_a);
+								composite[dst_idx + 2] = static_cast<uint8_t>(spriteData[src_idx + 2] * a + composite[dst_idx + 2] * inv_a);
 								composite[dst_idx + 3] = std::max(composite[dst_idx + 3], sa);
 							}
 						}


### PR DESCRIPTION
This PR addresses code smells identified by the Auditor agent.
It primarily focuses on:
1.  Replacing legacy C-style casts with C++ style `static_cast` in utility and renderer files.
2.  Modernizing the `ToolOptionsSurface` UI component by migrating its rendering backend from legacy `wxDC` to `NanoVG`, improving performance and visual consistency with the rest of the application's modern UI components. This involved refactoring the class structure, event handling, and implementing custom NanoVG drawing routines for tool icons, sliders, and checkboxes.

---
*PR created automatically by Jules for task [11682124573227969499](https://jules.google.com/task/11682124573227969499) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved rendering backend for tool options surface with updated drawing infrastructure.
  * Enhanced type-safety through cast modernization across rendering utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->