### PR TITLE
Modernize C++20 patterns and remove C-style casts

### DIFF
--- a/source/ingame_preview/floor_visibility_calculator.cpp
+++ b/source/ingame_preview/floor_visibility_calculator.cpp
@@ -66,7 +66,7 @@ namespace IngamePreview {
 		int first_floor = 0;
 
 		if (camera_z > GROUND_LAYER) {
-			first_floor = std::max(camera_z - AWARE_UNDERGROUND_FLOOR_RANGE, (int)GROUND_LAYER + 1);
+			first_floor = std::max(camera_z - AWARE_UNDERGROUND_FLOOR_RANGE, static_cast<int>(GROUND_LAYER) + 1);
 		}
 
 		// Check 3x3 area around camera for blocking tiles
@@ -107,7 +107,7 @@ namespace IngamePreview {
 			}
 		}
 
-		return std::clamp(first_floor, 0, (int)MAP_MAX_LAYER);
+		return std::clamp(first_floor, 0, static_cast<int>(MAP_MAX_LAYER));
 	}
 
 	int FloorVisibilityCalculator::CalcLastVisibleFloor(int camera_z) const {
@@ -117,7 +117,7 @@ namespace IngamePreview {
 		} else {
 			z = GROUND_LAYER;
 		}
-		return std::clamp(z, 0, (int)MAP_MAX_LAYER);
+		return std::clamp(z, 0, static_cast<int>(MAP_MAX_LAYER));
 	}
 
 } // namespace IngamePreview

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -554,7 +554,7 @@ bool IOMapOTBM::getVersionInfo(const FileName& filename, MapVersion& out_ver) {
 				}
 
 				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(new MemoryNodeFileReadHandle(buffer + 4, read_bytes - 4));
+				std::shared_ptr<NodeFileReadHandle> f = std::make_shared<MemoryNodeFileReadHandle>(buffer + 4, read_bytes - 4);
 
 				// Read the version info
 				return getVersionInfo(f.get(), out_ver);
@@ -647,9 +647,7 @@ bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {
 				g_gui.SetLoadDone(0, "Loading OTBM map...");
 
 				// Create a read handle on it
-				std::shared_ptr<NodeFileReadHandle> f(
-					new MemoryNodeFileReadHandle(otbm_buffer.data() + 4, otbm_size - 4)
-				);
+				std::shared_ptr<NodeFileReadHandle> f = std::make_shared<MemoryNodeFileReadHandle>(otbm_buffer.data() + 4, otbm_size - 4);
 
 				// Read the version info
 				if (!loadMap(map, *f.get())) {

--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -12,8 +12,8 @@ void RenderView::Setup(MapCanvas* canvas, const DrawingOptions& options) {
 	viewport_x = 0;
 	viewport_y = 0;
 
-	zoom = (float)canvas->GetZoom();
-	tile_size = std::max(1, (int)(TileSize / zoom)); // after zoom
+	zoom = static_cast<float>(canvas->GetZoom());
+	tile_size = std::max(1, static_cast<int>(TileSize / zoom)); // after zoom
 	floor = canvas->GetFloor();
 	camera_pos.z = floor;
 

--- a/source/rendering/core/shared_geometry.cpp
+++ b/source/rendering/core/shared_geometry.cpp
@@ -10,11 +10,11 @@
 
 void* GetCurrentGLContext() {
 #ifdef _WIN32
-	return (void*)wglGetCurrentContext();
+	return reinterpret_cast<void*>(wglGetCurrentContext());
 #elif defined(__linux__)
-	return (void*)glXGetCurrentContext();
+	return reinterpret_cast<void*>(glXGetCurrentContext());
 #elif defined(__APPLE__)
-	return (void*)CGLGetCurrentContext();
+	return reinterpret_cast<void*>(CGLGetCurrentContext());
 #else
 	return nullptr;
 #endif
@@ -28,7 +28,7 @@ bool SharedGeometry::initialize() {
 
 	std::lock_guard<std::mutex> lock(mutex_);
 
-	if (contexts_.find(ctx) != contexts_.end()) {
+	if (contexts_.contains(ctx)) {
 		return true;
 	}
 

--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -283,7 +283,7 @@ void SpriteBatch::flush(const AtlasManager& atlas_manager) {
 			ring_buffer_.advance();
 
 			processed += batch_size;
-			sprite_count_ += (int)batch_size;
+			sprite_count_ += static_cast<int>(batch_size);
 		}
 
 		// Flush remaining commands
@@ -319,14 +319,14 @@ void SpriteBatch::flush(const AtlasManager& atlas_manager) {
 			// Binding point 1 is used for instance data (Attributes 2, 3, 4, 5)
 			glVertexArrayVertexBuffer(vao_->GetID(), 1, ring_buffer_.getBufferId(), offset, sizeof(SpriteInstance));
 
-			glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, (GLsizei)batch_size);
+			glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, static_cast<GLsizei>(batch_size));
 
 			// Standard signal: Fence current and advance
 			ring_buffer_.signalFinished();
 
 			processed += batch_size;
 			draw_call_count_++;
-			sprite_count_ += (int)batch_size;
+			sprite_count_ += static_cast<int>(batch_size);
 		}
 	}
 

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -269,15 +269,15 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 	}
 
 	// Constants
-	float scale_x = (float)w / map_w;
-	float scale_y = (float)h / map_h;
+	float scale_x = static_cast<float>(w) / map_w;
+	float scale_y = static_cast<float>(h) / map_h;
 
 	// Determine visible tiles
 	// Clamp to integer grid
-	int start_col = (int)std::floor(map_x / TILE_SIZE);
-	int end_col = (int)std::floor((map_x + map_w) / TILE_SIZE);
-	int start_row = (int)std::floor(map_y / TILE_SIZE);
-	int end_row = (int)std::floor((map_y + map_h) / TILE_SIZE);
+	int start_col = static_cast<int>(std::floor(map_x / TILE_SIZE));
+	int end_col = static_cast<int>(std::floor((map_x + map_w) / TILE_SIZE));
+	int start_row = static_cast<int>(std::floor(map_y / TILE_SIZE));
+	int end_row = static_cast<int>(std::floor((map_y + map_h) / TILE_SIZE));
 
 	start_col = std::max(0, start_col);
 	start_row = std::max(0, start_row);
@@ -301,7 +301,7 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 
 			int layer = r * cols_ + c;
 
-			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = (float)layer });
+			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = static_cast<float>(layer) });
 		}
 	}
 

