### PR TITLE
🔒 Sentinel: Modernize UI Lists with NanoVG

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -209,6 +209,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/item_buttons.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/virtual_list_canvas.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.h
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.h
@@ -535,6 +536,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/add_tileset_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/virtual_list_canvas.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.cpp

--- a/source/ui/browse_tile_window.h
+++ b/source/ui/browse_tile_window.h
@@ -22,7 +22,7 @@
 #include "map/map.h"
 #include "map/tile.h"
 
-class BrowseTileListBox;
+class BrowseTileCanvas;
 
 class BrowseTileWindow : public wxDialog {
 public:
@@ -36,7 +36,7 @@ public:
 	void OnClickCancel(wxCommandEvent&);
 
 protected:
-	BrowseTileListBox* item_list;
+	BrowseTileCanvas* item_list;
 	wxStaticText* item_count_txt;
 	wxButton* delete_button;
 	wxButton* select_raw_button;

--- a/source/ui/controls/virtual_list_canvas.cpp
+++ b/source/ui/controls/virtual_list_canvas.cpp
@@ -1,0 +1,292 @@
+#include "ui/controls/virtual_list_canvas.h"
+#include <wx/wx.h>
+#include <algorithm>
+#include <nanovg.h>
+#include <spdlog/spdlog.h>
+
+VirtualListCanvas::VirtualListCanvas(wxWindow* parent, wxWindowID id, SelectionMode mode) :
+	NanoVGCanvas(parent, id, wxVSCROLL | wxWANTS_CHARS),
+	m_selectionMode(mode) {
+	Bind(wxEVT_LEFT_DOWN, &VirtualListCanvas::OnLeftDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &VirtualListCanvas::OnLeftDClick, this);
+	Bind(wxEVT_KEY_DOWN, &VirtualListCanvas::OnKeyDown, this);
+	Bind(wxEVT_SIZE, &VirtualListCanvas::OnSize, this);
+
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+	SetScrollStep(GetItemHeight());
+}
+
+VirtualListCanvas::~VirtualListCanvas() {
+}
+
+void VirtualListCanvas::RefreshList() {
+	UpdateScrollbar();
+	Refresh();
+}
+
+void VirtualListCanvas::UpdateScrollbar() {
+	m_itemHeight = GetItemHeight();
+	if (m_itemHeight <= 0) {
+		m_itemHeight = 32;
+	}
+	NanoVGCanvas::UpdateScrollbar(static_cast<int>(GetItemCount()) * m_itemHeight);
+}
+
+void VirtualListCanvas::EnsureVisible(int index) {
+	if (index < 0 || static_cast<size_t>(index) >= GetItemCount()) {
+		return;
+	}
+
+	int itemTop = index * m_itemHeight;
+	int itemBottom = itemTop + m_itemHeight;
+
+	int scrollTop = GetScrollPosition();
+	int scrollBottom = scrollTop + GetClientSize().y;
+
+	if (itemTop < scrollTop) {
+		SetScrollPosition(itemTop);
+	} else if (itemBottom > scrollBottom) {
+		SetScrollPosition(itemBottom - GetClientSize().y);
+	}
+}
+
+void VirtualListCanvas::SetSelection(int index) {
+	DeselectAll();
+	if (index != wxNOT_FOUND) {
+		Select(index, true);
+		m_anchorIndex = index;
+		EnsureVisible(index);
+	}
+	Refresh();
+	// Fire selection changed event
+	wxCommandEvent event(wxEVT_LISTBOX, GetId());
+	event.SetEventObject(this);
+	event.SetInt(index);
+	GetEventHandler()->ProcessEvent(event);
+}
+
+int VirtualListCanvas::GetSelection() const {
+	if (m_selections.empty()) {
+		return wxNOT_FOUND;
+	}
+	// Return the "first" selection (arbitrary if unordered_set, usually smallest index is expected)
+	// For compatibility, we can scan or just return *begin()
+	// To be robust, find min index
+	int minIdx = std::numeric_limits<int>::max();
+	for (int idx : m_selections) {
+		if (idx < minIdx) minIdx = idx;
+	}
+	return minIdx;
+}
+
+bool VirtualListCanvas::IsSelected(size_t index) const {
+	return m_selections.count(static_cast<int>(index)) > 0;
+}
+
+void VirtualListCanvas::Select(size_t index, bool select) {
+	if (index >= GetItemCount()) {
+		return;
+	}
+
+	if (select) {
+		if (m_selectionMode == SINGLE) {
+			m_selections.clear();
+		}
+		m_selections.insert(static_cast<int>(index));
+	} else {
+		m_selections.erase(static_cast<int>(index));
+	}
+}
+
+void VirtualListCanvas::DeselectAll() {
+	m_selections.clear();
+}
+
+void VirtualListCanvas::SelectAll() {
+	if (m_selectionMode == MULTIPLE) {
+		for (size_t i = 0; i < GetItemCount(); ++i) {
+			m_selections.insert(static_cast<int>(i));
+		}
+	}
+}
+
+size_t VirtualListCanvas::GetSelectedCount() const {
+	return m_selections.size();
+}
+
+std::vector<int> VirtualListCanvas::GetSelections() const {
+	std::vector<int> sels(m_selections.begin(), m_selections.end());
+	std::sort(sels.begin(), sels.end());
+	return sels;
+}
+
+void VirtualListCanvas::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	size_t count = GetItemCount();
+	if (count == 0) {
+		return;
+	}
+
+	int itemH = GetItemHeight();
+	int scrollTop = GetScrollPosition();
+	int startIndex = scrollTop / itemH;
+	int endIndex = (scrollTop + height + itemH - 1) / itemH;
+
+	startIndex = std::max(0, startIndex);
+	endIndex = std::min(static_cast<int>(count), endIndex);
+
+	// Retrieve system colors
+	wxColour highlight = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+	wxColour highlightText = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
+	wxColour listText = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
+
+	NVGcolor selBg = nvgRGBA(highlight.Red(), highlight.Green(), highlight.Blue(), 255);
+	// We might pass text color to OnDrawItem or rely on subclass to fetch it
+	// For simplicity, subclasses should handle text color based on IsSelected(index)
+
+	for (int i = startIndex; i < endIndex; ++i) {
+		int y = i * itemH; // Absolute Y
+		wxRect rect(0, y, width, itemH);
+
+		if (IsSelected(i)) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, (float)y, (float)width, (float)itemH);
+			nvgFillColor(vg, selBg);
+			nvgFill(vg);
+		}
+
+		OnDrawItem(vg, i, rect);
+	}
+}
+
+wxSize VirtualListCanvas::DoGetBestClientSize() const {
+	return FromDIP(wxSize(200, 300));
+}
+
+int VirtualListCanvas::HitTest(int y) const {
+	int itemH = GetItemHeight();
+	if (itemH <= 0) return wxNOT_FOUND;
+
+	int scrollTop = GetScrollPosition();
+	int absoluteY = scrollTop + y;
+	int index = absoluteY / itemH;
+
+	if (index >= 0 && static_cast<size_t>(index) < GetItemCount()) {
+		return index;
+	}
+	return wxNOT_FOUND;
+}
+
+void VirtualListCanvas::OnLeftDown(wxMouseEvent& event) {
+	SetFocus(); // Essential for key events
+
+	int index = HitTest(event.GetY());
+	if (index == wxNOT_FOUND) {
+		return;
+	}
+
+	if (m_selectionMode == MULTIPLE && event.ControlDown()) {
+		// Toggle
+		if (IsSelected(index)) {
+			Select(index, false);
+		} else {
+			Select(index, true);
+			m_anchorIndex = index;
+		}
+	} else if (m_selectionMode == MULTIPLE && event.ShiftDown() && m_anchorIndex != wxNOT_FOUND) {
+		// Range select
+		DeselectAll();
+		int start = std::min(m_anchorIndex, index);
+		int end = std::max(m_anchorIndex, index);
+		for (int i = start; i <= end; ++i) {
+			Select(i, true);
+		}
+	} else {
+		// Single click select (clears others)
+		DeselectAll();
+		Select(index, true);
+		m_anchorIndex = index;
+	}
+
+	Refresh();
+
+	// Fire event
+	wxCommandEvent evt(wxEVT_LISTBOX, GetId());
+	evt.SetEventObject(this);
+	evt.SetInt(index);
+	GetEventHandler()->ProcessEvent(evt);
+}
+
+void VirtualListCanvas::OnLeftDClick(wxMouseEvent& event) {
+	int index = HitTest(event.GetY());
+	if (index != wxNOT_FOUND) {
+		wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(index);
+		GetEventHandler()->ProcessEvent(evt);
+	}
+}
+
+void VirtualListCanvas::OnKeyDown(wxKeyEvent& event) {
+	int key = event.GetKeyCode();
+	int sel = GetSelection();
+	size_t count = GetItemCount();
+
+	if (count == 0) return;
+
+	int newSel = sel;
+
+	if (key == WXK_DOWN) {
+		if (sel == wxNOT_FOUND) newSel = 0;
+		else if (sel < (int)count - 1) newSel++;
+	} else if (key == WXK_UP) {
+		if (sel == wxNOT_FOUND) newSel = (int)count - 1;
+		else if (sel > 0) newSel--;
+	} else if (key == WXK_HOME) {
+		newSel = 0;
+	} else if (key == WXK_END) {
+		newSel = (int)count - 1;
+	} else if (key == WXK_PAGEUP) {
+		int visibleItems = GetClientSize().y / GetItemHeight();
+		newSel = std::max(0, sel - visibleItems);
+	} else if (key == WXK_PAGEDOWN) {
+		int visibleItems = GetClientSize().y / GetItemHeight();
+		newSel = std::min((int)count - 1, sel + visibleItems);
+	} else {
+		event.Skip();
+		return;
+	}
+
+	if (newSel != sel) {
+		if (m_selectionMode == MULTIPLE && event.ShiftDown()) {
+			// Range extension
+			// Simplified: Just extend from anchor
+			if (m_anchorIndex == wxNOT_FOUND) m_anchorIndex = sel != wxNOT_FOUND ? sel : 0;
+
+			DeselectAll();
+			int start = std::min(m_anchorIndex, newSel);
+			int end = std::max(m_anchorIndex, newSel);
+			for (int i = start; i <= end; ++i) {
+				Select(i, true);
+			}
+		} else {
+			// Move selection
+			DeselectAll();
+			Select(newSel, true);
+			m_anchorIndex = newSel;
+		}
+
+		EnsureVisible(newSel);
+		Refresh();
+
+		wxCommandEvent evt(wxEVT_LISTBOX, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(newSel);
+		GetEventHandler()->ProcessEvent(evt);
+	}
+}
+
+void VirtualListCanvas::OnSize(wxSizeEvent& event) {
+	UpdateScrollbar();
+	Refresh();
+	event.Skip();
+}

--- a/source/ui/controls/virtual_list_canvas.h
+++ b/source/ui/controls/virtual_list_canvas.h
@@ -1,0 +1,78 @@
+#ifndef RME_UI_CONTROLS_VIRTUAL_LIST_CANVAS_H_
+#define RME_UI_CONTROLS_VIRTUAL_LIST_CANVAS_H_
+
+#include "app/main.h"
+#include "util/nanovg_canvas.h"
+#include <vector>
+#include <unordered_set>
+
+/**
+ * @class VirtualListCanvas
+ * @brief A high-performance list control base class using NanoVG for rendering.
+ *
+ * This class replaces wxVListBox and wxListBox for cases requiring custom drawing
+ * (e.g., sprites, formatted text) with hardware acceleration.
+ *
+ * It supports:
+ * - Virtual data source (via GetItemCount/OnDrawItem)
+ * - Single or Multiple selection modes
+ * - Keyboard navigation
+ * - Mouse interaction
+ */
+class VirtualListCanvas : public NanoVGCanvas {
+public:
+	enum SelectionMode {
+		SINGLE,
+		MULTIPLE
+	};
+
+	VirtualListCanvas(wxWindow* parent, wxWindowID id = wxID_ANY, SelectionMode mode = SINGLE);
+	virtual ~VirtualListCanvas();
+
+	// Data Provider Interface
+	virtual size_t GetItemCount() const = 0;
+	virtual int GetItemHeight() const { return FromDIP(32); } // Default height
+
+	// Selection
+	void SetSelection(int index);
+	int GetSelection() const; // Returns first selected index or wxNOT_FOUND
+	bool IsSelected(size_t index) const;
+	void Select(size_t index, bool select = true);
+	void DeselectAll();
+	void SelectAll(); // Only for MULTIPLE mode
+	size_t GetSelectedCount() const;
+	std::vector<int> GetSelections() const;
+
+	// View Control
+	void RefreshList(); // Recalculates layout and repaints
+	void EnsureVisible(int index);
+
+protected:
+	// Drawing Hook
+	virtual void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) = 0;
+
+	// NanoVGCanvas Overrides
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Event Handlers
+	void OnLeftDown(wxMouseEvent& event);
+	void OnLeftDClick(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnSize(wxSizeEvent& event);
+
+	// Internal Helpers
+	int HitTest(int y) const;
+	void UpdateScrollbar();
+
+	SelectionMode m_selectionMode;
+	std::unordered_set<int> m_selections;
+	int m_hoverIndex = wxNOT_FOUND;
+	int m_anchorIndex = wxNOT_FOUND; // For shift-selection
+
+private:
+	// Cached metrics
+	int m_itemHeight = 32;
+};
+
+#endif // RME_UI_CONTROLS_VIRTUAL_LIST_CANVAS_H_

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,8 +3,8 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
 #include <vector>
+#include "ui/controls/virtual_list_canvas.h"
 
 class Brush;
 
@@ -19,18 +19,18 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogCanvas : public VirtualListCanvas {
 public:
-	FindDialogListBox(wxWindow* parent, wxWindowID id);
-	~FindDialogListBox();
+	FindDialogCanvas(wxWindow* parent, wxWindowID id);
+	~FindDialogCanvas();
 
-	void Clear();
+	void ClearList();
 	void SetNoMatches();
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	size_t GetItemCount() const override;
+	void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) override;
 
 protected:
 	bool cleared;
@@ -63,7 +63,7 @@ protected:
 	virtual void OnClickListInternal(wxCommandEvent&) = 0;
 	virtual void OnClickOKInternal() = 0;
 
-	FindDialogListBox* item_list;
+	FindDialogCanvas* item_list;
 	KeyForwardingTextCtrl* search_field;
 	wxTimer idle_input_timer;
 	const Brush* result_brush;

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -184,7 +184,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	// --------------- Items list ---------------
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
-	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
+	items_list = newd FindDialogCanvas(result_box_sizer->GetStaticBox(), wxID_ANY);
 	items_list->SetMinSize(wxSize(230, 512));
 	result_box_sizer->Add(items_list, 0, wxALL, 5);
 	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
@@ -282,7 +282,7 @@ void FindItemDialog::EnableProperties(bool enable) {
 }
 
 void FindItemDialog::RefreshContentsInternal() {
-	items_list->Clear();
+	items_list->ClearList();
 	ok_button->Enable(false);
 	ok_button->SetToolTip("Select an item to continue");
 
@@ -414,7 +414,7 @@ void FindItemDialog::RefreshContentsInternal() {
 		items_list->SetNoMatches();
 	}
 
-	items_list->Refresh();
+	items_list->RefreshList();
 }
 
 void FindItemDialog::OnOptionChange(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -27,7 +27,7 @@
 #include <wx/button.h>
 #include <wx/dialog.h>
 
-class FindDialogListBox;
+class FindDialogCanvas;
 
 class FindItemDialog : public wxDialog {
 public:
@@ -104,7 +104,7 @@ private:
 	wxCheckBox* floor_change;
 	wxCheckBox* invalid_item;
 
-	FindDialogListBox* items_list;
+	FindDialogCanvas* items_list;
 	wxStdDialogButtonSizer* buttons_box_sizer;
 	wxButton* ok_button;
 	wxButton* cancel_button;

--- a/source/ui/replace_items_window.h
+++ b/source/ui/replace_items_window.h
@@ -21,6 +21,7 @@
 #include "app/main.h"
 #include "ui/controls/item_buttons.h"
 #include "editor/editor.h"
+#include "ui/controls/virtual_list_canvas.h"
 
 struct ReplacingItem {
 	ReplacingItem() :
@@ -55,19 +56,23 @@ private:
 };
 
 // ============================================================================
-// ReplaceItemsListBox
+// ReplaceItemsCanvas
 
-class ReplaceItemsListBox : public wxVListBox {
+class ReplaceItemsCanvas : public VirtualListCanvas {
 public:
-	ReplaceItemsListBox(wxWindow* parent);
+	ReplaceItemsCanvas(wxWindow* parent);
 
 	bool AddItem(const ReplacingItem& item);
 	void MarkAsComplete(const ReplacingItem& item, uint32_t total);
 	void RemoveSelected();
 	bool CanAdd(uint16_t replaceId, uint16_t withId) const;
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) override;
+
+	size_t GetItemCount() const override {
+		return m_items.size();
+	}
+	int GetItemHeight() const override { return FromDIP(40); }
 
 	const std::vector<ReplacingItem>& GetItems() const {
 		return m_items;
@@ -78,8 +83,7 @@ public:
 
 private:
 	std::vector<ReplacingItem> m_items;
-	wxBitmap m_arrow_bitmap;
-	wxBitmap m_flag_bitmap;
+	// Bitmaps are replaced by NanoVG icons or we load them as static images
 };
 
 // ============================================================================
@@ -126,7 +130,7 @@ public:
 private:
 	void UpdateWidgets();
 
-	ReplaceItemsListBox* list;
+	ReplaceItemsCanvas* list;
 	ReplaceItemsButton* replace_button;
 	ReplaceItemsButton* with_button;
 	wxGauge* progress;


### PR DESCRIPTION
This PR modernizes the UI rendering for several list-based dialogs by replacing `wxVListBox` with a custom `NanoVGCanvas`-based `VirtualListCanvas`. This eliminates legacy `wxDC` immediate mode rendering (software blitting) in favor of hardware-accelerated OpenGL/NanoVG rendering, improving performance and consistency with the rest of the editor's rendering pipeline.

Changes:
- Added `source/ui/controls/virtual_list_canvas.h` and `.cpp`.
- Refactored `BrowseTileWindow` to use `BrowseTileCanvas`.
- Refactored `FindDialog` and `FindItemDialog` to use `FindDialogCanvas`.
- Refactored `ReplaceItemsWindow` to use `ReplaceItemsCanvas`.
- Updated `source/CMakeLists.txt` to include new files.
- Ensured HiDPI compliance using `FromDIP`.

---
*PR created automatically by Jules for task [957197433789861940](https://jules.google.com/task/957197433789861940) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a high-performance virtualized list control with hardware-accelerated GPU rendering for improved UI responsiveness and smoother scrolling.
  * Added support for flexible selection modes (single and multiple) with enhanced keyboard and mouse navigation capabilities.

* **Refactor**
  * Migrated existing list-based UI components to the new virtualized list architecture for consistent performance improvements across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->