### PR TITLE
Migrate lists to NanoVG

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -210,6 +210,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/item_buttons.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.h
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/properties/object_properties_base.h
@@ -536,6 +537,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/nanovg_listbox.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/properties/object_properties_base.cpp

--- a/source/ui/controls/nanovg_listbox.cpp
+++ b/source/ui/controls/nanovg_listbox.cpp
@@ -1,0 +1,232 @@
+#include "app/main.h"
+#include "ui/controls/nanovg_listbox.h"
+#include <nanovg.h>
+#include <spdlog/spdlog.h>
+
+NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
+	NanoVGCanvas(parent, id, style | wxVSCROLL | wxWANTS_CHARS),
+	m_itemCount(0),
+	m_selection(-1),
+	m_hover(-1),
+	m_multipleSelection(style & wxLB_MULTIPLE),
+	m_itemHeight(32),
+	m_animTimer(this) {
+
+	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnMouseDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &NanoVGListBox::OnLeftDClick, this);
+	Bind(wxEVT_MOTION, &NanoVGListBox::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &NanoVGListBox::OnLeave, this);
+	Bind(wxEVT_SIZE, &NanoVGListBox::OnSize, this);
+	Bind(wxEVT_TIMER, &NanoVGListBox::OnTimer, this);
+}
+
+NanoVGListBox::~NanoVGListBox() {
+	m_animTimer.Stop();
+}
+
+void NanoVGListBox::SetItemCount(int count) {
+	if (m_itemCount != count) {
+		m_itemCount = count;
+		if (m_selection >= m_itemCount) {
+			m_selection = -1;
+		}
+		// Prune selections
+		if (m_multipleSelection) {
+			auto it = m_selections.begin();
+			while (it != m_selections.end()) {
+				if (*it >= m_itemCount) {
+					it = m_selections.erase(it);
+				} else {
+					++it;
+				}
+			}
+		}
+		UpdateLayout();
+		Refresh();
+	}
+}
+
+void NanoVGListBox::SetSelection(int index) {
+	if (index < -1 || index >= m_itemCount) {
+		index = -1;
+	}
+
+	if (m_multipleSelection) {
+		m_selections.clear();
+		if (index != -1) {
+			m_selections.insert(index);
+		}
+		m_selection = index;
+		Refresh();
+
+		wxCommandEvent event(wxEVT_LISTBOX, GetId());
+		event.SetEventObject(this);
+		event.SetInt(m_selection);
+		ProcessEvent(event);
+	} else {
+		if (m_selection != index) {
+			m_selection = index;
+			Refresh();
+
+			wxCommandEvent event(wxEVT_LISTBOX, GetId());
+			event.SetEventObject(this);
+			event.SetInt(m_selection);
+			ProcessEvent(event);
+		}
+	}
+}
+
+bool NanoVGListBox::IsSelected(int index) const {
+	if (m_multipleSelection) {
+		return m_selections.count(index) > 0;
+	}
+	return m_selection == index;
+}
+
+void NanoVGListBox::Select(int index, bool select) {
+	if (index < 0 || index >= m_itemCount) return;
+
+	if (m_multipleSelection) {
+		if (select) m_selections.insert(index);
+		else m_selections.erase(index);
+		m_selection = index; // Last modified becomes 'primary'?
+		Refresh();
+
+		wxCommandEvent event(wxEVT_LISTBOX, GetId());
+		event.SetEventObject(this);
+		event.SetInt(index);
+		ProcessEvent(event);
+	} else {
+		if (select) SetSelection(index);
+		else if (m_selection == index) SetSelection(-1);
+	}
+}
+
+void NanoVGListBox::DeselectAll() {
+	if (m_multipleSelection) {
+		m_selections.clear();
+	}
+	m_selection = -1;
+	Refresh();
+}
+
+int NanoVGListBox::GetSelectedCount() const {
+	if (m_multipleSelection) return (int)m_selections.size();
+	return (m_selection != -1) ? 1 : 0;
+}
+
+void NanoVGListBox::SetItemHeight(int height) {
+	if (m_itemHeight != height) {
+		m_itemHeight = height;
+		UpdateLayout();
+		Refresh();
+	}
+}
+
+void NanoVGListBox::UpdateLayout() {
+	// Simple fixed height calculation
+	int totalHeight = m_itemCount * m_itemHeight;
+	UpdateScrollbar(totalHeight);
+}
+
+wxRect NanoVGListBox::GetItemRect(int index) const {
+	int w = GetClientSize().x;
+	return wxRect(0, index * m_itemHeight, w, m_itemHeight);
+}
+
+int NanoVGListBox::HitTest(int y) const {
+	int scrollPos = GetScrollPosition();
+	int realY = y + scrollPos;
+	int index = realY / m_itemHeight;
+
+	if (index >= 0 && index < m_itemCount) {
+		return index;
+	}
+	return -1;
+}
+
+void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int scrollPos = GetScrollPosition();
+
+	// Start drawing
+	int startIdx = scrollPos / m_itemHeight;
+	int endIdx = (scrollPos + height + m_itemHeight - 1) / m_itemHeight + 1;
+
+	if (startIdx < 0) startIdx = 0;
+	if (endIdx > m_itemCount) endIdx = m_itemCount;
+
+	for (int i = startIdx; i < endIdx; ++i) {
+		wxRect rect = GetItemRect(i);
+
+		// Background for selection/hover
+		if (IsSelected(i)) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
+			nvgFillColor(vg, nvgRGBA(80, 120, 180, 255)); // Blueish selection
+			nvgFill(vg);
+		} else if (i == m_hover) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
+			nvgFillColor(vg, nvgRGBA(60, 60, 65, 255)); // Hover highlight
+			nvgFill(vg);
+		}
+
+		// Draw content
+		nvgSave(vg);
+		OnDrawItem(vg, i, rect);
+		nvgRestore(vg);
+	}
+}
+
+void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
+	int index = HitTest(event.GetY());
+	if (index != -1) {
+		if (m_multipleSelection) {
+			bool selected = IsSelected(index);
+			Select(index, !selected);
+		} else {
+			if (index != m_selection) {
+				SetSelection(index);
+			}
+		}
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnLeftDClick(wxMouseEvent& event) {
+	int index = HitTest(event.GetY());
+	if (index != -1) {
+		wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(index);
+		ProcessEvent(evt);
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetY());
+	if (index != m_hover) {
+		m_hover = index;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnLeave(wxMouseEvent& event) {
+	if (m_hover != -1) {
+		m_hover = -1;
+		Refresh();
+	}
+	event.Skip();
+}
+
+void NanoVGListBox::OnSize(wxSizeEvent& event) {
+	UpdateLayout();
+	Refresh();
+	event.Skip();
+}
+
+void NanoVGListBox::OnTimer(wxTimerEvent& event) {
+	// Animation if needed
+}

--- a/source/ui/controls/nanovg_listbox.h
+++ b/source/ui/controls/nanovg_listbox.h
@@ -1,0 +1,58 @@
+#ifndef RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+#define RME_UI_CONTROLS_NANOVG_LISTBOX_H_
+
+#include "util/nanovg_canvas.h"
+#include <wx/timer.h>
+#include <unordered_set>
+
+class NanoVGListBox : public NanoVGCanvas {
+public:
+	NanoVGListBox(wxWindow* parent, wxWindowID id = wxID_ANY, long style = 0);
+	virtual ~NanoVGListBox();
+
+	void SetItemCount(int count);
+	int GetItemCount() const { return m_itemCount; }
+
+	void SetSelection(int index); // Clears others if single
+	int GetSelection() const { return m_selection; }
+	bool IsSelected(int index) const;
+	void Select(int index, bool select = true);
+	void DeselectAll();
+	int GetSelectedCount() const;
+
+	// Drawing interface
+	virtual void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) = 0;
+	virtual wxCoord OnMeasureItem(int index) const = 0; // Like wxVListBox
+
+	// Customization
+	void SetItemHeight(int height); // Helper for fixed height lists
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+
+	// Events
+	void OnMouseDown(wxMouseEvent& event);
+	void OnLeftDClick(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+	void OnSize(wxSizeEvent& event);
+	void OnTimer(wxTimerEvent& event);
+
+	int HitTest(int y) const;
+	void UpdateLayout();
+	wxRect GetItemRect(int index) const;
+
+	int m_itemCount;
+	int m_selection; // Primary selection (for anchor/focus)
+	int m_hover;
+
+	bool m_multipleSelection;
+	std::unordered_set<int> m_selections;
+
+	// Optimization for fixed height (if OnMeasureItem returns constant)
+	int m_itemHeight;
+
+	wxTimer m_animTimer;
+};
+
+#endif

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -6,6 +6,8 @@
 #include <wx/vlbox.h>
 #include <vector>
 
+#include "ui/controls/nanovg_listbox.h"
+
 class Brush;
 
 class KeyForwardingTextCtrl : public wxTextCtrl {
@@ -19,7 +21,7 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogListBox : public NanoVGListBox {
 public:
 	FindDialogListBox(wxWindow* parent, wxWindowID id);
 	~FindDialogListBox();
@@ -29,8 +31,8 @@ public:
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) override;
+	wxCoord OnMeasureItem(int index) const override;
 
 protected:
 	bool cleared;


### PR DESCRIPTION
This PR introduces `NanoVGListBox`, a high-performance replacement for `wxVListBox` that utilizes NanoVG for rendering. It migrates `BrowseTileListBox` and `FindDialogListBox` to use this new control, resolving potential GDI handle exhaustion issues when displaying large lists of sprites. The implementation supports virtual scrolling, single/multiple selection, and custom item rendering via NanoVG commands.

---
*PR created automatically by Jules for task [12394592315018623571](https://jules.google.com/task/12394592315018623571) started by @karolak6612*