--- a/source/rendering/ui/zoom_controller.cpp
+++ b/source/rendering/ui/zoom_controller.cpp
@@ -56,8 +56,8 @@ void ZoomController::ApplyRelativeZoom(MapCanvas* canvas, double diff) {
 
 	// This took a day to figure out!
 	// Using cursor position from canvas
-	int scroll_x = int(screensize_x * diff * (std::max(canvas->cursor_x, 1) / double(screensize_x))) * canvas->GetContentScaleFactor();
-	int scroll_y = int(screensize_y * diff * (std::max(canvas->cursor_y, 1) / double(screensize_y))) * canvas->GetContentScaleFactor();
+	int scroll_x = static_cast<int>(screensize_x * diff * (std::max(canvas->cursor_x, 1) / double(screensize_x))) * canvas->GetContentScaleFactor();
+	int scroll_y = static_cast<int>(screensize_y * diff * (std::max(canvas->cursor_y, 1) / double(screensize_y))) * canvas->GetContentScaleFactor();
 
 	static_cast<MapWindow*>(canvas->GetParent())->ScrollRelative(-scroll_x, -scroll_y);
 
@@ -65,7 +65,7 @@ void ZoomController::ApplyRelativeZoom(MapCanvas* canvas, double diff) {
 }
 
 void ZoomController::UpdateStatus(MapCanvas* canvas) {
-	int percentage = (int)((1.0 / canvas->zoom) * 100);
+	int percentage = static_cast<int>((1.0 / canvas->zoom) * 100);
 	wxString ss;
 	ss << "zoom: " << percentage << "%";
 	g_gui.root->SetStatusText(ss, 3);

--- a/source/util/virtual_item_grid.cpp
+++ b/source/util/virtual_item_grid.cpp
@@ -60,10 +60,10 @@ int VirtualItemGrid::HitTest(int x, int y) const {
 
 	size_t index = row * m_columns + col;
 	if (index < GetItemCount()) {
-		wxRect r = GetItemRect((int)index);
+		wxRect r = GetItemRect(static_cast<int>(index));
 		r.y -= scrollPos; // Convert back to local for test
 		if (r.Contains(x, y)) {
-			return (int)index;
+			return static_cast<int>(index);
 		}
 	}
 	return -1;
@@ -90,14 +90,14 @@ void VirtualItemGrid::SetSelection(int index) {
 }
 
 uint16_t VirtualItemGrid::GetSelectedItemId() const {
-	if (m_selectedIndex >= 0 && m_selectedIndex < (int)GetItemCount()) {
+	if (m_selectedIndex >= 0 && m_selectedIndex < static_cast<int>(GetItemCount())) {
 		return GetItem(m_selectedIndex);
 	}
 	return 0;
 }
 
 void VirtualItemGrid::EnsureVisible(int index) {
-	if (index < 0 || index >= (int)GetItemCount()) {
+	if (index < 0 || index >= static_cast<int>(GetItemCount())) {
 		return;
 	}
 
@@ -184,7 +184,7 @@ void VirtualItemGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 	int endRow = (scrollPos + height + rowHeight - 1) / rowHeight;
 
 	int startIdx = startRow * m_columns;
-	int endIdx = std::min((int)count, (endRow + 1) * m_columns);
+	int endIdx = std::min(static_cast<int>(count), (endRow + 1) * m_columns);
 
 	for (int i = startIdx; i < endIdx; ++i) {
 		if (i < 0) {


### PR DESCRIPTION
- Replaced C-style casts with `static_cast` in `source/ingame_preview/floor_visibility_calculator.cpp`, `source/util/virtual_item_grid.cpp`, `source/rendering/drawers/minimap_renderer.cpp`, `source/rendering/core/sprite_batch.cpp`, `source/rendering/core/render_view.cpp`, and `source/rendering/ui/zoom_controller.cpp`.
- Replaced `std::shared_ptr<T>(new T(...))` with `std::make_shared<T>(...)` in `source/io/iomap_otbm.cpp` to optimize memory allocation.
- Replaced `find() != end()` with `contains()` in `source/rendering/core/shared_geometry.cpp` taking advantage of C++20 standard.
- Verified compilation with `build_linux.sh`.

---
*PR created automatically by Jules for task [2569528284140030405](https://jules.google.com/task/2569528284140030405) started by @karolak6612*