### PR TITLE
Sentinel: Modernize rendering with RingBuffer and state fixes

### DIFF
--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -133,7 +133,18 @@ void SpriteBatch::begin(const glm::mat4& projection) {
 	sprite_count_ = 0;
 	global_tint_ = glm::vec4(1.0f);
 
-	glEnable(GL_BLEND);
+	// Save State
+	prev_blend_enabled_ = glIsEnabled(GL_BLEND);
+	glGetIntegerv(GL_BLEND_SRC_RGB, &prev_src_rgb_);
+	glGetIntegerv(GL_BLEND_DST_RGB, &prev_dst_rgb_);
+	glGetIntegerv(GL_BLEND_SRC_ALPHA, &prev_src_alpha_);
+	glGetIntegerv(GL_BLEND_DST_ALPHA, &prev_dst_alpha_);
+	glGetIntegerv(GL_BLEND_EQUATION_RGB, &prev_eq_rgb_);
+	glGetIntegerv(GL_BLEND_EQUATION_ALPHA, &prev_eq_alpha_);
+
+	if (!prev_blend_enabled_) {
+		glEnable(GL_BLEND);
+	}
 	glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
 	shader_->Use();
@@ -340,5 +351,11 @@ void SpriteBatch::end(const AtlasManager& atlas_manager) {
 
 	in_batch_ = false;
 	glBindVertexArray(0);
-	glDisable(GL_BLEND);
+
+	// Restore State
+	if (!prev_blend_enabled_) {
+		glDisable(GL_BLEND);
+	}
+	glBlendFuncSeparate(prev_src_rgb_, prev_dst_rgb_, prev_src_alpha_, prev_dst_alpha_);
+	glBlendEquationSeparate(prev_eq_rgb_, prev_eq_alpha_);
 }

--- a/source/rendering/core/sprite_batch.h
+++ b/source/rendering/core/sprite_batch.h
@@ -117,6 +117,15 @@ private:
 
 	int draw_call_count_ = 0;
 	int sprite_count_ = 0;
+
+	// State management
+	GLboolean prev_blend_enabled_ = GL_FALSE;
+	GLint prev_src_rgb_ = GL_ONE;
+	GLint prev_dst_rgb_ = GL_ZERO;
+	GLint prev_src_alpha_ = GL_ONE;
+	GLint prev_dst_alpha_ = GL_ZERO;
+	GLint prev_eq_rgb_ = GL_FUNC_ADD;
+	GLint prev_eq_alpha_ = GL_FUNC_ADD;
 };
 
 #endif

--- a/source/rendering/drawers/minimap_renderer.h
+++ b/source/rendering/drawers/minimap_renderer.h
@@ -5,6 +5,7 @@
 #include "rendering/core/pixel_buffer_object.h"
 #include "rendering/core/shader_program.h"
 #include "rendering/core/gl_resources.h"
+#include "rendering/core/ring_buffer.h"
 #include <vector>
 #include <memory>
 #include <glm/glm.hpp>
@@ -75,9 +76,8 @@ private:
 	std::unique_ptr<GLTextureResource> palette_texture_id_;
 	std::unique_ptr<GLVertexArray> vao_;
 
-	std::unique_ptr<GLBuffer> instance_vbo_;
+	std::unique_ptr<RingBuffer> instance_vbo_;
 	std::vector<InstanceData> instance_data_;
-	size_t instance_vbo_capacity_ = 0;
 
 	int width_ = 0;
 	int height_ = 0;

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -28,6 +28,7 @@
 #include "rendering/core/light_buffer.h"
 #include "rendering/core/shader_program.h"
 #include "rendering/core/gl_resources.h"
+#include "rendering/core/ring_buffer.h"
 
 struct DrawingOptions;
 struct RenderView;
@@ -52,11 +53,11 @@ private:
 	// Open GL Texture used for lightmap
 	// It is owned by this class and should be released when context is destroyed
 
-	std::unique_ptr<ShaderProgram> shader;
+	std::unique_ptr<ShaderProgram> generation_shader;
+	std::unique_ptr<ShaderProgram> composite_shader;
 	std::unique_ptr<GLVertexArray> vao;
 	std::unique_ptr<GLBuffer> vbo;
-	std::unique_ptr<GLBuffer> light_ssbo;
-	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
+	std::unique_ptr<RingBuffer> light_ssbo;
 
 	std::vector<GPULight> gpu_lights_;
 


### PR DESCRIPTION
This PR modernizes the rendering pipeline by introducing persistent buffer mapping (RingBuffer) to LightDrawer and MinimapRenderer, eliminating per-frame buffer uploads. It also splits the LightDrawer shader into two specialized shaders to remove branching logic and fixes OpenGL state leaks in SpriteBatch by properly saving and restoring blending state.

---
*PR created automatically by Jules for task [4472526075192917452](https://jules.google.com/task/4472526075192917452) started by @karolak6612*