### PR TITLE
[TILE] Optimize tile sprite preloading to remove redundant iteration

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -29,6 +29,7 @@
 #include "rendering/core/light_buffer.h"
 #include "rendering/core/sprite_batch.h"
 #include "rendering/core/primitive_renderer.h"
+#include "rendering/core/sprite_preloader.h"
 
 MapLayerDrawer::MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_drawer, Editor* editor) :
 	tile_renderer(tile_renderer),

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -28,6 +28,8 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
+	void PreloadItem(const Tile* tile, Item* item);
+
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;
 	CreatureDrawer* creature_drawer;

--- a/source/rendering/utilities/pattern_calculator.h
+++ b/source/rendering/utilities/pattern_calculator.h
@@ -1,0 +1,66 @@
+#ifndef RME_RENDERING_UTILITIES_PATTERN_CALCULATOR_H_
+#define RME_RENDERING_UTILITIES_PATTERN_CALCULATOR_H_
+
+#include "rendering/core/game_sprite.h"
+#include "game/items.h"
+#include "game/item.h"
+#include "map/tile.h"
+
+struct SpritePatterns {
+	int x = 0;
+	int y = 0;
+	int z = 0;
+	int frame = 0;
+	int subtype = -1;
+};
+
+class PatternCalculator {
+public:
+	static SpritePatterns Calculate(const GameSprite* spr, const ItemType& it, const Item* item, const Tile* tile, const Position& pos) {
+		SpritePatterns patterns;
+
+		if (!spr) {
+			return patterns;
+		}
+
+		patterns.x = (spr->pattern_x > 1) ? pos.x % spr->pattern_x : 0;
+		patterns.y = (spr->pattern_y > 1) ? pos.y % spr->pattern_y : 0;
+		patterns.z = (spr->pattern_z > 1) ? pos.z % spr->pattern_z : 0;
+		patterns.frame = (spr->animator) ? spr->animator->getFrame() : 0;
+
+		if (it.isSplash() || it.isFluidContainer()) {
+			patterns.subtype = item->getSubtype();
+		} else if (it.isHangable) {
+			if (tile && tile->hasHookSouth()) {
+				patterns.x = 1;
+			} else if (tile && tile->hasHookEast()) {
+				patterns.x = 2;
+			} else {
+				patterns.x = 0;
+			}
+		} else if (it.stackable) {
+			uint16_t itemSubtype = item->getSubtype();
+			if (itemSubtype <= 1) {
+				patterns.subtype = 0;
+			} else if (itemSubtype <= 2) {
+				patterns.subtype = 1;
+			} else if (itemSubtype <= 3) {
+				patterns.subtype = 2;
+			} else if (itemSubtype <= 4) {
+				patterns.subtype = 3;
+			} else if (itemSubtype < 10) {
+				patterns.subtype = 4;
+			} else if (itemSubtype < 25) {
+				patterns.subtype = 5;
+			} else if (itemSubtype < 50) {
+				patterns.subtype = 6;
+			} else {
+				patterns.subtype = 7;
+			}
+		}
+
+		return patterns;
+	}
+};
+
+#endif


### PR DESCRIPTION
Moved the sprite preloading logic from `MapLayerDrawer` to `TileRenderer::DrawTile`.
This removes a redundant O(N) iteration over items for every visible tile in `MapLayerDrawer`, as the preloading is now handled during the single drawing pass in `TileRenderer`.

- Removed explicit preloading loops in `source/rendering/drawers/map_layer_drawer.cpp`.
- Added `isSimpleAndLoaded` checks and `rme::collectTileSprites` calls in `source/rendering/drawers/tiles/tile_renderer.cpp`.
- This ensures sprites are still preloaded correctly (triggering async load if needed) without the overhead of iterating the item list twice per frame.

---
*PR created automatically by Jules for task [14885790403701219092](https://jules.google.com/task/14885790403701219092) started by @karolak6612*