### PR TITLE
Bolt: Optimize tile rendering and map spawn search

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -99,23 +99,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 
 							TileLocation* location = &floor->locs[map_x * 4 + map_y];
 
-							// Trigger preloading for this tile's sprites
-							if (Tile* tile = location->get()) {
-								if (tile->ground) {
-									GameSprite* spr = g_items[tile->ground->getID()].sprite;
-									if (spr && !spr->isSimpleAndLoaded()) {
-										rme::collectTileSprites(spr, 0, 0, 0, 0);
-									}
-								}
-								for (const auto& item : tile->items) {
-									GameSprite* spr = g_items[item->getID()].sprite;
-									if (spr && !spr->isSimpleAndLoaded()) {
-										rme::collectTileSprites(spr, 0, 0, 0, 0);
-									}
-								}
-							}
-
-							tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x, draw_y);
+							tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x, draw_y, true);
 							// draw light, but only if not zoomed too far
 							if (draw_lights) {
 								tile_renderer->AddLight(location, view, options, light_buffer);
@@ -164,23 +148,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 
 					TileLocation* location = &floor->locs[map_x * 4 + map_y];
 
-					// Trigger preloading for this tile's sprites
-					if (Tile* tile = location->get()) {
-						if (tile->ground) {
-							GameSprite* spr = g_items[tile->ground->getID()].sprite;
-							if (spr && !spr->isSimpleAndLoaded()) {
-								rme::collectTileSprites(spr, 0, 0, 0, 0);
-							}
-						}
-						for (const auto& item : tile->items) {
-							GameSprite* spr = g_items[item->getID()].sprite;
-							if (spr && !spr->isSimpleAndLoaded()) {
-								rme::collectTileSprites(spr, 0, 0, 0, 0);
-							}
-						}
-					}
-
-					tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x, draw_y);
+					tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x, draw_y, true);
 					// draw light, but only if not zoomed too far
 					if (draw_lights) {
 						tile_renderer->AddLight(location, view, options, light_buffer);

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -24,7 +24,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, bool preload_sprites = false);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:


### PR DESCRIPTION
Refactored TileRenderer::DrawTile to handle sprite preloading, removing a redundant loop in MapLayerDrawer.
Hoisted tile->getHouseID() and tile->isHouseTile() calls in TileRenderer::DrawTile.
Optimized Map::getSpawnList to use a local MapNode cache, reducing calls to SpatialHashGrid::getLeaf.

---
*PR created automatically by Jules for task [17308423030470235727](https://jules.google.com/task/17308423030470235727) started by @karolak6612*