### PR TITLE
👻 Phantom: Fix wxWidgets layout, UX, and control violations

### DIFF
--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -17,6 +17,7 @@
 #include <wx/textdlg.h>
 #include <wx/stdpaths.h>
 #include <wx/menu.h>
+#include <wx/valtext.h>
 #include <algorithm>
 #include <unordered_map>
 
@@ -177,11 +178,11 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
+	wxWrapSizer* palette_sizer = new wxWrapSizer(wxHORIZONTAL);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
 		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
+		palette_sizer->Add(swatch, 0, wxALL, 1);
 		color_buttons.push_back(swatch);
 
 		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
@@ -215,7 +216,8 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	text_fields->Add(speed_ctrl, 1, wxEXPAND);
 
 	text_fields->Add(new wxStaticText(this, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL);
-	name_ctrl = new wxTextCtrl(this, ID_NAME, current_name);
+	name_ctrl = new wxTextCtrl(this, ID_NAME, current_name, wxDefaultPosition, wxDefaultSize, 0, wxTextValidator(wxFILTER_NONE));
+	name_ctrl->SetMaxLength(29);
 	text_fields->Add(name_ctrl, 1, wxEXPAND);
 	text_fields->AddGrowableCol(1);
 	col1_sizer->Add(text_fields, 0, wxEXPAND | wxALL, 8);

--- a/source/ui/properties/container_properties_window.h
+++ b/source/ui/properties/container_properties_window.h
@@ -16,13 +16,26 @@ public:
 		DCButton(parent, wxID_ANY, wxDefaultPosition, DC_BTN_NORMAL, (large ? RENDER_SIZE_32x32 : RENDER_SIZE_16x16), (item ? item->getClientID() : 0)),
 		index(index),
 		item(item) {
-		SetToolTip(item ? wxstr(item->getName()) : wxstr("Empty Slot"));
+		UpdateToolTip();
 	}
 
 	void setItem(Item* new_item) {
 		item = new_item;
 		SetSprite(item ? item->getClientID() : 0);
-		SetToolTip(item ? wxstr(item->getName()) : wxstr("Empty Slot"));
+		UpdateToolTip();
+	}
+
+	void UpdateToolTip() {
+		if (item) {
+			wxString tip = wxstr(item->getName());
+			tip += wxString::Format("\nID: %d", item->getID());
+			if (item->isStackable() || item->isCharged()) {
+				tip += wxString::Format("\n%s: %d", (item->isCharged() ? "Charges" : "Count"), item->getCount());
+			}
+			SetToolTip(tip);
+		} else {
+			SetToolTip("Empty Slot");
+		}
 	}
 
 	Item* getItem() const {


### PR DESCRIPTION
This PR addresses critical wxWidgets violations identified by the Phantom agent:
- Replaced `wxFlexGridSizer` with `wxWrapSizer` in `OutfitChooserDialog` for the color palette to fix layout rigidity.
- Updated `ContainerItemButton` in `container_properties_window.h` to show detailed item information (ID, Count/Charges) in tooltips, improving UX.
- added input validation to the character name field in `OutfitChooserDialog` using `wxTextValidator` and `SetMaxLength`.

---
*PR created automatically by Jules for task [2097894664665062188](https://jules.google.com/task/2097894664665062188) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Outfit name field now enforces maximum 29 character limit with validation
  * Color palette layout improved with better wrapping and visual swatch borders
  * Container item tooltips now display comprehensive details including item name, ID, and quantity/charges information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->