### PR TITLE
[TILE/WXWIDGETS] Fix infinite loop risk in Map::getSpawnList and optimize ModernButton

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -421,6 +421,11 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
 			while (found != tile_loc->getSpawnCount()) {
+				if ((end_x - start_x) > std::max(width, height)) {
+					spdlog::warn("Map::getSpawnList: Infinite loop detected! Spawn count mismatch at {} {} {}", where->getX(), where->getY(), where->getZ());
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {

--- a/source/ui/controls/modern_button.cpp
+++ b/source/ui/controls/modern_button.cpp
@@ -22,9 +22,7 @@ void ModernButton::SetBitmap(const wxBitmap& bitmap) {
 }
 
 wxSize ModernButton::DoGetBestClientSize() const {
-	wxClientDC dc(const_cast<ModernButton*>(this));
-	dc.SetFont(GetFont());
-	wxSize text = dc.GetTextExtent(GetLabel());
+	wxSize text = GetTextExtent(GetLabel());
 
 	int width = text.x + FromDIP(40);
 	if (m_icon.IsOk()) {


### PR DESCRIPTION
Implemented safety mechanism in Map::getSpawnList to prevent infinite loops when spawn counts are corrupted. Optimized ModernButton by removing unnecessary GDI object creation.

---
*PR created automatically by Jules for task [38017200744801849](https://jules.google.com/task/38017200744801849) started by @karolak6612*