### PR TITLE
[MODERNIZE] Upgrade C++ loops and casts in IO and Rendering

### DIFF
--- a/source/io/filehandle.cpp
+++ b/source/io/filehandle.cpp
@@ -100,7 +100,7 @@ bool FileReadHandle::getRAW(uint8_t* ptr, size_t sz) {
 
 bool FileReadHandle::getRAW(std::string& str, size_t sz) {
 	str.resize(sz);
-	size_t o = fread(const_cast<char*>(str.data()), 1, sz, file);
+	size_t o = fread(str.data(), 1, sz, file);
 	if (o != sz) {
 		error_code = FILE_READ_ERROR;
 		return false;
@@ -234,8 +234,8 @@ DiskNodeFileReadHandle::DiskNodeFileReadHandle(const std::string& name, const st
 
 		if (ver[0] != 0 || ver[1] != 0 || ver[2] != 0 || ver[3] != 0) {
 			bool accepted = false;
-			for (std::vector<std::string>::const_iterator id_iter = acceptable_identifiers.begin(); id_iter != acceptable_identifiers.end(); ++id_iter) {
-				if (memcmp(ver, id_iter->c_str(), 4) == 0) {
+			for (const std::string& identifier : acceptable_identifiers) {
+				if (memcmp(ver, identifier.c_str(), 4) == 0) {
 					accepted = true;
 					break;
 				}
@@ -564,7 +564,7 @@ DiskNodeFileWriteHandle::DiskNodeFileWriteHandle(const std::string& name, const 
 
 	fwrite(identifier.c_str(), 1, 4, file);
 	if (!cache) {
-		cache = (uint8_t*)malloc(cache_size + 1);
+		cache = static_cast<uint8_t*>(malloc(cache_size + 1));
 	}
 	local_write_index = 0;
 }
@@ -589,7 +589,7 @@ void DiskNodeFileWriteHandle::renewCache() {
 			error_code = FILE_WRITE_ERROR;
 		}
 	} else {
-		cache = (uint8_t*)malloc(cache_size + 1);
+		cache = static_cast<uint8_t*>(malloc(cache_size + 1));
 	}
 	local_write_index = 0;
 }
@@ -599,7 +599,7 @@ void DiskNodeFileWriteHandle::renewCache() {
 
 MemoryNodeFileWriteHandle::MemoryNodeFileWriteHandle() {
 	if (!cache) {
-		cache = (uint8_t*)malloc(cache_size + 1);
+		cache = static_cast<uint8_t*>(malloc(cache_size + 1));
 	}
 	local_write_index = 0;
 }
@@ -629,12 +629,12 @@ size_t MemoryNodeFileWriteHandle::getSize() {
 void MemoryNodeFileWriteHandle::renewCache() {
 	if (cache) {
 		cache_size = cache_size * 2;
-		cache = (uint8_t*)realloc(cache, cache_size);
+		cache = static_cast<uint8_t*>(realloc(cache, cache_size));
 		if (!cache) {
 			exit(1);
 		}
 	} else {
-		cache = (uint8_t*)malloc(cache_size + 1);
+		cache = static_cast<uint8_t*>(malloc(cache_size + 1));
 	}
 }
 
@@ -706,18 +706,18 @@ bool NodeFileWriteHandle::addString(const std::string& str) {
 		return false;
 	}
 	addU16(uint16_t(str.size()));
-	addRAW((const uint8_t*)str.c_str(), str.size());
+	addRAW(reinterpret_cast<const uint8_t*>(str.c_str()), str.size());
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addLongString(const std::string& str) {
 	addU32(uint32_t(str.size()));
-	addRAW((const uint8_t*)str.c_str(), str.size());
+	addRAW(reinterpret_cast<const uint8_t*>(str.c_str()), str.size());
 	return error_code == FILE_NO_ERROR;
 }
 
 bool NodeFileWriteHandle::addRAW(std::string& str) {
-	writeBytes(reinterpret_cast<uint8_t*>(const_cast<char*>(str.data())), str.size());
+	writeBytes(reinterpret_cast<const uint8_t*>(str.data()), str.size());
 	return error_code == FILE_NO_ERROR;
 }
 

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -588,7 +588,7 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 	if (!root->getU32(u32)) { // Version
 		return false;
 	}
-	out_ver.otbm = (MapVersionID)u32;
+	out_ver.otbm = static_cast<MapVersionID>(u32);
 
 	root->getU16(u16); // map size X
 	root->getU16(u16); // map size Y
@@ -598,7 +598,7 @@ bool IOMapOTBM::getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver) {
 		return false;
 	}
 
-	out_ver.client = ClientVersionID(u32);
+	out_ver.client = static_cast<ClientVersionID>(u32);
 	return true;
 }
 
@@ -801,7 +801,7 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 		return false;
 	}
 
-	version.otbm = (MapVersionID)u32;
+	version.otbm = static_cast<MapVersionID>(u32);
 
 	if (version.otbm > MAP_OTBM_4) {
 		// Failed to read version
@@ -827,7 +827,7 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 
 	map.height = u16;
 
-	if (!root->getU32(u32) || u32 > (unsigned long)g_items.MajorVersion) { // OTB major version
+	if (!root->getU32(u32) || u32 > static_cast<unsigned long>(g_items.MajorVersion)) { // OTB major version
 		if (DialogUtil::PopupDialog("Map error", "The loaded map appears to be a items.otb format that deviates from the "
 												 "items.otb loaded by the editor. Do you still want to attempt to load the map?",
 									wxYES | wxNO)
@@ -839,10 +839,10 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 		}
 	}
 
-	if (!root->getU32(u32) || u32 > (unsigned long)g_items.MinorVersion) { // OTB minor version
+	if (!root->getU32(u32) || u32 > static_cast<unsigned long>(g_items.MinorVersion)) { // OTB minor version
 		warning("This editor needs an updated items.otb version");
 	}
-	version.client = (ClientVersionID)u32;
+	version.client = static_cast<ClientVersionID>(u32);
 
 	BinaryNode* mapHeaderNode = root->getChild();
 	if (mapHeaderNode == nullptr || !mapHeaderNode->getByte(u8) || u8 != OTBM_MAP_DATA) {
@@ -1094,7 +1094,7 @@ bool IOMapOTBM::loadMap(Map& map, NodeFileReadHandle& f) {
 }
 
 bool IOMapOTBM::loadSpawns(Map& map, const FileName& dir) {
-	std::string fn = (const char*)(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
+	std::string fn = static_cast<const char*>(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
 	fn += map.spawnfile;
 
 	FileName filename(wxstr(fn));
@@ -1104,7 +1104,7 @@ bool IOMapOTBM::loadSpawns(Map& map, const FileName& dir) {
 	}
 
 	// has to be declared again as encoding-specific characters break loading there
-	std::string encoded_path = (const char*)(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvWhateverWorks));
+	std::string encoded_path = static_cast<const char*>(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvWhateverWorks));
 	encoded_path += map.spawnfile;
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file(encoded_path.c_str());
@@ -1180,7 +1180,7 @@ bool IOMapOTBM::loadSpawns(Map& map, pugi::xml_document& doc) {
 			Direction direction = SOUTH;
 			int dir = creatureNode.attribute("direction").as_int(-1);
 			if (dir >= DIRECTION_FIRST && dir <= DIRECTION_LAST) {
-				direction = (Direction)dir;
+				direction = static_cast<Direction>(dir);
 			}
 
 			Position creaturePosition(spawnPosition);
@@ -1247,7 +1247,7 @@ bool IOMapOTBM::loadSpawns(Map& map, pugi::xml_document& doc) {
 }
 
 bool IOMapOTBM::loadHouses(Map& map, const FileName& dir) {
-	std::string fn = (const char*)(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
+	std::string fn = static_cast<const char*>(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
 	fn += map.housefile;
 
 	FileName filename(wxstr(fn));
@@ -1257,7 +1257,7 @@ bool IOMapOTBM::loadHouses(Map& map, const FileName& dir) {
 	}
 
 	// has to be declared again as encoding-specific characters break loading there
-	std::string encoded_path = (const char*)(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvWhateverWorks));
+	std::string encoded_path = static_cast<const char*>(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvWhateverWorks));
 	encoded_path += map.housefile;
 	pugi::xml_document doc;
 	pugi::xml_parse_result result = doc.load_file(encoded_path.c_str());
@@ -1323,7 +1323,7 @@ bool IOMapOTBM::loadHouses(Map& map, pugi::xml_document& doc) {
 }
 
 bool IOMapOTBM::loadWaypoints(Map& map, const FileName& dir) {
-	std::string fn = (const char*)(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
+	std::string fn = static_cast<const char*>(dir.GetPath(wxPATH_GET_SEPARATOR | wxPATH_GET_VOLUME).mb_str(wxConvUTF8));
 	fn += map.waypointfile;
 	FileName filename(wxstr(fn));
 	if (!filename.FileExists()) {
@@ -1464,7 +1464,7 @@ bool IOMapOTBM::saveMap(Map& map, const FileName& identifier) {
 	);
 
 	if (!f.isOk()) {
-		error("Can not open file %s for writing", (const char*)identifier.GetFullPath().mb_str(wxConvUTF8));
+		error("Can not open file %s for writing", static_cast<const char*>(identifier.GetFullPath().mb_str(wxConvUTF8)));
 		return false;
 	}
 

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -269,15 +269,15 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 	}
 
 	// Constants
-	float scale_x = (float)w / map_w;
-	float scale_y = (float)h / map_h;
+	float scale_x = static_cast<float>(w) / map_w;
+	float scale_y = static_cast<float>(h) / map_h;
 
 	// Determine visible tiles
 	// Clamp to integer grid
-	int start_col = (int)std::floor(map_x / TILE_SIZE);
-	int end_col = (int)std::floor((map_x + map_w) / TILE_SIZE);
-	int start_row = (int)std::floor(map_y / TILE_SIZE);
-	int end_row = (int)std::floor((map_y + map_h) / TILE_SIZE);
+	int start_col = static_cast<int>(std::floor(map_x / TILE_SIZE));
+	int end_col = static_cast<int>(std::floor((map_x + map_w) / TILE_SIZE));
+	int start_row = static_cast<int>(std::floor(map_y / TILE_SIZE));
+	int end_row = static_cast<int>(std::floor((map_y + map_h) / TILE_SIZE));
 
 	start_col = std::max(0, start_col);
 	start_row = std::max(0, start_row);
@@ -301,7 +301,7 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 
 			int layer = r * cols_ + c;
 
-			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = (float)layer });
+			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = static_cast<float>(layer) });
 		}
 	}
 


### PR DESCRIPTION
This PR modernizes legacy C++ patterns in `source/io/filehandle.cpp`, `source/io/iomap_otbm.cpp`, and `source/rendering/drawers/minimap_renderer.cpp`. Key changes include replacing raw iterator loops with range-based for loops, using `std::string::data()` for non-const access, and replacing C-style casts with `static_cast` and `reinterpret_cast` to improve type safety and readability. These changes align with the project's goal of adopting modern C++ standards.

---
*PR created automatically by Jules for task [14133253092959474219](https://jules.google.com/task/14133253092959474219) started by @karolak6612*