### PR TITLE
Fix Critical UB: Buffer Overflows, Strict Aliasing, and Exception Safety

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <memory>
 #include <vector>
+#include <cstring>
 
 #ifndef FORCEINLINE
 	#ifdef _MSV_VER
@@ -162,7 +163,7 @@ public:
 		return getType(u64);
 	}
 	FORCEINLINE bool skip(size_t sz) {
-		if (read_offset + sz > data.size()) {
+		if (sz > data.size() || read_offset > data.size() - sz) {
 			read_offset = data.size();
 			return false;
 		}
@@ -185,7 +186,7 @@ protected:
 			read_offset = data.size();
 			return false;
 		}
-		ref = *(T*)(data.data() + read_offset);
+		std::memcpy(&ref, data.data() + read_offset, sizeof(T));
 
 		read_offset += sizeof(ref);
 		return true;

--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -171,6 +171,13 @@ void LiveSocket::receiveFloor(NetworkMessage& message, Editor& editor, Action* a
 	data.insert(0, 1, ' ');
 	mapReader.assign(reinterpret_cast<const uint8_t*>(data.c_str()), data.size());
 
+	struct MapReaderGuard {
+		MemoryNodeFileReadHandle& reader;
+		~MapReaderGuard() {
+			reader.close();
+		}
+	} guard{mapReader};
+
 	BinaryNode* rootNode = mapReader.getRootNode();
 	BinaryNode* tileNode = rootNode->getChild();
 
@@ -188,7 +195,6 @@ void LiveSocket::receiveFloor(NetworkMessage& message, Editor& editor, Action* a
 			}
 		}
 	}
-	mapReader.close();
 }
 
 void LiveSocket::sendFloor(NetworkMessage& message, Floor* floor) {

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -39,6 +39,9 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
+	if (position + length > buffer.size()) {
+		throw std::out_of_range("NetworkMessage string read out of bounds");
+	}
 	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
 	position += length;
 	return std::string(strBuffer, length);

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -20,11 +20,13 @@
 
 #include "map/position.h"
 
+#include <cstring>
 #include <string>
 #include <vector>
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -35,7 +37,11 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::out_of_range("NetworkMessage read out of bounds");
+		}
+		T value;
+		std::memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}
@@ -43,7 +49,7 @@ struct NetworkMessage {
 	template <typename T>
 	void write(const T& value) {
 		expand(sizeof(T));
-		memcpy(&buffer[position], &value, sizeof(T));
+		std::memcpy(&buffer[position], &value, sizeof(T));
 		position += sizeof(T);
 	}
 


### PR DESCRIPTION
This PR addresses critical Undefined Behavior (UB) and security issues:
- **Buffer Overflow**: `NetworkMessage::read` now checks bounds.
- **Strict Aliasing**: Replaced unsafe casts with `memcpy`.
- **Exception Safety**: RAII cleanup for `mapReader`.
- **Integer Overflow**: Safe check in `BinaryNode::skip`.


---
*PR created automatically by Jules for task [4289085314598844690](https://jules.google.com/task/4289085314598844690) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened buffer overflow prevention with enhanced bounds checking across file I/O and network operations.
  * Added runtime validation for network message reading to prevent out-of-bounds access.
  * Improved memory safety in data deserialization by replacing unsafe pointer operations.
  * Ensured automatic resource cleanup in socket operations to prevent leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->