### PR TITLE
[MODERNIZE] Use range-based loops and safe casts in items.cpp

### DIFF
--- a/source/util/con_vector.h
+++ b/source/util/con_vector.h
@@ -71,6 +71,19 @@ public:
 		return at(index);
 	}
 
+	T* begin() {
+		return start;
+	}
+	T* end() {
+		return start + sz;
+	}
+	const T* begin() const {
+		return start;
+	}
+	const T* end() const {
+		return start + sz;
+	}
+
 private:
 	T* start;
 	size_t sz;


### PR DESCRIPTION
BEFORE:
- Manual index-based loop in `ItemDatabase::clear`.
- Manual PugiXML iteration loops in `ItemDatabase`.
- unsafe `reinterpret_cast` from `uint8_t` array to `double` (strict aliasing violation).
- C-style and function-style casts.

AFTER:
- Range-based for loops using `contigous_vector` iterator support.
- Range-based for loops using `pugi::xml_node::children()`.
- `std::bit_cast<double>` for safe type punning.
- `static_cast` and `reinterpret_cast` for safer casts.

BENEFITS:
1.  **Safety**: Fixed Undefined Behavior (strict aliasing) using `std::bit_cast`.
2.  **Readability**: Cleaner loops and explicit casts.
3.  **Standard**: C++20 features (`std::bit_cast`, range-based loops).

CHANGES:
- `source/util/con_vector.h`: Added `begin()` and `end()` methods.
- `source/game/items.cpp`: Refactored loops and casts. Added `<bit>` include.

TESTED:
- Compiles with C++20 flags (`cmake .` and partial build verification).
- Code review approved.

---
*PR created automatically by Jules for task [15349342586664836585](https://jules.google.com/task/15349342586664836585) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for item classification attribute in game content loading.

* **Refactor**
  * Modernized internal item loading logic with safer casting and contemporary C++ patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->