### PR TITLE
Refactor IOMapOTBM::loadMap to helper methods

### DIFF
--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -20,6 +20,8 @@
 
 #include "io/iomap.h"
 
+class BinaryNode;
+
 // Pragma pack is VERY important since otherwise it won't be able to load the structs correctly
 #pragma pack(1)
 
@@ -139,6 +141,11 @@ protected:
 	static bool getVersionInfo(NodeFileReadHandle* f, MapVersion& out_ver);
 
 	bool loadMap(Map& map, NodeFileReadHandle& handle);
+
+	bool loadOTGZ(Map& map, const FileName& identifier);
+	void readMapAttributes(BinaryNode* mapHeaderNode, Map& map);
+	bool readMapNodes(BinaryNode* mapHeaderNode, Map& map, NodeFileReadHandle& f);
+
 	bool loadSpawns(Map& map, const FileName& dir);
 	bool loadSpawns(Map& map, pugi::xml_document& doc);
 	bool loadHouses(Map& map, const FileName& dir);


### PR DESCRIPTION
Refactored `IOMapOTBM::loadMap` by extracting logic into helper methods: `loadOTGZ`, `readMapAttributes`, and `readMapNodes`. This reduces the complexity of `loadMap` and makes the code more modular and easier to read. Addressed initial implementation errors where helper methods were recursively calling themselves. Verified logic correctness manually.

---
*PR created automatically by Jules for task [6302143344811724228](https://jules.google.com/task/6302143344811724228) started by @karolak6612*