### PR TITLE
⚡ Throttle: Replace wxVListBox with NanoVGListBox in BrowseTileWindow and FindDialog

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -210,6 +210,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/item_buttons.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.h
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.h
@@ -537,6 +538,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/add_tileset_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.cpp

--- a/source/ui/controls/nanovg_listbox.cpp
+++ b/source/ui/controls/nanovg_listbox.cpp
@@ -1,0 +1,280 @@
+#include "app/main.h"
+#include "ui/controls/nanovg_listbox.h"
+#include "ui/theme.h"
+#include <nanovg.h>
+#include <wx/settings.h>
+#include <algorithm>
+
+NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
+	NanoVGCanvas(parent, id, style | wxVSCROLL | wxWANTS_CHARS),
+	m_itemCount(0),
+	m_itemHeight(24),
+	m_multipleSelection((style & wxLB_MULTIPLE) || (style & wxLB_EXTENDED)) {
+
+	m_itemHeight = FromDIP(24);
+
+	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnLeftDown, this);
+	Bind(wxEVT_LEFT_UP, &NanoVGListBox::OnLeftUp, this);
+	Bind(wxEVT_MOTION, &NanoVGListBox::OnMotion, this);
+	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
+	Bind(wxEVT_SIZE, &NanoVGListBox::OnSize, this);
+}
+
+NanoVGListBox::~NanoVGListBox() {
+}
+
+void NanoVGListBox::SetItemCount(size_t count) {
+	m_itemCount = count;
+	UpdateScrollbar(static_cast<int>(m_itemCount * m_itemHeight));
+	Refresh();
+}
+
+void NanoVGListBox::SetItemHeight(int height) {
+	m_itemHeight = height;
+	UpdateScrollbar(static_cast<int>(m_itemCount * m_itemHeight));
+	Refresh();
+}
+
+void NanoVGListBox::SetSelection(int n) {
+	if (n < 0 || n >= static_cast<int>(m_itemCount)) {
+		return;
+	}
+
+	if (!m_multipleSelection) {
+		for (int sel : m_selections) {
+			OnSelectionChanged(sel, false);
+		}
+		m_selections.clear();
+	}
+
+	if (m_selections.find(n) == m_selections.end()) {
+		m_selections.insert(n);
+		OnSelectionChanged(n, true);
+	}
+
+	EnsureVisible(n);
+	Refresh();
+}
+
+bool NanoVGListBox::IsSelected(int n) const {
+	return m_selections.find(n) != m_selections.end();
+}
+
+void NanoVGListBox::Select(int n) {
+	if (n >= 0 && n < static_cast<int>(m_itemCount)) {
+		if (m_selections.find(n) == m_selections.end()) {
+			m_selections.insert(n);
+			OnSelectionChanged(n, true);
+			Refresh();
+		}
+	}
+}
+
+void NanoVGListBox::Deselect(int n) {
+	if (m_selections.erase(n) > 0) {
+		OnSelectionChanged(n, false);
+		Refresh();
+	}
+}
+
+void NanoVGListBox::DeselectAll() {
+	std::set<int> oldSelections = m_selections;
+	m_selections.clear();
+	for (int n : oldSelections) {
+		OnSelectionChanged(n, false);
+	}
+	Refresh();
+}
+
+void NanoVGListBox::SelectAll() {
+	if (m_multipleSelection) {
+		for (size_t i = 0; i < m_itemCount; ++i) {
+			int n = static_cast<int>(i);
+			if (m_selections.find(n) == m_selections.end()) {
+				m_selections.insert(n);
+				OnSelectionChanged(n, true);
+			}
+		}
+		Refresh();
+	}
+}
+
+int NanoVGListBox::GetSelection() const {
+	if (m_selections.empty()) {
+		return -1;
+	}
+	return *m_selections.begin();
+}
+
+int NanoVGListBox::GetSelectedCount() const {
+	return static_cast<int>(m_selections.size());
+}
+
+void NanoVGListBox::EnsureVisible(int n) {
+	if (n < 0 || n >= static_cast<int>(m_itemCount)) {
+		return;
+	}
+
+	int itemTop = n * m_itemHeight;
+	int itemBottom = itemTop + m_itemHeight;
+	int scrollTop = GetScrollPosition();
+	int scrollBottom = scrollTop + GetClientSize().y;
+
+	if (itemTop < scrollTop) {
+		SetScrollPosition(itemTop);
+	} else if (itemBottom > scrollBottom) {
+		SetScrollPosition(itemBottom - GetClientSize().y);
+	}
+}
+
+int NanoVGListBox::OnMeasureItem(size_t n) const {
+	return m_itemHeight;
+}
+
+void NanoVGListBox::OnSelectionChanged(int n, bool selected) {
+	// Default implementation does nothing
+}
+
+void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int scrollY = GetScrollPosition();
+
+	// Background
+	// Coordinate system is shifted by -scrollPos (scrolled content).
+	// Viewport visible area is [0, scrollPos, width, height] in translated coordinates?
+	// No, translation is y -= scrollPos.
+	// So drawing at y=0 is content top.
+	// The viewport top in content space is scrollPos.
+	// So to fill the viewport background, we draw rect at y=scrollPos.
+
+	nvgBeginPath(vg);
+	nvgRect(vg, 0, scrollY, width, height);
+	wxColour bg = Theme::Get(Theme::Role::Background);
+	nvgFillColor(vg, nvgRGBA(bg.Red(), bg.Green(), bg.Blue(), 255));
+	nvgFill(vg);
+
+	// Calculate visible range
+	int firstItem = scrollY / m_itemHeight;
+	int lastItem = (scrollY + height) / m_itemHeight + 1;
+
+	firstItem = std::max(0, firstItem);
+	lastItem = std::min(static_cast<int>(m_itemCount), lastItem);
+
+	for (int i = firstItem; i < lastItem; ++i) {
+		wxRect rect(0, i * m_itemHeight, width, m_itemHeight);
+
+		// Draw selection background
+		if (IsSelected(i)) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+			wxColour selColor = Theme::Get(Theme::Role::Selected);
+			nvgFillColor(vg, nvgRGBA(selColor.Red(), selColor.Green(), selColor.Blue(), selColor.Alpha()));
+			nvgFill(vg);
+		}
+
+		// Draw item content
+		OnDrawItem(vg, rect, i);
+	}
+}
+
+void NanoVGListBox::OnLeftDown(wxMouseEvent& event) {
+	int index = HitTest(event.GetPosition());
+	if (index != -1) {
+		if (m_multipleSelection && event.ControlDown()) {
+			if (IsSelected(index)) {
+				Deselect(index);
+			} else {
+				Select(index);
+			}
+		} else if (m_multipleSelection && event.ShiftDown()) {
+			int last = GetSelection();
+			if (last != -1) {
+				int start = std::min(last, index);
+				int end = std::max(last, index);
+				if (!event.ControlDown()) {
+					DeselectAll();
+				}
+				for (int i = start; i <= end; ++i) {
+					Select(i);
+				}
+			} else {
+				SetSelection(index);
+			}
+		} else {
+			SetSelection(index);
+		}
+
+		wxCommandEvent evt(wxEVT_LISTBOX, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(index);
+		GetEventHandler()->ProcessEvent(evt);
+	}
+	SetFocus();
+}
+
+void NanoVGListBox::OnLeftUp(wxMouseEvent& event) {
+	event.Skip();
+}
+
+void NanoVGListBox::OnMotion(wxMouseEvent& event) {
+	event.Skip();
+}
+
+void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
+	if (m_itemCount == 0) {
+		event.Skip();
+		return;
+	}
+
+	int selection = GetSelection();
+	int newSelection = selection;
+	if (newSelection == -1) newSelection = 0;
+
+	switch (event.GetKeyCode()) {
+		case WXK_UP:
+			newSelection--;
+			break;
+		case WXK_DOWN:
+			newSelection++;
+			break;
+		case WXK_HOME:
+			newSelection = 0;
+			break;
+		case WXK_END:
+			newSelection = static_cast<int>(m_itemCount) - 1;
+			break;
+		case WXK_PAGEUP:
+			newSelection -= (GetClientSize().y / m_itemHeight);
+			break;
+		case WXK_PAGEDOWN:
+			newSelection += (GetClientSize().y / m_itemHeight);
+			break;
+		default:
+			event.Skip();
+			return;
+	}
+
+	newSelection = std::clamp(newSelection, 0, static_cast<int>(m_itemCount) - 1);
+
+	if (newSelection != selection) {
+		SetSelection(newSelection);
+		wxCommandEvent evt(wxEVT_LISTBOX, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(newSelection);
+		GetEventHandler()->ProcessEvent(evt);
+	}
+}
+
+void NanoVGListBox::OnSize(wxSizeEvent& event) {
+	UpdateScrollbar(static_cast<int>(m_itemCount * m_itemHeight));
+	Refresh();
+	event.Skip();
+}
+
+int NanoVGListBox::HitTest(const wxPoint& pt) const {
+	int y = pt.y + GetScrollPosition();
+	int index = y / m_itemHeight;
+	if (index >= 0 && index < static_cast<int>(m_itemCount)) {
+		return index;
+	}
+	return -1;
+}

--- a/source/ui/controls/nanovg_listbox.h
+++ b/source/ui/controls/nanovg_listbox.h
@@ -1,0 +1,62 @@
+#ifndef RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+#define RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+
+#include "util/nanovg_canvas.h"
+#include <vector>
+#include <set>
+
+class NanoVGListBox : public NanoVGCanvas {
+public:
+	NanoVGListBox(wxWindow* parent, wxWindowID id, long style = 0);
+	virtual ~NanoVGListBox();
+
+	void SetItemCount(size_t count);
+	size_t GetItemCount() const {
+		return m_itemCount;
+	}
+
+	void SetItemHeight(int height);
+	int GetItemHeight() const {
+		return m_itemHeight;
+	}
+
+	// Selection
+	void SetSelection(int n); // Selects item n, deselects others if single selection
+	bool IsSelected(int n) const;
+	void Select(int n); // Adds n to selection
+	void Deselect(int n); // Removes n from selection
+	void DeselectAll();
+	void SelectAll(); // Only if multiple selection is allowed
+
+	int GetSelection() const; // Returns first selected item or -1
+	int GetSelectedCount() const;
+
+	// Scroll to ensure item is visible
+	void EnsureVisible(int n);
+
+protected:
+	virtual void OnSelectionChanged(int n, bool selected);
+
+	virtual void OnDrawItem(struct NVGcontext* vg, const wxRect& rect, size_t n) const = 0;
+	virtual int OnMeasureItem(size_t n) const; // Default implementation returns m_itemHeight
+
+	void OnNanoVGPaint(struct NVGcontext* vg, int width, int height) override;
+
+	// Event handlers
+	void OnLeftDown(wxMouseEvent& event);
+	void OnLeftUp(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnSize(wxSizeEvent& event);
+
+	size_t m_itemCount;
+	int m_itemHeight; // Fixed height for optimization
+	std::set<int> m_selections;
+
+	// For hit testing
+	int HitTest(const wxPoint& pt) const;
+
+	bool m_multipleSelection;
+};
+
+#endif

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,7 +3,7 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
+#include "ui/controls/nanovg_listbox.h"
 #include <vector>
 
 class Brush;
@@ -19,7 +19,7 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogListBox : public NanoVGListBox {
 public:
 	FindDialogListBox(wxWindow* parent, wxWindowID id);
 	~FindDialogListBox();
@@ -29,8 +29,8 @@ public:
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(struct NVGcontext* vg, const wxRect& rect, size_t index) const override;
+	int OnMeasureItem(size_t index) const override;
 
 protected:
 	bool cleared;


### PR DESCRIPTION
Implemented NanoVGListBox, a hardware-accelerated list control inheriting from NanoVGCanvas. Refactored BrowseTileListBox and FindDialogListBox to use NanoVGListBox, removing wxDC dependencies and improving rendering performance and consistency. Implemented virtual scrolling, multi-selection, and theme support.

---
*PR created automatically by Jules for task [15040845071757003594](https://jules.google.com/task/15040845071757003594) started by @karolak6612*