### PR TITLE
[WXWIDGETS/UX] Fix MapStatisticsDialog icon and implement XML export

### DIFF
--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -417,7 +417,10 @@ void MainMenuBar::OnMapEditMonsters(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void MainMenuBar::OnMapStatistics(wxCommandEvent& WXUNUSED(event)) {
-	MapStatisticsDialog::Show(frame);
+	if (g_gui.IsEditorOpen()) {
+		MapStatisticsDialog dlg(frame, &g_gui.GetCurrentMap());
+		dlg.ShowModal();
+	}
 }
 
 void MainMenuBar::OnMapCleanup(wxCommandEvent& event) {

--- a/source/ui/map_statistics_dialog.h
+++ b/source/ui/map_statistics_dialog.h
@@ -5,11 +5,23 @@
 #ifndef RME_UI_MAP_STATISTICS_DIALOG_H_
 #define RME_UI_MAP_STATISTICS_DIALOG_H_
 
-#include <wx/window.h>
+#include "app/main.h"
+#include <wx/dialog.h>
+#include "map/map_statistics.h"
 
-class MapStatisticsDialog {
+class Map;
+
+class MapStatisticsDialog : public wxDialog {
 public:
-	static void Show(wxWindow* parent);
+	MapStatisticsDialog(wxWindow* parent, Map* map);
+
+private:
+	void createUI();
+	void OnExport(wxCommandEvent& event);
+	void OnClose(wxCommandEvent& event);
+
+	Map* map;
+	MapStatistics stats;
 };
 
 #endif


### PR DESCRIPTION
ISSUE: MapStatisticsDialog had a bug where the window icon was set after the dialog was closed (making it invisible). The "Export as XML" button was present but disabled and unimplemented. The dialog was implemented as a procedural static method constructing a raw `wxDialog`.

IMPACT: Users could not export map statistics, which is useful for server management. The dialog looked unpolished due to missing icon and old layout.

FIX:
1.  Refactored `MapStatisticsDialog` into a proper class inheriting `wxDialog`.
2.  Moved UI creation and logic into the constructor and member methods.
3.  Fixed the icon setting order so it appears correctly.
4.  Implemented the XML export using `pugixml`, saving tile, item, creature, and location data.
5.  Updated `MainMenuBar` to instantiate the new dialog class.

DOMAIN CONTEXT: Map statistics are domain-specific data (tiles, items, creatures) that are often analyzed by server owners. Exporting this data allows for external analysis.

PERFORMANCE: The export logic uses efficient `pugixml` writing. The dialog creation is lightweight.

TESTED: Editor runs. Verified dialog shows up when requested. Code uses correct string formatting and path handling for cross-platform compatibility.

---
*PR created automatically by Jules for task [13265597719892507279](https://jules.google.com/task/13265597719892507279) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map Statistics can now be exported to XML format

* **Improvements**
  * Map Statistics dialog now displays only when the editor is open
  * Enhanced dialog interface with dedicated Export to XML and Close buttons
  * Refined statistics display and formatting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->