### PR TITLE
Palette: Implemented 10 micro-UX improvements

### DIFF
--- a/source/ui/add_item_window.cpp
+++ b/source/ui/add_item_window.cpp
@@ -36,6 +36,7 @@
 #include "ui/add_item_window.h"
 #include "ui/properties/container_properties_window.h"
 #include "ui/find_item_window.h"
+#include "util/image_manager.h"
 
 // ============================================================================
 // Add Item Window
@@ -83,9 +84,11 @@ AddItemWindow::AddItemWindow(wxWindow* win_parent, TilesetCategoryType categoryT
 
 	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "Add");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	okBtn->SetToolTip("Add item to tileset");
 	subsizer_->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
 	cancelBtn->SetToolTip("Close this window");
 	subsizer_->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));

--- a/source/ui/add_tileset_window.cpp
+++ b/source/ui/add_tileset_window.cpp
@@ -36,6 +36,7 @@
 #include "ui/add_tileset_window.h"
 #include "ui/properties/container_properties_window.h"
 #include "ui/find_item_window.h"
+#include "util/image_manager.h"
 
 // ============================================================================
 // Add Tileset Window
@@ -86,9 +87,11 @@ AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType cat
 
 	wxSizer* subsizer_ = newd wxBoxSizer(wxHORIZONTAL);
 	auto okBtn = newd wxButton(this, wxID_OK, "Add");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	okBtn->SetToolTip("Create new tileset");
 	subsizer_->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	auto cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
 	cancelBtn->SetToolTip("Cancel");
 	subsizer_->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(subsizer_, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -11,6 +11,7 @@
 #include "map/map.h"
 #include "game/town.h"
 #include "game/house.h"
+#include "util/image_manager.h"
 
 #include <wx/wx.h>
 #include <sstream>
@@ -92,10 +93,12 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* export_button = newd wxButton(dg, wxID_OK, "Export as XML");
+	export_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
 	export_button->SetToolTip("Not implemented yet");
 	export_button->Enable(false);
-	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "OK");
+	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "Close");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
 	okBtn->SetToolTip("Close this window");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -26,6 +26,7 @@
 #include "ui/properties/property_validator.h"
 #include "ui/properties/property_applier.h"
 #include "ui/properties/teleport_service.h"
+#include "util/image_manager.h"
 
 #include <wx/grid.h>
 #include <wx/wrapsizer.h>
@@ -66,9 +67,11 @@ void PropertiesWindow::createUI() {
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
 	okBtn->SetToolTip("Apply changes and close");
 	optSizer->Add(okBtn, wxSizerFlags(0).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
 	cancelBtn->SetToolTip("Discard changes and close");
 	optSizer->Add(cancelBtn, wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
@@ -210,10 +213,12 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* addBtn = newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute");
+	addBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	addBtn->SetToolTip("Add a new custom attribute");
 	optSizer->Add(addBtn, wxSizerFlags(0).Center());
 
 	wxButton* removeBtn = newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute");
+	removeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
 	removeBtn->SetToolTip("Remove selected custom attribute");
 	optSizer->Add(removeBtn, wxSizerFlags(0).Center());
 

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -359,6 +359,7 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 			hover_brush = tr.brush;
 			if (prev_hover != hover_brush) {
 				SetToolTip(tr.tooltip);
+				g_gui.SetStatusText(tr.tooltip);
 			}
 			hand_cursor = true;
 			break;
@@ -366,6 +367,7 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 	}
 	if (!hover_brush && prev_hover) {
 		UnsetToolTip();
+		g_gui.SetStatusText("");
 	}
 
 	// Sliders Interaction
@@ -450,14 +452,36 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 	if (interactables.preview_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_preview = true;
 		hand_cursor = true;
-	}
-	if (interactables.lock_check_rect.Contains(m_hoverPos)) {
+		if (!prev_preview) {
+			SetToolTip("Toggle automatic border preview");
+			g_gui.SetStatusText("Toggle automatic border preview");
+		}
+	} else if (interactables.lock_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_lock = true;
 		hand_cursor = true;
-	}
-
-	if (interactables.size_slider_rect.Contains(m_hoverPos) || interactables.thickness_slider_rect.Contains(m_hoverPos)) {
+		if (!prev_lock) {
+			SetToolTip("Lock Door Placement (Shift)");
+			g_gui.SetStatusText("Lock door placement to prevent overwriting existing doors (Hold Shift)");
+		}
+	} else if (interactables.size_slider_rect.Contains(m_hoverPos)) {
 		hand_cursor = true;
+		wxString tip = "Brush Size (Double-click to reset)";
+		if (GetToolTipText() != tip) {
+			SetToolTip(tip);
+			g_gui.SetStatusText("Brush Size: Adjust the size of the brush (Double-click to reset to 1)");
+		}
+	} else if (interactables.thickness_slider_rect.Contains(m_hoverPos)) {
+		hand_cursor = true;
+		wxString tip = "Brush Thickness (Double-click to reset)";
+		if (GetToolTipText() != tip) {
+			SetToolTip(tip);
+			g_gui.SetStatusText("Brush Thickness: Adjust the line thickness (Double-click to reset to 100)");
+		}
+	} else if (!hover_brush) {
+		if (GetToolTip()) {
+			UnsetToolTip();
+			g_gui.SetStatusText("");
+		}
 	}
 
 	SetCursor(hand_cursor ? wxCursor(wxCURSOR_HAND) : wxCursor(wxCURSOR_ARROW));


### PR DESCRIPTION
Implemented 10 micro-UX improvements as per Palette instructions.
1. Added tooltips to Size slider in ToolOptionsSurface.
2. Added tooltips to Thickness slider in ToolOptionsSurface.
3. Added tooltips to Preview checkbox in ToolOptionsSurface.
4. Added tooltips to Lock checkbox in ToolOptionsSurface.
5. Added status bar feedback on hover for all interactable elements in ToolOptionsSurface.
6. Added icons to OK/Cancel buttons in PropertiesWindow.
7. Added icons to Add/Remove Attribute buttons in PropertiesWindow.
8. Added icons to MapStatisticsDialog buttons and renamed OK to Close.
9. Added icons to AddItemWindow buttons.
10. Added icons to AddTilesetWindow buttons.

---
*PR created automatically by Jules for task [4189422407196914790](https://jules.google.com/task/4189422407196914790) started by @karolak6612*