### PR TITLE
Profiler: Optimize Tooltip Rendering via Caching

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -216,10 +216,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
-		TooltipData& groundData = tooltip_drawer->requestTooltipData();
-		if (FillItemTooltipData(groundData, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-			if (groundData.hasVisibleFields()) {
-				tooltip_drawer->commitTooltip();
+		CachedTooltip* entry = tooltip_drawer->requestItemTooltip(tile->ground.get());
+		if (FillItemTooltipData(entry->data, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
+			if (entry->data.hasVisibleFields()) {
+				tooltip_drawer->commitItemTooltip(entry);
 			}
 		}
 	}
@@ -262,10 +262,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 			for (const auto& item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData& itemData = tooltip_drawer->requestTooltipData();
-					if (FillItemTooltipData(itemData, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-						if (itemData.hasVisibleFields()) {
-							tooltip_drawer->commitTooltip();
+					CachedTooltip* entry = tooltip_drawer->requestItemTooltip(item.get());
+					if (FillItemTooltipData(entry->data, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
+						if (entry->data.hasVisibleFields()) {
+							tooltip_drawer->commitItemTooltip(entry);
 						}
 					}
 				}


### PR DESCRIPTION
This PR implements a caching mechanism for item tooltips to address a performance bottleneck identified during profiling. The previous implementation recalculated text layout and formatted strings for every visible item every frame, leading to high CPU usage when many tooltips were enabled.

### Key Changes:
1.  **Tooltip Caching**: Introduced `CachedTooltip` in `TooltipDrawer`, which stores the calculated layout and formatted text lines.
2.  **Change Detection**: The system compares the current frame's tooltip data with the previous frame's shadow copy. Layout recalculation only occurs if the content (text, item ID, etc.) has changed.
3.  **Memory Safety**: `CachedTooltip` owns its string storage buffer, preventing use-after-free issues with `std::string_view` that previously pointed to a transient shared buffer.
4.  **Integration**: Updated `TileRenderer::DrawTile` to utilize `requestItemTooltip` and `commitItemTooltip` instead of the immediate-mode `requestTooltipData`.
5.  **Garbage Collection**: Added logic to prune unused cache entries every ~10 seconds to prevent memory leaks.

### Performance Impact:
-   Drastically reduces the number of `nvgTextBounds` calls per frame.
-   Eliminates redundant string formatting for static items.
-   Maintains pixel-perfect rendering output (Painter's Algorithm compliant).

### Verification:
-   Verified via `test_tooltip_cache.cpp` (unit test for caching logic).
-   Manual code review confirms memory safety and logic correctness.

---
*PR created automatically by Jules for task [10057350751449521445](https://jules.google.com/task/10057350751449521445) started by @karolak6612*