### PR TITLE
Add icons to EditorTab subclasses

### DIFF
--- a/source/editor/editor_tabs.cpp
+++ b/source/editor/editor_tabs.cpp
@@ -133,7 +133,7 @@ void MapTabbook::OnAllowNotebookDND(wxAuiNotebookEvent& evt) {
 
 void MapTabbook::AddTab(EditorTab* tab, bool select) {
 	tab->GetWindow()->Reparent(notebook);
-	notebook->AddPage(tab->GetWindow(), tab->GetTitle(), select);
+	notebook->AddPage(tab->GetWindow(), tab->GetTitle(), select, tab->GetIcon());
 	conv[tab->GetWindow()] = tab;
 }
 

--- a/source/editor/editor_tabs.h
+++ b/source/editor/editor_tabs.h
@@ -19,6 +19,7 @@
 #define RME_EDITOR_TABS_H_
 
 #include "ui/gui_ids.h"
+#include <wx/bmpbndl.h>
 
 class EditorTab;
 
@@ -60,6 +61,9 @@ public:
 	// Properties
 	virtual wxWindow* GetWindow() const = 0;
 	virtual wxString GetTitle() const = 0;
+	virtual wxBitmapBundle GetIcon() const {
+		return wxBitmapBundle();
+	}
 
 	//
 	virtual void OnSwitchEditorMode(EditorMode mode) { }

--- a/source/live/live_tab.cpp
+++ b/source/live/live_tab.cpp
@@ -24,6 +24,7 @@
 #include "live/live_socket.h"
 #include "live/live_peer.h"
 #include "editor/hotkey_manager.h"
+#include "util/image_manager.h"
 
 class myGrid : public wxGrid {
 public:
@@ -130,6 +131,10 @@ wxString LiveLogTab::GetTitle() const {
 		return "Live Log - " + socket->getHostName();
 	}
 	return "Live Log - Disconnected";
+}
+
+wxBitmapBundle LiveLogTab::GetIcon() const {
+	return IMAGE_MANAGER.GetBitmapBundle(ICON_TERMINAL);
 }
 
 void LiveLogTab::Disconnect() {

--- a/source/live/live_tab.h
+++ b/source/live/live_tab.h
@@ -44,6 +44,7 @@ public:
 		return (wxPanel*)this;
 	}
 	virtual wxString GetTitle() const;
+	wxBitmapBundle GetIcon() const override;
 
 	bool IsConnected() const {
 		return socket != nullptr;

--- a/source/ui/map_tab.cpp
+++ b/source/ui/map_tab.cpp
@@ -24,6 +24,7 @@
 #include "ui/map_tab.h"
 #include "editor/editor_tabs.h"
 #include "rendering/ui/map_display.h"
+#include "util/image_manager.h"
 
 #include <spdlog/spdlog.h>
 
@@ -83,6 +84,10 @@ wxString MapTab::GetTitle() const {
 	wxString ss;
 	ss << wxstr(iref->session.editor->map.getName()) << (iref->session.editor->map.hasChanged() ? "*" : "");
 	return ss;
+}
+
+wxBitmapBundle MapTab::GetIcon() const {
+	return IMAGE_MANAGER.GetBitmapBundle(ICON_MAP);
 }
 
 Editor* MapTab::GetEditor() const {

--- a/source/ui/map_tab.h
+++ b/source/ui/map_tab.h
@@ -39,6 +39,7 @@ public:
 	MapCanvas* GetCanvas() const;
 	wxWindow* GetWindow() const;
 	wxString GetTitle() const;
+	wxBitmapBundle GetIcon() const override;
 	Editor* GetEditor() const;
 	Map* GetMap() const;
 	MapSession* GetSession() const {


### PR DESCRIPTION
Added `GetIcon()` to `EditorTab` and implemented it for `MapTab` and `LiveLogTab` to display icons on tabs.

---
*PR created automatically by Jules for task [15777292316573981390](https://jules.google.com/task/15777292316573981390) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon support to editor tabs. Tabs now display relevant icons alongside their titles for improved visual organization and identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->