### PR TITLE
OpenGL Audit and SpriteBatch Robustness Fix

### DIFF
--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -216,12 +216,12 @@ void SpriteBatch::flush(const AtlasManager& atlas_manager) {
 		return;
 	}
 
+	// Ensure shader and VAO are bound to handle interleaved renderer calls
+	shader_->Use();
 	atlas_manager.bind(0);
 
-	if (last_bound_vao_ != vao_->GetID()) {
-		glBindVertexArray(vao_->GetID());
-		last_bound_vao_ = vao_->GetID();
-	}
+	glBindVertexArray(vao_->GetID());
+	last_bound_vao_ = vao_->GetID();
 
 	glBindBuffer(GL_ARRAY_BUFFER, ring_buffer_.getBufferId());
 


### PR DESCRIPTION
Performed an autonomous audit of the OpenGL rendering system as the 'Raster' agent. 
Identified that `TileRenderer` interleaves `SpriteBatch` (for tiles) and `PrimitiveRenderer` (for hooks/debug), which causes GL state (Shader/VAO) thrashing.
`PrimitiveRenderer` correctly sets its state on flush, but `SpriteBatch` previously assumed its state persisted.
Modified `SpriteBatch::flush` in `source/rendering/core/sprite_batch.cpp` to always bind its shader and VAO, preventing state corruption.
Generated `OPENGL_REPORT.md` documenting the findings.

---
*PR created automatically by Jules for task [12764960982853623618](https://jules.google.com/task/12764960982853623618) started by @karolak6612*