### PR TITLE
[WXWIDGETS] Fix Property Window "Remove Attribute" button state

### DIFF
--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -48,6 +48,8 @@ PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile*
 	Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &PropertiesWindow::OnNotebookPageChanged, this, wxID_ANY);
 
 	Bind(wxEVT_GRID_CELL_CHANGED, &PropertiesWindow::OnGridValueChanged, this);
+	Bind(wxEVT_GRID_RANGE_SELECT, &PropertiesWindow::OnGridSelectionChanged, this);
+	Bind(wxEVT_GRID_LABEL_LEFT_CLICK, &PropertiesWindow::OnGridSelectionChanged, this);
 
 	createUI();
 }
@@ -215,6 +217,7 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 
 	wxButton* removeBtn = newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute");
 	removeBtn->SetToolTip("Remove selected custom attribute");
+	removeBtn->Enable(false);
 	optSizer->Add(removeBtn, wxSizerFlags(0).Center());
 
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
@@ -320,8 +323,19 @@ void PropertiesWindow::OnClickRemoveAttribute(wxCommandEvent&) {
 
 	int rowIndex = rowIndexes[0];
 	attributesGrid->DeleteRows(rowIndex, 1);
+
+	if (wxWindow* btn = FindWindow(ITEM_PROPERTIES_REMOVE_ATTRIBUTE)) {
+		btn->Enable(false);
+	}
 }
 
 void PropertiesWindow::OnClickCancel(wxCommandEvent&) {
 	EndModal(0);
+}
+
+void PropertiesWindow::OnGridSelectionChanged(wxNotifyEvent& event) {
+	if (wxWindow* btn = FindWindow(ITEM_PROPERTIES_REMOVE_ATTRIBUTE)) {
+		btn->Enable(attributesGrid->GetSelectedRows().GetCount() > 0);
+	}
+	event.Skip();
 }

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -43,6 +43,7 @@ public:
 	void OnResize(wxSizeEvent&);
 	void OnNotebookPageChanged(wxNotebookEvent&);
 	void OnGridValueChanged(wxGridEvent&);
+	void OnGridSelectionChanged(wxNotifyEvent&);
 
 	void Update();
 


### PR DESCRIPTION
FIX: "Remove Attribute" button in Item Properties Window was always enabled.
IMPACT: Users could click the button without selection (no-op but confusing UX).
DOMAIN CONTEXT: Improved wxWidgets usage by properly binding selection events to UI state.
TESTED: Verified implementation logic and compilation (via agent checks). Button state is now managed by selection events and explicit updates.

---
*PR created automatically by Jules for task [11613826150641020069](https://jules.google.com/task/11613826150641020069) started by @karolak6612*