### PR TITLE
Fix SpriteBatch::setGlobalTint and update IngamePreviewRenderer

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -126,7 +126,9 @@ namespace IngamePreview {
 
 			// Sync viewport and start batch for this floor
 			sprite_batch->begin(view.projectionMatrix);
-			sprite_batch->setGlobalTint(1.0f, 1.0f, 1.0f, alpha);
+			if (g_gui.gfx.ensureAtlasManager()) {
+				sprite_batch->setGlobalTint(*g_gui.gfx.getAtlasManager(), 1.0f, 1.0f, 1.0f, alpha);
+			}
 
 			// Pre-calculate view offsets for this floor
 			int floor_offset = (z <= GROUND_LAYER)
@@ -180,7 +182,9 @@ namespace IngamePreview {
 					}
 				}
 			}
-			sprite_batch->end(*g_gui.gfx.getAtlasManager());
+			if (g_gui.gfx.ensureAtlasManager()) {
+				sprite_batch->end(*g_gui.gfx.getAtlasManager());
+			}
 		}
 
 		// Draw Preview Character (Center Screen)
@@ -217,7 +221,9 @@ namespace IngamePreview {
 
 			creature_drawer->BlitCreature(*sprite_batch, sprite_drawer.get(), draw_x, draw_y, preview_outfit, preview_direction, 255, 255, 255, 255, animation_phase);
 
-			sprite_batch->end(*g_gui.gfx.getAtlasManager());
+			if (g_gui.gfx.ensureAtlasManager()) {
+				sprite_batch->end(*g_gui.gfx.getAtlasManager());
+			}
 		}
 
 		if (lighting_enabled && light_drawer) {

--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -143,17 +143,14 @@ void SpriteBatch::begin(const glm::mat4& projection) {
 	shader_->SetVec4("uGlobalTint", global_tint_);
 }
 
-void SpriteBatch::setGlobalTint(float r, float g, float b, float a) {
+void SpriteBatch::setGlobalTint(const AtlasManager& atlas_manager, float r, float g, float b, float a) {
 	if (!in_batch_) {
 		return;
 	}
 
 	// If pending sprites exist, must flush to apply previous tint
 	if (!pending_sprites_.empty()) {
-		// Warning: This causes a flush and state change
-		// We can't access AtlasManager here, so we must assume calling code
-		// flushes or sets tint at appropriate times.
-		// Ideally setGlobalTint is called when batch is empty.
+		flush(atlas_manager);
 	}
 
 	global_tint_ = glm::vec4(r, g, b, a);

--- a/source/rendering/core/sprite_batch.h
+++ b/source/rendering/core/sprite_batch.h
@@ -83,7 +83,7 @@ public:
 	/**
 	 * Set global tint for subsequent draws in current batch.
 	 */
-	void setGlobalTint(float r, float g, float b, float a);
+	void setGlobalTint(const AtlasManager& atlas_manager, float r, float g, float b, float a);
 
 	/**
 	 * Ensure capacity in pending vector.


### PR DESCRIPTION
This PR addresses a logic error in `SpriteBatch::setGlobalTint` where changing the global tint mid-batch would incorrectly apply the new tint to previously queued sprites (if they hadn't been flushed yet). 

Changes:
1.  **Refactored `SpriteBatch::setGlobalTint`**: It now requires `const AtlasManager&` and calls `flush()` if there are pending sprites. This forces a draw call with the *old* tint before updating the uniform for the *new* tint.
2.  **Updated `IngamePreviewRenderer`**: Updated call sites to match the new signature. Added `ensureAtlasManager()` checks to guard against null pointer dereferences if the atlas is missing.

This work was performed as part of the "OpenGL Rendering Specialist" daily audit. A full report was generated and summarized in the commit message.

---
*PR created automatically by Jules for task [17868069044519558199](https://jules.google.com/task/17868069044519558199) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sprite tinting to properly apply color changes to all pending sprites during rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->