### PR TITLE
[ICONS] Modernize icons in toolbars and dialogs

### DIFF
--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -67,7 +67,7 @@ void ReplaceItemsButton::SetItemId(uint16_t id) {
 ReplaceItemsListBox::ReplaceItemsListBox(wxWindow* parent) :
 	wxVListBox(parent, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE) {
 	m_arrow_bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCATION_ARROW, FROM_DIP(parent, wxSize(16, 16)));
-	m_flag_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PROTECTION_ZONE_SMALL, FROM_DIP(parent, wxSize(16, 16)));
+	m_flag_bitmap = IMAGE_MANAGER.GetBitmap(ICON_FLAG, FROM_DIP(parent, wxSize(16, 16)));
 }
 
 bool ReplaceItemsListBox::AddItem(const ReplacingItem& item) {

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -18,21 +18,21 @@ const wxString BrushToolBar::PANE_NAME = "brush_toolbar";
 BrushToolBar::BrushToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_OPTIONAL_BORDER_SMALL, icon_size);
-	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_ERASER_SMALL, icon_size);
-	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PROTECTION_ZONE_SMALL, icon_size);
-	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_PVP_ZONE_SMALL, icon_size);
-	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_LOGOUT_ZONE_SMALL, icon_size);
-	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PVP_ZONE_SMALL, icon_size);
-	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_SMALL, icon_size);
-	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_LOCKED_SMALL, icon_size);
-	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_MAGIC_SMALL, icon_size);
-	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_QUEST_SMALL, icon_size);
-	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_ALT_SMALL, icon_size);
-	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_ARCHWAY_SMALL, icon_size);
+	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(ICON_BORDER_ALL, icon_size);
+	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ERASER, icon_size);
+	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SHIELD_HALVED, icon_size);
+	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_HANDSHAKE_SIMPLE_SLASH, icon_size);
+	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(ICON_USER_LOCK, icon_size);
+	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SKULL, icon_size);
+	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, icon_size);
+	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCK, icon_size);
+	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WAND_MAGIC, icon_size);
+	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(ICON_BOX_OPEN, icon_size);
+	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, icon_size);
+	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ARCHWAY, icon_size);
 
-	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_HATCH_SMALL, icon_size);
-	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_NORMAL_SMALL, icon_size);
+	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MINIMIZE, icon_size);
+	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MAXIMIZE, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_BRUSHES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);

--- a/source/ui/toolbar/size_toolbar.cpp
+++ b/source/ui/toolbar/size_toolbar.cpp
@@ -15,15 +15,15 @@ const wxString SizeToolBar::PANE_NAME = "sizes_toolbar";
 SizeToolBar::SizeToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size);
-	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size);
-	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size);
-	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size);
-	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size);
-	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size);
-	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size);
+	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_CIRCLE, icon_size);
+	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SQUARE, icon_size);
+	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(ICON_1, icon_size);
+	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(ICON_2, icon_size);
+	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(ICON_3, icon_size);
+	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(ICON_4, icon_size);
+	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(ICON_5, icon_size);
+	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(ICON_6, icon_size);
+	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(ICON_7, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_SIZES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
@@ -69,27 +69,9 @@ void SizeToolBar::UpdateBrushSize(BrushShape shape, int size) {
 	if (shape == BRUSHSHAPE_CIRCLE) {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, true);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, false);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_7_SMALL, icon_size));
 	} else {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, false);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, true);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size));
 	}
 
 	toolbar->ToggleTool(TOOLBAR_SIZES_1, size == 0);


### PR DESCRIPTION
Replaced legacy `IMAGE_*` PNG assets with standardized `ICON_*` SVG assets in `BrushToolBar`, `SizeToolBar`, and `ReplaceItemsDialog` to modernize the UI and ensure consistent iconography.

- Updated `source/ui/toolbar/brush_toolbar.cpp` to use SVG icons for tools.
- Updated `source/ui/toolbar/size_toolbar.cpp` to use numeric SVG icons for sizes and shape icons for brush shapes, simplifying logic.
- Updated `source/ui/replace_items_window.cpp` to use `ICON_FLAG` instead of a legacy protection zone image.


---
*PR created automatically by Jules for task [5089210204490136335](https://jules.google.com/task/5089210204490136335) started by @karolak6612*