### PR TITLE
[TILE/WXWIDGETS] Optimize MapWindow scrolling refresh

### DIFF
--- a/source/ui/map_window.cpp
+++ b/source/ui/map_window.cpp
@@ -228,7 +228,7 @@ void MapWindow::OnSize(wxSizeEvent& event) {
 }
 
 void MapWindow::OnScroll(wxScrollEvent& event) {
-	Refresh();
+	canvas->Refresh();
 }
 
 void MapWindow::OnScrollLineDown(wxScrollEvent& event) {
@@ -237,7 +237,7 @@ void MapWindow::OnScrollLineDown(wxScrollEvent& event) {
 	} else {
 		ScrollRelative(0, 96);
 	}
-	Refresh();
+	canvas->Refresh();
 }
 
 void MapWindow::OnScrollLineUp(wxScrollEvent& event) {
@@ -246,7 +246,7 @@ void MapWindow::OnScrollLineUp(wxScrollEvent& event) {
 	} else {
 		ScrollRelative(0, -96);
 	}
-	Refresh();
+	canvas->Refresh();
 }
 
 void MapWindow::OnScrollPageDown(wxScrollEvent& event) {
@@ -255,7 +255,7 @@ void MapWindow::OnScrollPageDown(wxScrollEvent& event) {
 	} else {
 		ScrollRelative(0, 5 * 96);
 	}
-	Refresh();
+	canvas->Refresh();
 }
 
 void MapWindow::OnScrollPageUp(wxScrollEvent& event) {
@@ -264,5 +264,5 @@ void MapWindow::OnScrollPageUp(wxScrollEvent& event) {
 	} else {
 		ScrollRelative(0, -5 * 96);
 	}
-	Refresh();
+	canvas->Refresh();
 }


### PR DESCRIPTION
ISSUE: MapWindow scrolling triggered full window repaints (`Refresh()`), causing unnecessary redraws of the container and sibling widgets.
IMPACT: Potential flickering and reduced performance during high-frequency scroll events (e.g., thumb tracking).
FIX: Changed `Refresh()` to `canvas->Refresh()` in `OnScroll`, `OnScrollLineDown`, `OnScrollLineUp`, `OnScrollPageDown`, and `OnScrollPageUp`.
DOMAIN CONTEXT: This aligns with wxWidgets best practices for composite controls where child windows (like `MapCanvas`) should be refreshed independently when their view changes, rather than invalidating the entire parent hierarchy.
PERFORMANCE: Reduces paint overhead during scrolling.
TESTED: Verified that all scroll event handlers now target the canvas.


---
*PR created automatically by Jules for task [4006659792928629366](https://jules.google.com/task/4006659792928629366) started by @karolak6612*