### PR TITLE
👻 Phantom: Fix tooltips and optimize waypoint list

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -94,8 +94,13 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetToolTip("Save changes");
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetToolTip("Discard changes");
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -59,8 +59,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetToolTip("Add House");
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetToolTip("Edit House");
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetToolTip("Remove House");
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);
@@ -72,7 +75,9 @@ HousePalette::HousePalette(wxWindow* parent) :
 	wxStaticBoxSizer* brush_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Brushes");
 
 	house_brush_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_HOUSE_BRUSH, "House tiles");
+	house_brush_button->SetToolTip("Paint house tiles");
 	select_exit_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_EXIT_BRUSH, "Select Exit");
+	select_exit_button->SetToolTip("Select house exit");
 
 	brush_sizer->Add(house_brush_button, 0, wxEXPAND | wxBOTTOM, 2);
 	brush_sizer->Add(select_exit_button, 0, wxEXPAND);

--- a/source/palette/palette_waypoints.h
+++ b/source/palette/palette_waypoints.h
@@ -23,6 +23,35 @@
 #include "game/waypoints.h"
 #include "palette/palette_common.h"
 
+class VirtualWaypointListCtrl : public wxListCtrl {
+public:
+	VirtualWaypointListCtrl(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) :
+		wxListCtrl(parent, id, pos, size, style) {
+	}
+
+	void UpdateItems(const WaypointMap& waypoints) {
+		item_cache.clear();
+		item_cache.reserve(waypoints.size());
+		for (const auto& [name, wp] : waypoints) {
+			item_cache.push_back(name);
+		}
+		SetItemCount(item_cache.size());
+		Refresh();
+	}
+
+protected:
+	wxString OnGetItemText(long item, long column) const override {
+		if (item < 0 || item >= (long)item_cache.size()) {
+			return wxEmptyString;
+		}
+		// Return in reverse order to match original behavior (newest/last added/highest key first)
+		return wxstr(item_cache[item_cache.size() - 1 - item]);
+	}
+
+private:
+	std::vector<std::string> item_cache;
+};
+
 class WaypointPalettePanel : public PalettePanel {
 public:
 	WaypointPalettePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
@@ -59,7 +88,7 @@ public:
 
 protected:
 	Map* map;
-	wxListCtrl* waypoint_list;
+	VirtualWaypointListCtrl* waypoint_list;
 	wxButton* add_waypoint_button;
 	wxButton* remove_waypoint_button;
 };


### PR DESCRIPTION
This PR addresses several issues identified by the Phantom agent:
1.  **Missing Tooltips**: Added tooltips to buttons in `HousePalette`, `EditHouseDialog`, and `WaypointPalettePanel` to improve usability and compliance with UI guidelines.
2.  **Performance Optimization**: Converted `WaypointPalettePanel`'s list control to a virtual list control (`VirtualWaypointListCtrl`). This avoids the overhead of inserting items one by one, which is flagged as a performance anti-pattern for lists potentially containing many items. The virtual list maintains a sorted cache of waypoint names for efficient display.

These changes improve both the user experience and the internal efficiency of the application.

---
*PR created automatically by Jules for task [1044933849506220748](https://jules.google.com/task/1044933849506220748) started by @karolak6612*