### PR TITLE
📊 Profiler: Fix CPU bottleneck in Tooltip generation

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -30,125 +30,6 @@ TileRenderer::TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd,
 	item_drawer(id), sprite_drawer(sd), creature_drawer(cd), floor_drawer(fd), marker_drawer(md), tooltip_drawer(td), creature_name_drawer(cnd), editor(ed) {
 }
 
-// Helper function to populate tooltip data from an item (in-place)
-static bool FillItemTooltipData(TooltipData& data, Item* item, const Position& pos, bool isHouseTile, float zoom) {
-	if (!item) {
-		return false;
-	}
-
-	const uint16_t id = item->getID();
-	if (id < 100) {
-		return false;
-	}
-
-	uint16_t unique = 0;
-	uint16_t action = 0;
-	std::string_view text;
-	std::string_view description;
-	uint8_t doorId = 0;
-	Position destination;
-	bool hasContent = false;
-
-	bool is_complex = item->isComplex();
-	// Early exit for simple items
-	// isTooltipable is cached (isContainer || isDoor || isTeleport)
-	if (!is_complex && !g_items[id].isTooltipable()) {
-		return false;
-	}
-
-	bool is_container = g_items[id].isContainer();
-	bool is_door = isHouseTile && item->isDoor();
-	bool is_teleport = item->isTeleport();
-
-	if (is_complex) {
-		unique = item->getUniqueID();
-		action = item->getActionID();
-		text = item->getText();
-		description = item->getDescription();
-	}
-
-	// Check if it's a door
-	if (is_door) {
-		if (const Door* door = item->asDoor()) {
-			if (door->isRealDoor()) {
-				doorId = door->getDoorID();
-			}
-		}
-	}
-
-	// Check if it's a teleport
-	if (is_teleport) {
-		Teleport* tp = static_cast<Teleport*>(item);
-		if (tp->hasDestination()) {
-			destination = tp->getDestination();
-		}
-	}
-
-	// Check if container has content
-	if (is_container) {
-		if (const Container* container = item->asContainer()) {
-			hasContent = container->getItemCount() > 0;
-		}
-	}
-
-	// Only create tooltip if there's something to show
-	if (unique == 0 && action == 0 && doorId == 0 && text.empty() && description.empty() && destination.x == 0 && !hasContent) {
-		return false;
-	}
-
-	// Get item name from database
-	std::string_view itemName = g_items[id].name;
-	if (itemName.empty()) {
-		itemName = "Item";
-	}
-
-	data.pos = pos;
-	data.itemId = id;
-	data.itemName = itemName; // Assign string_view to string_view (no copy)
-
-	data.actionId = action;
-	data.uniqueId = unique;
-	data.doorId = doorId;
-	data.text = text;
-	data.description = description;
-	data.destination = destination;
-
-	// Populate container items
-	if (g_items[id].isContainer() && zoom <= 1.5f) {
-		if (const Container* container = item->asContainer()) {
-			// Set capacity for rendering empty slots
-			data.containerCapacity = static_cast<uint8_t>(container->getVolume());
-
-			const auto& items = container->getVector();
-			data.containerItems.clear();
-			data.containerItems.reserve(items.size());
-			for (const auto& subItem : items) {
-				if (subItem) {
-					ContainerItem ci;
-					ci.id = subItem->getID();
-					ci.subtype = subItem->getSubtype();
-					ci.count = subItem->getCount();
-					// Sanity check for count
-					if (ci.count == 0) {
-						ci.count = 1;
-					}
-
-					data.containerItems.push_back(ci);
-
-					// Limit preview items to avoid massive tooltips
-					if (data.containerItems.size() >= 32) {
-						break;
-					}
-				}
-			}
-		}
-	}
-
-	data.updateCategory();
-
-	return true;
-}
-
 void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y) {
 	if (!location) {
 		return;
@@ -216,12 +97,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
-		TooltipData& groundData = tooltip_drawer->requestTooltipData();
-		if (FillItemTooltipData(groundData, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-			if (groundData.hasVisibleFields()) {
-				tooltip_drawer->commitTooltip();
-			}
-		}
+		tooltip_drawer->addItemTooltip(tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom);
 	}
 
 	// end filters for ground tile
@@ -262,12 +138,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 			for (const auto& item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData& itemData = tooltip_drawer->requestTooltipData();
-					if (FillItemTooltipData(itemData, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-						if (itemData.hasVisibleFields()) {
-							tooltip_drawer->commitTooltip();
-						}
-					}
+					tooltip_drawer->addItemTooltip(item.get(), location->getPosition(), tile->isHouseTile(), view.zoom);
 				}
 
 				// item sprite

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -159,36 +159,19 @@ public:
 	// Add a waypoint tooltip
 	void addWaypointTooltip(Position pos, std::string_view name);
 
+	// Add an item tooltip (cached)
+	void addItemTooltip(const Item* item, const Position& pos, bool isHouseTile, float zoom);
+
 	// Draw all tooltips
 	void draw(NVGcontext* vg, const RenderView& view);
 
 	// Clear all tooltips
 	void clear();
 
+	// Garbage collect old cache entries
+	void garbageCollect();
+
 protected:
-	struct FieldLine {
-		std::string_view label;
-		std::string_view value;
-		uint8_t r, g, b;
-		std::vector<std::string_view> wrappedLines; // For multi-line values
-	};
-	std::vector<FieldLine> scratch_fields;
-	size_t scratch_fields_count = 0;
-	std::string storage; // Scratch buffer for text generation
-
-	std::vector<TooltipData> tooltips;
-	size_t active_count = 0;
-
-	std::unordered_map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
-	NVGcontext* lastContext = nullptr;
-
-	// Helper to get or load sprite image
-	int getSpriteImage(NVGcontext* vg, uint16_t itemId);
-
-	// Helper to get header color based on category
-	void getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const;
-
-	// Refactored drawing helpers
 	struct LayoutMetrics {
 		float width;
 		float height;
@@ -202,11 +185,54 @@ protected:
 		int numContainerItems;
 	};
 
-	void prepareFields(const TooltipData& tooltip);
-	LayoutMetrics calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize);
+	struct FieldLine {
+		std::string_view label;
+		std::string_view value;
+		uint8_t r, g, b;
+		std::vector<std::string_view> wrappedLines; // For multi-line values
+	};
+
+	struct CachedTooltipEntry {
+		uint64_t hash = 0;
+		uint64_t lastFrameSeen = 0;
+		bool isEmpty = true;
+		TooltipData data;
+
+		// Layout cache
+		std::string storage;
+		std::vector<FieldLine> fields;
+		LayoutMetrics layout;
+	};
+
+	std::vector<FieldLine> scratch_fields;
+	size_t scratch_fields_count = 0;
+	std::string storage; // Scratch buffer for text generation
+
+	std::vector<TooltipData> tooltips;
+	size_t active_count = 0;
+
+	// Cache for item tooltips
+	std::unordered_map<const Item*, CachedTooltipEntry> cache;
+	std::vector<CachedTooltipEntry*> active_tooltips;
+	uint64_t current_frame = 0;
+
+	std::unordered_map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
+	NVGcontext* lastContext = nullptr;
+
+	// Helper to get or load sprite image
+	int getSpriteImage(NVGcontext* vg, uint16_t itemId);
+
+	// Helper to get header color based on category
+	void getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const;
+
+	// Refactored drawing helpers
+	// LayoutMetrics moved up
+
+	void prepareFields(const TooltipData& tooltip, std::vector<FieldLine>& fields, std::string& storage);
+	LayoutMetrics calculateLayout(NVGcontext* vg, const TooltipData& tooltip, std::vector<FieldLine>& fields, float maxWidth, float minWidth, float padding, float fontSize);
 	void drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip);
-	void drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize);
-	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout);
+	void drawFields(NVGcontext* vg, float x, float y, const std::vector<FieldLine>& fields, float valueStartX, float lineHeight, float padding, float fontSize);
+	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout, const std::vector<FieldLine>& fields);
 };
 
 #endif


### PR DESCRIPTION
- Implemented `CachedTooltipEntry` struct and `cache` map in `TooltipDrawer`.
- Added `computeItemHash` to detect changes in item state (including position, zoom, and container content).
- Migrated `FillItemTooltipData` logic from `TileRenderer` to `TooltipDrawer::addItemTooltip`.
- Updated `TooltipDrawer::draw` to use cached layout and fields, skipping expensive `prepareFields` and `calculateLayout` calls when possible.
- Added garbage collection to prune old cache entries.
- Refactored `TileRenderer::DrawTile` to delegate tooltip handling to `TooltipDrawer`.

---
*PR created automatically by Jules for task [18139537825539751552](https://jules.google.com/task/18139537825539751552) started by @karolak6612*