### PR TITLE
Modernize UI: NanoVG ToolOptions and Unified Brush Grid

### DIFF
--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -21,8 +21,9 @@ public:
 	 * @param parent Parent window
 	 * @param _tileset The tileset category containing brushes
 	 * @param rsz Icon render size (16x16 or 32x32)
+	 * @param ltype The layout type (grid or list)
 	 */
-	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz);
+	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz, BrushListType ltype = BRUSHLIST_LARGE_ICONS);
 	~VirtualBrushGrid() override;
 
 	wxWindow* GetSelfWindow() override {
@@ -48,15 +49,18 @@ protected:
 	// Event Handlers
 	void OnMouseDown(wxMouseEvent& event);
 	void OnMotion(wxMouseEvent& event);
+	void OnKey(wxKeyEvent& event);
 
 	// Internal helpers
 	void UpdateLayout();
+	void NotifySelectionChanged();
 	int HitTest(int x, int y) const;
 	wxRect GetItemRect(int index) const;
 	int GetOrCreateBrushTexture(NVGcontext* vg, Brush* brush);
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
 
 	RenderSize icon_size;
+	BrushListType list_type;
 	int selected_index;
 	int hover_index;
 	int columns;

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -22,7 +22,6 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
 
-	Bind(wxEVT_LISTBOX, &BrushPanel::OnClickListBoxRow, this, wxID_ANY);
 }
 
 BrushPanel::~BrushPanel() {
@@ -70,14 +69,14 @@ void BrushPanel::LoadContents() {
 
 	switch (list_type) {
 		case BRUSHLIST_LARGE_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32);
+			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32, BRUSHLIST_LARGE_ICONS);
 			break;
 		case BRUSHLIST_SMALL_ICONS:
-			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16);
+			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_16x16, BRUSHLIST_SMALL_ICONS);
 			break;
 		case BRUSHLIST_LISTBOX:
 		case BRUSHLIST_TEXT_LISTBOX:
-			brushbox = newd BrushListBox(this, tileset);
+			brushbox = newd VirtualBrushGrid(this, tileset, RENDER_SIZE_32x32, list_type);
 			break;
 		default:
 			break;
@@ -137,114 +136,4 @@ void BrushPanel::OnSwitchOut() {
 	////
 }
 
