### PR TITLE
👻 Phantom: Migrate wxVListBox usage to NanoVGListBox

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -211,6 +211,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/item_buttons.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.h
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/properties/object_properties_base.h
@@ -538,6 +539,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/properties/object_properties_base.cpp

--- a/source/ui/controls/nanovg_listbox.cpp
+++ b/source/ui/controls/nanovg_listbox.cpp
@@ -1,0 +1,336 @@
+#include "ui/controls/nanovg_listbox.h"
+#include <wx/wx.h>
+#include <nanovg.h>
+#include "app/main.h"
+
+NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) :
+	NanoVGCanvas(parent, id, wxVSCROLL | wxWANTS_CHARS),
+	m_itemCount(0),
+	m_hoverIndex(-1),
+	m_style(style),
+	m_lastFocusIndex(-1),
+	m_totalHeight(0) {
+
+	if (pos != wxDefaultPosition) SetPosition(pos);
+	if (size != wxDefaultSize) SetSize(size);
+
+	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnMouseDown, this);
+	Bind(wxEVT_MOTION, &NanoVGListBox::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &NanoVGListBox::OnLeave, this);
+	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
+	Bind(wxEVT_SIZE, &NanoVGListBox::OnSize, this);
+	Bind(wxEVT_CHAR, &NanoVGListBox::OnChar, this);
+
+	RecalculateHeights();
+}
+
+NanoVGListBox::~NanoVGListBox() {
+	////
+}
+
+void NanoVGListBox::SetItemCount(size_t count) {
+	if (count == m_itemCount) return;
+
+	m_itemCount = count;
+	m_selections.clear();
+	m_lastFocusIndex = -1;
+	m_hoverIndex = -1;
+
+	RecalculateHeights();
+	UpdateScrollbar(m_totalHeight);
+	Refresh();
+}
+
+void NanoVGListBox::RecalculateHeights() {
+	m_itemY.clear();
+	m_itemY.reserve(m_itemCount + 1);
+
+	int y = 0;
+	m_itemY.push_back(y);
+	for (size_t i = 0; i < m_itemCount; ++i) {
+		int h = OnMeasureItem(i);
+		y += h;
+		m_itemY.push_back(y);
+	}
+	m_totalHeight = y;
+	UpdateScrollbar(m_totalHeight);
+}
+
+int NanoVGListBox::GetSelection() const {
+	if (m_selections.empty()) return wxNOT_FOUND;
+	return *m_selections.begin();
+}
+
+bool NanoVGListBox::IsSelected(size_t n) const {
+	return m_selections.find(n) != m_selections.end();
+}
+
+size_t NanoVGListBox::GetSelectedCount() const {
+	return m_selections.size();
+}
+
+void NanoVGListBox::DeselectAll() {
+	bool changed = !m_selections.empty();
+	m_selections.clear();
+	if (changed) Refresh();
+}
+
+bool NanoVGListBox::Select(size_t n, bool select) {
+	if (n >= m_itemCount) return false;
+
+	bool changed = false;
+	if (select) {
+		if (m_selections.find(n) == m_selections.end()) {
+			m_selections.insert(n);
+			changed = true;
+		}
+	} else {
+		if (m_selections.erase(n) > 0) {
+			changed = true;
+		}
+	}
+
+	if (changed) {
+		RefreshItem(n);
+	}
+	return changed;
+}
+
+bool NanoVGListBox::SetSelection(int n) {
+	if (n == wxNOT_FOUND) {
+		DeselectAll();
+		return true;
+	}
+	if (n < 0 || (size_t)n >= m_itemCount) return false;
+
+	bool changed = false;
+	if (m_selections.size() != 1 || *m_selections.begin() != (size_t)n) {
+		changed = true;
+		m_selections.clear();
+		m_selections.insert((size_t)n);
+		m_lastFocusIndex = n;
+		EnsureVisible((size_t)n);
+		Refresh();
+	}
+	return changed;
+}
+
+void NanoVGListBox::RefreshItem(size_t n) {
+	// For now, just refresh whole canvas as NanoVG redraws everything anyway
+	Refresh();
+}
+
+void NanoVGListBox::RefreshAll() {
+	Refresh();
+}
+
+void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int scrollPos = GetScrollPosition();
+
+	// Find visible range
+	// Since m_itemY is sorted, we can binary search or just linear search if few items
+	// But binary search is O(log N) which is better.
+
+	auto startIt = std::lower_bound(m_itemY.begin(), m_itemY.end(), scrollPos);
+	size_t startIdx = std::distance(m_itemY.begin(), startIt);
+	if (startIdx > 0 && m_itemY[startIdx] > scrollPos) startIdx--; // Adjust for partial visibility
+
+	size_t endIdx = startIdx;
+	int endY = scrollPos + height;
+	while (endIdx < m_itemCount && m_itemY[endIdx] < endY) {
+		endIdx++;
+	}
+	if (endIdx < m_itemCount) endIdx++; // Ensure last item is included
+
+	// Background
+	nvgBeginPath(vg);
+	nvgRect(vg, 0, scrollPos, width, height);
+	nvgFillColor(vg, nvgRGBAf(m_bgRed, m_bgGreen, m_bgBlue, 1.0f));
+	nvgFill(vg);
+
+	for (size_t i = startIdx; i < endIdx && i < m_itemCount; ++i) {
+		int y = m_itemY[i];
+		int h = m_itemY[i+1] - y;
+		wxRect rect(0, y, width, h);
+
+		OnDrawBackground(vg, rect, i);
+		OnDrawItem(vg, rect, i);
+	}
+}
+
+void NanoVGListBox::OnDrawBackground(NVGcontext* vg, const wxRect& rect, size_t n) const {
+	bool selected = IsSelected(n);
+	bool hovered = ((int)n == m_hoverIndex);
+
+	if (selected || hovered) {
+		nvgBeginPath(vg);
+		nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
+		if (selected) {
+			if (HasFocus()) {
+				nvgFillColor(vg, nvgRGBA(0, 120, 215, 255)); // Standard selection blue
+			} else {
+				nvgFillColor(vg, nvgRGBA(80, 80, 80, 255)); // Unfocused selection grey
+			}
+		} else {
+			nvgFillColor(vg, nvgRGBA(60, 60, 60, 255)); // Hover grey
+		}
+		nvgFill(vg);
+	}
+}
+
+void NanoVGListBox::OnSize(wxSizeEvent& event) {
+	RecalculateHeights();
+	event.Skip();
+}
+
+int NanoVGListBox::HitTest(int x, int y) const {
+	int scrollPos = GetScrollPosition();
+	int realY = y + scrollPos;
+
+	auto it = std::lower_bound(m_itemY.begin(), m_itemY.end(), realY);
+	if (it == m_itemY.end()) {
+		// Could be last item
+		if (realY < m_totalHeight) return m_itemCount - 1;
+		return wxNOT_FOUND;
+	}
+
+	size_t idx = std::distance(m_itemY.begin(), it);
+	if (idx > 0 && m_itemY[idx] > realY) idx--;
+
+	if (idx < m_itemCount) return (int)idx;
+	return wxNOT_FOUND;
+}
+
+wxRect NanoVGListBox::GetItemRect(size_t n) const {
+	if (n >= m_itemCount) return wxRect();
+	return wxRect(0, m_itemY[n], GetClientSize().x, m_itemY[n+1] - m_itemY[n]);
+}
+
+void NanoVGListBox::EnsureVisible(size_t n) {
+	if (n >= m_itemCount) return;
+
+	int y = m_itemY[n];
+	int h = m_itemY[n+1] - y;
+	int scrollPos = GetScrollPosition();
+	int clientHeight = GetClientSize().y;
+
+	if (y < scrollPos) {
+		SetScrollPosition(y);
+	} else if (y + h > scrollPos + clientHeight) {
+		SetScrollPosition(y + h - clientHeight);
+	}
+}
+
+void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
+	SetFocus();
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != wxNOT_FOUND) {
+		int flags = 0;
+		if (event.ControlDown()) flags |= 1;
+		if (event.ShiftDown()) flags |= 2;
+		HandleClick(index, flags);
+
+		wxCommandEvent cmd(wxEVT_LISTBOX, GetId());
+		cmd.SetEventObject(this);
+		cmd.SetInt(index);
+		GetEventHandler()->ProcessEvent(cmd);
+
+		// Also handle double click via timer? No, wxMouseEvent has LeftDClick
+	}
+}
+
+void NanoVGListBox::HandleClick(int index, int flags) {
+	if (m_style & wxLB_MULTIPLE) {
+		if (flags & 1) { // Ctrl
+			Select(index, !IsSelected(index));
+			m_lastFocusIndex = index;
+		} else if (flags & 2) { // Shift
+			if (m_lastFocusIndex != -1) {
+				int start = std::min(m_lastFocusIndex, index);
+				int end = std::max(m_lastFocusIndex, index);
+				m_selections.clear();
+				for (int i = start; i <= end; ++i) {
+					m_selections.insert(i);
+				}
+			} else {
+				m_selections.clear();
+				m_selections.insert(index);
+				m_lastFocusIndex = index;
+			}
+		} else {
+			m_selections.clear();
+			m_selections.insert(index);
+			m_lastFocusIndex = index;
+		}
+	} else {
+		// Single selection
+		SetSelection(index);
+	}
+	Refresh();
+}
+
+void NanoVGListBox::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != m_hoverIndex) {
+		m_hoverIndex = index;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnLeave(wxMouseEvent& event) {
+	if (m_hoverIndex != -1) {
+		m_hoverIndex = -1;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
+	int selection = GetSelection();
+	if (selection == wxNOT_FOUND && m_itemCount > 0) selection = 0;
+
+	int newSelection = selection;
+	int pageSize = 10; // Approx
+	if (m_itemCount > 0) {
+		pageSize = GetClientSize().y / (m_totalHeight / m_itemCount + 1);
+	}
+
+	switch (event.GetKeyCode()) {
+		case WXK_UP:
+			if (newSelection > 0) newSelection--;
+			break;
+		case WXK_DOWN:
+			if (newSelection < (int)m_itemCount - 1) newSelection++;
+			break;
+		case WXK_HOME:
+			newSelection = 0;
+			break;
+		case WXK_END:
+			newSelection = m_itemCount - 1;
+			break;
+		case WXK_PAGEUP:
+			newSelection = std::max(0, newSelection - pageSize);
+			break;
+		case WXK_PAGEDOWN:
+			newSelection = std::min((int)m_itemCount - 1, newSelection + pageSize);
+			break;
+		default:
+			event.Skip();
+			return;
+	}
+
+	if (newSelection != selection || GetSelection() == wxNOT_FOUND) {
+		SetSelection(newSelection);
+
+		wxCommandEvent cmd(wxEVT_LISTBOX, GetId());
+		cmd.SetEventObject(this);
+		cmd.SetInt(newSelection);
+		GetEventHandler()->ProcessEvent(cmd);
+	}
+}
+
+void NanoVGListBox::OnChar(wxKeyEvent& event) {
+	// Simple search/jump could be implemented here
+	event.Skip();
+}

--- a/source/ui/controls/nanovg_listbox.h
+++ b/source/ui/controls/nanovg_listbox.h
@@ -1,0 +1,65 @@
+#ifndef RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+#define RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+
+#include "util/nanovg_canvas.h"
+#include <vector>
+#include <set>
+
+class NanoVGListBox : public NanoVGCanvas {
+public:
+	NanoVGListBox(wxWindow* parent, wxWindowID id, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize, long style = 0);
+	virtual ~NanoVGListBox();
+
+	// wxVListBox-like interface
+	void SetItemCount(size_t count);
+	size_t GetItemCount() const { return m_itemCount; }
+
+	int GetSelection() const;
+	bool IsSelected(size_t n) const;
+	bool Select(size_t n, bool select = true);
+	size_t GetSelectedCount() const;
+	void DeselectAll();
+	bool SetSelection(int n); // Selects only this one, deselects others. Returns true if changed.
+
+	// Helper
+	void RefreshItem(size_t n);
+	void RefreshAll();
+
+	// Virtuals to implement by subclasses
+	virtual void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n) const = 0;
+	virtual wxCoord OnMeasureItem(size_t n) const = 0;
+
+	// Optional virtuals
+	virtual void OnDrawBackground(NVGcontext* vg, const wxRect& rect, size_t n) const;
+	virtual void OnDrawSeparator(NVGcontext* vg, const wxRect& rect, size_t n) const {}
+
+protected:
+	// Event handling
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnSize(wxSizeEvent& event);
+	void OnChar(wxKeyEvent& event);
+
+	void RecalculateHeights();
+	int HitTest(int x, int y) const;
+	wxRect GetItemRect(size_t n) const;
+	void EnsureVisible(size_t n);
+
+	// Selection helpers
+	void HandleClick(int index, int flags);
+
+	size_t m_itemCount;
+	std::set<size_t> m_selections;
+	int m_hoverIndex;
+	long m_style;
+	int m_lastFocusIndex; // For shift-click range selection
+
+	// Layout cache
+	std::vector<int> m_itemY; // Y position of each item. Size = m_itemCount + 1.
+	int m_totalHeight;
+};
+
+#endif // RME_UI_CONTROLS_NANOVG_LISTBOX_H_

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,7 +3,7 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
+#include "ui/controls/nanovg_listbox.h"
 #include <vector>
 
 class Brush;
@@ -19,7 +19,7 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogListBox : public NanoVGListBox {
 public:
 	FindDialogListBox(wxWindow* parent, wxWindowID id);
 	~FindDialogListBox();
@@ -29,8 +29,8 @@ public:
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) const override;
+	wxCoord OnMeasureItem(size_t index) const override;
 
 protected:
 	bool cleared;

--- a/source/ui/replace_items_window.h
+++ b/source/ui/replace_items_window.h
@@ -20,6 +20,7 @@
 
 #include "app/main.h"
 #include "ui/controls/item_buttons.h"
+#include "ui/controls/nanovg_listbox.h"
 #include "editor/editor.h"
 
 struct ReplacingItem {
@@ -57,7 +58,7 @@ private:
 // ============================================================================
 // ReplaceItemsListBox
 
-class ReplaceItemsListBox : public wxVListBox {
+class ReplaceItemsListBox : public NanoVGListBox {
 public:
 	ReplaceItemsListBox(wxWindow* parent);
 
@@ -66,8 +67,8 @@ public:
 	void RemoveSelected();
 	bool CanAdd(uint16_t replaceId, uint16_t withId) const;
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) const override;
+	wxCoord OnMeasureItem(size_t index) const override;
 
 	const std::vector<ReplacingItem>& GetItems() const {
 		return m_items;
@@ -78,8 +79,6 @@ public:
 
 private:
 	std::vector<ReplacingItem> m_items;
-	wxBitmap m_arrow_bitmap;
-	wxBitmap m_flag_bitmap;
 };
 
 // ============================================================================


### PR DESCRIPTION
- Created `NanoVGListBox`, a hardware-accelerated replacement for `wxVListBox` supporting virtual scrolling, selection, and keyboard navigation.
- Migrated `FindDialogListBox` to `NanoVGListBox`.
- Migrated `ReplaceItemsListBox` to `NanoVGListBox`.
- Migrated `BrowseTileListBox` to `NanoVGListBox`.
- Fixed integer division bug in `ReplaceItemsDialog` progress bar.
- Updated `CMakeLists.txt` to include new files.

---
*PR created automatically by Jules for task [1304343973037936334](https://jules.google.com/task/1304343973037936334) started by @karolak6612*