### PR TITLE
Refactor GroundBrushLoader::load to fix Long Method smell

### DIFF
--- a/smell_report.txt
+++ b/smell_report.txt
@@ -1,0 +1,362 @@
+[Large Class/File] source/io/iomap_otbm.cpp: 1915 lines
+[Switch Statement] source/io/iomap_otbm.cpp:91
+[Long Method] source/io/iomap_otbm.cpp:90 Function 'Item::readItemAttribute_OTBM' is 82 lines long
+[Long Method] source/io/iomap_otbm.cpp:426 Function 'Podium::readItemAttribute_OTBM' is 54 lines long
+[Long Method] source/io/iomap_otbm.cpp:604 Function 'IOMapOTBM::loadMapFromOTGZ' is 115 lines long
+[Long Method] source/io/iomap_otbm.cpp:721 Function 'IOMapOTBM::loadMapFromDisk' is 64 lines long
+[Long Method] source/io/iomap_otbm.cpp:796 Function 'IOMapOTBM::loadMapRoot' is 65 lines long
+[Switch Statement] source/io/iomap_otbm.cpp:866
+[Switch Statement] source/io/iomap_otbm.cpp:976
+[Long Method] source/io/iomap_otbm.cpp:925 Function 'IOMapOTBM::readTileArea' is 105 lines long
+[Long Method] source/io/iomap_otbm.cpp:1156 Function 'IOMapOTBM::loadSpawns' is 128 lines long
+[Long Method] source/io/iomap_otbm.cpp:1308 Function 'IOMapOTBM::loadHouses' is 52 lines long
+[Long Method] source/io/iomap_otbm.cpp:1381 Function 'IOMapOTBM::saveMapToOTGZ' is 117 lines long
+[Long Method] source/io/iomap_otbm.cpp:1536 Function 'IOMapOTBM::saveMap' is 56 lines long
+[Long Method] source/io/iomap_otbm.cpp:1594 Function 'IOMapOTBM::writeTileData' is 77 lines long
+[Long Method] source/io/iomap_otbm.cpp:1724 Function 'IOMapOTBM::saveSpawns' is 59 lines long
+[Large Class/File] source/io/filehandle.cpp: 724 lines
+[Switch Statement] source/io/filehandle.cpp:36
+[Long Method] source/io/filehandle.cpp:360 Function 'BinaryNode::advance' is 58 lines long
+[Switch Statement] source/io/filehandle.cpp:465
+[Long Method] source/io/filehandle.cpp:420 Function 'BinaryNode::load' is 72 lines long
+[Large Class/File] source/io/iomap_otmm.cpp: 973 lines
+[Switch Statement] source/io/iomap_otmm.cpp:41
+[Long Method] source/io/iomap_otmm.cpp:40 Function 'Item::readItemAttribute_OTMM' is 58 lines long
+[Switch Statement] source/io/iomap_otmm.cpp:389
+[Switch Statement] source/io/iomap_otmm.cpp:454
+[Long Method] source/io/iomap_otmm.cpp:328 Function 'IOMapOTMM::loadMap' is 411 lines long
+[Long Method] source/io/iomap_otmm.cpp:760 Function 'IOMapOTMM::saveMap' is 213 lines long
+[Long Method] source/io/loaders/spr_loader.cpp:19 Function 'SprLoader::LoadData' is 74 lines long
+[Long Method] source/io/loaders/spr_loader.cpp:110 Function 'SprLoader::ReadSprites' is 78 lines long
+[Large Class/File] source/io/loaders/dat_loader.cpp: 509 lines
+[Switch Statement] source/io/loaders/dat_loader.cpp:41
+[Long Parameter List] source/io/loaders/dat_loader.cpp:76 Function 'ReadFlagData' has 6 parameters
+[Switch Statement] source/io/loaders/dat_loader.cpp:77
+[Long Method] source/io/loaders/dat_loader.cpp:76 Function 'ReadFlagData' is 132 lines long
+[Long Method] source/io/loaders/dat_loader.cpp:256 Function 'DatLoader::LoadMetadata' is 116 lines long
+[Long Method] source/io/loaders/dat_loader.cpp:374 Function 'DatLoader::ReadSpriteGroup' is 135 lines long
+[Switch Statement] source/live/live_client.cpp:290
+[Switch Statement] source/live/live_client.cpp:336
+[Switch Statement] source/live/live_peer.cpp:111
+[Switch Statement] source/live/live_peer.cpp:131
+[Long Parameter List] source/live/live_socket.cpp:93 Function 'LiveSocket::receiveNode' has 6 parameters
+[Long Parameter List] source/live/live_socket.cpp:156 Function 'LiveSocket::receiveFloor' has 8 parameters
+[Switch Statement] source/live/live_socket.cpp:321
+[Long Method] source/live/live_socket.cpp:271 Function 'LiveSocket::readTile' is 99 lines long
+[Long Method] source/ingame_preview/ingame_preview_canvas.cpp:91 Function 'IngamePreviewCanvas::OnKeyDown' is 53 lines long
+[Long Method] source/ingame_preview/ingame_preview_canvas.cpp:198 Function 'IngamePreviewCanvas::StartWalk' is 57 lines long
+[Long Method] source/ingame_preview/ingame_preview_canvas.cpp:257 Function 'IngamePreviewCanvas::UpdateWalk' is 87 lines long
+[Long Method] source/ingame_preview/ingame_preview_canvas.cpp:394 Function 'IngamePreviewCanvas::Render' is 73 lines long
+[Long Parameter List] source/ingame_preview/ingame_preview_renderer.cpp:63 Function 'IngamePreviewRenderer::Render' has 15 parameters
+[Long Method] source/ingame_preview/ingame_preview_renderer.cpp:63 Function 'IngamePreviewRenderer::Render' is 217 lines long
+[Long Method] source/util/virtual_item_grid.cpp:173 Function 'VirtualItemGrid::OnNanoVGPaint' is 116 lines long
+[Large Class/File] source/util/image_manager.h: 1777 lines
+[Long Method] source/util/nanovg_canvas.cpp:219 Function 'NanoVGCanvas::CreateGameSpriteTexture' is 68 lines long
+[Long Method] source/rendering/map_drawer.cpp:286 Function 'MapDrawer::Draw' is 72 lines long
+[Long Method] source/rendering/utilities/sprite_icon_generator.cpp:52 Function 'SpriteIconGenerator::Generate' is 122 lines long
+[Long Parameter List] source/rendering/utilities/icon_renderer.cpp:8 Function 'DrawIconWithBorder' has 7 parameters
+[Long Parameter List] source/rendering/utilities/light_drawer.cpp:70 Function 'LightDrawer::draw' has 6 parameters
+[Long Method] source/rendering/utilities/light_drawer.cpp:70 Function 'LightDrawer::draw' is 207 lines long
+[Long Method] source/rendering/utilities/light_drawer.cpp:279 Function 'LightDrawer::initRenderResources' is 113 lines long
+[Long Method] source/rendering/postprocess/effects/xbrz.cpp:93 Function 'main' is 167 lines long
+[Long Parameter List] source/rendering/drawers/map_layer_drawer.cpp:43 Function 'MapLayerDrawer::Draw' has 6 parameters
+[Long Method] source/rendering/drawers/map_layer_drawer.cpp:43 Function 'MapLayerDrawer::Draw' is 125 lines long
+[Long Method] source/rendering/drawers/minimap_drawer.cpp:23 Function 'MinimapDrawer::Draw' is 132 lines long
+[Long Method] source/rendering/drawers/minimap_renderer.cpp:60 Function 'MinimapRenderer::initialize' is 65 lines long
+[Long Parameter List] source/rendering/drawers/minimap_renderer.cpp:175 Function 'MinimapRenderer::updateRegion' has 6 parameters
+[Long Method] source/rendering/drawers/minimap_renderer.cpp:175 Function 'MinimapRenderer::updateRegion' is 89 lines long
+[Long Parameter List] source/rendering/drawers/minimap_renderer.cpp:266 Function 'MinimapRenderer::render' has 9 parameters
+[Long Method] source/rendering/drawers/minimap_renderer.cpp:266 Function 'MinimapRenderer::render' is 80 lines long
+[Long Parameter List] source/rendering/drawers/tiles/tile_renderer.cpp:154 Function 'TileRenderer::DrawTile' has 7 parameters
+[Long Method] source/rendering/drawers/tiles/tile_renderer.cpp:154 Function 'TileRenderer::DrawTile' is 163 lines long
+[Long Parameter List] source/rendering/drawers/tiles/floor_drawer.cpp:24 Function 'FloorDrawer::draw' has 7 parameters
+[Long Parameter List] source/rendering/drawers/tiles/tile_color_calculator.cpp:8 Function 'TileColorCalculator::Calculate' has 7 parameters
+[Long Method] source/rendering/drawers/tiles/tile_color_calculator.cpp:8 Function 'TileColorCalculator::Calculate' is 71 lines long
+[Long Parameter List] source/rendering/drawers/overlays/marker_drawer.cpp:16 Function 'MarkerDrawer::draw' has 9 parameters
+[Long Method] source/rendering/drawers/overlays/grid_drawer.cpp:38 Function 'GridDrawer::DrawIngameBox' is 61 lines long
+[Long Parameter List] source/rendering/drawers/overlays/grid_drawer.cpp:112 Function 'GridDrawer::drawRect' has 7 parameters
+[Long Parameter List] source/rendering/drawers/overlays/grid_drawer.cpp:121 Function 'GridDrawer::drawFilledRect' has 6 parameters
+[Long Parameter List] source/rendering/drawers/overlays/preview_drawer.cpp:23 Function 'PreviewDrawer::draw' has 10 parameters
+[Long Method] source/rendering/drawers/overlays/preview_drawer.cpp:23 Function 'PreviewDrawer::draw' is 110 lines long
+[Long Method] source/rendering/drawers/overlays/selection_drawer.cpp:13 Function 'SelectionDrawer::draw' is 70 lines long
+[Switch Statement] source/rendering/drawers/overlays/brush_overlay_drawer.cpp:52
+[Long Parameter List] source/rendering/drawers/overlays/brush_overlay_drawer.cpp:103 Function 'BrushOverlayDrawer::draw' has 9 parameters
+[Long Method] source/rendering/drawers/overlays/brush_overlay_drawer.cpp:103 Function 'BrushOverlayDrawer::draw' is 315 lines long
+[Long Parameter List] source/rendering/drawers/overlays/brush_overlay_drawer.cpp:420 Function 'BrushOverlayDrawer::get_color' has 6 parameters
+[Long Method] source/rendering/drawers/entities/creature_name_drawer.cpp:31 Function 'CreatureNameDrawer::draw' is 52 lines long
+[Long Parameter List] source/rendering/drawers/entities/creature_drawer.cpp:26 Function 'CreatureDrawer::BlitCreature' has 11 parameters
+[Long Parameter List] source/rendering/drawers/entities/creature_drawer.cpp:35 Function 'CreatureDrawer::BlitCreature' has 11 parameters
+[Long Method] source/rendering/drawers/entities/creature_drawer.cpp:35 Function 'CreatureDrawer::BlitCreature' is 74 lines long
+[Long Parameter List] source/rendering/drawers/entities/sprite_drawer.cpp:31 Function 'SpriteDrawer::glBlitAtlasQuad' has 8 parameters
+[Long Parameter List] source/rendering/drawers/entities/sprite_drawer.cpp:47 Function 'SpriteDrawer::glBlitSquare' has 8 parameters
+[Long Parameter List] source/rendering/drawers/entities/sprite_drawer.cpp:64 Function 'SpriteDrawer::glDrawBox' has 9 parameters
+[Long Parameter List] source/rendering/drawers/entities/sprite_drawer.cpp:81 Function 'SpriteDrawer::BlitSprite' has 8 parameters
+[Long Parameter List] source/rendering/drawers/entities/sprite_drawer.cpp:90 Function 'SpriteDrawer::BlitSprite' has 8 parameters
+[Long Parameter List] source/rendering/drawers/entities/item_drawer.cpp:33 Function 'ItemDrawer::BlitItem' has 13 parameters
+[Long Parameter List] source/rendering/drawers/entities/item_drawer.cpp:38 Function 'ItemDrawer::BlitItem' has 14 parameters
+[Switch Statement] source/rendering/drawers/entities/item_drawer.cpp:74
+[Long Method] source/rendering/drawers/entities/item_drawer.cpp:38 Function 'ItemDrawer::BlitItem' is 192 lines long
+[Long Parameter List] source/rendering/drawers/entities/item_drawer.cpp:232 Function 'ItemDrawer::DrawRawBrush' has 9 parameters
+[Switch Statement] source/rendering/drawers/entities/item_drawer.cpp:236
+[Long Parameter List] source/rendering/drawers/cursors/brush_cursor_drawer.cpp:14 Function 'BrushCursorDrawer::draw' has 8 parameters
+[Long Method] source/rendering/drawers/cursors/brush_cursor_drawer.cpp:14 Function 'BrushCursorDrawer::draw' is 73 lines long
+[Long Parameter List] source/rendering/drawers/cursors/drag_shadow_drawer.cpp:35 Function 'DragShadowDrawer::draw' has 7 parameters
+[Long Method] source/rendering/drawers/cursors/drag_shadow_drawer.cpp:35 Function 'DragShadowDrawer::draw' is 60 lines long
+[Long Parameter List] source/rendering/core/editor_sprite.cpp:18 Function 'EditorSprite::DrawTo' has 6 parameters
+[Large Class/File] source/rendering/core/game_sprite.cpp: 793 lines
+[Long Parameter List] source/rendering/core/game_sprite.cpp:31 Function 'CreatureSprite::DrawTo' has 6 parameters
+[Long Parameter List] source/rendering/core/game_sprite.cpp:127 Function 'GameSprite::getIndex' has 7 parameters
+[Long Parameter List] source/rendering/core/game_sprite.cpp:276 Function 'GameSprite::DrawTo' has 6 parameters
+[Long Parameter List] source/rendering/core/game_sprite.cpp:298 Function 'GameSprite::DrawTo' has 7 parameters
+[Long Method] source/rendering/core/sprite_preloader.cpp:57 Function 'SpritePreloader::preload' is 59 lines long
+[Long Method] source/rendering/core/sprite_preloader.cpp:155 Function 'SpritePreloader::update' is 57 lines long
+[Long Method] source/rendering/core/texture_atlas.cpp:96 Function 'TextureAtlas::addLayer' is 52 lines long
+[Long Method] source/rendering/core/texture_atlas.cpp:150 Function 'TextureAtlas::addSprite' is 81 lines long
+[Long Parameter List] source/rendering/core/coordinate_mapper.cpp:12 Function 'CoordinateMapper::ScreenToMap' has 9 parameters
+[Long Parameter List] source/rendering/core/text_renderer.cpp:88 Function 'TextRenderer::DrawText' has 6 parameters
+[Long Parameter List] source/rendering/core/text_renderer.cpp:100 Function 'TextRenderer::DrawTextBox' has 7 parameters
+[Long Parameter List] source/rendering/core/text_renderer.cpp:112 Function 'TextRenderer::DrawRect' has 6 parameters
+[Long Method] source/rendering/core/sprite_batch.cpp:55 Function 'SpriteBatch::initialize' is 71 lines long
+[Long Parameter List] source/rendering/core/sprite_batch.cpp:169 Function 'SpriteBatch::draw' has 9 parameters
+[Long Parameter List] source/rendering/core/sprite_batch.cpp:192 Function 'SpriteBatch::drawRect' has 6 parameters
+[Long Parameter List] source/rendering/core/sprite_batch.cpp:199 Function 'SpriteBatch::drawRectLines' has 6 parameters
+[Long Method] source/rendering/core/sprite_batch.cpp:210 Function 'SpriteBatch::flush' is 122 lines long
+[Switch Statement] source/rendering/ui/clipboard_handler.cpp:73
+[Long Method] source/rendering/ui/drawing_controller.cpp:43 Function 'DrawingController::HandleClick' is 143 lines long
+[Long Method] source/rendering/ui/drawing_controller.cpp:188 Function 'DrawingController::HandleDrag' is 89 lines long
+[Long Method] source/rendering/ui/drawing_controller.cpp:279 Function 'DrawingController::HandleRelease' is 121 lines long
+[Large Class/File] source/rendering/ui/map_display.cpp: 667 lines
+[Long Method] source/rendering/ui/map_display.cpp:181 Function 'MapCanvas::OnPaint' is 155 lines long
+[Long Method] source/rendering/ui/minimap_window.cpp:102 Function 'MinimapWindow::OnPaint' is 67 lines long
+[Switch Statement] source/rendering/ui/keyboard_handler.cpp:30
+[Long Method] source/rendering/ui/keyboard_handler.cpp:29 Function 'KeyboardHandler::OnKeyDown' is 89 lines long
+[Long Method] source/rendering/ui/keyboard_handler.cpp:167 Function 'KeyboardHandler::HandleHotkeys' is 57 lines long
+[Large Class/File] source/rendering/ui/tooltip_drawer.cpp: 607 lines
+[Switch Statement] source/rendering/ui/tooltip_drawer.cpp:92
+[Long Method] source/rendering/ui/tooltip_drawer.cpp:122 Function 'TooltipDrawer::getSpriteImage' is 99 lines long
+[Long Method] source/rendering/ui/tooltip_drawer.cpp:223 Function 'TooltipDrawer::prepareFields' is 54 lines long
+[Long Parameter List] source/rendering/ui/tooltip_drawer.cpp:279 Function 'TooltipDrawer::calculateLayout' has 6 parameters
+[Long Method] source/rendering/ui/tooltip_drawer.cpp:279 Function 'TooltipDrawer::calculateLayout' is 127 lines long
+[Long Parameter List] source/rendering/ui/tooltip_drawer.cpp:408 Function 'TooltipDrawer::drawBackground' has 7 parameters
+[Long Parameter List] source/rendering/ui/tooltip_drawer.cpp:440 Function 'TooltipDrawer::drawFields' has 7 parameters
+[Long Method] source/rendering/ui/tooltip_drawer.cpp:470 Function 'TooltipDrawer::drawContainerGrid' is 85 lines long
+[Long Method] source/rendering/ui/selection_controller.cpp:34 Function 'SelectionController::HandleClick' is 111 lines long
+[Long Method] source/rendering/ui/selection_controller.cpp:174 Function 'SelectionController::HandleRelease' is 62 lines long
+[Switch Statement] source/rendering/ui/selection_controller.cpp:342
+[Long Method] source/rendering/ui/selection_controller.cpp:323 Function 'SelectionController::ExecuteBoundboxSelection' is 110 lines long
+[Large Class/File] source/ext/pugixml.cpp: 10155 lines
+[Switch Statement] source/ext/pugixml.cpp:1599
+[Switch Statement] source/ext/pugixml.cpp:1833
+[Switch Statement] source/ext/pugixml.cpp:1986
+[Long Method] source/ext/pugixml.cpp:2186 Function 'parse_exclamation' is 109 lines long
+[Long Method] source/ext/pugixml.cpp:2297 Function 'parse_question' is 85 lines long
+[Long Method] source/ext/pugixml.cpp:2384 Function 'parse' is 233 lines long
+[Long Parameter List] source/ext/pugixml.cpp:2953 Function 'write' has 6 parameters
+[Switch Statement] source/ext/pugixml.cpp:3006
+[Switch Statement] source/ext/pugixml.cpp:3090
+[Switch Statement] source/ext/pugixml.cpp:3248
+[Switch Statement] source/ext/pugixml.cpp:4154
+[Switch Statement] source/ext/pugixml.cpp:4166
+[Switch Statement] source/ext/pugixml.cpp:4773
+[Switch Statement] source/ext/pugixml.cpp:5111
+[Long Parameter List] source/ext/pugixml.cpp:5564 Function 'partition' has 6 parameters
+[Long Method] source/ext/pugixml.cpp:5564 Function 'partition' is 60 lines long
+[Switch Statement] source/ext/pugixml.cpp:6035
+[Long Method] source/ext/pugixml.cpp:6160 Function 'operator' is 53 lines long
+[Switch Statement] source/ext/pugixml.cpp:6263
+[Switch Statement] source/ext/pugixml.cpp:6710
+[Switch Statement] source/ext/pugixml.cpp:6735
+[Switch Statement] source/ext/pugixml.cpp:6809
+[Switch Statement] source/ext/pugixml.cpp:7007
+[Long Method] source/ext/pugixml.cpp:6997 Function 'next' is 250 lines long
+[Switch Statement] source/ext/pugixml.cpp:7579
+[Switch Statement] source/ext/pugixml.cpp:7606
+[Long Method] source/ext/pugixml.cpp:7601 Function 'step_push' is 55 lines long
+[Switch Statement] source/ext/pugixml.cpp:7662
+[Long Method] source/ext/pugixml.cpp:7659 Function 'step_fill' is 171 lines long
+[Switch Statement] source/ext/pugixml.cpp:7836
+[Long Method] source/ext/pugixml.cpp:7833 Function 'step_fill' is 70 lines long
+[Switch Statement] source/ext/pugixml.cpp:7993
+[Switch Statement] source/ext/pugixml.cpp:8089
+[Long Method] source/ext/pugixml.cpp:7992 Function 'eval_boolean' is 119 lines long
+[Switch Statement] source/ext/pugixml.cpp:8114
+[Switch Statement] source/ext/pugixml.cpp:8211
+[Long Method] source/ext/pugixml.cpp:8113 Function 'eval_number' is 120 lines long
+[Long Method] source/ext/pugixml.cpp:8235 Function 'eval_string_concat' is 53 lines long
+[Switch Statement] source/ext/pugixml.cpp:8291
+[Switch Statement] source/ext/pugixml.cpp:8476
+[Long Method] source/ext/pugixml.cpp:8290 Function 'eval_string' is 208 lines long
+[Switch Statement] source/ext/pugixml.cpp:8501
+[Switch Statement] source/ext/pugixml.cpp:8537
+[Long Method] source/ext/pugixml.cpp:8500 Function 'eval_node_set' is 121 lines long
+[Switch Statement] source/ext/pugixml.cpp:8624
+[Switch Statement] source/ext/pugixml.cpp:8733
+[Long Method] source/ext/pugixml.cpp:8732 Function 'parse_function' is 119 lines long
+[Switch Statement] source/ext/pugixml.cpp:8856
+[Long Method] source/ext/pugixml.cpp:8853 Function 'parse_axis_name' is 71 lines long
+[Switch Statement] source/ext/pugixml.cpp:8927
+[Switch Statement] source/ext/pugixml.cpp:8965
+[Long Method] source/ext/pugixml.cpp:8964 Function 'parse_primary_expression' is 102 lines long
+[Long Method] source/ext/pugixml.cpp:9102 Function 'parse_step' is 137 lines long
+[Switch Statement] source/ext/pugixml.cpp:9756
+[Long Method] source/brushes/brush.cpp:107 Function 'Brushes::unserializeBrush' is 75 lines long
+[Long Parameter List] source/brushes/brush_utility.cpp:18 Function 'BrushUtility::GetTilesToDraw' has 6 parameters
+[Long Method] source/brushes/brush_utility.cpp:18 Function 'BrushUtility::GetTilesToDraw' is 68 lines long
+[Long Parameter List] source/brushes/brush_utility.cpp:88 Function 'BrushUtility::FloodFill' has 6 parameters
+[Long Method] source/brushes/brush_utility.cpp:88 Function 'BrushUtility::FloodFill' is 51 lines long
+[Long Method] source/brushes/table/table_brush_loader.cpp:19 Function 'TableBrushLoader::load' is 67 lines long
+[Long Method] source/brushes/table/table_border_calculator.cpp:31 Function 'TableBorderCalculator::doTables' is 67 lines long
+[Long Method] source/brushes/managers/doodad_preview_manager.cpp:28 Function 'DoodadPreviewManager::FillBuffer' is 145 lines long
+[Long Method] source/brushes/wall/wall_brush_loader.cpp:74 Function 'WallBrushLoader::load' is 168 lines long
+[Long Method] source/brushes/wall/wall_brush.cpp:36 Function 'WallBrush::draw' is 73 lines long
+[Long Method] source/brushes/wall/wall_brush.cpp:166 Function 'WallDecorationBrush::draw' is 89 lines long
+[Long Method] source/brushes/wall/wall_border_calculator.cpp:36 Function 'WallBorderCalculator::doWalls' is 169 lines long
+[Long Method] source/brushes/carpet/carpet_brush_loader.cpp:20 Function 'CarpetBrushLoader::load' is 96 lines long
+[Long Method] source/brushes/carpet/carpet_border_calculator.cpp:28 Function 'CarpetBorderCalculator::calculate' is 51 lines long
+[Long Method] source/brushes/ground/ground_brush_loader.cpp:20 Function 'GroundBrushLoader::load' is 396 lines long
+[Long Method] source/brushes/ground/ground_border_calculator.cpp:16 Function 'GroundBorderCalculator::calculate' is 388 lines long
+[Long Method] source/brushes/ground/auto_border.cpp:42 Function 'AutoBorder::load' is 59 lines long
+[Long Method] source/brushes/doodad/doodad_brush_loader.cpp:28 Function 'DoodadBrushLoader::load' is 70 lines long
+[Long Method] source/brushes/doodad/doodad_brush_loader.cpp:100 Function 'DoodadBrushLoader::loadAlternative' is 107 lines long
+[Long Method] source/brushes/door/door_brush.cpp:165 Function 'DoorBrush::draw' is 117 lines long
+[Switch Statement] source/palette/palette_common.cpp:99
+[Switch Statement] source/palette/palette_window.cpp:259
+[Long Method] source/palette/palette_window.cpp:254 Function 'PaletteWindow::OnSelectBrush' is 88 lines long
+[Long Method] source/palette/house/edit_house_dialog.cpp:120 Function 'EditHouseDialog::OnClickOK' is 65 lines long
+[Long Method] source/palette/house/house_palette.cpp:150 Function 'HousePalette::FilterHouses' is 52 lines long
+[Switch Statement] source/palette/panels/brush_panel.cpp:69
+[Long Method] source/palette/controls/virtual_brush_grid.cpp:90 Function 'VirtualBrushGrid::DrawBrushItem' is 91 lines long
+[Long Method] source/map/otml.cpp:230 Function 'OTMLEmitter::emitNode' is 53 lines long
+[Long Method] source/map/otml.cpp:344 Function 'OTMLParser::parseNode' is 71 lines long
+[Large Class/File] source/map/tile.cpp: 659 lines
+[Long Method] source/map/tile.cpp:453 Function 'Tile::update' is 64 lines long
+[Long Parameter List] source/map/tile.cpp:656 Function 'std::equal' has 6 parameters
+[Long Parameter List] source/map/spatial_hash_grid.h:93 Function 'visitLeavesByViewport' has 9 parameters
+[Long Parameter List] source/map/spatial_hash_grid.h:140 Function 'visitLeavesByCells' has 9 parameters
+[Long Method] source/map/spatial_hash_grid.h:140 Function 'visitLeavesByCells' is 58 lines long
+[Long Method] source/map/map_statistics.cpp:10 Function 'MapStatisticsCollector::Collect' is 111 lines long
+[Long Method] source/map/tileset.cpp:87 Function 'Tileset::loadCategory' is 72 lines long
+[Long Method] source/map/tileset.cpp:176 Function 'TilesetCategory::loadBrush' is 94 lines long
+[Long Parameter List] source/map/map_search.cpp:98 Function 'MapSearchUtility::SearchItems' has 6 parameters
+[Long Method] source/map/map_search.cpp:98 Function 'MapSearchUtility::SearchItems' is 73 lines long
+[Long Method] source/map/map.cpp:127 Function 'Map::convert' is 132 lines long
+[Long Method] source/ui/dcbutton.cpp:123 Function 'DCButton::OnNanoVGPaint' is 60 lines long
+[Switch Statement] source/ui/theme.h:27
+[Long Method] source/ui/map_popup_menu.cpp:42 Function 'MapPopupMenu::Update' is 199 lines long
+[Large Class/File] source/ui/tool_options_surface.cpp: 526 lines
+[Long Parameter List] source/ui/tool_options_surface.cpp:70 Function 'ToolOptionsSurface::DoSetSizeHints' has 6 parameters
+[Long Method] source/ui/tool_options_surface.cpp:74 Function 'ToolOptionsSurface::RebuildLayout' is 113 lines long
+[Long Parameter List] source/ui/tool_options_surface.cpp:272 Function 'ToolOptionsSurface::DrawSlider' has 7 parameters
+[Long Method] source/ui/tool_options_surface.cpp:342 Function 'ToolOptionsSurface::OnMouse' is 126 lines long
+[Long Method] source/ui/map_statistics_dialog.cpp:21 Function 'MapStatisticsDialog::Show' is 98 lines long
+[Long Method] source/ui/dialog_helper.cpp:24 Function 'DialogHelper::OpenProperties' is 57 lines long
+[Long Method] source/ui/main_frame.cpp:211 Function 'MainFrame::DoQuerySave' is 66 lines long
+[Long Method] source/ui/replace_items_window.cpp:330 Function 'ReplaceItemsDialog::OnExecuteButtonClicked' is 59 lines long
+[Long Method] source/ui/live_dialogs.cpp:20 Function 'LiveDialogs::ShowHostDialog' is 81 lines long
+[Long Method] source/ui/live_dialogs.cpp:103 Function 'LiveDialogs::ShowJoinDialog' is 81 lines long
+[Large Class/File] source/ui/main_menubar.cpp: 560 lines
+[Long Parameter List] source/ui/menubar_loader.cpp:12 Function 'MenuBarLoader::Load' has 9 parameters
+[Long Parameter List] source/ui/menubar_loader.cpp:53 Function 'MenuBarLoader::LoadItem' has 9 parameters
+[Long Method] source/ui/menubar_loader.cpp:53 Function 'MenuBarLoader::LoadItem' is 87 lines long
+[Long Method] source/ui/find_item_window.cpp:284 Function 'FindItemDialog::RefreshContentsInternal' is 134 lines long
+[Long Parameter List] source/ui/dialog_util.cpp:13 Function 'DialogUtil::PopupDialog' has 6 parameters
+[Long Method] source/ui/replace_tool/rule_list_control.cpp:54 Function 'RuleListControl::OnNanoVGPaint' is 72 lines long
+[Large Class/File] source/ui/replace_tool/replace_tool_window.cpp: 523 lines
+[Long Method] source/ui/replace_tool/replace_tool_window.cpp:101 Function 'ReplaceToolWindow::InitLayout' is 194 lines long
+[Long Method] source/ui/replace_tool/replace_tool_window.cpp:352 Function 'ReplaceToolWindow::OnExecute' is 61 lines long
+[Long Method] source/ui/replace_tool/replace_tool_window.cpp:415 Function 'ReplaceToolWindow::OnAddVisibleTiles' is 61 lines long
+[Long Method] source/ui/replace_tool/card_panel.cpp:46 Function 'CardPanel::OnNanoVGPaint' is 136 lines long
+[Long Method] source/ui/replace_tool/library_panel.cpp:39 Function 'LibraryPanel::InitLayout' is 64 lines long
+[Long Method] source/ui/replace_tool/visual_similarity_service.cpp:237 Function 'VisualSimilarityService::FindSimilar' is 115 lines long
+[Long Method] source/ui/replace_tool/rule_builder_panel.cpp:36 Function 'RuleBuilderPanel::ItemDropTarget::OnDropText' is 66 lines long
+[Long Method] source/ui/replace_tool/rule_builder_panel.cpp:256 Function 'RuleBuilderPanel::OnMouse' is 55 lines long
+[Long Method] source/ui/replace_tool/rule_builder_panel.cpp:313 Function 'RuleBuilderPanel::HitTest' is 98 lines long
+[Long Parameter List] source/ui/replace_tool/rule_card_renderer.cpp:88 Function 'RuleCardRenderer::DrawRuleCard' has 9 parameters
+[Long Method] source/ui/replace_tool/rule_card_renderer.cpp:88 Function 'RuleCardRenderer::DrawRuleCard' is 109 lines long
+[Long Parameter List] source/ui/replace_tool/rule_card_renderer.cpp:252 Function 'RuleCardRenderer::DrawRuleItemCard' has 11 parameters
+[Long Method] source/ui/replace_tool/rule_card_renderer.cpp:252 Function 'RuleCardRenderer::DrawRuleItemCard' is 80 lines long
+[Long Method] source/ui/replace_tool/replacement_engine.cpp:47 Function 'ReplacementEngine::ExecuteReplacement' is 89 lines long
+[Long Method] source/ui/toolbar/brush_toolbar.cpp:66 Function 'BrushToolBar::Update' is 59 lines long
+[Switch Statement] source/ui/toolbar/brush_toolbar.cpp:132
+[Long Method] source/ui/toolbar/brush_toolbar.cpp:127 Function 'BrushToolBar::OnToolbarClick' is 51 lines long
+[Switch Statement] source/ui/toolbar/toolbar_registry.cpp:64
+[Switch Statement] source/ui/toolbar/size_toolbar.cpp:111
+[Switch Statement] source/ui/toolbar/standard_toolbar.cpp:96
+[Long Method] source/ui/dialogs/outfit_selection_grid.cpp:141 Function 'OutfitSelectionGrid::OnNanoVGPaint' is 100 lines long
+[Switch Statement] source/ui/dialogs/find_dialog.cpp:90
+[Long Method] source/ui/dialogs/find_dialog.cpp:178 Function 'FindBrushDialog::OnClickOKInternal' is 61 lines long
+[Long Method] source/ui/dialogs/find_dialog.cpp:241 Function 'FindBrushDialog::RefreshContentsInternal' is 61 lines long
+[Long Method] source/ui/managers/layout_manager.cpp:32 Function 'LayoutManager::LoadPerspective' is 148 lines long
+[Switch Statement] source/ui/properties/properties_window.cpp:265
+[Switch Statement] source/ui/properties/attribute_service.cpp:17
+[Long Parameter List] source/ui/controls/modern_button.cpp:38 Function 'ModernButton::DoSetSizeHints' has 6 parameters
+[Switch Statement] source/ui/map/map_properties_window.cpp:39
+[Long Method] source/ui/map/towns_window.cpp:141 Function 'EditTownsDialog::UpdateSelection' is 63 lines long
+[Long Method] source/ui/map/towns_window.cpp:267 Function 'EditTownsDialog::OnClickOK' is 68 lines long
+[Switch Statement] source/ui/map/import_map_window.cpp:124
+[Switch Statement] source/ui/map/import_map_window.cpp:133
+[Switch Statement] source/ui/menubar/view_settings_handler.cpp:29
+[Long Method] source/ui/menubar/view_settings_handler.cpp:11 Function 'ViewSettingsHandler::LoadValues' is 62 lines long
+[Long Method] source/ui/menubar/view_settings_handler.cpp:75 Function 'ViewSettingsHandler::OnChangeViewSettings' is 57 lines long
+[Switch Statement] source/ui/menubar/view_settings_handler.cpp:138
+[Long Method] source/ui/menubar/menubar_action_manager.cpp:12 Function 'MenuBarActionManager::RegisterActions' is 164 lines long
+[Long Method] source/ui/menubar/menubar_action_manager.cpp:178 Function 'MenuBarActionManager::UpdateState' is 112 lines long
+[Switch Statement] source/editor/action.cpp:121
+[Long Method] source/editor/action.cpp:116 Function 'Action::commit' is 141 lines long
+[Switch Statement] source/editor/action.cpp:269
+[Long Method] source/editor/action.cpp:259 Function 'Action::undo' is 128 lines long
+[Long Method] source/editor/action_queue.cpp:54 Function 'ActionQueue::addBatch' is 53 lines long
+[Long Method] source/editor/managers/editor_manager.cpp:276 Function 'EditorManager::LoadMap' is 68 lines long
+[Long Method] source/editor/operations/map_version_changer.cpp:39 Function 'MapVersionChanger::changeMapVersion' is 70 lines long
+[Large Class/File] source/editor/operations/draw_operations.cpp: 545 lines
+[Long Method] source/editor/operations/draw_operations.cpp:28 Function 'DrawOperations::draw' is 169 lines long
+[Long Method] source/editor/operations/draw_operations.cpp:199 Function 'DrawOperations::draw' is 63 lines long
+[Long Method] source/editor/operations/draw_operations.cpp:264 Function 'DrawOperations::draw' is 281 lines long
+[Long Method] source/editor/operations/copy_operations.cpp:72 Function 'CopyOperations::cut' is 96 lines long
+[Long Method] source/editor/operations/copy_operations.cpp:170 Function 'CopyOperations::paste' is 129 lines long
+[Long Method] source/editor/operations/selection_operations.cpp:87 Function 'SelectionOperations::moveSelection' is 247 lines long
+[Long Method] source/editor/operations/selection_operations.cpp:336 Function 'SelectionOperations::destroySelection' is 78 lines long
+[Long Method] source/editor/persistence/tileset_exporter.cpp:13 Function 'TilesetExporter::exportTilesets' is 77 lines long
+[Large Class/File] source/editor/persistence/editor_persistence.cpp: 565 lines
+[Long Method] source/editor/persistence/editor_persistence.cpp:44 Function 'EditorPersistence::saveMap' is 195 lines long
+[Long Parameter List] source/editor/persistence/editor_persistence.cpp:241 Function 'EditorPersistence::importMap' has 6 parameters
+[Switch Statement] source/editor/persistence/editor_persistence.cpp:281
+[Switch Statement] source/editor/persistence/editor_persistence.cpp:342
+[Switch Statement] source/editor/persistence/editor_persistence.cpp:418
+[Long Method] source/editor/persistence/editor_persistence.cpp:241 Function 'EditorPersistence::importMap' is 320 lines long
+[Long Parameter List] source/editor/persistence/editor_persistence.cpp:563 Function 'EditorPersistence::importMiniMap' has 6 parameters
+[Switch Statement] source/app/settings.cpp:139
+[Long Method] source/app/settings.cpp:152 Function 'Settings::IO' is 228 lines long
+[Large Class/File] source/app/preferences.cpp: 755 lines
+[Long Method] source/app/preferences.cpp:91 Function 'PreferencesWindow::CreateGeneralPage' is 71 lines long
+[Long Method] source/app/preferences.cpp:164 Function 'PreferencesWindow::CreateEditorPage' is 60 lines long
+[Long Method] source/app/preferences.cpp:226 Function 'PreferencesWindow::CreateGraphicsPage' is 131 lines long
+[Long Method] source/app/preferences.cpp:394 Function 'PreferencesWindow::CreateUIPage' is 110 lines long
+[Long Method] source/app/preferences.cpp:506 Function 'PreferencesWindow::CreateClientPage' is 69 lines long
+[Long Method] source/app/preferences.cpp:599 Function 'PreferencesWindow::Apply' is 156 lines long
+[Large Class/File] source/app/client_version.cpp: 574 lines
+[Long Method] source/app/client_version.cpp:37 Function 'ClientVersion::loadVersions' is 96 lines long
+[Long Method] source/app/client_version.cpp:175 Function 'ClientVersion::loadVersion' is 103 lines long
+[Long Method] source/app/client_version.cpp:416 Function 'ClientVersion::hasValidPaths' is 83 lines long
+[Long Method] source/app/application.cpp:68 Function 'Application::OnInit' is 189 lines long
+[Long Method] source/app/managers/version_manager.cpp:81 Function 'VersionManager::LoadDataFiles' is 87 lines long
+[Long Method] source/game/materials.cpp:87 Function 'Materials::loadExtensions' is 106 lines long
+[Long Method] source/game/materials.cpp:232 Function 'Materials::createOtherTileset' is 65 lines long
+[Large Class/File] source/game/item.cpp: 531 lines
+[Long Method] source/game/item.cpp:98 Function 'transformItem' is 53 lines long
+[Switch Statement] source/game/item.cpp:180
+[Long Method] source/game/item.cpp:178 Function 'Item::hasProperty' is 54 lines long
+[Switch Statement] source/game/item.cpp:364
+[Switch Statement] source/game/item.cpp:429
+[Long Method] source/game/item.cpp:428 Function 'Item::LiquidID2Name' is 51 lines long
+[Large Class/File] source/game/items.cpp: 791 lines
+[Long Method] source/game/items.cpp:155 Function 'ItemDatabase::loadFromOtbGeneric' is 267 lines long
+[Long Method] source/game/items.cpp:424 Function 'ItemDatabase::loadFromOtb' is 72 lines long
+[Long Method] source/game/items.cpp:574 Function 'ItemDatabase::loadItemFromGameXml' is 134 lines long
+[Long Method] source/game/creatures.cpp:64 Function 'CreatureType::loadFromXML' is 77 lines long
+[Long Method] source/game/creatures.cpp:143 Function 'CreatureType::loadFromOTXML' is 82 lines long
+[Long Method] source/game/creatures.cpp:323 Function 'CreatureDatabase::importXMLFromOT' is 87 lines long
+[Switch Statement] source/game/item_attributes.cpp:288
+[Long Method] source/game/item_attributes.cpp:282 Function 'ItemAttribute::unserialize' is 58 lines long
+[Switch Statement] source/game/item_attributes.cpp:347
+[Switch Statement] source/game/creature.cpp:39

