### PR TITLE
⚡ Throttle: Fix Map::getSpawnList hang and optimize TileRenderer tooltips

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -421,6 +421,13 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
 			while (found != tile_loc->getSpawnCount()) {
+				// Safety check to prevent infinite loops if spawn count is corrupted
+				// or if spawns are unreachable (outside map bounds)
+				if (start_x < -width && end_x > width * 2 && start_y < -height && end_y > height * 2) {
+					spdlog::warn("Map::getSpawnList: Infinite loop detected! Spawn count mismatch at {} {} {}", where->getX(), where->getY(), where->getZ());
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {


### PR DESCRIPTION
This PR implements performance optimizations and safety fixes identified by the Throttle agent.
- Fix: Added safety bounds check to Map::getSpawnList to prevent infinite loops when spawn counts are corrupted or unreachable.
- Opt: Optimized TileRenderer::DrawTile to only populate container contents for tooltips when the mouse is hovering over the tile. Critical viewport labels (ActionID, Text, etc.) remain always visible.
- Verified compilation with build_linux.sh.

---
*PR created automatically by Jules for task [3333373268729959925](https://jules.google.com/task/3333373268729959925) started by @karolak6612*