### PR TITLE
[ICONS] Add and modernize SVG icons across UI surfaces

### DIFF
--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -180,6 +180,10 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	select_raw_button->Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickSelectRaw, this);
 	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickOK, this, wxID_OK);
 	Bind(wxEVT_BUTTON, &BrowseTileWindow::OnClickCancel, this, wxID_CANCEL);
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_LIST, wxSize(32, 32)));
+	SetIcon(icon);
 }
 
 BrowseTileWindow::~BrowseTileWindow() {

--- a/source/ui/dialog_util.cpp
+++ b/source/ui/dialog_util.cpp
@@ -60,6 +60,10 @@ void DialogUtil::ListDialog(wxWindow* parent, wxString title, const std::vector<
 
 	dlg->SetSizerAndFit(sizer);
 
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_LIST, wxSize(32, 32)));
+	dlg->SetIcon(icon);
+
 	// Show the window
 	dlg->ShowModal();
 	dlg->Destroy();
@@ -78,6 +82,10 @@ void DialogUtil::ShowTextBox(wxWindow* parent, wxString title, wxString content)
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(0).Center());
 	dlg->SetSizerAndFit(topsizer);
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_LINES, wxSize(32, 32)));
+	dlg->SetIcon(icon);
 
 	dlg->ShowModal();
 	dlg->Destroy();

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -48,6 +48,7 @@
 #include "ui/menubar/palette_menu_handler.h"
 #include "ui/menubar/menubar_action_manager.h"
 #include "ingame_preview/ingame_preview_manager.h"
+#include "util/image_manager.h"
 
 #include <wx/chartype.h>
 
@@ -237,6 +238,11 @@ void MainMenuBar::OnExportTilesets(wxCommandEvent& event) {
 void MainMenuBar::OnDebugViewDat(wxCommandEvent& event) {
 	wxDialog dlg(frame, wxID_ANY, "Debug .dat file", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
 	new DatDebugView(&dlg);
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_BUG, wxSize(32, 32)));
+	dlg.SetIcon(icon);
+
 	dlg.ShowModal();
 }
 

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -105,15 +105,15 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 	dg->SetSizerAndFit(topsizer);
 	dg->Centre(wxBOTH);
 
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHART_BAR, wxSize(32, 32)));
+	dg->SetIcon(icon);
+
 	int ret = dg->ShowModal();
 
 	if (ret == wxID_OK) {
 	} else if (ret == wxID_CANCEL) {
 	}
-
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHART_BAR, wxSize(32, 32)));
-	dg->SetIcon(icon);
 
 	dg->Destroy();
 }

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -18,21 +18,21 @@ const wxString BrushToolBar::PANE_NAME = "brush_toolbar";
 BrushToolBar::BrushToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_OPTIONAL_BORDER_SMALL, icon_size);
-	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_ERASER_SMALL, icon_size);
-	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PROTECTION_ZONE_SMALL, icon_size);
-	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_PVP_ZONE_SMALL, icon_size);
-	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_LOGOUT_ZONE_SMALL, icon_size);
-	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PVP_ZONE_SMALL, icon_size);
-	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_SMALL, icon_size);
-	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_LOCKED_SMALL, icon_size);
-	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_MAGIC_SMALL, icon_size);
-	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_QUEST_SMALL, icon_size);
-	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_ALT_SMALL, icon_size);
-	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_ARCHWAY_SMALL, icon_size);
+	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(ICON_BORDER_ALL, icon_size);
+	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ERASER, icon_size);
+	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SHIELD, icon_size);
+	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOVE, icon_size);
+	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(ICON_USER_LOCK, icon_size);
+	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SKULL_CROSSBONES, icon_size);
+	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, icon_size);
+	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCK, icon_size);
+	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WAND_MAGIC, icon_size);
+	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(ICON_QUESTION, icon_size);
+	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, icon_size);
+	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ARCHWAY, icon_size);
 
-	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_HATCH_SMALL, icon_size);
-	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_NORMAL_SMALL, icon_size);
+	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MINIMIZE, icon_size);
+	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MAXIMIZE, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_BRUSHES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);

--- a/source/ui/toolbar/size_toolbar.cpp
+++ b/source/ui/toolbar/size_toolbar.cpp
@@ -15,15 +15,15 @@ const wxString SizeToolBar::PANE_NAME = "sizes_toolbar";
 SizeToolBar::SizeToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size);
-	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size);
-	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size);
-	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size);
-	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size);
-	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size);
-	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size);
+	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_CIRCLE_SOLID, icon_size);
+	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SQUARE_FULL_SOLID, icon_size);
+	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(ICON_1, icon_size);
+	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(ICON_2, icon_size);
+	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(ICON_3, icon_size);
+	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(ICON_4, icon_size);
+	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(ICON_5, icon_size);
+	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(ICON_6, icon_size);
+	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(ICON_7, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_SIZES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
@@ -69,27 +69,9 @@ void SizeToolBar::UpdateBrushSize(BrushShape shape, int size) {
 	if (shape == BRUSHSHAPE_CIRCLE) {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, true);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, false);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_7_SMALL, icon_size));
 	} else {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, false);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, true);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size));
 	}
 
 	toolbar->ToggleTool(TOOLBAR_SIZES_1, size == 0);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -182,6 +182,10 @@ WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionT
 	Centre();
 	new WelcomePanel(this, rmeLogo, recentFiles);
 	SetSize(FromDIP(800), FromDIP(500));
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_GLOBE, wxSize(32, 32)));
+	SetIcon(icon);
 }
 
 void WelcomeDialog::OnButtonClicked(wxCommandEvent& event) {


### PR DESCRIPTION
This PR addresses the "Icon" agent mission to add/replace icons across the UI. 

Key changes:
1.  **Dialog Window Icons:** Added `SetIcon` calls to several dialogs that were missing them (`WelcomeDialog`, `BrowseTileWindow`, etc.) using appropriate SVGs (`ICON_GLOBE`, `ICON_LIST`, `ICON_BUG`).
2.  **Size Toolbar Modernization:** Replaced 9 legacy PNG button images with modern SVG icons from the `ImageManager` (`ICON_1`...`ICON_7`, `ICON_SQUARE_FULL_SOLID`, `ICON_CIRCLE_SOLID`). Simplified the code by removing the need to swap bitmaps based on brush shape.
3.  **Brush Toolbar Modernization:** Replaced 14 legacy PNG button images with semantic SVG icons (e.g., `ICON_SHIELD` for Protection Zone, `ICON_DOVE` for No-PvP, `ICON_ARCHWAY`, `ICON_WINDOW_MAXIMIZE` for Window).

These changes improve UI consistency and resolution independence by moving away from fixed-size PNGs to scalable SVGs.

---
*PR created automatically by Jules for task [13504796815703571567](https://jules.google.com/task/13504796815703571567) started by @karolak6612*