### PR TITLE
[UB FIX] Fix critical file reading bug, potential crash and infinite loop

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -132,8 +132,7 @@ protected:
 
 	template <class T>
 	bool getType(T& ref) {
-		fread(&ref, sizeof(ref), 1, file.get());
-		return ferror(file.get()) == 0;
+		return fread(&ref, sizeof(ref), 1, file.get()) == 1;
 	}
 };
 

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -420,7 +420,9 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int z = where->getZ();
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
-			while (found != tile_loc->getSpawnCount()) {
+			int search_radius = 1;
+			// Limit search to prevent infinite loops if spawnCount is corrupted
+			while (found != tile_loc->getSpawnCount() && search_radius < 512) {
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {
@@ -448,6 +450,12 @@ SpawnList Map::getSpawnList(Tile* where) {
 				}
 				--start_x, --start_y;
 				++end_x, ++end_y;
+				++search_radius;
+			}
+
+			if (found != tile_loc->getSpawnCount()) {
+				spdlog::warn("Map::getSpawnList: Could not find all spawns (found {}/{}) at {},{},{}",
+					found, tile_loc->getSpawnCount(), where->getX(), where->getY(), where->getZ());
 			}
 		}
 	}

--- a/source/util/virtual_item_grid.cpp
+++ b/source/util/virtual_item_grid.cpp
@@ -247,12 +247,16 @@ void VirtualItemGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 		if (tex > 0) {
 			// Fixed 32x32 rendering area
 			float iconSize = 32.0f;
-			int tw, th;
+			int tw = 0;
+			int th = 0;
 			nvgImageSize(vg, tex, &tw, &th);
 
-			float scale = iconSize / std::max(tw, th);
-			if (scale > 1.0f && std::max(tw, th) >= 32) {
-				scale = 1.0f;
+			float scale = 1.0f;
+			if (tw > 0 && th > 0) {
+				scale = iconSize / std::max(tw, th);
+				if (scale > 1.0f && std::max(tw, th) >= 32) {
+					scale = 1.0f;
+				}
 			}
 
 			float dw = tw * scale;


### PR DESCRIPTION
BUG TYPE: Undefined Behavior / Logic Bug / Crash
SEVERITY: CRITICAL / HIGH
ISSUE:
1. `FileReadHandle::getType` returned true even if `fread` failed (EOF), leading to reading uninitialized memory.
2. `VirtualItemGrid` used uninitialized `tw`/`th` variables if `nvgImageSize` failed, and could divide by zero.
3. `Map::getSpawnList` could loop infinitely if `spawnCount` was corrupted.

FIX:
1. Checked `fread` return value.
2. Initialized variables and added check for positive dimensions.
3. Added search radius limit to spawn list search.

PREVENTION:
- Use initialized variables.
- Check return values of C file APIs.
- Add safety limits to potentially infinite loops.

---
*PR created automatically by Jules for task [7798491991562912191](https://jules.google.com/task/7798491991562912191) started by @karolak6612*