### PR TITLE
Sentinel: Modernize TooltipDrawer and cleanup legacy comments

### DIFF
--- a/source/rendering/drawers/overlays/brush_overlay_drawer.cpp
+++ b/source/rendering/drawers/overlays/brush_overlay_drawer.cpp
@@ -171,8 +171,6 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 				}
 			}
 		} else {
-			// if (brush->is<RAWBrush>()) { glEnable(GL_TEXTURE_2D); } -> handled by DrawRawBrush or BatchRenderer
-
 			if (g_gui.GetBrushShape() == BRUSHSHAPE_SQUARE || brush->is<SpawnBrush>()) {
 				if (brush->is<RAWBrush>() || brush->is<OptionalBorderBrush>()) {
 					int start_x, end_x;
@@ -300,7 +298,6 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 				}
 			}
 
-			// if (brush->is<RAWBrush>()) { glDisable(GL_TEXTURE_2D); }
 		}
 	} else {
 		if (brush->is<WallBrush>()) {
@@ -347,7 +344,6 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 				sprite_batch.drawRect((float)cx, (float)cy, (float)TileSize, (float)TileSize, get_check_color(brush, editor, Position(view.mouse_map_x, view.mouse_map_y, view.floor)), *g_gui.gfx.getAtlasManager());
 			}
 		} else if (brush->is<CreatureBrush>()) {
-			// glEnable(GL_TEXTURE_2D);
 			int cy = (view.mouse_map_y) * TileSize - view.view_scroll_y - view.getFloorAdjustment();
 			int cx = (view.mouse_map_x) * TileSize - view.view_scroll_x - view.getFloorAdjustment();
 			CreatureBrush* creature_brush = brush->as<CreatureBrush>();
@@ -356,11 +352,9 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 			} else {
 				creature_drawer->BlitCreature(sprite_batch, sprite_drawer, cx, cy, creature_brush->getType()->outfit, SOUTH, 255, 64, 64, 160);
 			}
-			// glDisable(GL_TEXTURE_2D);
 		} else if (!brush->is<DoodadBrush>()) {
 			RAWBrush* raw_brush = nullptr;
 			if (brush->is<RAWBrush>()) { // Textured brush
-				// glEnable(GL_TEXTURE_2D);
 				raw_brush = brush->as<RAWBrush>();
 			}
 
@@ -412,10 +406,6 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 					}
 				}
 			}
-
-			// if (brush->is<RAWBrush>()) { // Textured brush
-			// 	glDisable(GL_TEXTURE_2D);
-			// }
 		}
 	}
 }

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -412,16 +412,17 @@ void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width
 	uint8_t borderR, borderG, borderB;
 	getHeaderColor(tooltip.category, borderR, borderG, borderB);
 
-	// Shadow (multi-layer soft shadow)
-	for (int i = 3; i >= 0; i--) {
-		float alpha = 35.0f + (3 - i) * 20.0f;
-		float spread = i * 2.0f;
-		float offsetY = 3.0f + i * 1.0f;
-		nvgBeginPath(vg);
-		nvgRoundedRect(vg, x - spread, y + offsetY - spread, width + spread * 2, height + spread * 2, cornerRadius + spread);
-		nvgFillColor(vg, nvgRGBA(0, 0, 0, static_cast<unsigned char>(alpha)));
-		nvgFill(vg);
-	}
+	// Shadow (single nvgBoxGradient)
+	float shadowBlur = 8.0f;
+	float shadowOffset = 4.0f;
+	// BoxGradient: x, y, w, h, r, f, col1, col2
+	NVGpaint shadowPaint = nvgBoxGradient(vg, x, y + shadowOffset, width, height, cornerRadius, shadowBlur, nvgRGBA(0, 0, 0, 128), nvgRGBA(0, 0, 0, 0));
+
+	nvgBeginPath(vg);
+	// Draw a rect that encompasses the shadow area
+	nvgRect(vg, x - shadowBlur - 10, y - shadowBlur - 10, width + (shadowBlur + 10) * 2, height + (shadowBlur + 10) * 2 + shadowOffset);
+	nvgFillPaint(vg, shadowPaint);
+	nvgFill(vg);
 
 	// Main background
 	nvgBeginPath(vg);

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -212,7 +212,6 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// So we draw a textured quad.
 
 	// We can reuse the `shader` but we need a "PASS THROUGH" mode or a separate shader.
-	// Easier to just use `glEnable(GL_TEXTURE_2D)` and fixed function if compatible? No, we are in Core Profile likely.
 	// Let's assume we need a simple texture shader.
 	// BUT wait, `LightDrawer::draw` previously drew a quad with the computed light.
 	// We can just use a simple "Texture Shader" here.


### PR DESCRIPTION
This PR modernizes the `TooltipDrawer` by optimizing shadow rendering using `nvgBoxGradient`, reducing draw calls. It also cleans up legacy OpenGL comments in `BrushOverlayDrawer` and `LightDrawer`.

---
*PR created automatically by Jules for task [10809274923595371855](https://jules.google.com/task/10809274923595371855) started by @karolak6612*