### PR TITLE
🗝️ Keeper: Fix NanoVG context destruction order in MapCanvas

### DIFF
--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -150,11 +150,13 @@ MapCanvas::MapCanvas(MapWindow* parent, Editor& editor, int* attriblist) :
 }
 
 MapCanvas::~MapCanvas() {
-	if (auto context = g_gui.GetGLContext(this)) {
+	if (m_glContext) {
+		SetCurrent(*m_glContext);
+	} else if (auto context = g_gui.GetGLContext(this)) {
 		SetCurrent(*context);
-		drawer.reset();
-		m_nvg.reset();
 	}
+	drawer.reset();
+	m_nvg.reset();
 }
 
 void MapCanvas::Refresh() {

--- a/source/rendering/ui/map_display.h
+++ b/source/rendering/ui/map_display.h
@@ -43,6 +43,9 @@ class ScreenshotController;
 class MapMenuHandler;
 
 class MapCanvas : public wxGLCanvas {
+	std::unique_ptr<wxGLContext> m_glContext;
+	std::unique_ptr<NVGcontext, NVGDeleter> m_nvg;
+
 public:
 	MapCanvas(MapWindow* parent, Editor& editor, int* attriblist);
 	~MapCanvas() override;
@@ -181,8 +184,6 @@ public:
 private:
 	MapWindow* GetMapWindow() const;
 	bool renderer_initialized = false;
-	std::unique_ptr<wxGLContext> m_glContext;
-	std::unique_ptr<NVGcontext, NVGDeleter> m_nvg;
 };
 
 #endif


### PR DESCRIPTION
This PR addresses a potential use-after-free issue in `MapCanvas` destruction.

**Changes:**
- Moved `m_glContext` and `m_nvg` declarations to the top of `MapCanvas` class in `source/rendering/ui/map_display.h`. This ensures they are destroyed *after* `drawer` (which depends on `m_nvg` for cleanup via `TooltipDrawer`).
- Updated `MapCanvas::~MapCanvas` in `source/rendering/ui/map_display.cpp` to prefer using the instance's own `m_glContext` for setting the current context during cleanup, ensuring robustness even if `g_gui.GetGLContext(this)` fails.

**Reasoning:**
- `TooltipDrawer` (owned by `MapDrawer` owned by `MapCanvas::drawer`) caches NanoVG images and tries to delete them in its destructor.
- `nvgDeleteImage` requires a valid NanoVG context.
- Previously, `m_nvg` was declared last in `MapCanvas`, meaning it was destroyed *before* `drawer` during automatic destruction (if the manual reset block was skipped or executed in wrong order).
- By moving `m_nvg` declaration before `drawer`, we ensure `drawer` is destroyed first, so `TooltipDrawer` can safely access `m_nvg` to delete images.
- Explicitly setting `m_glContext` current ensures the GL driver is in the correct state for resource deletion.

---
*PR created automatically by Jules for task [10865448531444047234](https://jules.google.com/task/10865448531444047234) started by @karolak6612*