### PR TITLE
📜 Auditor: Modernize Constants, CreatureDatabase, and Settings

### DIFF
--- a/source/app/definitions.h
+++ b/source/app/definitions.h
@@ -19,6 +19,8 @@
 #define RME_DEFINITIONS_H_
 
 #include <cstdint>
+#include <numbers>
+#include <string_view>
 
 #define __W_RME_APPLICATION_NAME__ wxString("OTAcademy Map Editor")
 #define __RME_APPLICATION_NAME__ std::string("OTAcademy Map Editor")
@@ -115,16 +117,16 @@
 #endif
 
 // Mathematical constants
-#define PI 3.14159265358979323846264338327950288419716939937510
-#define DEG2RAD (PI / 180.0)
-#define RAD2DEG (180.0 / DEG)
+constexpr double PI = std::numbers::pi_v<double>;
+constexpr double DEG2RAD = (PI / 180.0);
+constexpr double RAD2DEG = (180.0 / PI);
 
 // The height of the map (there should be more checks for this...)
-#define MAP_LAYERS 16
+constexpr int MAP_LAYERS = 16;
 
-#define MAP_MAX_WIDTH 65000
-#define MAP_MAX_HEIGHT 65000
-#define MAP_MAX_LAYER 15
+constexpr int MAP_MAX_WIDTH = 65000;
+constexpr int MAP_MAX_HEIGHT = 65000;
+constexpr int MAP_MAX_LAYER = 15;
 
 // Sanity limit for sprite counts
 constexpr std::uint32_t MAX_SPRITES = 3000000;
@@ -136,20 +138,20 @@ constexpr int TileSize = 32;
 constexpr int PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS = TileSize * 6;
 
 // The default size of sprites
-#define SPRITE_PIXELS 32
-#define SPRITE_PIXELS_SIZE SPRITE_PIXELS* SPRITE_PIXELS
+constexpr int SPRITE_PIXELS = 32;
+constexpr int SPRITE_PIXELS_SIZE = SPRITE_PIXELS * SPRITE_PIXELS;
 
 // The sea layer
-#define GROUND_LAYER 7
+constexpr int GROUND_LAYER = 7;
 
 constexpr int ClientMapWidth = 17;
 constexpr int ClientMapHeight = 13;
 
-#define MAP_LOAD_FILE_WILDCARD_OTGZ "OpenTibia Binary Map (*.otbm;*.otgz)|*.otbm;*.otgz"
-#define MAP_SAVE_FILE_WILDCARD_OTGZ "OpenTibia Binary Map (*.otbm)|*.otbm|Compressed OpenTibia Binary Map (*.otgz)|*.otgz"
+constexpr std::string_view MAP_LOAD_FILE_WILDCARD_OTGZ = "OpenTibia Binary Map (*.otbm;*.otgz)|*.otbm;*.otgz";
+constexpr std::string_view MAP_SAVE_FILE_WILDCARD_OTGZ = "OpenTibia Binary Map (*.otbm)|*.otbm|Compressed OpenTibia Binary Map (*.otgz)|*.otgz";
 
-#define MAP_LOAD_FILE_WILDCARD "OpenTibia Binary Map (*.otbm)|*.otbm"
-#define MAP_SAVE_FILE_WILDCARD "OpenTibia Binary Map (*.otbm)|*.otbm"
+constexpr std::string_view MAP_LOAD_FILE_WILDCARD = "OpenTibia Binary Map (*.otbm)|*.otbm";
+constexpr std::string_view MAP_SAVE_FILE_WILDCARD = "OpenTibia Binary Map (*.otbm)|*.otbm";
 
 // Lights
 constexpr int MaxLightIntensity = 8;

--- a/source/app/settings.cpp
+++ b/source/app/settings.cpp
@@ -56,8 +56,8 @@ bool Settings::getBoolean(uint32_t key) const {
 	}
 
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		return dv.intval != 0;
+	if (auto pval = std::get_if<int>(&dv.value)) {
+		return *pval != 0;
 	}
 	return false;
 }
@@ -67,8 +67,8 @@ int Settings::getInteger(uint32_t key) const {
 		return 0;
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		return dv.intval;
+	if (auto pval = std::get_if<int>(&dv.value)) {
+		return *pval;
 	}
 	return 0;
 }
@@ -78,8 +78,8 @@ float Settings::getFloat(uint32_t key) const {
 		return 0.0;
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_FLOAT) {
-		return dv.floatval;
+	if (auto pval = std::get_if<float>(&dv.value)) {
+		return *pval;
 	}
 	return 0.0;
 }
@@ -89,8 +89,8 @@ std::string Settings::getString(uint32_t key) const {
 		return "";
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_STR && dv.strval != nullptr) {
-		return *dv.strval;
+	if (auto pval = std::get_if<std::string>(&dv.value)) {
+		return *pval;
 	}
 	return "";
 }
@@ -100,11 +100,8 @@ void Settings::setInteger(uint32_t key, int newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		dv.intval = newval;
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_INT;
-		dv.intval = newval;
+	if (std::holds_alternative<int>(dv.value) || std::holds_alternative<std::monostate>(dv.value)) {
+		dv.value = newval;
 	}
 }
 
@@ -113,11 +110,8 @@ void Settings::setFloat(uint32_t key, float newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_FLOAT) {
-		dv.floatval = newval;
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_FLOAT;
-		dv.floatval = newval;
+	if (std::holds_alternative<float>(dv.value) || std::holds_alternative<std::monostate>(dv.value)) {
+		dv.value = newval;
 	}
 }
 