--- a/source/brushes/ground/ground_brush_loader.cpp
+++ b/source/brushes/ground/ground_brush_loader.cpp
@@ -42,369 +42,19 @@ bool GroundBrushLoader::load(GroundBrush& brush, pugi::xml_node node, std::vecto
 	for (pugi::xml_node childNode : node.children()) {
 		std::string_view childName = childNode.name();
 		if (std::ranges::equal(childName, std::string_view("item"), iequal)) {
-			uint16_t itemId = childNode.attribute("id").as_ushort();
-			int32_t chance = 1;
-			if (auto attribute = childNode.attribute("chance")) {
-				chance = attribute.as_int();
-			}
-
-			if (chance < 0) {
-				warnings.push_back("\nChance for ground item " + std::to_string(itemId) + " is negative, defaulting to 0.");
-				chance = 0;
-			}
-
-			ItemType& it = g_items[itemId];
-			if (it.id == 0) {
-				warnings.push_back("\nInvalid item id " + std::to_string(itemId));
-				return false;
-			}
-
-			if (!it.isGroundTile()) {
-				warnings.push_back("\nItem " + std::to_string(itemId) + " is not ground item.");
-				return false;
-			}
-
-			if (it.brush && it.brush != &brush) {
-				warnings.push_back("\nItem " + std::to_string(itemId) + " can not be member of two brushes");
-				return false;
-			}
-
-			it.brush = &brush;
-			brush.total_chance += chance;
-
-			GroundBrush::ItemChanceBlock ci;
-			ci.id = itemId;
-			ci.chance = brush.total_chance;
-			brush.border_items.push_back(ci);
+			if (!loadItem(brush, childNode, warnings)) return false;
 		} else if (std::ranges::equal(childName, std::string_view("optional"), iequal)) {
-			// Mountain border!
-			if (brush.optional_border) {
-				warnings.push_back("\nDuplicate optional borders!");
-				continue;
-			}
-
-			if ((attribute = childNode.attribute("ground_equivalent"))) {
-				uint16_t ground_equivalent = attribute.as_ushort();
-
-				// Load from inline definition
-				ItemType& it = g_items[ground_equivalent];
-				if (it.id == 0) {
-					warnings.push_back("Invalid id of ground dependency equivalent item.\n");
-					continue;
-				} else if (!it.isGroundTile()) {
-					warnings.push_back("Ground dependency equivalent is not a ground item.\n");
-					continue;
-				} else if (it.brush && it.brush != &brush) {
-					warnings.push_back("Ground dependency equivalent does not use the same brush as ground border.\n");
-					continue;
-				}
-
-				auto autoBorder = std::make_unique<AutoBorder>(0);
-				autoBorder->ground = true;
-				autoBorder->load(childNode, warnings, &brush, ground_equivalent);
-				brush.owned_optional_border = std::move(autoBorder);
-				brush.optional_border = brush.owned_optional_border.get();
-			} else {
-				// Load from ID
-				if (!(attribute = childNode.attribute("id"))) {
-					warnings.push_back("\nMissing tag id for border node");
-					continue;
-				}
-
-				uint16_t id = attribute.as_ushort();
-				auto it = g_brushes.borders.find(id);
-				if (it == g_brushes.borders.end() || !it->second) {
-					warnings.push_back("\nCould not find border id " + std::to_string(id));
-					continue;
-				}
-
-				brush.optional_border = it->second.get();
-			}
+			loadOptional(brush, childNode, warnings);
 		} else if (std::ranges::equal(childName, std::string_view("border"), iequal)) {
-			std::unique_ptr<AutoBorder> newAutoBorder;
-			AutoBorder* autoBorderPtr = nullptr;
-
-			if (!(attribute = childNode.attribute("id"))) {
-				if (!(attribute = childNode.attribute("ground_equivalent"))) {
-					continue;
-				}
-
-				uint16_t ground_equivalent = attribute.as_ushort();
-				ItemType& it = g_items[ground_equivalent];
-				bool valid = true;
-				if (it.id == 0) {
-					warnings.push_back("Invalid id of ground dependency equivalent item.\n");
-					valid = false;
-				} else if (!it.isGroundTile()) { // Changed to else if to avoid duplicate warnings
-					warnings.push_back("Ground dependency equivalent is not a ground item.\n");
-					valid = false;
-				} else if (it.brush && it.brush != &brush) {
-					warnings.push_back("Ground dependency equivalent does not use the same brush as ground border.\n");
-					valid = false;
-				}
-
-				if (valid) {
-					newAutoBorder = std::make_unique<AutoBorder>(0);
-					newAutoBorder->ground = true;
-					newAutoBorder->load(childNode, warnings, &brush, ground_equivalent);
-					autoBorderPtr = newAutoBorder.get();
-				} else {
-					continue;
-				}
-			} else {
-				int32_t id = attribute.as_int();
-				if (id == 0) {
-					autoBorderPtr = nullptr;
-				} else {
-					auto it = g_brushes.borders.find(id);
-					if (it == g_brushes.borders.end() || !it->second) {
-						warnings.push_back("\nCould not find border id " + std::to_string(id));
-						continue;
-					}
-					autoBorderPtr = it->second.get();
-				}
-			}
-
-			auto borderBlock = std::make_unique<GroundBrush::BorderBlock>();
-			borderBlock->super = false;
-			borderBlock->outer = true;
-			if (newAutoBorder) {
-				borderBlock->owned_autoborder = std::move(newAutoBorder);
-			}
-			borderBlock->autoborder = autoBorderPtr;
-
-			if ((attribute = childNode.attribute("to"))) {
-				const std::string_view value = attribute.as_string();
-				if (value == "all") {
-					borderBlock->to = 0xFFFFFFFF;
-				} else if (value == "none") {
-					borderBlock->to = 0;
-				} else {
-					Brush* tobrush = g_brushes.getBrush(value);
-					if (!tobrush) {
-						warnings.push_back((wxString("To brush ") + wxstr(value) + " doesn't exist.").ToStdString());
-						// newAutoBorder is automatically deleted if borderBlock is destroyed or reset (RAII via std::unique_ptr)
-						continue;
-					}
-					borderBlock->to = tobrush->getID();
-				}
-			} else {
-				borderBlock->to = 0xFFFFFFFF;
-			}
-
-			if ((attribute = childNode.attribute("super")) && attribute.as_bool()) {
-				borderBlock->super = true;
-			}
-
-			if ((attribute = childNode.attribute("align"))) {
-				const std::string_view value = attribute.as_string();
-				if (value == "outer") {
-					borderBlock->outer = true;
-				} else if (value == "inner") {
-					borderBlock->outer = false;
-				} else {
-					borderBlock->outer = true;
-				}
-			}
-
-			if (borderBlock->outer) {
-				if (borderBlock->to == 0) {
-					brush.has_zilch_outer_border = true;
-				} else {
-					brush.has_outer_border = true;
-				}
-			} else {
-				if (borderBlock->to == 0) {
-					brush.has_zilch_inner_border = true;
-				} else {
-					brush.has_inner_border = true;
-				}
-			}
-
-			for (pugi::xml_node subChildNode : childNode.children()) {
-				if (!std::ranges::equal(std::string_view(subChildNode.name()), std::string_view("specific"), iequal)) {
-					continue;
-				}
-
-				std::unique_ptr<GroundBrush::SpecificCaseBlock> specificCaseBlock;
-				for (pugi::xml_node superChildNode : subChildNode.children()) {
-					std::string_view superChildName = superChildNode.name();
-					if (std::ranges::equal(superChildName, std::string_view("conditions"), iequal)) {
-						for (pugi::xml_node conditionChild : superChildNode.children()) {
-							std::string_view conditionName = conditionChild.name();
-							if (std::ranges::equal(conditionName, std::string_view("match_border"), iequal)) {
-								if (!(attribute = conditionChild.attribute("id"))) {
-									continue;
-								}
-
-								int32_t border_id = attribute.as_int();
-								if (!(attribute = conditionChild.attribute("edge"))) {
-									continue;
-								}
-
-								int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
-								auto it = g_brushes.borders.find(border_id);
-								if (it == g_brushes.borders.end()) {
-									warnings.push_back("Unknown border id in specific case match block " + std::to_string(border_id));
-									continue;
-								}
-
-								AutoBorder* autoBorder = it->second.get();
-								ASSERT(autoBorder != nullptr);
-
-								uint32_t match_itemid = autoBorder->tiles[edge_id];
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-								specificCaseBlock->items_to_match.push_back(match_itemid);
-							} else if (std::ranges::equal(conditionName, std::string_view("match_group"), iequal)) {
-								if (!(attribute = conditionChild.attribute("group"))) {
-									continue;
-								}
-
-								uint16_t group = attribute.as_ushort();
-								if (!(attribute = conditionChild.attribute("edge"))) {
-									continue;
-								}
-
-								int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-
-								specificCaseBlock->match_group = group;
-								specificCaseBlock->group_match_alignment = ::BorderType(edge_id);
-								specificCaseBlock->items_to_match.push_back(group);
-							} else if (std::ranges::equal(conditionName, std::string_view("match_item"), iequal)) {
-								if (!(attribute = conditionChild.attribute("id"))) {
-									continue;
-								}
-
-								int32_t match_itemid = attribute.as_int();
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-
-								specificCaseBlock->match_group = 0;
-								specificCaseBlock->items_to_match.push_back(match_itemid);
-							}
-						}
-					} else if (std::ranges::equal(superChildName, std::string_view("actions"), iequal)) {
-						for (pugi::xml_node actionChild : superChildNode.children()) {
-							std::string_view actionName = actionChild.name();
-							if (std::ranges::equal(actionName, std::string_view("replace_border"), iequal)) {
-								if (!(attribute = actionChild.attribute("id"))) {
-									continue;
-								}
-
-								int32_t border_id = attribute.as_int();
-								if (!(attribute = actionChild.attribute("edge"))) {
-									continue;
-								}
-
-								int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
-								if (!(attribute = actionChild.attribute("with"))) {
-									continue;
-								}
-
-								int32_t with_id = attribute.as_int();
-								auto itt = g_brushes.borders.find(border_id);
-								if (itt == g_brushes.borders.end()) {
-									warnings.push_back("Unknown border id in specific case match block " + std::to_string(border_id));
-									continue;
-								}
-
-								AutoBorder* autoBorder = itt->second.get();
-								ASSERT(autoBorder != nullptr);
-
-								ItemType& it = g_items[with_id];
-								if (it.id == 0) {
-									return false;
-								}
-
-								it.isBorder = true;
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-
-								specificCaseBlock->to_replace_id = autoBorder->tiles[edge_id];
-								specificCaseBlock->with_id = with_id;
-							} else if (std::ranges::equal(actionName, std::string_view("replace_item"), iequal)) {
-								if (!(attribute = actionChild.attribute("id"))) {
-									continue;
-								}
-
-								int32_t to_replace_id = attribute.as_int();
-								if (!(attribute = actionChild.attribute("with"))) {
-									continue;
-								}
-
-								int32_t with_id = attribute.as_int();
-								ItemType& it = g_items[with_id];
-								if (it.id == 0) {
-									return false;
-								}
-
-								it.isBorder = true;
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-
-								specificCaseBlock->to_replace_id = to_replace_id;
-								specificCaseBlock->with_id = with_id;
-							} else if (std::ranges::equal(actionName, std::string_view("delete_borders"), iequal)) {
-								if (!specificCaseBlock) {
-									specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
-								}
-								specificCaseBlock->delete_all = true;
-							}
-						}
-					}
-				}
-				if (specificCaseBlock) {
-					if ((attribute = subChildNode.attribute("keep_border"))) {
-						specificCaseBlock->keepBorder = attribute.as_bool();
-					}
-
-					borderBlock->specific_cases.push_back(std::move(specificCaseBlock));
-				}
-			}
-			brush.borders.push_back(std::move(borderBlock));
+			if (!loadBorder(brush, childNode, warnings)) return false;
 		} else if (std::ranges::equal(childName, std::string_view("friend"), iequal)) {
-			const std::string_view name = childNode.attribute("name").as_string();
-			if (!name.empty()) {
-				if (name == "all") {
-					brush.friends.push_back(0xFFFFFFFF);
-				} else {
-					Brush* otherBrush = g_brushes.getBrush(name);
-					if (otherBrush) {
-						brush.friends.push_back(otherBrush->getID());
-					} else {
-						warnings.push_back((wxString("Brush '") + wxstr(name) + "' is not defined.").ToStdString());
-					}
-				}
-			}
-			brush.hate_friends = false;
+			loadFriend(brush, childNode, warnings, false);
 		} else if (std::ranges::equal(childName, std::string_view("enemy"), iequal)) {
-			const std::string_view name = childNode.attribute("name").as_string();
-			if (!name.empty()) {
-				if (name == "all") {
-					brush.friends.push_back(0xFFFFFFFF);
-				} else {
-					Brush* otherBrush = g_brushes.getBrush(name);
-					if (otherBrush) {
-						brush.friends.push_back(otherBrush->getID());
-					} else {
-						warnings.push_back((wxString("Brush '") + wxstr(name) + "' is not defined.").ToStdString());
-					}
-				}
-			}
-			brush.hate_friends = true;
+			loadFriend(brush, childNode, warnings, true);
 		} else if (std::ranges::equal(childName, std::string_view("clear_borders"), iequal)) {
-			brush.borders.clear();
+			clearBorders(brush);
 		} else if (std::ranges::equal(childName, std::string_view("clear_friends"), iequal)) {
-			brush.friends.clear();
-			brush.hate_friends = false;
+			clearFriends(brush);
 		}
 	}
 
@@ -413,4 +63,369 @@ bool GroundBrushLoader::load(GroundBrush& brush, pugi::xml_node node, std::vecto
 	}
 
 	return true;
+}
+
+bool GroundBrushLoader::loadItem(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings) {
+	uint16_t itemId = node.attribute("id").as_ushort();
+	int32_t chance = 1;
+	if (auto attribute = node.attribute("chance")) {
+		chance = attribute.as_int();
+	}
+
+	if (chance < 0) {
+		warnings.push_back("\nChance for ground item " + std::to_string(itemId) + " is negative, defaulting to 0.");
+		chance = 0;
+	}
+
+	ItemType& it = g_items[itemId];
+	if (it.id == 0) {
+		warnings.push_back("\nInvalid item id " + std::to_string(itemId));
+		return false;
+	}
+
+	if (!it.isGroundTile()) {
+		warnings.push_back("\nItem " + std::to_string(itemId) + " is not ground item.");
+		return false;
+	}
+
+	if (it.brush && it.brush != &brush) {
+		warnings.push_back("\nItem " + std::to_string(itemId) + " can not be member of two brushes");
+		return false;
+	}
+
+	it.brush = &brush;
+	brush.total_chance += chance;
+
+	GroundBrush::ItemChanceBlock ci;
+	ci.id = itemId;
+	ci.chance = brush.total_chance;
+	brush.border_items.push_back(ci);
+	return true;
+}
+
+void GroundBrushLoader::loadOptional(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings) {
+	pugi::xml_attribute attribute;
+	// Mountain border!
+	if (brush.optional_border) {
+		warnings.push_back("\nDuplicate optional borders!");
+		return;
+	}
+
+	if ((attribute = node.attribute("ground_equivalent"))) {
+		uint16_t ground_equivalent = attribute.as_ushort();
+
+		// Load from inline definition
+		ItemType& it = g_items[ground_equivalent];
+		if (it.id == 0) {
+			warnings.push_back("Invalid id of ground dependency equivalent item.\n");
+			return;
+		} else if (!it.isGroundTile()) {
+			warnings.push_back("Ground dependency equivalent is not a ground item.\n");
+			return;
+		} else if (it.brush && it.brush != &brush) {
+			warnings.push_back("Ground dependency equivalent does not use the same brush as ground border.\n");
+			return;
+		}
+
+		auto autoBorder = std::make_unique<AutoBorder>(0);
+		autoBorder->ground = true;
+		autoBorder->load(node, warnings, &brush, ground_equivalent);
+		brush.owned_optional_border = std::move(autoBorder);
+		brush.optional_border = brush.owned_optional_border.get();
+	} else {
+		// Load from ID
+		if (!(attribute = node.attribute("id"))) {
+			warnings.push_back("\nMissing tag id for border node");
+			return;
+		}
+
+		uint16_t id = attribute.as_ushort();
+		auto it = g_brushes.borders.find(id);
+		if (it == g_brushes.borders.end() || !it->second) {
+			warnings.push_back("\nCould not find border id " + std::to_string(id));
+			return;
+		}
+
+		brush.optional_border = it->second.get();
+	}
+}
+
+bool GroundBrushLoader::loadBorder(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings) {
+	pugi::xml_attribute attribute;
+	std::unique_ptr<AutoBorder> newAutoBorder;
+	AutoBorder* autoBorderPtr = nullptr;
+
+	if (!(attribute = node.attribute("id"))) {
+		if (!(attribute = node.attribute("ground_equivalent"))) {
+			return true; // continue
+		}
+
+		uint16_t ground_equivalent = attribute.as_ushort();
+		ItemType& it = g_items[ground_equivalent];
+		bool valid = true;
+		if (it.id == 0) {
+			warnings.push_back("Invalid id of ground dependency equivalent item.\n");
+			valid = false;
+		} else if (!it.isGroundTile()) { // Changed to else if to avoid duplicate warnings
+			warnings.push_back("Ground dependency equivalent is not a ground item.\n");
+			valid = false;
+		} else if (it.brush && it.brush != &brush) {
+			warnings.push_back("Ground dependency equivalent does not use the same brush as ground border.\n");
+			valid = false;
+		}
+
+		if (valid) {
+			newAutoBorder = std::make_unique<AutoBorder>(0);
+			newAutoBorder->ground = true;
+			newAutoBorder->load(node, warnings, &brush, ground_equivalent);
+			autoBorderPtr = newAutoBorder.get();
+		} else {
+			return true; // continue
+		}
+	} else {
+		int32_t id = attribute.as_int();
+		if (id == 0) {
+			autoBorderPtr = nullptr;
+		} else {
+			auto it = g_brushes.borders.find(id);
+			if (it == g_brushes.borders.end() || !it->second) {
+				warnings.push_back("\nCould not find border id " + std::to_string(id));
+				return true; // continue
+			}
+			autoBorderPtr = it->second.get();
+		}
+	}
+
+	auto borderBlock = std::make_unique<GroundBrush::BorderBlock>();
+	borderBlock->super = false;
+	borderBlock->outer = true;
+	if (newAutoBorder) {
+		borderBlock->owned_autoborder = std::move(newAutoBorder);
+	}
+	borderBlock->autoborder = autoBorderPtr;
+
+	if ((attribute = node.attribute("to"))) {
+		const std::string_view value = attribute.as_string();
+		if (value == "all") {
+			borderBlock->to = 0xFFFFFFFF;
+		} else if (value == "none") {
+			borderBlock->to = 0;
+		} else {
+			Brush* tobrush = g_brushes.getBrush(value);
+			if (!tobrush) {
+				warnings.push_back((wxString("To brush ") + wxstr(value) + " doesn't exist.").ToStdString());
+				// newAutoBorder is automatically deleted if borderBlock is destroyed or reset (RAII via std::unique_ptr)
+				return true; // continue
+			}
+			borderBlock->to = tobrush->getID();
+		}
+	} else {
+		borderBlock->to = 0xFFFFFFFF;
+	}
+
+	if ((attribute = node.attribute("super")) && attribute.as_bool()) {
+		borderBlock->super = true;
+	}
+
+	if ((attribute = node.attribute("align"))) {
+		const std::string_view value = attribute.as_string();
+		if (value == "outer") {
+			borderBlock->outer = true;
+		} else if (value == "inner") {
+			borderBlock->outer = false;
+		} else {
+			borderBlock->outer = true;
+		}
+	}
+
+	if (borderBlock->outer) {
+		if (borderBlock->to == 0) {
+			brush.has_zilch_outer_border = true;
+		} else {
+			brush.has_outer_border = true;
+		}
+	} else {
+		if (borderBlock->to == 0) {
+			brush.has_zilch_inner_border = true;
+		} else {
+			brush.has_inner_border = true;
+		}
+	}
+
+	for (pugi::xml_node subChildNode : node.children()) {
+		if (!std::ranges::equal(std::string_view(subChildNode.name()), std::string_view("specific"), iequal)) {
+			continue;
+		}
+
+		std::unique_ptr<GroundBrush::SpecificCaseBlock> specificCaseBlock;
+		for (pugi::xml_node superChildNode : subChildNode.children()) {
+			std::string_view superChildName = superChildNode.name();
+			if (std::ranges::equal(superChildName, std::string_view("conditions"), iequal)) {
+				for (pugi::xml_node conditionChild : superChildNode.children()) {
+					std::string_view conditionName = conditionChild.name();
+					if (std::ranges::equal(conditionName, std::string_view("match_border"), iequal)) {
+						if (!(attribute = conditionChild.attribute("id"))) {
+							continue;
+						}
+
+						int32_t border_id = attribute.as_int();
+						if (!(attribute = conditionChild.attribute("edge"))) {
+							continue;
+						}
+
+						int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
+						auto it = g_brushes.borders.find(border_id);
+						if (it == g_brushes.borders.end()) {
+							warnings.push_back("Unknown border id in specific case match block " + std::to_string(border_id));
+							continue;
+						}
+
+						AutoBorder* autoBorder = it->second.get();
+						ASSERT(autoBorder != nullptr);
+
+						uint32_t match_itemid = autoBorder->tiles[edge_id];
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+						specificCaseBlock->items_to_match.push_back(match_itemid);
+					} else if (std::ranges::equal(conditionName, std::string_view("match_group"), iequal)) {
+						if (!(attribute = conditionChild.attribute("group"))) {
+							continue;
+						}
+
+						uint16_t group = attribute.as_ushort();
+						if (!(attribute = conditionChild.attribute("edge"))) {
+							continue;
+						}
+
+						int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+
+						specificCaseBlock->match_group = group;
+						specificCaseBlock->group_match_alignment = ::BorderType(edge_id);
+						specificCaseBlock->items_to_match.push_back(group);
+					} else if (std::ranges::equal(conditionName, std::string_view("match_item"), iequal)) {
+						if (!(attribute = conditionChild.attribute("id"))) {
+							continue;
+						}
+
+						int32_t match_itemid = attribute.as_int();
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+
+						specificCaseBlock->match_group = 0;
+						specificCaseBlock->items_to_match.push_back(match_itemid);
+					}
+				}
+			} else if (std::ranges::equal(superChildName, std::string_view("actions"), iequal)) {
+				for (pugi::xml_node actionChild : superChildNode.children()) {
+					std::string_view actionName = actionChild.name();
+					if (std::ranges::equal(actionName, std::string_view("replace_border"), iequal)) {
+						if (!(attribute = actionChild.attribute("id"))) {
+							continue;
+						}
+
+						int32_t border_id = attribute.as_int();
+						if (!(attribute = actionChild.attribute("edge"))) {
+							continue;
+						}
+
+						int32_t edge_id = AutoBorder::edgeNameToID(attribute.as_string());
+						if (!(attribute = actionChild.attribute("with"))) {
+							continue;
+						}
+
+						int32_t with_id = attribute.as_int();
+						auto itt = g_brushes.borders.find(border_id);
+						if (itt == g_brushes.borders.end()) {
+							warnings.push_back("Unknown border id in specific case match block " + std::to_string(border_id));
+							continue;
+						}
+
+						AutoBorder* autoBorder = itt->second.get();
+						ASSERT(autoBorder != nullptr);
+
+						ItemType& it = g_items[with_id];
+						if (it.id == 0) {
+							return false;
+						}
+
+						it.isBorder = true;
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+
+						specificCaseBlock->to_replace_id = autoBorder->tiles[edge_id];
+						specificCaseBlock->with_id = with_id;
+					} else if (std::ranges::equal(actionName, std::string_view("replace_item"), iequal)) {
+						if (!(attribute = actionChild.attribute("id"))) {
+							continue;
+						}
+
+						int32_t to_replace_id = attribute.as_int();
+						if (!(attribute = actionChild.attribute("with"))) {
+							continue;
+						}
+
+						int32_t with_id = attribute.as_int();
+						ItemType& it = g_items[with_id];
+						if (it.id == 0) {
+							return false;
+						}
+
+						it.isBorder = true;
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+
+						specificCaseBlock->to_replace_id = to_replace_id;
+						specificCaseBlock->with_id = with_id;
+					} else if (std::ranges::equal(actionName, std::string_view("delete_borders"), iequal)) {
+						if (!specificCaseBlock) {
+							specificCaseBlock = std::make_unique<GroundBrush::SpecificCaseBlock>();
+						}
+						specificCaseBlock->delete_all = true;
+					}
+				}
+			}
+		}
+		if (specificCaseBlock) {
+			if ((attribute = subChildNode.attribute("keep_border"))) {
+				specificCaseBlock->keepBorder = attribute.as_bool();
+			}
+
+			borderBlock->specific_cases.push_back(std::move(specificCaseBlock));
+		}
+	}
+	brush.borders.push_back(std::move(borderBlock));
+	return true;
+}
+
+void GroundBrushLoader::loadFriend(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings, bool hate) {
+	const std::string_view name = node.attribute("name").as_string();
+	if (!name.empty()) {
+		if (name == "all") {
+			brush.friends.push_back(0xFFFFFFFF);
+		} else {
+			Brush* otherBrush = g_brushes.getBrush(name);
+			if (otherBrush) {
+				brush.friends.push_back(otherBrush->getID());
+			} else {
+				warnings.push_back((wxString("Brush '") + wxstr(name) + "' is not defined.").ToStdString());
+			}
+		}
+	}
+	brush.hate_friends = hate;
+}
+
+void GroundBrushLoader::clearBorders(GroundBrush& brush) {
+	brush.borders.clear();
+}
+
+void GroundBrushLoader::clearFriends(GroundBrush& brush) {
+	brush.friends.clear();
+	brush.hate_friends = false;
 }

