### PR TITLE
🗝️ Keeper: Fix NanoVG texture leaks and modernization

### DIFF
--- a/source/ingame_preview/ingame_preview_canvas.cpp
+++ b/source/ingame_preview/ingame_preview_canvas.cpp
@@ -6,6 +6,7 @@
 #include "rendering/map_drawer.h"
 #include "rendering/ui/map_display.h"
 #include "rendering/core/text_renderer.h"
+#include "util/image_manager.h"
 #include <spdlog/spdlog.h>
 #include <glad/glad.h>
 #include <nanovg.h>
@@ -69,7 +70,14 @@ namespace IngamePreview {
 		animation_timer.Start(16); // ~60 FPS update
 	}
 
-	IngamePreviewCanvas::~IngamePreviewCanvas() = default;
+	IngamePreviewCanvas::~IngamePreviewCanvas() {
+		if (m_glContext) {
+			SetCurrent(*m_glContext);
+			if (m_nvg) {
+				IMAGE_MANAGER.ClearCache(m_nvg.get());
+			}
+		}
+	}
 
 	void IngamePreviewCanvas::OnPaint(wxPaintEvent& event) {
 		// Validating the paint event prevents infinite paint loops on some platforms

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -40,6 +40,7 @@
 #include "rendering/utilities/tile_describer.h"
 #include "rendering/core/coordinate_mapper.h"
 #include "rendering/ui/map_display.h"
+#include "util/image_manager.h"
 #include "rendering/ui/map_status_updater.h"
 #include "rendering/map_drawer.h"
 #include "rendering/core/text_renderer.h"
@@ -153,6 +154,9 @@ MapCanvas::~MapCanvas() {
 	if (auto context = g_gui.GetGLContext(this)) {
 		SetCurrent(*context);
 		drawer.reset();
+		if (m_nvg) {
+			IMAGE_MANAGER.ClearCache(m_nvg.get());
+		}
 		m_nvg.reset();
 	}
 }

--- a/source/rendering/ui/minimap_window.cpp
+++ b/source/rendering/ui/minimap_window.cpp
@@ -25,6 +25,7 @@
 
 #include "ui/gui.h"
 #include "rendering/ui/map_display.h"
+#include "util/image_manager.h"
 #include "rendering/ui/minimap_window.h"
 
 #include "rendering/drawers/minimap_drawer.h"
@@ -73,6 +74,9 @@ MinimapWindow::~MinimapWindow() {
 		spdlog::default_logger()->flush();
 		SetCurrent(*context);
 		drawer.reset();
+		if (nvg) {
+			IMAGE_MANAGER.ClearCache(nvg.get());
+		}
 		nvg.reset();
 	}
 	spdlog::debug("MinimapWindow destructor finished");

--- a/source/util/image_manager.h
+++ b/source/util/image_manager.h
@@ -34,6 +34,7 @@ public:
 
 	// Cleanup
 	void ClearCache();
+	void ClearCache(NVGcontext* vg);
 
 private:
 	ImageManager();
@@ -44,7 +45,7 @@ private:
 	// Caches
 	std::map<std::string, wxBitmapBundle> m_bitmapBundleCache;
 	std::map<std::pair<std::string, uint32_t>, wxBitmap> m_tintedBitmapCache;
-	std::map<std::pair<std::string, uint32_t>, int> m_nvgImageCache;
+	std::map<NVGcontext*, std::map<std::pair<std::string, uint32_t>, int>> m_nvgContextCache;
 	std::map<std::string, uint32_t> m_glTextureCache;
 
 	// Helper for tinting

--- a/source/util/nanovg_canvas.cpp
+++ b/source/util/nanovg_canvas.cpp
@@ -43,6 +43,9 @@ NanoVGCanvas::~NanoVGCanvas() {
 	if (m_glContext) {
 		SetCurrent(*m_glContext);
 		ClearImageCache();
+		if (m_nvg) {
+			IMAGE_MANAGER.ClearCache(m_nvg.get());
+		}
 	}
 }
 


### PR DESCRIPTION
Refactored `ImageManager` to make NanoVG image caching context-aware (`m_nvgContextCache`).
Implemented `ImageManager::ClearCache(NVGcontext*)` to correctly delete images for a specific context.
Updated destructors of `NanoVGCanvas`, `MapCanvas`, `MinimapWindow`, and `IngamePreviewCanvas` to invoke this cleanup method before destroying their NanoVG contexts.
This prevents invalid handle reuse across contexts and ensures proper cleanup of GPU resources.

---
*PR created automatically by Jules for task [3158414239162533206](https://jules.google.com/task/3158414239162533206) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved memory efficiency in graphics rendering through optimized per-context caching and proper resource cleanup when rendering components are destroyed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->