### PR TITLE
UX: Add tooltips to Replace, Outfit, and Welcome dialogs

### DIFF
--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -164,12 +164,16 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
 	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
 	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(16, 16)));
+	head_btn->SetToolTip("Select head color");
 	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
 	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHIRT, wxSize(16, 16)));
+	body_btn->SetToolTip("Select primary color");
 	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
 	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SOCKS, wxSize(16, 16)));
+	legs_btn->SetToolTip("Select secondary color");
 	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
 	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHOE_PRINTS, wxSize(16, 16)));
+	feet_btn->SetToolTip("Select detail color");
 
 	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
 	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);
@@ -212,10 +216,12 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxFlexGridSizer* text_fields = new wxFlexGridSizer(2, 2, 4, 8);
 	text_fields->Add(new wxStaticText(this, wxID_ANY, "Speed:"), 0, wxALIGN_CENTER_VERTICAL);
 	speed_ctrl = new wxSpinCtrl(this, ID_SPEED, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 50, 3000, current_speed);
+	speed_ctrl->SetToolTip("Set movement speed for preview");
 	text_fields->Add(speed_ctrl, 1, wxEXPAND);
 
 	text_fields->Add(new wxStaticText(this, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL);
 	name_ctrl = new wxTextCtrl(this, ID_NAME, current_name);
+	name_ctrl->SetToolTip("Set character name for preview");
 	text_fields->Add(name_ctrl, 1, wxEXPAND);
 	text_fields->AddGrowableCol(1);
 	col1_sizer->Add(text_fields, 0, wxEXPAND | wxALL, 8);
@@ -248,6 +254,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	wxButton* fav_btn = new wxButton(this, ID_ADD_FAVORITE, "Save Current Outfit as Favorite", wxDefaultPosition, wxSize(-1, 28));
 	fav_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_STAR, wxSize(16, 16)));
+	fav_btn->SetToolTip("Save current outfit configuration to favorites");
 	favs_sizer->Add(fav_btn, 0, wxEXPAND | wxTOP, 8);
 
 	main_sizer->Add(favs_sizer, 0, wxEXPAND | wxLEFT, 5);

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -166,18 +166,21 @@ void ReplaceToolWindow::InitLayout() {
 
 	m_addRuleBtn = new wxButton(actionsCard, wxID_ANY, "ADD", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+	m_addRuleBtn->SetToolTip("Create a new replacement rule");
 	m_addRuleBtn->SetBackgroundColour(wxColour(40, 180, 40)); // Green
 	m_addRuleBtn->SetForegroundColour(*wxWHITE);
 	m_addRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_editRuleBtn = new wxButton(actionsCard, wxID_ANY, "EDIT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
+	m_editRuleBtn->SetToolTip("Edit selected rule set name");
 	m_editRuleBtn->SetBackgroundColour(wxColour(80, 80, 80)); // Neutral Dark Gray
 	m_editRuleBtn->SetForegroundColour(*wxWHITE);
 	m_editRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_deleteRuleBtn = new wxButton(actionsCard, wxID_ANY, "DEL", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
+	m_deleteRuleBtn->SetToolTip("Delete selected rule set");
 	m_deleteRuleBtn->SetBackgroundColour(wxColour(180, 40, 40)); // Red
 	m_deleteRuleBtn->SetForegroundColour(*wxWHITE);
 	m_deleteRuleBtn->SetFont(Theme::GetFont(9, true));
@@ -190,6 +193,7 @@ void ReplaceToolWindow::InitLayout() {
 
 	m_addVisibleBtn = new wxButton(actionsCard, wxID_ANY, "ADD VISIBLE FROM VIEWPORT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, wxSize(16, 16)));
+	m_addVisibleBtn->SetToolTip("Add rules for all visible items in the viewport");
 	m_addVisibleBtn->SetBackgroundColour(wxColour(45, 120, 180)); // Sky Blue
 	m_addVisibleBtn->SetForegroundColour(*wxWHITE);
 	m_addVisibleBtn->SetFont(Theme::GetFont(9, true));
@@ -221,6 +225,7 @@ void ReplaceToolWindow::InitLayout() {
 	// Execute Button
 	m_executeBtn = new wxButton(actionsCard, wxID_ANY, "EXECUTE REPLACE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
 	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, wxSize(16, 16)));
+	m_executeBtn->SetToolTip("Execute the replacement rules on the map");
 	m_executeBtn->SetDefault();
 	m_executeBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Blue
 	m_executeBtn->SetForegroundColour(*wxWHITE);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -107,8 +107,11 @@ public:
 		sideSizer->Add(version, 0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, FromDIP(25));
 
 		// Actions (Nav-style)
-		auto addButton = [&](const wxString& label, int id, const char* icon) {
+		auto addButton = [&](const wxString& label, int id, const char* icon, const wxString& tooltip = "") {
 			ModernButton* btn = new ModernButton(sidebar, id, label);
+			if (!tooltip.IsEmpty()) {
+				btn->SetToolTip(tooltip);
+			}
 			btn->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
 			btn->SetMinSize(wxSize(-1, FromDIP(35))); // More compact nav height
 			if (icon) {
@@ -118,9 +121,9 @@ public:
 			btn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, parent);
 		};
 
-		addButton("New Project", wxID_NEW, ICON_NEW);
-		addButton("Open Project", wxID_OPEN, ICON_OPEN);
-		addButton("Preferences", wxID_PREFERENCES, ICON_GEAR);
+		addButton("New Project", wxID_NEW, ICON_NEW, "Create a new empty map");
+		addButton("Open Project", wxID_OPEN, ICON_OPEN, "Open an existing map file");
+		addButton("Preferences", wxID_PREFERENCES, ICON_GEAR, "Configure editor settings");
 
 		sideSizer->AddStretchSpacer();
 
@@ -158,6 +161,7 @@ public:
 		wxBoxSizer* footerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 		wxCheckBox* startupCheck = new wxCheckBox(footer, wxID_ANY, "Show on Startup");
+		startupCheck->SetToolTip("Show this dialog when starting the editor");
 		startupCheck->SetFont(wxFontInfo(8));
 		startupCheck->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT));
 		startupCheck->SetValue(g_settings.getInteger(Config::WELCOME_DIALOG) != 0);


### PR DESCRIPTION
This PR implements UX improvements requested by the Palette agent. It adds tooltips to interactive elements in `ReplaceToolWindow`, `OutfitChooserDialog`, and `WelcomeDialog` to guide users and explain functionality.

Changes:
- **ReplaceToolWindow**: Added tooltips to rule management buttons and execute button.
- **OutfitChooserDialog**: Added tooltips to color part selectors, favorite button, and input fields.
- **WelcomeDialog**: Updated `addButton` helper to support tooltips and added tooltips to main action buttons and startup checkbox.

---
*PR created automatically by Jules for task [17881086319882374836](https://jules.google.com/task/17881086319882374836) started by @karolak6612*