### PR TITLE
Sentinel: Modernize OpenGL resources and fix SpriteBatch tinting

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -117,6 +117,10 @@ namespace IngamePreview {
 			creature_name_drawer->clear(); // Clear old labels
 		}
 
+		if (!g_gui.gfx.ensureAtlasManager()) {
+			return;
+		}
+
 		// Render floors from bottom to top
 		for (int z = last_visible; z >= 0; z--) {
 			float alpha = floor_opacity[z];
@@ -126,7 +130,7 @@ namespace IngamePreview {
 
 			// Sync viewport and start batch for this floor
 			sprite_batch->begin(view.projectionMatrix);
-			sprite_batch->setGlobalTint(1.0f, 1.0f, 1.0f, alpha);
+			sprite_batch->setGlobalTint(1.0f, 1.0f, 1.0f, alpha, *g_gui.gfx.getAtlasManager());
 
 			// Pre-calculate view offsets for this floor
 			int floor_offset = (z <= GROUND_LAYER)

--- a/source/rendering/core/gl_resources.h
+++ b/source/rendering/core/gl_resources.h
@@ -5,6 +5,51 @@
 #include <utility> // for std::exchange
 #include <spdlog/spdlog.h>
 
+// RAII wrapper for OpenGL Shaders
+class GLShader {
+public:
+	explicit GLShader(GLenum type) {
+		id = glCreateShader(type);
+		// spdlog::trace("GLShader created [ID={}]", id);
+	}
+
+	~GLShader() {
+		if (id) {
+			// spdlog::trace("GLShader deleted [ID={}]", id);
+			glDeleteShader(id);
+		}
+	}
+
+	// Disable copy
+	GLShader(const GLShader&) = delete;
+	GLShader& operator=(const GLShader&) = delete;
+
+	// Enable move
+	GLShader(GLShader&& other) noexcept :
+		id(std::exchange(other.id, 0)) { }
+
+	GLShader& operator=(GLShader&& other) noexcept {
+		if (this != &other) {
+			if (id) {
+				glDeleteShader(id);
+			}
+			id = std::exchange(other.id, 0);
+		}
+		return *this;
+	}
+
+	// Explicit conversion
+	explicit operator GLuint() const {
+		return id;
+	}
+	GLuint GetID() const {
+		return id;
+	}
+
+private:
+	GLuint id = 0;
+};
+
 // RAII wrapper for OpenGL Buffers (VBO, EBO, UBO, SSBO)
 class GLBuffer {
 public:

--- a/source/rendering/core/shader_program.h
+++ b/source/rendering/core/shader_program.h
@@ -37,7 +37,7 @@ private:
 	mutable std::unordered_map<std::string, GLint> uniform_cache;
 
 	GLint GetUniformLocation(const std::string& name) const;
-	GLuint CompileShader(GLenum type, const std::string& source);
+	bool CompileShader(GLuint shader, const std::string& source);
 };
 
 #endif

--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -143,17 +143,14 @@ void SpriteBatch::begin(const glm::mat4& projection) {
 	shader_->SetVec4("uGlobalTint", global_tint_);
 }
 
-void SpriteBatch::setGlobalTint(float r, float g, float b, float a) {
+void SpriteBatch::setGlobalTint(float r, float g, float b, float a, const AtlasManager& atlas_manager) {
 	if (!in_batch_) {
 		return;
 	}
 
 	// If pending sprites exist, must flush to apply previous tint
 	if (!pending_sprites_.empty()) {
-		// Warning: This causes a flush and state change
-		// We can't access AtlasManager here, so we must assume calling code
-		// flushes or sets tint at appropriate times.
-		// Ideally setGlobalTint is called when batch is empty.
+		flush(atlas_manager);
 	}
 
 	global_tint_ = glm::vec4(r, g, b, a);

--- a/source/rendering/core/sprite_batch.h
+++ b/source/rendering/core/sprite_batch.h
@@ -82,8 +82,9 @@ public:
 
 	/**
 	 * Set global tint for subsequent draws in current batch.
+	 * If pending sprites exist, they will be flushed using the provided atlas manager.
 	 */
-	void setGlobalTint(float r, float g, float b, float a);
+	void setGlobalTint(float r, float g, float b, float a, const AtlasManager& atlas_manager);
 
 	/**
 	 * Ensure capacity in pending vector.


### PR DESCRIPTION
This PR addresses modernization tasks from the Sentinel agent.

**Key Changes:**
1.  **Safety:** Introduced `GLShader` RAII wrapper to automatically handle `glDeleteShader`. This prevents leaks if shader compilation fails or exceptions are thrown (though exceptions are not currently used for this flow).
2.  **Refactoring:** `ShaderProgram::Load` and `CompileShader` now use `GLShader`, removing manual `glDeleteShader` calls and simplifying error handling.
3.  **Correctness:** Fixed a rendering state issue in `SpriteBatch::setGlobalTint`. Previously, changing the global tint (uniform) did not flush pending sprites, meaning the new tint would retrospectively apply to sprites already batched but not yet drawn. The method now accepts `const AtlasManager&` and calls `flush()` if needed.
4.  **Integration:** Updated `IngamePreviewRenderer` to pass the `AtlasManager` when setting global tint for floor fading effects.

**Verification:**
- Verified code changes manually.
- Build system integration (Conan) prevented full local build verification within timeout, but code changes are standard C++17/20 refactorings and align with existing patterns.


---
*PR created automatically by Jules for task [6266011039412501546](https://jules.google.com/task/6266011039412501546) started by @karolak6612*