### PR TITLE
👻 Phantom: Fix wxWidgets violations in OutfitChooser and HousePalette

### DIFF
--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -59,8 +59,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetToolTip("Add a new house");
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetToolTip("Edit selected house");
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetToolTip("Remove selected house");
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);
@@ -72,7 +75,9 @@ HousePalette::HousePalette(wxWindow* parent) :
 	wxStaticBoxSizer* brush_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Brushes");
 
 	house_brush_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_HOUSE_BRUSH, "House tiles");
+	house_brush_button->SetToolTip("Paint house tiles (Zone)");
 	select_exit_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_EXIT_BRUSH, "Select Exit");
+	select_exit_button->SetToolTip("Set the exit position for the selected house");
 
 	brush_sizer->Add(house_brush_button, 0, wxEXPAND | wxBOTTOM, 2);
 	brush_sizer->Add(select_exit_button, 0, wxEXPAND);

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -177,11 +177,11 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
+	wxWrapSizer* palette_sizer = new wxWrapSizer(wxHORIZONTAL);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
 		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
+		palette_sizer->Add(swatch, 0, wxALL, 1);
 		color_buttons.push_back(swatch);
 
 		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {


### PR DESCRIPTION
This PR addresses wxWidgets violations identified by the Phantom agent. 

Changes:
1.  **Layout Fix**: In `source/ui/dialogs/outfit_chooser_dialog.cpp`, the color palette grid used a fixed `wxFlexGridSizer`. This has been replaced with `wxWrapSizer` to allow the palette to flow responsively with window resizing.
2.  **UX Improvement**: In `source/palette/house/house_palette.cpp`, tooltips were missing for several buttons. Added tooltips to clarify button actions.

These changes align with the goal of modernizing the UI and improving responsiveness.

---
*PR created automatically by Jules for task [4438426094199004623](https://jules.google.com/task/4438426094199004623) started by @karolak6612*