### PR TITLE
Core System Optimizations: Selection, Map Search, and Brushes

### DIFF
--- a/source/brushes/brush.cpp
+++ b/source/brushes/brush.cpp
@@ -118,6 +118,8 @@ bool Brushes::unserializeBrush(pugi::xml_node node, std::vector<std::string>& wa
 	}
 
 	Brush* brush = getBrush(brushName);
+	std::unique_ptr<Brush> newBrush;
+
 	if (!brush) {
 		attribute = node.attribute("type");
 		if (!attribute) {
@@ -127,18 +129,19 @@ bool Brushes::unserializeBrush(pugi::xml_node node, std::vector<std::string>& wa
 
 		const std::string_view brushType = attribute.as_string();
 
-		static const std::unordered_map<std::string_view, std::function<Brush*()>> typeMap = {
-			{ "border", [] { return newd GroundBrush(); } },
-			{ "ground", [] { return newd GroundBrush(); } },
-			{ "wall", [] { return newd WallBrush(); } },
-			{ "wall decoration", [] { return newd WallDecorationBrush(); } },
-			{ "carpet", [] { return newd CarpetBrush(); } },
-			{ "table", [] { return newd TableBrush(); } },
-			{ "doodad", [] { return newd DoodadBrush(); } }
+		static const std::unordered_map<std::string_view, std::function<std::unique_ptr<Brush>()>> typeMap = {
+			{ "border", [] { return std::make_unique<GroundBrush>(); } },
+			{ "ground", [] { return std::make_unique<GroundBrush>(); } },
+			{ "wall", [] { return std::make_unique<WallBrush>(); } },
+			{ "wall decoration", [] { return std::make_unique<WallDecorationBrush>(); } },
+			{ "carpet", [] { return std::make_unique<CarpetBrush>(); } },
+			{ "table", [] { return std::make_unique<TableBrush>(); } },
+			{ "doodad", [] { return std::make_unique<DoodadBrush>(); } }
 		};
 
 		if (auto it = typeMap.find(brushType); it != typeMap.end()) {
-			brush = it->second();
+			newBrush = it->second();
+			brush = newBrush.get();
 		} else {
 			warnings.push_back(std::format("Unknown brush type {}", brushType));
 			return false;
@@ -149,7 +152,9 @@ bool Brushes::unserializeBrush(pugi::xml_node node, std::vector<std::string>& wa
 	}
 
 	if (!node.first_child()) {
-		brushes.insert(std::make_pair(brush->getName(), brush));
+		if (newBrush) {
+			brushes.emplace(brush->getName(), std::move(newBrush));
+		}
 		return true;
 	}
 
@@ -163,7 +168,7 @@ bool Brushes::unserializeBrush(pugi::xml_node node, std::vector<std::string>& wa
 
 	if (brush->getName() == "all" || brush->getName() == "none") {
 		warnings.push_back(std::format("Using reserved brushname '{}'.", brush->getName()));
-		delete brush;
+		// newBrush deleted automatically
 		return false;
 	}
 
@@ -171,13 +176,19 @@ bool Brushes::unserializeBrush(pugi::xml_node node, std::vector<std::string>& wa
 	if (otherBrush) {
 		if (otherBrush != brush) {
 			warnings.push_back(std::string(wxstr(std::format("Duplicate brush name {}. Undefined behaviour may ensue.", brush->getName())).mb_str()));
+			if (newBrush) {
+				brushes.emplace(brush->getName(), std::move(newBrush));
+			}
 		} else {
 			// Don't insert
 			return true;
 		}
+	} else {
+		if (newBrush) {
+			brushes.emplace(brush->getName(), std::move(newBrush));
+		}
 	}
 
-	brushes.insert(std::make_pair(brush->getName(), brush));
 	return true;
 }
 


### PR DESCRIPTION
- **Selection Optimization**: Added `std::unordered_set<Tile*> lookup` to `Selection` class for O(1) membership checks. Modified `addInternal` and `removeInternal` to use `pending` lists and lazy `flush` to avoid O(N) insertion/erasure during batch operations.
- **Map Search Optimization**: Refactored `Map::getSpawnList` to use explicit bounds checking, safer loops, and fixed a bug where `getSize()` was ignored (counting non-covering spawns). Added safety limit for infinite loops.
- **Brush System Modernization**: Updated `Brushes::unserializeBrush` to use `std::unique_ptr` and safe factory map, replacing raw pointer manipulation.

---
*PR created automatically by Jules for task [5205576581414997594](https://jules.google.com/task/5205576581414997594) started by @karolak6612*