@@ -126,27 +120,23 @@ void Settings::setString(uint32_t key, std::string newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_STR) {
-		delete dv.strval;
-		dv.strval = newd std::string(newval);
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_STR;
-		dv.strval = newd std::string(newval);
+	if (std::holds_alternative<std::string>(dv.value) || std::holds_alternative<std::monostate>(dv.value)) {
+		dv.value = std::move(newval);
 	}
 }
 
 std::string Settings::DynamicValue::str() {
-	switch (type) {
-		case TYPE_FLOAT:
-			return f2s(floatval);
-		case TYPE_STR:
-			return std::string(*strval);
-		case TYPE_INT:
-			return i2s(intval);
-		default:
-		case TYPE_NONE:
-			return "";
-	}
+	if (auto pval = std::get_if<int>(&value)) return i2s(*pval);
+	if (auto pval = std::get_if<float>(&value)) return f2s(*pval);
+	if (auto pval = std::get_if<std::string>(&value)) return *pval;
+	return "";
+}
+
+Settings::DynamicType Settings::DynamicValue::getType() const {
+	if (std::holds_alternative<int>(value)) return TYPE_INT;
+	if (std::holds_alternative<float>(value)) return TYPE_FLOAT;
+	if (std::holds_alternative<std::string>(value)) return TYPE_STR;
+	return TYPE_NONE;
 }
 
 void Settings::IO(IOMode mode) {

--- a/source/app/settings.h
+++ b/source/app/settings.h
@@ -19,6 +19,7 @@
 #define RME_SETTINGS_H_
 
 #include "app/main.h"
+#include <variant>
 
 namespace Config {
 	enum Key {
@@ -240,49 +241,30 @@ public:
 	};
 	class DynamicValue {
 	public:
-		DynamicValue() :
-			type(TYPE_NONE) {
-			intval = 0;
-		};
-		DynamicValue(DynamicType t) :
-			type(t) {
-			if (t == TYPE_STR) {
-				strval = nullptr;
-			} else if (t == TYPE_INT) {
-				intval = 0;
-			} else if (t == TYPE_FLOAT) {
-				floatval = 0.0;
-			} else {
-				intval = 0;
-			}
-		};
-		~DynamicValue() {
-			if (type == TYPE_STR) {
-				delete strval;
+		DynamicValue() = default;
+		DynamicValue(DynamicType t) {
+			switch (t) {
+				case TYPE_INT:
+					value = 0;
+					break;
+				case TYPE_FLOAT:
+					value = 0.0f;
+					break;
+				case TYPE_STR:
+					value = std::string();
+					break;
+				default:
+					value = std::monostate{};
+					break;
 			}
 		}
-		DynamicValue(const DynamicValue& dv) :
-			type(dv.type) {
-			if (dv.type == TYPE_STR) {
-				strval = newd std::string(*dv.strval);
-			} else if (dv.type == TYPE_INT) {
-				intval = dv.intval;
-			} else if (dv.type == TYPE_FLOAT) {
-				floatval = dv.floatval;
-			} else {
-				intval = 0;
-			}
-		};
+		// Rule of zero: automatic destructor, copy/move constructors and assignment
 
 		std::string str();
+		DynamicType getType() const;
 
 	private:
-		DynamicType type;
-		union {
-			int intval;
-			std::string* strval;
-			float floatval;
-		};
+		std::variant<std::monostate, int, float, std::string> value;
 
 		friend class Settings;
 	};

--- a/source/game/creatures.h
+++ b/source/game/creatures.h
@@ -22,11 +22,13 @@
 
 #include <string>
 #include <map>
+#include <memory>
+#include <vector>
 
 class CreatureType;
 class CreatureBrush;
 
-using CreatureMap = std::map<std::string, CreatureType*>;
+using CreatureMap = std::map<std::string, std::unique_ptr<CreatureType>>;
 
 class CreatureDatabase {
 protected:
@@ -74,8 +76,8 @@ public:
 	Outfit outfit;
 	CreatureBrush* brush;
 
-	static CreatureType* loadFromXML(pugi::xml_node node, std::vector<std::string>& warnings);
-	static CreatureType* loadFromOTXML(const FileName& filename, pugi::xml_document& node, std::vector<std::string>& warnings);
+	static std::unique_ptr<CreatureType> loadFromXML(pugi::xml_node node, std::vector<std::string>& warnings);
+	static std::unique_ptr<CreatureType> loadFromOTXML(const FileName& filename, pugi::xml_document& node, std::vector<std::string>& warnings);
 };
 
 extern CreatureDatabase g_creatures;

--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -278,7 +278,7 @@ void Materials::createOtherTileset() {
 	}
 
 	for (CreatureMap::iterator iter = g_creatures.begin(); iter != g_creatures.end(); ++iter) {
-		CreatureType* type = iter->second;
+		CreatureType* type = iter->second.get();
 
 		if (type->brush == nullptr) {
 			type->brush = newd CreatureBrush(type);


### PR DESCRIPTION
Modernized codebase by replacing legacy C++ patterns with C++20 features.
- Constants: Replaced `#define` with `constexpr`.
- Memory: Replaced manual `new`/`delete` in `CreatureDatabase` with `std::unique_ptr`.
- Safety: Replaced `union` in `Settings` with `std::variant`.
- Fixes: Preserved runtime properties in `CreatureDatabase::importXMLFromOT` during reload.

---
*PR created automatically by Jules for task [3526716154469107291](https://jules.google.com/task/3526716154469107291) started by @karolak6612*