-void BrushPanel::OnClickListBoxRow(wxCommandEvent& event) {
-	ASSERT(tileset->getType() >= TILESET_UNKNOWN && tileset->getType() <= TILESET_HOUSE);
-	// We just notify the GUI of the action, it will take care of everything else
-	ASSERT(brushbox);
-	size_t n = event.GetSelection();
 
-	wxWindow* w = this->GetParent();
-	while (w) {
-		PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
-		if (pw) {
-			g_gui.ActivatePalette(pw);
-			break;
-		}
-		w = w->GetParent();
-	}
-
-	g_gui.SelectBrush(tileset->brushlist[n], tileset->getType());
-}
-
-// ============================================================================
-// BrushListBox
-
-BrushListBox::BrushListBox(wxWindow* parent, const TilesetCategory* tileset) :
-	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE),
-	BrushBoxInterface(tileset) {
-	SetItemCount(tileset->size());
-	Bind(wxEVT_KEY_DOWN, &BrushListBox::OnKey, this);
-}
-
-BrushListBox::~BrushListBox() {
-	////
-}
-
-void BrushListBox::SelectFirstBrush() {
-	SetSelection(0);
-	wxWindow::ScrollLines(-1);
-}
-
-Brush* BrushListBox::GetSelectedBrush() const {
-	if (!tileset) {
-		return nullptr;
-	}
-
-	int n = GetSelection();
-	if (n != wxNOT_FOUND) {
-		return tileset->brushlist[n];
-	} else if (tileset->size() > 0) {
-		return tileset->brushlist[0];
-	}
-	return nullptr;
-}
-
-bool BrushListBox::SelectBrush(const Brush* whatbrush) {
-	auto it = std::ranges::find(tileset->brushlist, whatbrush);
-	if (it != tileset->brushlist.end()) {
-		SetSelection(std::distance(tileset->brushlist.begin(), it));
-		return true;
-	}
-	return false;
-}
-
-void BrushListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	ASSERT(n < tileset->size());
-	Sprite* spr = tileset->brushlist[n]->getSprite();
-	if (!spr) {
-		spr = g_gui.gfx.getSprite(tileset->brushlist[n]->getLookID());
-	}
-	if (spr) {
-		spr->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-	dc.DrawText(wxstr(tileset->brushlist[n]->getName()), rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord BrushListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
-
-void BrushListBox::OnKey(wxKeyEvent& event) {
-	switch (event.GetKeyCode()) {
-		case WXK_UP:
-		case WXK_DOWN:
-		case WXK_LEFT:
-		case WXK_RIGHT:
-		case WXK_PAGEUP:
-		case WXK_PAGEDOWN:
-		case WXK_HOME:
-		case WXK_END:
-			if (g_settings.getInteger(Config::LISTBOX_EATS_ALL_EVENTS)) {
-				event.Skip(true);
-			} else {
-				if (g_gui.GetCurrentTab() != nullptr) {
-					g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-				}
-			}
-			break;
-		default:
-			if (g_gui.GetCurrentTab() != nullptr) {
-				g_gui.GetCurrentMapTab()->GetEventHandler()->AddPendingEvent(event);
-			}
-			break;
-	}
-}

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -35,29 +35,6 @@ protected:
 	bool loaded;
 };
 
-class BrushListBox : public wxVListBox, public BrushBoxInterface {
-public:
-	BrushListBox(wxWindow* parent, const TilesetCategory* _tileset);
-	~BrushListBox();
-
-	wxWindow* GetSelfWindow() override {
-		return this;
-	}
-
-	// Select the first brush
-	void SelectFirstBrush() override;
-	// Returns the currently selected brush (First brush if panel is not loaded)
-	Brush* GetSelectedBrush() const override;
-	// Select the brush in the parameter, this only changes the look of the panel
-	bool SelectBrush(const Brush* brush) override;
-
-	// Event handlers
-	virtual void OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const override;
-	virtual wxCoord OnMeasureItem(size_t n) const override;
-
-	void OnKey(wxKeyEvent& event);
-};
-
 class BrushPanel : public wxPanel {
 public:
 	BrushPanel(wxWindow* parent);
@@ -86,9 +63,6 @@ public:
 	void OnSwitchIn();
 	// Called when this page is hidden
 	void OnSwitchOut();
-
-	// wxWidgets event handlers
-	void OnClickListBoxRow(wxCommandEvent& event);
 
 protected:
 	const TilesetCategory* tileset;

--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -138,6 +138,13 @@ void MinimapWindow::OnPaint(wxPaintEvent& event) {
 		GetClientSize(&w, &h);
 		nvgBeginFrame(vg, w, h, 1.0f);
 
+		// Vignette (Darken corners)
+		NVGpaint vignette = nvgRadialGradient(vg, w / 2, h / 2, std::min(w, h) / 2, std::max(w, h), nvgRGBA(0, 0, 0, 0), nvgRGBA(0, 0, 0, 100));
+		nvgBeginPath(vg);
+		nvgRect(vg, 0, 0, w, h);
+		nvgFillPaint(vg, vignette);
+		nvgFill(vg);
+
 		// Subtle glass border
 		nvgBeginPath(vg);
 		nvgRoundedRect(vg, 1.5f, 1.5f, w - 3.0f, h - 3.0f, 4.0f);

--- a/source/ui/tool_options_surface.h
+++ b/source/ui/tool_options_surface.h
@@ -6,12 +6,13 @@
 #include <wx/timer.h>
 #include <vector>
 #include "palette/palette_common.h"
+#include "util/nanovg_canvas.h"
 
 class Brush;
 
 // A custom-drawn, high-density surface for tool options.
 // Replaces the old panel-based layout with a unified, paint-optimized control.
-class ToolOptionsSurface : public wxControl {
+class ToolOptionsSurface : public NanoVGCanvas {
 public:
 	ToolOptionsSurface(wxWindow* parent);
 	~ToolOptionsSurface();
@@ -21,8 +22,7 @@ public:
 	void DoSetSizeHints(int minW, int minH, int maxW, int maxH, int incW, int incH) override;
 
 	// Event Handlers
-	void OnPaint(wxPaintEvent& evt);
-	void OnEraseBackground(wxEraseEvent& evt); // No-op
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
 	void OnMouse(wxMouseEvent& evt);
 	void OnLeave(wxMouseEvent& evt);
 	void OnSize(wxSizeEvent& evt);
@@ -82,9 +82,9 @@ private:
 
 	// Internal Helpers
 	void RebuildLayout();
-	void DrawToolIcon(wxDC& dc, const ToolRect& tr);
-	void DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
-	void DrawCheckbox(wxDC& dc, const wxRect& rect, const wxString& label, bool value, bool hover);
+	void DrawToolIcon(NVGcontext* vg, const ToolRect& tr);
+	void DrawSlider(NVGcontext* vg, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
+	void DrawCheckbox(NVGcontext* vg, const wxRect& rect, const wxString& label, bool value, bool hover);
 
 	Brush* GetBrushAt(const wxPoint& pt);
 	void HandleClick(const wxPoint& pt);


### PR DESCRIPTION
- Replaced `BrushListBox` with `VirtualBrushGrid` (list mode) to eliminate GDI exhaustion and unify brush rendering.
- Refactored `ToolOptionsSurface` to use NanoVG for hardware-accelerated rendering, improving visual quality (rounded corners, gradients).
- Enhanced `MinimapWindow` with a vignette effect.
- Implemented keyboard navigation in `VirtualBrushGrid` respecting configuration.
- Fixed pointer casting safety and string encoding issues.

---
*PR created automatically by Jules for task [11840619044034569632](https://jules.google.com/task/11840619044034569632) started by @karolak6612*