### PR TITLE
Remove dead logging code from SpriteDrawer

### DIFF
--- a/source/rendering/drawers/entities/sprite_drawer.cpp
+++ b/source/rendering/drawers/entities/sprite_drawer.cpp
@@ -8,9 +8,6 @@
 #include "rendering/core/sprite_batch.h"
 #include "rendering/core/atlas_manager.h"
 
-static int s_blitCount = 0;
-static int s_zeroTextureCount = 0;
-
 SpriteDrawer::SpriteDrawer() :
 	last_bound_texture_(0) {
 }
@@ -20,12 +17,6 @@ SpriteDrawer::~SpriteDrawer() {
 
 void SpriteDrawer::ResetCache() {
 	last_bound_texture_ = 0;
-	// Log stats each frame
-	if (s_blitCount > 0) {
-		spdlog::info("SpriteDrawer: {} sprites drawn, {} zero-texture skipped", s_blitCount, s_zeroTextureCount);
-	}
-	s_blitCount = 0;
-	s_zeroTextureCount = 0;
 }
 
 void SpriteDrawer::glBlitAtlasQuad(SpriteBatch& sprite_batch, int sx, int sy, const AtlasRegion* region, int red, int green, int blue, int alpha) {


### PR DESCRIPTION
Removed unused static variables `s_blitCount` and `s_zeroTextureCount` and the associated logging logic in `SpriteDrawer::ResetCache`. These variables were initialized to 0 and never incremented, making the logging condition unreachable. This cleans up dead code. I also audited the codebase for OpenGL performance issues as requested and found the current implementation to be highly optimized (using `SpriteBatch`, MDI, texture arrays, etc.), contradicting the hypothetical issues listed in the example report.

---
*PR created automatically by Jules for task [4427018557738820592](https://jules.google.com/task/4427018557738820592) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal performance statistics logging from sprite rendering operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->