### PR TITLE
[MODERNIZE] Use range-based for loops in ClientVersion, Materials, and IOMapOTMM

### DIFF
--- a/source/app/client_version.cpp
+++ b/source/app/client_version.cpp
@@ -355,9 +355,9 @@ ClientVersion* ClientVersion::get(ClientVersionID id) {
 }
 
 ClientVersion* ClientVersion::get(std::string id) {
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->getName() == id) {
-			return i->second.get();
+	for (const auto& [key, version] : client_versions) {
+		if (version->getName() == id) {
+			return version.get();
 		}
 	}
 	return nullptr;
@@ -365,17 +365,17 @@ ClientVersion* ClientVersion::get(std::string id) {
 
 ClientVersionList ClientVersion::getAll() {
 	ClientVersionList l;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		l.push_back(i->second.get());
+	for (const auto& [key, version] : client_versions) {
+		l.push_back(version.get());
 	}
 	return l;
 }
 
 ClientVersionList ClientVersion::getAllVisible() {
 	ClientVersionList l;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->isVisible()) {
-			l.push_back(i->second.get());
+	for (const auto& [key, version] : client_versions) {
+		if (version->isVisible()) {
+			l.push_back(version.get());
 		}
 	}
 	return l;
@@ -383,11 +383,11 @@ ClientVersionList ClientVersion::getAllVisible() {
 
 ClientVersionList ClientVersion::getAllForOTBMVersion(MapVersionID id) {
 	ClientVersionList list;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->isVisible()) {
-			for (std::vector<MapVersionID>::iterator v = i->second->map_versions_supported.begin(); v != i->second->map_versions_supported.end(); ++v) {
-				if (*v == id) {
-					list.push_back(i->second.get());
+	for (const auto& [key, version] : client_versions) {
+		if (version->isVisible()) {
+			for (MapVersionID v : version->map_versions_supported) {
+				if (v == id) {
+					list.push_back(version.get());
 				}
 			}
 		}
@@ -522,9 +522,9 @@ bool ClientVersion::loadValidPaths() {
 }
 
 DatFormat ClientVersion::getDatFormatForSignature(uint32_t signature) const {
-	for (std::vector<ClientData>::const_iterator iter = data_versions.begin(); iter != data_versions.end(); ++iter) {
-		if (iter->datSignature == signature) {
-			return iter->datFormat;
+	for (const auto& clientData : data_versions) {
+		if (clientData.datSignature == signature) {
+			return clientData.datFormat;
 		}
 	}
 

--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -40,12 +40,12 @@ Materials::~Materials() {
 }
 
 void Materials::clear() {
-	for (TilesetContainer::iterator iter = tilesets.begin(); iter != tilesets.end(); ++iter) {
-		delete iter->second;
+	for (auto& [name, tileset] : tilesets) {
+		delete tileset;
 	}
 
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		delete *iter;
+	for (auto* extension : extensions) {
+		delete extension;
 	}
 
 	tilesets.clear();
@@ -58,9 +58,9 @@ const MaterialsExtensionList& Materials::getExtensions() {
 
 MaterialsExtensionList Materials::getExtensionsByVersion(uint16_t version_id) {
 	MaterialsExtensionList ret_list;
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		if ((*iter)->isForVersion(version_id)) {
-			ret_list.push_back(*iter);
+	for (auto* extension : extensions) {
+		if (extension->isForVersion(version_id)) {
+			ret_list.push_back(extension);
 		}
 	}
 	return ret_list;
@@ -277,9 +277,7 @@ void Materials::createOtherTileset() {
 		}
 	}
 
-	for (CreatureMap::iterator iter = g_creatures.begin(); iter != g_creatures.end(); ++iter) {
-		CreatureType* type = iter->second;
-
+	for (auto& [name, type] : g_creatures) {
 		if (type->brush == nullptr) {
 			type->brush = newd CreatureBrush(type);
 			g_brushes.addBrush(type->brush);

--- a/source/io/iomap_otmm.cpp
+++ b/source/io/iomap_otmm.cpp
@@ -263,8 +263,8 @@ bool Container::serializeItemNode_OTMM(const IOMap& maphandle, NodeFileWriteHand
 	f.addU16(id);
 	serializeItemAttributes_OTMM(maphandle, f);
 
-	for (ItemVector::const_iterator it = contents.begin(); it != contents.end(); ++it) {
-		(*it)->serializeItemNode_OTMM(maphandle, f);
+	for (const auto& item : contents) {
+		item->serializeItemNode_OTMM(maphandle, f);
 	}
 	f.endNode();
 	return true;


### PR DESCRIPTION
BEFORE: Raw iterator loops were used to iterate over maps and vectors.
AFTER: Replaced with C++11/17 range-based for loops and structured bindings.
BENEFITS:
- Code more readable
- Intent clearer (iterating elements, not iterators)
- Consistent with modern C++ style
STANDARD: C++17/20
CHANGES:
source/app/client_version.cpp: Modernized 5 loops.
source/game/materials.cpp: Modernized 4 loops.
source/io/iomap_otmm.cpp: Modernized 1 loop.
TESTED:
Compiles with C++20 (Verified via code review and partial build, full build skipped due to env limitations).
No behavior change expected (pure refactoring).

---
*PR created automatically by Jules for task [17700370853961797730](https://jules.google.com/task/17700370853961797730) started by @karolak6612*