### PR TITLE
Fix UB: Spawn position overflow and NetworkConnection data race

### DIFF
--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,7 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <atomic>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -81,7 +82,7 @@ public:
 private:
 	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
-	bool stopped;
+	std::atomic<bool> stopped;
 };
 
 #endif


### PR DESCRIPTION
This PR addresses critical undefined behavior (UB) and potential crashes identified during bug hunting (Phantom agent):

1.  **Signed Integer Overflow in Spawn Loading:**
    *   In `source/io/iomap_otbm.cpp`, `creaturePosition` was calculated by adding `int` offsets to `int` spawn position without checking for overflow. This is now fixed by using `long long` for the calculation and checking `std::numeric_limits<int>` bounds.
    *   Spawn radius read from XML is now clamped to `Config::MAX_SPAWN_RADIUS` (or 100 as fallback) to prevent creating `Spawn` objects with excessive size, which could lead to infinite loops or stack overflows in recursive operations or iterations.

2.  **Data Race in Network Connection:**
    *   In `source/net/net_connection.h` and `source/net/net_connection.cpp`, the `stopped` flag was accessed by multiple threads without synchronization. It is now `std::atomic<bool>`.

The changes were verified by compiling the project (after installing missing Linux dependencies). The existing configuration key `Config::MAX_SPAWN_RADIUS` is used. `NetworkConnection` is a singleton, so move semantics concerns are minimal.

---
*PR created automatically by Jules for task [230698110129234510](https://jules.google.com/task/230698110129234510) started by @karolak6612*