### PR TITLE
[TILE/WXWIDGETS] Fix data loss in OTBM serialization for flag-only tiles

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -1637,7 +1637,7 @@ void IOMapOTBM::writeTileData(const Map& map, NodeFileWriteHandle& f) {
 					}
 
 					// Is it an empty tile that we can skip? (Leftovers...)
-					if (save_tile->size() == 0) {
+					if (save_tile->size() == 0 && !save_tile->isHouseTile() && !save_tile->getMapFlags()) {
 						continue;
 					}
 


### PR DESCRIPTION
FIX: IOMapOTBM::writeTileData now checks for `isHouseTile()` and `getMapFlags()` before skipping a tile, preventing data loss for tiles that only contain metadata (like PZ or House ID) but no items.

IMPACT: Prevents map data corruption where house definitions or protection zones painted on void space would disappear after saving and reloading.

TESTED: Code review confirmed logic. Verified by inspection that `Tile::size()` does not account for flags/houseID.

---
*PR created automatically by Jules for task [1798742212934000519](https://jules.google.com/task/1798742212934000519) started by @karolak6612*