### PR TITLE
Fix critical bugs: Network race, Map infinite loop, and min/max truncation

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -444,6 +444,11 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
 			while (found != tile_loc->getSpawnCount()) {
+				if (start_x < 0 && start_y < 0 && end_x >= width && end_y >= height) {
+					spdlog::warn("Map::getSpawnList - infinite loop detected, aborting search at {} {} {} {}", start_x, start_y, end_x, end_y);
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <thread>
 #include <mutex>
+#include <atomic>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -80,7 +81,7 @@ public:
 private:
 	boost::asio::io_context* service;
 	std::thread thread;
-	bool stopped;
+	std::atomic<bool> stopped;
 };
 
 #endif

--- a/source/util/common.h
+++ b/source/util/common.h
@@ -26,6 +26,7 @@
 #include <iomanip>
 #include <string>
 #include <string_view>
+#include <algorithm>
 
 //
 inline bool testFlags(size_t flags, size_t test) {
@@ -108,26 +109,26 @@ T max(T t, U u) {
 
 template <class T, class U, class V>
 inline T min(T t, U u, V v) {
-	int min = t;
-	if (u < min) {
-		min = u;
+	T min_val = t;
+	if (u < min_val) {
+		min_val = static_cast<T>(u);
 	}
-	if (v < min) {
-		min = v;
+	if (v < min_val) {
+		min_val = static_cast<T>(v);
 	}
-	return min;
+	return min_val;
 }
 
 template <class T, class U, class V>
 inline T max(T t, U u, V v) {
-	int max = t;
-	if (u > max) {
-		max = u;
+	T max_val = t;
+	if (u > max_val) {
+		max_val = static_cast<T>(u);
 	}
-	if (v > max) {
-		max = v;
+	if (v > max_val) {
+		max_val = static_cast<T>(v);
 	}
-	return max;
+	return max_val;
 }
 
 #endif


### PR DESCRIPTION
This PR addresses three critical issues identified by the Phantom agent:
1.  **Race Condition in `NetworkConnection`**: The `stopped` flag was a simple `bool` accessed from multiple threads. It is now `std::atomic<bool>` to ensure thread safety.
2.  **Infinite Loop in `Map::getSpawnList`**: If the spawn count on a tile is inconsistent with actual spawns, the search loop could expand indefinitely. A bounds check using map dimensions has been added to abort the search if it exceeds the map size.
3.  **Data Truncation in `min`/`max`**: The 3-argument templates in `common.h` used an `int` intermediate variable, causing truncation for float/double or large integer types. This has been fixed to use the template type `T` for intermediate storage.

---
*PR created automatically by Jules for task [2307168570926024123](https://jules.google.com/task/2307168570926024123) started by @karolak6612*