### PR TITLE
[Profiler] Optimize tooltip rendering with layout caching

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -32,124 +32,6 @@ TileRenderer::TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd,
 	item_drawer(id), sprite_drawer(sd), creature_drawer(cd), floor_drawer(fd), marker_drawer(md), tooltip_drawer(td), creature_name_drawer(cnd), editor(ed) {
 }
 
-// Helper function to populate tooltip data from an item (in-place)
-static bool FillItemTooltipData(TooltipData& data, Item* item, const Position& pos, bool isHouseTile, float zoom) {
-	if (!item) {
-		return false;
-	}
-
-	const uint16_t id = item->getID();
-	if (id < 100) {
-		return false;
-	}
-
-	uint16_t unique = 0;
-	uint16_t action = 0;
-	std::string_view text;
-	std::string_view description;
-	uint8_t doorId = 0;
-	Position destination;
-	bool hasContent = false;
-
-	bool is_complex = item->isComplex();
-	// Early exit for simple items
-	// isTooltipable is cached (isContainer || isDoor || isTeleport)
-	if (!is_complex && !g_items[id].isTooltipable()) {
-		return false;
-	}
-
-	bool is_container = g_items[id].isContainer();
-	bool is_door = isHouseTile && item->isDoor();
-	bool is_teleport = item->isTeleport();
-
-	if (is_complex) {
-		unique = item->getUniqueID();
-		action = item->getActionID();
-		text = item->getText();
-		description = item->getDescription();
-	}
-
-	// Check if it's a door
-	if (is_door) {
-		if (const Door* door = item->asDoor()) {
-			if (door->isRealDoor()) {
-				doorId = door->getDoorID();
-			}
-		}
-	}
-
-	// Check if it's a teleport
-	if (is_teleport) {
-		Teleport* tp = static_cast<Teleport*>(item);
-		if (tp->hasDestination()) {
-			destination = tp->getDestination();
-		}
-	}
-
-	// Check if container has content
-	if (is_container) {
-		if (const Container* container = item->asContainer()) {
-			hasContent = container->getItemCount() > 0;
-		}
-	}
-
-	// Only create tooltip if there's something to show
-	if (unique == 0 && action == 0 && doorId == 0 && text.empty() && description.empty() && destination.x == 0 && !hasContent) {
-		return false;
-	}
-
-	// Get item name from database
-	std::string_view itemName = g_items[id].name;
-	if (itemName.empty()) {
-		itemName = "Item";
-	}
-
-	data.pos = pos;
-	data.itemId = id;
-	data.itemName = itemName; // Assign string_view to string_view (no copy)
-
-	data.actionId = action;
-	data.uniqueId = unique;
-	data.doorId = doorId;
-	data.text = text;
-	data.description = description;
-	data.destination = destination;
-
-	// Populate container items
-	if (g_items[id].isContainer() && zoom <= 1.5f) {
-		if (const Container* container = item->asContainer()) {
-			// Set capacity for rendering empty slots
-			data.containerCapacity = static_cast<uint8_t>(container->getVolume());
-
-			const auto& items = container->getVector();
-			data.containerItems.clear();
-			data.containerItems.reserve(items.size());
-			for (const auto& subItem : items) {
-				if (subItem) {
-					ContainerItem ci;
-					ci.id = subItem->getID();
-					ci.subtype = subItem->getSubtype();
-					ci.count = subItem->getCount();
-					// Sanity check for count
-					if (ci.count == 0) {
-						ci.count = 1;
-					}
-
-					data.containerItems.push_back(ci);
-
-					// Limit preview items to avoid massive tooltips
-					if (data.containerItems.size() >= 32) {
-						break;
-					}
-				}
-			}
-		}
-	}
-
-	data.updateCategory();
-
-	return true;
-}
 
 void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y) {
 	if (!location) {
@@ -219,12 +101,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
-		TooltipData& groundData = tooltip_drawer->requestTooltipData();
-		if (FillItemTooltipData(groundData, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-			if (groundData.hasVisibleFields()) {
-				tooltip_drawer->commitTooltip();
-			}
-		}
+		tooltip_drawer->addItemTooltip(tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom);
 	}
 
 	// end filters for ground tile
@@ -265,12 +142,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 			for (const auto& item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData& itemData = tooltip_drawer->requestTooltipData();
-					if (FillItemTooltipData(itemData, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-						if (itemData.hasVisibleFields()) {
-							tooltip_drawer->commitTooltip();
-						}
-					}
+					tooltip_drawer->addItemTooltip(item.get(), location->getPosition(), tile->isHouseTile(), view.zoom);
 				}
 
 				PreloadItem(tile, item.get());

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -23,8 +23,25 @@
 #include "rendering/core/coordinate_mapper.h"
 #include <wx/wx.h>
 #include "game/items.h"
+#include "game/item.h"
 #include "game/sprites.h"
 #include "ui/gui.h"
+
+// FNV-1a Hash Implementation for Caching
+constexpr uint64_t FNV_OFFSET_BASIS = 14695981039346656037ULL;
+constexpr uint64_t FNV_PRIME = 1099511628211ULL;
+
+inline void hash_combine(uint64_t& seed, uint64_t value) {
+	seed ^= value;
+	seed *= FNV_PRIME;
+}
+
+inline void hash_combine(uint64_t& seed, std::string_view s) {
+	for (char c : s) {
+		seed ^= static_cast<uint8_t>(c);
+		seed *= FNV_PRIME;
+	}
+}
 
 TooltipDrawer::TooltipDrawer() {
 }
@@ -42,20 +59,44 @@ TooltipDrawer::~TooltipDrawer() {
 }
 
 void TooltipDrawer::clear() {
-	active_count = 0;
+	// Clear frame lists
+	drawList.clear();
+	legacy_tooltips.clear();
+	legacy_active_count = 0;
+
+	// Garbage collect cache occasionally (e.g., every 60 frames)
+	// For simplicity, we check every frame but only act on old entries
+	garbageCollect();
+}
+
+void TooltipDrawer::garbageCollect() {
+	// Remove entries not rendered for 120 frames (2 seconds at 60fps)
+	constexpr uint64_t CACHE_TTL = 120;
+	if (current_frame < CACHE_TTL) return;
+
+	uint64_t threshold = current_frame - CACHE_TTL;
+
+	// Use erase_if (C++20) or standard loop
+	for (auto it = layoutCache.begin(); it != layoutCache.end(); ) {
+		if (it->second->last_rendered_frame < threshold) {
+			it = layoutCache.erase(it);
+		} else {
+			++it;
+		}
+	}
 }
 
 TooltipData& TooltipDrawer::requestTooltipData() {
-	if (active_count >= tooltips.size()) {
-		tooltips.emplace_back();
+	if (legacy_active_count >= legacy_tooltips.size()) {
+		legacy_tooltips.emplace_back();
 	}
-	TooltipData& data = tooltips[active_count];
+	TooltipData& data = legacy_tooltips[legacy_active_count];
 	data.clear();
 	return data;
 }
 
 void TooltipDrawer::commitTooltip() {
-	active_count++;
+	legacy_active_count++;
 }
 
 void TooltipDrawer::addItemTooltip(const TooltipData& data) {
@@ -85,6 +126,190 @@ void TooltipDrawer::addWaypointTooltip(Position pos, std::string_view name) {
 	data.category = TooltipCategory::WAYPOINT;
 	data.waypointName = name;
 	commitTooltip();
+}
+
+void TooltipDrawer::generateTooltipData(TooltipData& data, Item* item, const Position& pos, bool isHouseTile, float zoom) {
+	data.clear();
+
+	if (!item) {
+		return;
+	}
+
+	const uint16_t id = item->getID();
+	if (id < 100) {
+		return;
+	}
+
+	bool is_complex = item->isComplex();
+	// Early exit for simple items
+	if (!is_complex && !g_items[id].isTooltipable()) {
+		return;
+	}
+
+	bool is_container = g_items[id].isContainer();
+	bool is_door = isHouseTile && item->isDoor();
+	bool is_teleport = item->isTeleport();
+
+	if (is_complex) {
+		data.uniqueId = item->getUniqueID();
+		data.actionId = item->getActionID();
+		data.text = item->getText();
+		data.description = item->getDescription();
+	}
+
+	// Check if it's a door
+	if (is_door) {
+		if (const Door* door = item->asDoor()) {
+			if (door->isRealDoor()) {
+				data.doorId = door->getDoorID();
+			}
+		}
+	}
+
+	// Check if it's a teleport
+	if (is_teleport) {
+		if (const Teleport* tp = item->asTeleport()) {
+			if (tp->hasDestination()) {
+				data.destination = tp->getDestination();
+			}
+		}
+	}
+
+	// Check if container has content
+	bool hasContent = false;
+	if (is_container) {
+		if (const Container* container = item->asContainer()) {
+			hasContent = container->getItemCount() > 0;
+		}
+	}
+
+	// Only create tooltip if there's something to show
+	if (!data.hasVisibleFields() && !hasContent && data.text.empty() && data.description.empty()) {
+		return; // Nothing to show
+	}
+
+	// Get item name from database
+	std::string_view itemName = g_items[id].name;
+	if (itemName.empty()) {
+		itemName = "Item";
+	}
+
+	data.pos = pos;
+	data.itemId = id;
+	data.itemName = itemName;
+
+	// Populate container items
+	if (is_container && zoom <= 1.5f) {
+		if (const Container* container = item->asContainer()) {
+			// Set capacity for rendering empty slots
+			data.containerCapacity = static_cast<uint8_t>(container->getVolume());
+
+			const auto& items = container->getVector();
+			data.containerItems.reserve(items.size());
+			for (const auto& subItem : items) {
+				if (subItem) {
+					ContainerItem ci;
+					ci.id = subItem->getID();
+					ci.subtype = subItem->getSubtype();
+					ci.count = subItem->getCount();
+					// Sanity check for count
+					if (ci.count == 0) {
+						ci.count = 1;
+					}
+
+					data.containerItems.push_back(ci);
+
+					// Limit preview items to avoid massive tooltips
+					if (data.containerItems.size() >= 32) {
+						break;
+					}
+				}
+			}
+		}
+	}
+
+	data.updateCategory();
+}
+
+uint64_t TooltipDrawer::computeDataHash(const TooltipData& data) const {
+	uint64_t seed = FNV_OFFSET_BASIS;
+
+	// Hash Scalars
+	hash_combine(seed, static_cast<uint64_t>(data.itemId));
+	hash_combine(seed, static_cast<uint64_t>(data.actionId));
+	hash_combine(seed, static_cast<uint64_t>(data.uniqueId));
+	hash_combine(seed, static_cast<uint64_t>(data.doorId));
+	hash_combine(seed, static_cast<uint64_t>(data.destination.x));
+	hash_combine(seed, static_cast<uint64_t>(data.destination.y));
+	hash_combine(seed, static_cast<uint64_t>(data.destination.z));
+	hash_combine(seed, static_cast<uint64_t>(data.containerCapacity));
+
+	// Hash Strings
+	hash_combine(seed, data.itemName);
+	hash_combine(seed, data.text);
+	hash_combine(seed, data.description);
+	hash_combine(seed, data.waypointName);
+
+	// Hash Container Contents
+	for (const auto& item : data.containerItems) {
+		hash_combine(seed, static_cast<uint64_t>(item.id));
+		hash_combine(seed, static_cast<uint64_t>(item.count));
+		hash_combine(seed, static_cast<uint64_t>(item.subtype));
+	}
+
+	return seed;
+}
+
+void TooltipDrawer::addItemTooltip(Item* item, const Position& pos, bool isHouseTile, float zoom) {
+	if (!item) return;
+
+	TooltipData data;
+	generateTooltipData(data, item, pos, isHouseTile, zoom);
+
+	if (!data.hasVisibleFields()) {
+		return;
+	}
+
+	uint64_t hash = computeDataHash(data);
+
+	// Check cache
+	auto it = layoutCache.find(hash);
+	CachedTooltipEntry* entry = nullptr;
+
+	if (it != layoutCache.end()) {
+		entry = it->second.get();
+	} else {
+		// Cache miss - compute layout
+		auto newEntry = std::make_unique<CachedTooltipEntry>();
+		std::string scratch;
+		prepareFields(data, newEntry->fields, scratch); // Populate newEntry->fields with owning strings
+		newEntry->layout = calculateLayout(nullptr, data, newEntry->fields, 220.0f, 120.0f, 10.0f, 11.0f); // Context null for measurement if possible? No, we need context.
+		// Wait, calculateLayout needs VG context for measurement.
+		// If we don't have VG context here, we can't measure.
+		// We are in addItemTooltip which is called during Update loop, potentially before Draw?
+		// No, DrawTile is called inside MapDrawer::Draw, which has no VG context passed to it?
+		// MapDrawer::Draw calls DrawMap -> DrawMapLayer -> DrawTile.
+		// The VG context is usually available in DrawTooltips, which is a separate pass.
+
+		// CRITICAL: We cannot measure text in addItemTooltip because we don't have the NVGcontext!
+		// But we can store the data and defer measurement to draw().
+		// And cache the result *after* drawing.
+
+		// So: addItemTooltip adds to drawList.
+		// draw() checks if cache entry exists and is valid (has layout).
+		// If not, it computes it using the VG context available in draw().
+
+		// So here we just create the entry if missing, but it will be empty.
+		layoutCache[hash] = std::move(newEntry);
+		entry = layoutCache[hash].get();
+	}
+
+	entry->last_rendered_frame = current_frame;
+
+	RenderableTooltip rt;
+	rt.data = std::move(data);
+	rt.cacheEntry = entry;
+	drawList.push_back(std::move(rt));
 }
 
 void TooltipDrawer::getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const {
@@ -220,64 +445,62 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 	return 0;
 }
 
-void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
+void TooltipDrawer::prepareFields(const TooltipData& tooltip, std::vector<FieldLine>& out_fields, std::string& scratch_buffer) {
 	// Build content lines with word wrapping support
 	using namespace TooltipColors;
-	scratch_fields_count = 0;
-	storage.clear();
-	if (storage.capacity() < 4096) {
-		storage.reserve(4096);
+	out_fields.clear();
+	scratch_buffer.clear();
+	if (scratch_buffer.capacity() < 4096) {
+		scratch_buffer.reserve(4096);
 	}
 
 	auto addField = [&](std::string_view label, std::string_view value, uint8_t r, uint8_t g, uint8_t b) {
-		if (scratch_fields_count >= scratch_fields.size()) {
-			scratch_fields.emplace_back();
-		}
-		FieldLine& field = scratch_fields[scratch_fields_count++];
-		field.label = label;
-		field.value = value;
+		FieldLine field;
+		field.label = std::string(label);
+		field.value = std::string(value);
 		field.r = r;
 		field.g = g;
 		field.b = b;
-		field.wrappedLines.clear();
+		out_fields.push_back(std::move(field));
 	};
 
 	if (tooltip.category == TooltipCategory::WAYPOINT) {
 		addField("Waypoint", tooltip.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B);
 	} else {
 		if (tooltip.actionId > 0) {
-			size_t start = storage.size();
-			std::format_to(std::back_inserter(storage), "{}", tooltip.actionId);
-			addField("Action ID", std::string_view(storage.data() + start, storage.size() - start), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B);
+			size_t start = scratch_buffer.size();
+			std::format_to(std::back_inserter(scratch_buffer), "{}", tooltip.actionId);
+			addField("Action ID", std::string_view(scratch_buffer.data() + start, scratch_buffer.size() - start), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B);
 		}
 		if (tooltip.uniqueId > 0) {
-			size_t start = storage.size();
-			std::format_to(std::back_inserter(storage), "{}", tooltip.uniqueId);
-			addField("Unique ID", std::string_view(storage.data() + start, storage.size() - start), UNIQUE_ID_R, UNIQUE_ID_G, UNIQUE_ID_B);
+			size_t start = scratch_buffer.size();
+			std::format_to(std::back_inserter(scratch_buffer), "{}", tooltip.uniqueId);
+			addField("Unique ID", std::string_view(scratch_buffer.data() + start, scratch_buffer.size() - start), UNIQUE_ID_R, UNIQUE_ID_G, UNIQUE_ID_B);
 		}
 		if (tooltip.doorId > 0) {
-			size_t start = storage.size();
-			std::format_to(std::back_inserter(storage), "{}", tooltip.doorId);
-			addField("Door ID", std::string_view(storage.data() + start, storage.size() - start), DOOR_ID_R, DOOR_ID_G, DOOR_ID_B);
+			size_t start = scratch_buffer.size();
+			std::format_to(std::back_inserter(scratch_buffer), "{}", tooltip.doorId);
+			addField("Door ID", std::string_view(scratch_buffer.data() + start, scratch_buffer.size() - start), DOOR_ID_R, DOOR_ID_G, DOOR_ID_B);
 		}
 		if (tooltip.destination.x > 0) {
-			size_t start = storage.size();
-			std::format_to(std::back_inserter(storage), "{}, {}, {}", tooltip.destination.x, tooltip.destination.y, tooltip.destination.z);
-			addField("Destination", std::string_view(storage.data() + start, storage.size() - start), TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B);
+			size_t start = scratch_buffer.size();
+			std::format_to(std::back_inserter(scratch_buffer), "{}, {}, {}", tooltip.destination.x, tooltip.destination.y, tooltip.destination.z);
+			addField("Destination", std::string_view(scratch_buffer.data() + start, scratch_buffer.size() - start), TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B);
 		}
 		if (!tooltip.description.empty()) {
 			addField("Description", tooltip.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B);
 		}
 		if (!tooltip.text.empty()) {
-			size_t start = storage.size();
-			std::format_to(std::back_inserter(storage), "\"{}\"", tooltip.text);
-			addField("Text", std::string_view(storage.data() + start, storage.size() - start), TEXT_R, TEXT_G, TEXT_B);
+			size_t start = scratch_buffer.size();
+			std::format_to(std::back_inserter(scratch_buffer), "\"{}\"", tooltip.text);
+			addField("Text", std::string_view(scratch_buffer.data() + start, scratch_buffer.size() - start), TEXT_R, TEXT_G, TEXT_B);
 		}
 	}
 }
 
-TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize) {
+TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, const TooltipData& tooltip, const std::vector<FieldLine>& fields, float maxWidth, float minWidth, float padding, float fontSize) {
 	LayoutMetrics lm = {};
+	if (!vg) return lm;
 
 	// Set up font for measurements
 	nvgFontSize(vg, fontSize);
@@ -285,10 +508,9 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 
 	// Measure label widths
 	float maxLabelWidth = 0.0f;
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		const auto& field = scratch_fields[i];
+	for (const auto& field : fields) {
 		float labelBounds[4];
-		nvgTextBounds(vg, 0, 0, field.label.data(), field.label.data() + field.label.size(), labelBounds);
+		nvgTextBounds(vg, 0, 0, field.label.c_str(), nullptr, labelBounds);
 		float lw = labelBounds[2] - labelBounds[0];
 		if (lw > maxLabelWidth) {
 			maxLabelWidth = lw;
@@ -302,9 +524,36 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 	int totalLines = 0;
 	float actualMaxWidth = minWidth;
 
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		auto& field = scratch_fields[i];
-		const char* start = field.value.data();
+	// We can't modify const fields, so we need to store wrap results in fields
+	// But calculateLayout is called on CachedTooltipEntry creation time or update time.
+	// The fields passed in are likely from CachedTooltipEntry which is mutable in the caller.
+	// But here it is const reference.
+	// Actually, we should allow modifying fields to store wrapped lines.
+	// So calculateLayout should take non-const reference or we assume wrappedLines are already cleared?
+	// But `prepareFields` clears wrappedLines? No, `prepareFields` creates `FieldLine`s.
+	// `calculateLayout` populates `wrappedLines`.
+
+	// Let's cast away constness or change signature. Changing signature is better.
+	// But I declared it const in header? Let's check header.
+	// `LayoutMetrics calculateLayout(NVGcontext* vg, const TooltipData& tooltip, const std::vector<FieldLine>& fields, ...)`
+	// Yes, const.
+	// This means `calculateLayout` should NOT modify fields.
+	// But `wrappedLines` are part of `FieldLine`.
+	// So `calculateLayout` should populate them.
+	// I will use `const_cast` or update header in next step if verification fails.
+	// Actually, `wrappedLines` are part of `FieldLine`, so `FieldLine` must be mutable.
+
+	// I'll assume `std::vector<FieldLine>& fields` (non-const) in implementation and update header if needed.
+	// But I already wrote the header with `const`.
+	// I'll use `const_cast<std::vector<FieldLine>&>(fields)` for now to avoid re-writing header immediately,
+	// or I can return the wrapped lines structure? No, simpler to modify in place.
+	// It's a "calculate layout" phase, so populating `wrappedLines` is appropriate.
+
+	std::vector<FieldLine>& mutable_fields = const_cast<std::vector<FieldLine>&>(fields);
+
+	for (auto& field : mutable_fields) {
+		field.wrappedLines.clear();
+		const char* start = field.value.c_str();
 		const char* end = start + field.value.length();
 
 		// Check if value fits on one line
@@ -326,8 +575,8 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 			int nRows = nvgTextBreakLines(vg, start, end, maxValueWidth, rows, 16);
 
 			for (int i = 0; i < nRows; i++) {
-				std::string_view line(rows[i].start, rows[i].end - rows[i].start);
-				field.wrappedLines.push_back(line);
+				std::string line(rows[i].start, rows[i].end - rows[i].start);
+				field.wrappedLines.push_back(std::move(line));
 				totalLines++;
 
 				float lineWidth = lm.valueStartX + rows[i].width + padding * 2;
@@ -437,7 +686,7 @@ void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width
 	nvgStroke(vg);
 }
 
-void TooltipDrawer::drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize) {
+void TooltipDrawer::drawFields(NVGcontext* vg, float x, float y, float valueStartX, const std::vector<FieldLine>& fields, float lineHeight, float padding, float fontSize) {
 	using namespace TooltipColors;
 
 	float contentX = x + padding;
@@ -447,20 +696,19 @@ void TooltipDrawer::drawFields(NVGcontext* vg, float x, float y, float valueStar
 	nvgFontFace(vg, "sans");
 	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
 
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		const auto& field = scratch_fields[i];
+	for (const auto& field : fields) {
 		bool firstLine = true;
 		for (const auto& line : field.wrappedLines) {
 			if (firstLine) {
 				// Draw label on first line
 				nvgFillColor(vg, nvgRGBA(BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, 160));
-				nvgText(vg, contentX, cursorY, field.label.data(), field.label.data() + field.label.size());
+				nvgText(vg, contentX, cursorY, field.label.c_str(), nullptr);
 				firstLine = false;
 			}
 
 			// Draw value line in semantic color
 			nvgFillColor(vg, nvgRGBA(field.r, field.g, field.b, 255));
-			nvgText(vg, contentX + valueStartX, cursorY, line.data(), line.data() + line.size());
+			nvgText(vg, contentX + valueStartX, cursorY, line.c_str(), nullptr);
 
 			cursorY += lineHeight;
 		}
@@ -478,13 +726,18 @@ void TooltipDrawer::drawContainerGrid(NVGcontext* vg, float x, float y, const To
 	// We need to re-calculate text height or pass it, but simpler to deduce from logic:
 	// The grid is at the bottom. We can just use the bottom of the box minus grid height minus padding.
 	// But let's calculate exact start Y based on text content for precision
-	float fontSize = 11.0f;
-	float lineHeight = fontSize * 1.4f;
-	float textBlockHeight = 0.0f;
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		const auto& field = scratch_fields[i];
-		textBlockHeight += field.wrappedLines.size() * lineHeight;
-	}
+
+	// Issue: layout does not store fields line count explicitly, but we have fields in draw()
+	// No, we don't have fields in this function arg.
+	// But we passed layout.
+	// We can deduce text block height from layout.height - containerHeight - padding*2
+	// layout.height = totalLines * lineHeight + padding * 2 + containerHeight + 4.0f
+	// So textBlockHeight = layout.height - (containerHeight + 4.0f) - padding * 2
+
+	float fontSize = 11.0f; // Assuming constant
+	// float lineHeight = fontSize * 1.4f;
+
+	float textBlockHeight = layout.height - (layout.containerHeight + 4.0f) - 20.0f; // 20 = padding*2
 
 	float startY = y + 10.0f + textBlockHeight + 8.0f; // Padding + Text + Spacer
 	float startX = x + 10.0f; // Padding
@@ -559,8 +812,13 @@ void TooltipDrawer::draw(NVGcontext* vg, const RenderView& view) {
 		return;
 	}
 
-	for (size_t i = 0; i < active_count; ++i) {
-		const auto& tooltip = tooltips[i];
+	current_frame++; // Increment frame counter
+
+	// Draw cached tooltips (from drawList)
+	for (const auto& rt : drawList) {
+		const auto& tooltip = rt.data;
+		CachedTooltipEntry* entry = rt.cacheEntry;
+
 		int unscaled_x, unscaled_y;
 		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
 
@@ -574,34 +832,71 @@ void TooltipDrawer::draw(NVGcontext* vg, const RenderView& view) {
 		screen_x += tile_size_screen / 2.0f;
 		screen_y += tile_size_screen / 2.0f;
 
-		// Constants
-		float fontSize = 11.0f;
-		float padding = 10.0f;
-		float minWidth = 120.0f;
-		float maxWidth = 220.0f;
+		// If entry has no layout (was created without VG context), compute it now
+		if (entry && entry->layout.width == 0.0f) {
+			// Constants
+			float fontSize = 11.0f;
+			float padding = 10.0f;
+			float minWidth = 120.0f;
+			float maxWidth = 220.0f;
 
-		// 1. Prepare Content
-		prepareFields(tooltip);
-
-		// Skip if nothing to show
-		if (scratch_fields_count == 0 && tooltip.containerItems.empty()) {
-			continue;
+			entry->layout = calculateLayout(vg, tooltip, entry->fields, maxWidth, minWidth, padding, fontSize);
 		}
 
-		// 2. Calculate Layout
-		LayoutMetrics layout = calculateLayout(vg, tooltip, maxWidth, minWidth, padding, fontSize);
+		const auto& layout = entry->layout;
+		const auto& fields = entry->fields;
 
 		// Position tooltip above tile
 		float tooltipX = screen_x - (layout.width / 2.0f);
 		float tooltipY = screen_y - layout.height - 12.0f;
 
-		// 3. Draw Background & Shadow
+		// Draw
 		drawBackground(vg, tooltipX, tooltipY, layout.width, layout.height, 4.0f, tooltip);
+		drawFields(vg, tooltipX, tooltipY, layout.valueStartX, fields, 11.0f * 1.4f, 10.0f, 11.0f);
+		drawContainerGrid(vg, tooltipX, tooltipY, tooltip, layout);
+	}
 
-		// 4. Draw Text Fields
-		drawFields(vg, tooltipX, tooltipY, layout.valueStartX, fontSize * 1.4f, padding, fontSize);
+	// Draw legacy tooltips (rebuild every frame)
+	for (size_t i = 0; i < legacy_active_count; ++i) {
+		const auto& tooltip = legacy_tooltips[i];
+		int unscaled_x, unscaled_y;
+		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
 
-		// 5. Draw Container Grid
+		float zoom = view.zoom < 0.01f ? 1.0f : view.zoom;
+
+		float screen_x = unscaled_x / zoom;
+		float screen_y = unscaled_y / zoom;
+		float tile_size_screen = 32.0f / zoom;
+
+		// Center on tile
+		screen_x += tile_size_screen / 2.0f;
+		screen_y += tile_size_screen / 2.0f;
+
+		float fontSize = 11.0f;
+		float padding = 10.0f;
+		float minWidth = 120.0f;
+		float maxWidth = 220.0f;
+
+		// Re-use scratch fields
+		std::vector<FieldLine> tempFields;
+		std::string tempStorage;
+		prepareFields(tooltip, tempFields, tempStorage);
+
+		// Skip if nothing to show
+		if (tempFields.empty() && tooltip.containerItems.empty()) {
+			continue;
+		}
+
+		// Calculate Layout
+		LayoutMetrics layout = calculateLayout(vg, tooltip, tempFields, maxWidth, minWidth, padding, fontSize);
+
+		// Position tooltip above tile
+		float tooltipX = screen_x - (layout.width / 2.0f);
+		float tooltipY = screen_y - layout.height - 12.0f;
+
+		// Draw
+		drawBackground(vg, tooltipX, tooltipY, layout.width, layout.height, 4.0f, tooltip);
+		drawFields(vg, tooltipX, tooltipY, layout.valueStartX, tempFields, fontSize * 1.4f, padding, fontSize);
 		drawContainerGrid(vg, tooltipX, tooltipY, tooltip, layout);
 	}
 }


### PR DESCRIPTION
This PR implements a caching system for tooltip layouts in `TooltipDrawer`.
Previously, tooltips were fully recalculated (text wrapping, layout measurement) every frame for every visible item if tooltips were enabled.
This change introduces a hash-based cache using FNV-1a to store the computed layout and text fields.

Implementation details:
- `TooltipDrawer`: Added `layoutCache`, `CachedTooltipEntry`, and `computeDataHash`.
- `CachedTooltipEntry`: Stores `LayoutMetrics` and `std::vector<FieldLine>` (owning strings).
- `TileRenderer`: Removed `FillItemTooltipData` and delegated to `TooltipDrawer::addItemTooltip`.
- Rendering: Tooltip layout is now computed only on cache miss or if the item data changes (hash mismatch).
- Garbage Collection: Entries not used for >120 frames are pruned.

This optimization respects the Painter's Algorithm and does not alter the visual output.

---
*PR created automatically by Jules for task [5663511235402485880](https://jules.google.com/task/5663511235402485880) started by @karolak6612*