### PR TITLE
[UB FIX] Fix race condition, UAF, and UB in Live networking

### DIFF
--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -204,8 +204,9 @@ void LiveClient::receive(uint32_t packetSize) {
 }
 
 void LiveClient::send(NetworkMessage& message) {
-	memcpy(&message.buffer[0], &message.size, 4);
-	boost::asio::async_write(*socket, boost::asio::buffer(message.buffer, message.size + 4), [this](const boost::system::error_code& error, size_t bytesTransferred) -> void {
+	auto msgPtr = std::make_shared<NetworkMessage>(message);
+	memcpy(&msgPtr->buffer[0], &msgPtr->size, 4);
+	boost::asio::async_write(*socket, boost::asio::buffer(msgPtr->buffer, msgPtr->size + 4), [this, msgPtr](const boost::system::error_code& error, size_t bytesTransferred) -> void {
 		if (error) {
 			logMessage(wxString() + getHostName() + ": " + error.message());
 		}

--- a/source/live/live_server.cpp
+++ b/source/live/live_server.cpp
@@ -163,6 +163,8 @@ bool LiveServer::setPort(int32_t newPort) {
 }
 
 uint32_t LiveServer::getFreeClientId() {
+	std::lock_guard<std::mutex> lock(clientMutex);
+
 	// Start from bit 4 (16) to avoid colliding with reserved visibility flags (bits 0-3)
 	for (int32_t bit = (1 << 4); bit < (1 << 16); bit <<= 1) {
 		if (!testFlags(clientIds, bit)) {


### PR DESCRIPTION
Fixes three critical bugs in the Live system:
1.  **Race Condition**: `LiveServer::getFreeClientId` now uses `clientMutex` to protect `clientIds`.
2.  **Use-After-Free**: `LivePeer::send` and `LiveClient::send` now use `std::shared_ptr` to keep the `NetworkMessage` alive during `boost::asio::async_write`.
3.  **Undefined Behavior**: `LivePeer::parseReceiveChanges` no longer uses `data.c_str() - 1`. It now explicitly inserts `NODE_START` into the data string before parsing.

---
*PR created automatically by Jules for task [16861515147123041172](https://jules.google.com/task/16861515147123041172) started by @karolak6612*