### PR TITLE
Profiler: Optimize TooltipDrawer allocations

### DIFF
--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -167,12 +167,21 @@ public:
 
 protected:
 	struct FieldLine {
-		std::string label;
-		std::string value;
+		std::string_view label;
+		std::string_view external_value;
+		std::string storage; // For numeric values or generated strings
 		uint8_t r, g, b;
-		std::vector<std::string> wrappedLines; // For multi-line values
+		std::vector<std::string_view> wrappedLines; // For multi-line values (views into value or storage)
+
+		std::string_view getValue() const {
+			if (!storage.empty()) {
+				return storage;
+			}
+			return external_value;
+		}
 	};
 	std::vector<FieldLine> scratch_fields;
+	size_t active_field_count = 0;
 
 	std::vector<TooltipData> tooltips;
 	size_t active_count = 0;


### PR DESCRIPTION
This change optimizes `TooltipDrawer` to significantly reduce CPU usage and memory allocations during the render loop, addressing a common CPU bottleneck when tooltips are active. By reusing field objects and buffers, and utilizing `std::string_view` and `fmt::format_to`, it eliminates hundreds of string allocations per frame for tooltip generation. The implementation ensures memory safety by correctly managing string lifetimes and preventing dangling views during vector resizing.

---
*PR created automatically by Jules for task [16476407393253182304](https://jules.google.com/task/16476407393253182304) started by @karolak6612*