### PR TITLE
Optimize rendering by avoiding redundant pattern calculations

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -30,12 +30,12 @@ ItemDrawer::ItemDrawer() {
 ItemDrawer::~ItemDrawer() {
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, std::optional<SpritePatterns> pre_calculated_patterns) {
 	const Position& pos = tile->getPosition();
-	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile);
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile, pre_calculated_patterns);
 }
 
-void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile, std::optional<SpritePatterns> pre_calculated_patterns) {
 	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
@@ -118,7 +118,12 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	draw_x -= spr->draw_height;
 	draw_y -= spr->draw_height;
 
-	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+	SpritePatterns patterns;
+	if (pre_calculated_patterns) {
+		patterns = *pre_calculated_patterns;
+	} else {
+		patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+	}
 	int subtype = patterns.subtype;
 	int pattern_x = patterns.x;
 	int pattern_y = patterns.y;

--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -7,6 +7,8 @@
 
 #include "app/definitions.h"
 #include "map/position.h"
+#include <optional>
+#include "rendering/utilities/pattern_calculator.h"
 
 // Forward declarations
 class SpriteDrawer;
@@ -25,8 +27,8 @@ public:
 	ItemDrawer();
 	~ItemDrawer();
 
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, std::optional<SpritePatterns> pre_calculated_patterns = std::nullopt);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr, std::optional<SpritePatterns> pre_calculated_patterns = std::nullopt);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -209,8 +209,8 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		}
 	} else {
 		if (tile->ground) {
-			PreloadItem(tile, tile->ground.get());
-			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b);
+			auto patterns = PreloadItem(tile, tile->ground.get());
+			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b, 255, patterns);
 		} else if (options.always_show_zones && (r != 255 || g != 255 || b != 255)) {
 			ItemType* zoneItem = &g_items[SPRITE_ZONE];
 			item_drawer->DrawRawBrush(sprite_batch, sprite_drawer, draw_x, draw_y, zoneItem, r, g, b, 60);
@@ -273,11 +273,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 					}
 				}
 
-				PreloadItem(tile, item.get());
+				auto patterns = PreloadItem(tile, item.get());
 
 				// item sprite
 				if (item->isBorder()) {
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b, 255, patterns);
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
@@ -297,7 +297,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 							}
 						}
 					}
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib, 255, patterns);
 				}
 			}
 			// monster/npc on tile
@@ -316,9 +316,9 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 }
 
-void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
+std::optional<SpritePatterns> TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (!item) {
-		return;
+		return std::nullopt;
 	}
 
 	const ItemType& it = g_items[item->getID()];
@@ -326,7 +326,9 @@ void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (spr && !spr->isSimpleAndLoaded()) {
 		SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, tile->getPosition());
 		rme::collectTileSprites(spr, patterns.x, patterns.y, patterns.z, patterns.frame);
+		return patterns;
 	}
+	return std::nullopt;
 }
 
 void TileRenderer::AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <sstream>
 #include <stdint.h>
+#include <optional>
+#include "rendering/utilities/pattern_calculator.h"
 
 class TileLocation;
 struct RenderView;
@@ -28,7 +30,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item);
+	std::optional<SpritePatterns> PreloadItem(const Tile* tile, Item* item);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This change optimizes the OpenGL rendering pipeline by eliminating redundant calls to `PatternCalculator::Calculate`. 

Previously, `PatternCalculator::Calculate` was called twice for every item: once in `TileRenderer::PreloadItem` (to trigger sprite preloading) and again in `ItemDrawer::BlitItem` (to determine draw coordinates). 

The fix modifies `PreloadItem` to return the calculated patterns, which are then passed to `BlitItem`. `BlitItem` now accepts an optional `SpritePatterns` argument and uses it if provided, falling back to calculation only if necessary. This aligns with the "Raster" agent's goal of identifying and fixing rendering inefficiencies.

---
*PR created automatically by Jules for task [12004488010637674495](https://jules.google.com/task/12004488010637674495) started by @karolak6612*