### PR TITLE
👻 Phantom: Threading, DPI, and Tooltip Fixes

### DIFF
--- a/source/app/updater.cpp
+++ b/source/app/updater.cpp
@@ -72,11 +72,13 @@ void UpdateChecker::connect(wxEvtHandler* receiver) {
 		// We need to be careful with event posting from a detached thread if the receiver might be destroyed.
 		// However, we are replicating existing logic here where UpdateConnectionThread was also detached.
 		// In a real robust app, we'd need weak pointers or valid lifetime guarantees.
-		if (receiver) {
-			wxCommandEvent event(EVT_UPDATE_CHECK_FINISHED);
-			event.SetClientData(newd std::string(data));
-			receiver->AddPendingEvent(event);
-		}
+		wxGetApp().CallAfter([receiver, data]() {
+			if (receiver) {
+				wxCommandEvent event(EVT_UPDATE_CHECK_FINISHED);
+				event.SetClientData(newd std::string(data));
+				receiver->AddPendingEvent(event);
+			}
+		});
 	}).detach();
 }
 

--- a/source/palette/palette_creature.cpp
+++ b/source/palette/palette_creature.cpp
@@ -47,16 +47,20 @@ CreaturePalettePanel::CreaturePalettePanel(wxWindow* parent, wxWindowID id) :
 
 	grid->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), wxID_ANY, "Spawntime"));
 	creature_spawntime_spin = newd wxSpinCtrl(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_CREATURE_SPAWN_TIME, i2ws(g_settings.getInteger(Config::DEFAULT_SPAWNTIME)), wxDefaultPosition, wxSize(50, 20), wxSP_ARROW_KEYS, 0, 86400, g_settings.getInteger(Config::DEFAULT_SPAWNTIME));
+	creature_spawntime_spin->SetToolTip("Spawn time (seconds)");
 	grid->Add(creature_spawntime_spin, 0, wxEXPAND);
 	creature_brush_button = newd wxToggleButton(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_CREATURE_BRUSH_BUTTON, "Place Creature");
 	creature_brush_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
+	creature_brush_button->SetToolTip("Place Creature");
 	grid->Add(creature_brush_button, 0, wxEXPAND);
 
 	grid->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), wxID_ANY, "Spawn size"));
 	spawn_size_spin = newd wxSpinCtrl(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_CREATURE_SPAWN_SIZE, i2ws(5), wxDefaultPosition, wxSize(50, 20), wxSP_ARROW_KEYS, 1, g_settings.getInteger(Config::MAX_SPAWN_RADIUS), g_settings.getInteger(Config::CURRENT_SPAWN_RADIUS));
+	spawn_size_spin->SetToolTip("Spawn radius");
 	grid->Add(spawn_size_spin, 0, wxEXPAND);
 	spawn_brush_button = newd wxToggleButton(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_SPAWN_BRUSH_BUTTON, "Place Spawn");
 	spawn_brush_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
+	spawn_brush_button->SetToolTip("Place Spawn");
 	grid->Add(spawn_brush_button, 0, wxEXPAND);
 
 	sidesizer->Add(grid, 0, wxEXPAND);

--- a/source/ui/dcbutton.cpp
+++ b/source/ui/dcbutton.cpp
@@ -35,8 +35,8 @@ DCButton::DCButton() :
 	size(RENDER_SIZE_16x16),
 	sprite(nullptr),
 	overlay(nullptr) {
-	SetSize(36, 36);
-	SetMinSize(wxSize(36, 36));
+	SetSize(FromDIP(wxSize(36, 36)));
+	SetMinSize(FromDIP(wxSize(36, 36)));
 	Bind(wxEVT_LEFT_DOWN, &DCButton::OnClick, this);
 	SetSprite(0);
 }
@@ -51,11 +51,11 @@ DCButton::DCButton(wxWindow* parent, wxWindowID id, wxPoint pos, int type, Rende
 
 	wxSize winSize;
 	if (sz == RENDER_SIZE_64x64) {
-		winSize = wxSize(68, 68);
+		winSize = FromDIP(wxSize(68, 68));
 	} else if (sz == RENDER_SIZE_32x32) {
-		winSize = wxSize(36, 36);
+		winSize = FromDIP(wxSize(36, 36));
 	} else {
-		winSize = wxSize(20, 20);
+		winSize = FromDIP(wxSize(20, 20));
 	}
 
 	SetSize(winSize);


### PR DESCRIPTION
This PR addresses three key areas identified by the Phantom agent:
1.  **Threading Safety:** Prevents potential crashes by ensuring that the updater thread posts events to the UI receiver safely using `CallAfter`.
2.  **High DPI Support:** Ensures `DCButton` (used for GEM and other custom buttons) scales correctly on high-resolution displays.
3.  **Usability:** Adds tooltips to the Creature Palette controls (brush buttons and spin controls) to guide users.

---
*PR created automatically by Jules for task [15550989329253380423](https://jules.google.com/task/15550989329253380423) started by @karolak6612*