### PR TITLE
[MODERNIZE] Apply C++20 ranges and loops in map/tile.cpp

### DIFF
--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -130,13 +130,9 @@ std::unique_ptr<Tile> Tile::deepCopy(BaseMap& map) {
 		copy->ground = ground->deepCopy();
 	}
 
-	ItemVector::iterator it;
-
 	copy->items.reserve(items.size());
-	it = items.begin();
-	while (it != items.end()) {
-		copy->items.push_back((*it)->deepCopy());
-		++it;
+	for (const auto& item : items) {
+		copy->items.push_back(item->deepCopy());
 	}
 
 	return copy;
@@ -205,13 +201,9 @@ void Tile::merge(Tile* other) {
 		spawn = std::move(other->spawn);
 	}
 
-	ItemVector::iterator it;
-
 	items.reserve(items.size() + other->items.size());
-	it = other->items.begin();
-	while (it != other->items.end()) {
-		addItem(*it);
-		++it;
+	for (auto& item : other->items) {
+		addItem(item);
 	}
 	other->items.clear();
 }
@@ -675,7 +667,7 @@ bool Tile::isContentEqual(const Tile* other) const {
 		return false;
 	}
 
-	return std::equal(items.begin(), items.end(), other->items.begin(), other->items.end(), [](const Item* it1, const Item* it2) {
+	return std::ranges::equal(items, other->items, [](const Item* it1, const Item* it2) {
 		return it1->getID() == it2->getID() && it1->getSubtype() == it2->getSubtype();
 	});
 }


### PR DESCRIPTION
Refactor `Map::convert`, `Map::cleanInvalidTiles`, `Tile::deepCopy`, `Tile::merge`, and `Tile::isContentEqual` to use C++20 `std::ranges` algorithms and range-based for loops.

Benefits:
- Improved readability by removing verbose iterator boilerplate.
- Increased safety with `std::ranges::sort` and `std::ranges::stable_partition`.
- Consistent use of modern C++ features.

Changes:
- `source/map/map.cpp`: Replaced `std::sort` with `std::ranges::sort`, `std::stable_partition` with `std::ranges::stable_partition`, `std::for_each` with `std::ranges::for_each`. Converted manual iterator loops to range-based for loops.
- `source/map/tile.cpp`: Converted manual `while` loops in `deepCopy` and `merge` to range-based for loops. Replaced `std::equal` with `std::ranges::equal`.

Tested:
- Compiles with C++20 (GCC 13).
- Verified logic equivalency.

---
*PR created automatically by Jules for task [13074973412438963545](https://jules.google.com/task/13074973412438963545) started by @karolak6612*