### PR TITLE
[WXWIDGETS] Fix wxWidgets violations in FindDialog and IngamePreview

### DIFF
--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -54,29 +54,29 @@ namespace IngamePreview {
 		wxBoxSizer* toolbar_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 		// Toggles
-		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, wxSize(28, 24));
-		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, wxSize(FromDIP(28), FromDIP(24)));
+		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(76, 175, 80)));
 		follow_btn->SetValue(true);
 		follow_btn->SetToolTip("Follow Selection / Camera");
 		toolbar_sizer->Add(follow_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, wxSize(28, 24));
-		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SUNNY, wxSize(16, 16), wxColour(255, 235, 59)));
+		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, wxSize(FromDIP(28), FromDIP(24)));
+		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SUNNY, wxColour(255, 235, 59)));
 		lighting_btn->SetValue(false);
 		lighting_btn->SetToolTip("Toggle Lighting");
 		toolbar_sizer->Add(lighting_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, wxSize(28, 24));
-		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ACCOUNT, wxSize(16, 16), wxColour(96, 125, 139)));
+		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, wxSize(FromDIP(28), FromDIP(24)));
+		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_ACCOUNT, wxColour(96, 125, 139)));
 		outfit_btn->SetToolTip("Change Preview Creature Outfit");
 		toolbar_sizer->Add(outfit_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
 		// Sliders
-		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, wxSize(60, -1));
+		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, wxSize(FromDIP(60), -1));
 		ambient_slider->SetToolTip("Ambient Light");
 		toolbar_sizer->Add(ambient_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, wxSize(60, -1));
+		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, wxSize(FromDIP(60), -1));
 		intensity_slider->SetToolTip("Light Intensity");
 		toolbar_sizer->Add(intensity_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
@@ -87,29 +87,29 @@ namespace IngamePreview {
 
 		// Viewport Controls
 		// Width
-		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_MINUS, wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_w_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
-		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
+		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, wxSize(FromDIP(30), -1), wxTE_READONLY | wxTE_CENTER);
 		toolbar_sizer->Add(viewport_x_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS, wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_w_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
 		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
 		// Height
-		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_MINUS, wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_h_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
-		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
+		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, wxSize(FromDIP(30), -1), wxTE_READONLY | wxTE_CENTER);
 		toolbar_sizer->Add(viewport_y_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, wxSize(FromDIP(24), FromDIP(24)));
+		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS, wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_h_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
 		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
@@ -184,9 +184,9 @@ namespace IngamePreview {
 	void IngamePreviewWindow::SetFollowSelection(bool follow) {
 		follow_selection = follow;
 		if (follow_selection) {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(76, 175, 80)));
 		} else {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(158, 158, 158)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(158, 158, 158)));
 		}
 		follow_btn->SetValue(follow_selection);
 	}

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -52,11 +52,11 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
 	okBtn->SetToolTip("Jump to selected item/brush");
 	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
-	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
 	cancelBtn->SetToolTip("Close this window");
 	stdsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
@@ -75,9 +75,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	// We can't call it here since it calls an abstract function, call in child constructors instead.
 	// RefreshContents();
 
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(32, 32)));
-	SetIcon(icon);
+	SetIcon(IMAGE_MANAGER.GetBitmapBundle(ICON_SEARCH).GetIcon(FromDIP(wxSize(32, 32))));
 }
 
 FindDialog::~FindDialog() = default;
@@ -364,12 +362,12 @@ void FindDialogListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const
 
 		if (IsSelected(n)) {
 			if (HasFocus()) {
-				dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
+				dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 			} else {
-				dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
+				dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
 			}
 		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+			dc.SetTextForeground(wxSystemSettings::GetColour(wxSYS_COLOUR_WINDOWTEXT));
 		}
 
 		dc.DrawText(wxstr(brushlist[n]->getName()), rect.GetX() + rect.GetHeight() + FROM_DIP(this, 8), rect.GetY() + FROM_DIP(this, 6));


### PR DESCRIPTION
This PR addresses wxWidgets violations identified by the WxFixer agent.
It focuses on High DPI support and theming in `FindDialog` and `IngamePreviewWindow`.

Changes:
- `source/ui/dialogs/find_dialog.cpp`: Updated buttons to use `GetBitmapBundle`, and updated `OnDrawItem` to use system colors.
- `source/ingame_preview/ingame_preview_window.cpp`: Updated buttons and sliders to use `GetBitmapBundle` and `FromDIP` for sizing.

This ensures the UI scales correctly on high-resolution displays and respects the system theme (e.g. Dark Mode).

---
*PR created automatically by Jules for task [13201688200339143740](https://jules.google.com/task/13201688200339143740) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed UI element scaling on high-resolution displays with improved DPI support
  * Updated dialog colors and text styling to respect system theme preferences

<!-- end of auto-generated comment: release notes by coderabbit.ai -->