### PR TITLE
📊 Profiler: Optimize sprite pattern calculation

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -30,12 +30,12 @@ ItemDrawer::ItemDrawer() {
 ItemDrawer::~ItemDrawer() {
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, std::optional<SpritePatterns> patterns) {
 	const Position& pos = tile->getPosition();
-	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile);
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile, patterns);
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile, std::optional<SpritePatterns> patterns) {
 	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
@@ -118,12 +118,12 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	draw_x -= spr->draw_height;
 	draw_y -= spr->draw_height;
 
-	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
-	int subtype = patterns.subtype;
-	int pattern_x = patterns.x;
-	int pattern_y = patterns.y;
-	int pattern_z = patterns.z;
-	int frame = patterns.frame;
+	SpritePatterns sp = patterns ? *patterns : PatternCalculator::Calculate(spr, it, item, tile, pos);
+	int subtype = sp.subtype;
+	int pattern_x = sp.x;
+	int pattern_y = sp.y;
+	int pattern_z = sp.z;
+	int frame = sp.frame;
 
 	if (!ephemeral && options.transparent_items && (!it.isGroundTile() || spr->width > 1 || spr->height > 1) && !it.isSplash() && (!it.isBorder || spr->width > 1 || spr->height > 1)) {
 		alpha /= 2;

--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -8,6 +8,8 @@
 #include "app/definitions.h"
 #include "map/position.h"
 
+#include <optional>
+
 // Forward declarations
 class SpriteDrawer;
 class CreatureDrawer;
@@ -16,6 +18,7 @@ class Item;
 class ItemType;
 class HookIndicatorDrawer;
 class DoorIndicatorDrawer;
+struct SpritePatterns;
 
 struct DrawingOptions;
 class SpriteBatch;
@@ -25,8 +28,8 @@ public:
 	ItemDrawer();
 	~ItemDrawer();
 
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, std::optional<SpritePatterns> patterns = std::nullopt);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr, std::optional<SpritePatterns> patterns = std::nullopt);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -209,8 +209,8 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		}
 	} else {
 		if (tile->ground) {
-			PreloadItem(tile, tile->ground.get());
-			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b);
+			auto patterns = PreloadItem(tile, tile->ground.get());
+			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b, 255, patterns);
 		} else if (options.always_show_zones && (r != 255 || g != 255 || b != 255)) {
 			ItemType* zoneItem = &g_items[SPRITE_ZONE];
 			item_drawer->DrawRawBrush(sprite_batch, sprite_drawer, draw_x, draw_y, zoneItem, r, g, b, 60);
@@ -273,11 +273,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 					}
 				}
 
-				PreloadItem(tile, item.get());
+				auto patterns = PreloadItem(tile, item.get());
 
 				// item sprite
 				if (item->isBorder()) {
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b, 255, patterns);
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
@@ -297,7 +297,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 							}
 						}
 					}
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib, 255, patterns);
 				}
 			}
 			// monster/npc on tile
@@ -316,9 +316,9 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 }
 
-void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
+std::optional<SpritePatterns> TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (!item) {
-		return;
+		return std::nullopt;
 	}
 
 	const ItemType& it = g_items[item->getID()];
@@ -326,7 +326,9 @@ void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (spr && !spr->isSimpleAndLoaded()) {
 		SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, tile->getPosition());
 		rme::collectTileSprites(spr, patterns.x, patterns.y, patterns.z, patterns.frame);
+		return patterns;
 	}
+	return std::nullopt;
 }
 
 void TileRenderer::AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -4,10 +4,12 @@
 #include <memory>
 #include <sstream>
 #include <stdint.h>
+#include <optional>
 
 class TileLocation;
 struct RenderView;
 struct DrawingOptions;
+struct SpritePatterns;
 class Editor;
 class ItemDrawer;
 class SpriteDrawer;
@@ -28,7 +30,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item);
+	std::optional<SpritePatterns> PreloadItem(const Tile* tile, Item* item);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This PR implements an optimization identified by the Profiler agent to reduce redundant CPU calculations during rendering.

**Bottleneck:**
`PatternCalculator::Calculate` was being called twice for every complex item (animated, multi-part, etc.) in the viewport: once in `TileRenderer::PreloadItem` and again in `ItemDrawer::BlitItem`.

**Fix:**
- Modified `TileRenderer::PreloadItem` to return `std::optional<SpritePatterns>` containing the calculated patterns (if any).
- Updated `TileRenderer::DrawTile` to capture this result.
- Updated `ItemDrawer::BlitItem` to accept an optional `SpritePatterns` argument. If provided, it uses the pre-calculated patterns; otherwise, it calculates them as before (maintaining backward compatibility for other call sites).

**Impact:**
- Eliminates one `PatternCalculator::Calculate` call per complex item per frame.
- Reduces CPU usage in the rendering loop, especially for scenes with many animated items or fields.
- Fully compliant with Painter's Algorithm (no visual changes, just data reuse).


---
*PR created automatically by Jules for task [15568817641456853428](https://jules.google.com/task/15568817641456853428) started by @karolak6612*