### PR TITLE
📊 Profiler: Fix CPU bottleneck in Tile Rendering

### DIFF
--- a/.jules/profiler.md
+++ b/.jules/profiler.md
@@ -12,3 +12,8 @@ Learning: Single-entry caching in nested loops must respect the iteration order.
 Finding: `GraphicManager::getSpriteFile()` returned `std::string` by value, causing a heap allocation and copy for every item in the render loop during sprite preloading checks.
 Impact: Reduced memory allocations per frame significantly (thousands of allocations avoided per frame).
 Learning: Returning `std::string` by value from a getter called in a hot loop is a major performance killer. Always use `const std::string&` or `std::string_view` for members.
+
+## 2026-02-15 - Optimization of Sprite Pattern Calculation and Tooltip Logic
+Finding: `PatternCalculator::Calculate` was being called twice for every complex item in the render loop: once during sprite preloading and again during drawing. Additionally, `requestTooltipData` was being called for every item regardless of whether it could have a tooltip.
+Impact: Eliminated redundant arithmetic and logic for sprite pattern calculation by caching the result from the preload step. Reduced unnecessary tooltip processing calls by pre-checking `isTooltipable` flag.
+Learning: Passing calculation results from a "prepare/preload" step to the "draw" step via `std::optional` is an effective way to avoid redundant work in immediate mode rendering loops.

--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -30,12 +30,12 @@ ItemDrawer::ItemDrawer() {
 ItemDrawer::~ItemDrawer() {
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const std::optional<SpritePatterns>& cached_patterns) {
 	const Position& pos = tile->getPosition();
-	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile);
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile, cached_patterns);
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile, const std::optional<SpritePatterns>& cached_patterns) {
 	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
@@ -118,7 +118,13 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	draw_x -= spr->draw_height;
 	draw_y -= spr->draw_height;
 
-	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+	SpritePatterns patterns;
+	if (cached_patterns) {
+		patterns = *cached_patterns;
+	} else {
+		patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+	}
+
 	int subtype = patterns.subtype;
 	int pattern_x = patterns.x;
 	int pattern_y = patterns.y;

--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -7,6 +7,8 @@
 
 #include "app/definitions.h"
 #include "map/position.h"
+#include <optional>
+#include "rendering/utilities/pattern_calculator.h"
 
 // Forward declarations
 class SpriteDrawer;
@@ -25,8 +27,8 @@ public:
 	ItemDrawer();
 	~ItemDrawer();
 
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const std::optional<SpritePatterns>& cached_patterns = std::nullopt);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr, const std::optional<SpritePatterns>& cached_patterns = std::nullopt);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <sstream>
 #include <stdint.h>
+#include <optional>
+#include "rendering/utilities/pattern_calculator.h"
 
 class TileLocation;
 struct RenderView;
@@ -28,7 +30,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item);
+	std::optional<SpritePatterns> PreloadItem(const Tile* tile, Item* item);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
🎯 Bottleneck: CPU
📈 Before/After: Redundant pattern calculations removed. Tooltip request overhead reduced.
🔍 Root Cause: `PatternCalculator::Calculate` called twice per item (Preload + Blit). `requestTooltipData` called for every item.
⚡ Fix: Cached patterns in `PreloadItem` and passed to `BlitItem`. Added `isTooltipable` check before tooltip logic.
✅ Compliance: Painter's Algorithm preserved.
📊 Impact: Reduced arithmetic operations and string/allocation overhead per frame.

---
*PR created automatically by Jules for task [15818124165374546821](https://jules.google.com/task/15818124165374546821) started by @karolak6612*