### PR TITLE
🔒 Sentinel: Modernize OpenGL Resource Management

### DIFF
--- a/source/rendering/core/gl_resources.h
+++ b/source/rendering/core/gl_resources.h
@@ -50,6 +50,51 @@ private:
 	GLuint id = 0;
 };
 
+// RAII wrapper for OpenGL Programs
+class GLProgram {
+public:
+	GLProgram() {
+		id = glCreateProgram();
+		// spdlog::trace("GLProgram created [ID={}]", id);
+	}
+
+	~GLProgram() {
+		if (id) {
+			// spdlog::trace("GLProgram deleted [ID={}]", id);
+			glDeleteProgram(id);
+		}
+	}
+
+	// Disable copy
+	GLProgram(const GLProgram&) = delete;
+	GLProgram& operator=(const GLProgram&) = delete;
+
+	// Enable move
+	GLProgram(GLProgram&& other) noexcept :
+		id(std::exchange(other.id, 0)) { }
+
+	GLProgram& operator=(GLProgram&& other) noexcept {
+		if (this != &other) {
+			if (id) {
+				glDeleteProgram(id);
+			}
+			id = std::exchange(other.id, 0);
+		}
+		return *this;
+	}
+
+	// Explicit conversion
+	explicit operator GLuint() const {
+		return id;
+	}
+	GLuint GetID() const {
+		return id;
+	}
+
+private:
+	GLuint id = 0;
+};
+
 // RAII wrapper for OpenGL Buffers (VBO, EBO, UBO, SSBO)
 class GLBuffer {
 public:

--- a/source/rendering/core/ring_buffer.cpp
+++ b/source/rendering/core/ring_buffer.cpp
@@ -10,12 +10,11 @@ RingBuffer::~RingBuffer() {
 
 RingBuffer::RingBuffer(RingBuffer&& other) noexcept
 	:
-	buffer_id_(other.buffer_id_),
+	buffer_resource_(std::move(other.buffer_resource_)),
 	mapped_ptr_(other.mapped_ptr_), element_size_(other.element_size_), max_elements_(other.max_elements_), section_size_(other.section_size_), current_section_(other.current_section_), use_persistent_mapping_(other.use_persistent_mapping_), initialized_(other.initialized_) {
 	for (size_t i = 0; i < BUFFER_COUNT; ++i) {
 		fences_[i] = std::move(other.fences_[i]);
 	}
-	other.buffer_id_ = 0;
 	other.mapped_ptr_ = nullptr;
 	other.initialized_ = false;
 }
@@ -23,7 +22,7 @@ RingBuffer::RingBuffer(RingBuffer&& other) noexcept
 RingBuffer& RingBuffer::operator=(RingBuffer&& other) noexcept {
 	if (this != &other) {
 		cleanup();
-		buffer_id_ = other.buffer_id_;
+		buffer_resource_ = std::move(other.buffer_resource_);
 		mapped_ptr_ = other.mapped_ptr_;
 		for (size_t i = 0; i < BUFFER_COUNT; ++i) {
 			fences_[i] = std::move(other.fences_[i]);
@@ -35,7 +34,6 @@ RingBuffer& RingBuffer::operator=(RingBuffer&& other) noexcept {
 		use_persistent_mapping_ = other.use_persistent_mapping_;
 		initialized_ = other.initialized_;
 
-		other.buffer_id_ = 0;
 		other.mapped_ptr_ = nullptr;
 		other.initialized_ = false;
 	}
@@ -55,27 +53,27 @@ bool RingBuffer::initialize(size_t element_size, size_t max_elements) {
 	size_t total_size = section_size_ * BUFFER_COUNT;
 
 	// Create buffer
-	glCreateBuffers(1, &buffer_id_);
-	if (buffer_id_ == 0) {
+	buffer_resource_ = std::make_unique<GLBuffer>();
+	if (!buffer_resource_ || buffer_resource_->GetID() == 0) {
 		spdlog::error("RingBuffer: Failed to create buffer");
 		return false;
 	}
+	GLuint id = buffer_resource_->GetID();
 
 	// GL 4.4+ persistent coherent mapping
 	GLbitfield storage_flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
 
 	// Use NamedBufferStorage if available (GL 4.5+) or bind and use BufferStorage
 	// RME uses GL 4.5, so glNamedBufferStorage is safe
-	glNamedBufferStorage(buffer_id_, total_size, nullptr, storage_flags);
+	glNamedBufferStorage(id, total_size, nullptr, storage_flags);
 
 	GLbitfield map_flags = GL_MAP_WRITE_BIT | GL_MAP_PERSISTENT_BIT | GL_MAP_COHERENT_BIT;
 
-	mapped_ptr_ = glMapNamedBufferRange(buffer_id_, 0, total_size, map_flags);
+	mapped_ptr_ = glMapNamedBufferRange(id, 0, total_size, map_flags);
 
 	if (!mapped_ptr_) {
 		spdlog::error("RingBuffer: Persistent mapping failed");
-		glDeleteBuffers(1, &buffer_id_);
-		buffer_id_ = 0;
+		buffer_resource_.reset();
 		return false;
 	}
 
@@ -95,13 +93,12 @@ void RingBuffer::cleanup() {
 	}
 
 	// Unmap and delete buffer
-	if (buffer_id_) {
+	if (buffer_resource_) {
 		if (mapped_ptr_) {
-			glUnmapNamedBuffer(buffer_id_);
+			glUnmapNamedBuffer(buffer_resource_->GetID());
 			mapped_ptr_ = nullptr;
 		}
-		glDeleteBuffers(1, &buffer_id_);
-		buffer_id_ = 0;
+		buffer_resource_.reset();
 	}
 
 	initialized_ = false;

--- a/source/rendering/core/ring_buffer.h
+++ b/source/rendering/core/ring_buffer.h
@@ -3,8 +3,10 @@
 
 #include "app/main.h"
 #include "rendering/core/sync_handle.h"
+#include "rendering/core/gl_resources.h"
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 
 /**
  * Triple-buffered ring buffer with persistent mapping for zero-copy GPU uploads.
@@ -77,7 +79,7 @@ public:
 	 * Get the OpenGL buffer ID.
 	 */
 	GLuint getBufferId() const {
-		return buffer_id_;
+		return buffer_resource_ ? buffer_resource_->GetID() : 0;
 	}
 
 	/**
@@ -100,7 +102,7 @@ public:
 	}
 
 private:
-	GLuint buffer_id_ = 0;
+	std::unique_ptr<GLBuffer> buffer_resource_;
 	void* mapped_ptr_ = nullptr;
 	SyncHandle fences_[BUFFER_COUNT];
 

--- a/source/rendering/core/shader_program.h
+++ b/source/rendering/core/shader_program.h
@@ -2,9 +2,11 @@
 #define RME_RENDERING_CORE_SHADER_PROGRAM_H_
 
 #include "app/main.h"
+#include "rendering/core/gl_resources.h"
 #include <string>
 #include <unordered_map>
 #include <glm/glm.hpp>
+#include <memory>
 
 class ShaderProgram {
 public:
@@ -25,15 +27,15 @@ public:
 	void SetMat4(const std::string& name, const glm::mat4& value) const;
 
 	bool IsValid() const {
-		return program_id != 0;
+		return program_resource_ && program_resource_->GetID() != 0;
 	}
 
 	GLuint GetID() const {
-		return program_id;
+		return program_resource_ ? program_resource_->GetID() : 0;
 	}
 
 private:
-	GLuint program_id;
+	std::unique_ptr<GLProgram> program_resource_;
 	mutable std::unordered_map<std::string, GLint> uniform_cache;
 
 	GLint GetUniformLocation(const std::string& name) const;

--- a/source/rendering/core/texture_array.h
+++ b/source/rendering/core/texture_array.h
@@ -2,7 +2,9 @@
 #define RME_RENDERING_CORE_TEXTURE_ARRAY_H_
 
 #include "app/main.h"
+#include "rendering/core/gl_resources.h"
 #include <vector>
+#include <memory>
 
 /**
  * OpenGL Texture Array (GL_TEXTURE_2D_ARRAY) for sprite atlas.
@@ -55,7 +57,7 @@ public:
 	 * Get the OpenGL texture ID.
 	 */
 	GLuint getTextureId() const {
-		return textureId_;
+		return texture_resource_ ? texture_resource_->GetID() : 0;
 	}
 
 	/**
@@ -87,7 +89,7 @@ public:
 	void cleanup();
 
 private:
-	GLuint textureId_ = 0;
+	std::unique_ptr<GLTextureResource> texture_resource_;
 	int width_ = 0;
 	int height_ = 0;
 	int maxLayers_ = 0;


### PR DESCRIPTION
This change modernizes the OpenGL resource management for `ShaderProgram`, `TextureArray`, and `RingBuffer` by replacing manual `GLuint` handling with RAII wrappers (`GLProgram`, `GLTextureResource`, `GLBuffer`) managed by `std::unique_ptr`. This ensures proper resource cleanup, exception safety, and adherence to modern C++ practices as mandated by the Sentinel agent instructions.

---
*PR created automatically by Jules for task [2645379004000113125](https://jules.google.com/task/2645379004000113125) started by @karolak6612*