### PR TITLE
⚡ Optimize DatLoader vector allocation

### DIFF
--- a/source/io/loaders/dat_loader.cpp
+++ b/source/io/loaders/dat_loader.cpp
@@ -471,6 +471,7 @@ bool DatLoader::ReadSpriteGroup(GraphicManager* manager, FileReadHandle& file, G
 	uint32_t numsprites = static_cast<uint32_t>(width) * static_cast<uint32_t>(height) * static_cast<uint32_t>(layers) * static_cast<uint32_t>(pattern_x) * static_cast<uint32_t>(pattern_y) * static_cast<uint32_t>(pattern_z) * static_cast<uint32_t>(frames);
 	if (group_index == 0) {
 		sType->numsprites = numsprites;
+		sType->spriteList.reserve(numsprites);
 	}
 
 	// Read the sprite ids


### PR DESCRIPTION
💡 **What:** Added `sType->spriteList.reserve(numsprites);` in `source/io/loaders/dat_loader.cpp` before the sprite loading loop.

🎯 **Why:** To prevent multiple reallocations of the `spriteList` vector as sprites are pushed back, improving loading performance for large sprite groups.

📊 **Measured Improvement:**
Runtime benchmark was impractical due to the requirement of a valid proprietary `.dat` file and a graphical environment (GTK+ / Display) which is not available in the test sandbox.
However, this is a standard `std::vector::reserve` optimization with O(1) complexity added to O(N) loop, eliminating O(log N) reallocations. The correctness was verified by successful compilation of the modified file and the application linking without errors.

---
*PR created automatically by Jules for task [1682641253667409862](https://jules.google.com/task/1682641253667409862) started by @karolak6612*