### PR TITLE
[REFACTOR] Fix Long Method in ItemDatabase::loadFromOtbGeneric

### DIFF
--- a/source/game/items.h
+++ b/source/game/items.h
@@ -452,6 +452,12 @@ public:
 	ItemType& getItemType(int id);
 	ItemType& getItemIdByClientID(int spriteId);
 
+	void updateMaxItemId(uint16_t id) {
+		if (id > max_item_id) {
+			max_item_id = id;
+		}
+	}
+
 	bool loadFromOtb(const FileName& datafile, wxString& error, std::vector<std::string>& warnings);
 	bool loadFromGameXml(const FileName& datafile, wxString& error, std::vector<std::string>& warnings);
 	bool loadItemFromGameXml(pugi::xml_node itemNode, int id);


### PR DESCRIPTION
Refactored `ItemDatabase::loadFromOtbGeneric` to reduce method length and complexity by extracting attribute handling logic into helper functions.

---
*PR created automatically by Jules for task [12873367011240614495](https://jules.google.com/task/12873367011240614495) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal item data handling and parsing logic through code reorganization and centralized helper functions, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->