--- a/source/brushes/ground/ground_brush_loader.h
+++ b/source/brushes/ground/ground_brush_loader.h
@@ -28,6 +28,14 @@ public:
 	 * @return true if loading was successful, false otherwise.
 	 */
 	static bool load(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings);
+
+private:
+	static bool loadItem(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings);
+	static void loadOptional(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings);
+	static bool loadBorder(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings);
+	static void loadFriend(GroundBrush& brush, pugi::xml_node node, std::vector<std::string>& warnings, bool hate);
+	static void clearBorders(GroundBrush& brush);
+	static void clearFriends(GroundBrush& brush);
 };
 
 #endif // RME_GROUND_BRUSH_LOADER_H

--- a/tools/smell_scanner.py
+++ b/tools/smell_scanner.py
@@ -1,0 +1,66 @@
+import os
+import re
+
+def scan_file(filepath):
+    try:
+        with open(filepath, 'r', encoding='utf-8') as f:
+            lines = f.readlines()
+    except Exception as e:
+        print(f"Error reading {filepath}: {e}")
+        return
+
+    file_length = len(lines)
+    if file_length > 500:
+        print(f"[Large Class/File] {filepath}: {file_length} lines")
+
+    current_function = None
+    function_start_line = 0
+    brace_balance = 0
+    in_function = False
+
+    # Simple C++ function detection regex (return type, name, params)
+    # This is a very rough heuristic
+    func_pattern = re.compile(r'^\s*[\w\:<>]+[\*\&]*\s+([\w\:]+)\s*\((.*)\)\s*(const|noexcept|override|final)*\s*\{?')
+
+    for i, line in enumerate(lines):
+        line_stripped = line.strip()
+
+        # Check for switch
+        if re.search(r'\bswitch\s*\(', line_stripped):
+             print(f"[Switch Statement] {filepath}:{i+1}")
+
+        # Function detection heuristic
+        match = func_pattern.match(line)
+        if match and not line_stripped.startswith('if') and not line_stripped.startswith('for') and not line_stripped.startswith('while') and not line_stripped.startswith('switch') and ';' not in line_stripped:
+            func_name = match.group(1)
+            params = match.group(2)
+            param_count = len(params.split(',')) if params.strip() else 0
+
+            if param_count > 5:
+                 print(f"[Long Parameter List] {filepath}:{i+1} Function '{func_name}' has {param_count} parameters")
+
+            if not in_function:
+                current_function = func_name
+                function_start_line = i
+                in_function = True
+                brace_balance = 0
+
+        if in_function:
+            brace_balance += line.count('{')
+            brace_balance -= line.count('}')
+
+            if brace_balance <= 0 and line.count('}') > 0:
+                func_length = i - function_start_line
+                if func_length > 50:
+                    print(f"[Long Method] {filepath}:{function_start_line+1} Function '{current_function}' is {func_length} lines long")
+                in_function = False
+
+def main():
+    source_dir = 'source'
+    for root, dirs, files in os.walk(source_dir):
+        for file in files:
+            if file.endswith('.cpp') or file.endswith('.h'):
+                scan_file(os.path.join(root, file))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Refactored `GroundBrushLoader::load` in `source/brushes/ground/ground_brush_loader.cpp` to address the "Long Method" code smell. The method was split into smaller, more focused private helper methods handling specific XML node types. Corresponding declarations were added to `source/brushes/ground/ground_brush_loader.h`.

---
*PR created automatically by Jules for task [11412931441665061651](https://jules.google.com/task/11412931441665061651) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modularized ground brush loader with new helper methods for improved code organization and maintainability.

* **Chores**
  * Added code quality analysis tool to identify potential refactoring targets across the codebase.
  * Generated code quality report highlighting areas for improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->