### PR TITLE
feat(ux): implement 10 micro-UX improvements for tooltips and accessibility

### DIFF
--- a/source/ui/add_tileset_window.cpp
+++ b/source/ui/add_tileset_window.cpp
@@ -71,14 +71,17 @@ AddTilesetWindow::AddTilesetWindow(wxWindow* win_parent, TilesetCategoryType cat
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Item"), wxSizerFlags(1).CenterVertical());
 	item_button = newd DCButton(this, wxID_ANY, wxDefaultPosition, DC_BTN_TOGGLE, RENDER_SIZE_32x32, 0);
+	item_button->SetToolTip("Click to select an icon for this tileset");
 	subsizer->Add(item_button);
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Item Id of First Item"));
 	item_id_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(itemId), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, 100000);
+	item_id_field->SetToolTip("Enter the item ID of the first item in the tileset");
 	subsizer->Add(item_id_field, wxSizerFlags(1).Expand());
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Tileset Name"));
 	tileset_name_field = newd wxTextCtrl(this, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE);
+	tileset_name_field->SetToolTip("Enter a name for the new tileset");
 	subsizer->Add(tileset_name_field);
 
 	boxsizer->Add(subsizer, wxSizerFlags(1).Expand());

--- a/source/ui/dialog_util.cpp
+++ b/source/ui/dialog_util.cpp
@@ -55,6 +55,7 @@ void DialogUtil::ListDialog(wxWindow* parent, wxString title, const std::vector<
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(dlg, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Close list");
 	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center());
 
@@ -75,6 +76,7 @@ void DialogUtil::ShowTextBox(wxWindow* parent, wxString title, wxString content)
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(dlg, wxID_CANCEL, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Close window");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(0).Center());
 	dlg->SetSizerAndFit(topsizer);

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -57,7 +57,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancelBtn->SetToolTip("Close this window");
+	cancelBtn->SetToolTip("Cancel and close window");
 	stdsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
 

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -29,11 +29,11 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	okBtn->SetToolTip("Go to position");
+	okBtn->SetToolTip("Go to specified coordinates");
 	tmpsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancelBtn->SetToolTip("Close this window");
+	cancelBtn->SetToolTip("Cancel navigation");
 	tmpsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(tmpsizer, 0, wxALL | wxCENTER, 20); // Border to top too
 

--- a/source/ui/properties/container_properties_window.h
+++ b/source/ui/properties/container_properties_window.h
@@ -16,13 +16,13 @@ public:
 		DCButton(parent, wxID_ANY, wxDefaultPosition, DC_BTN_NORMAL, (large ? RENDER_SIZE_32x32 : RENDER_SIZE_16x16), (item ? item->getClientID() : 0)),
 		index(index),
 		item(item) {
-		SetToolTip(item ? wxstr(item->getName()) : wxstr("Empty Slot"));
+		UpdateToolTip();
 	}
 
 	void setItem(Item* new_item) {
 		item = new_item;
 		SetSprite(item ? item->getClientID() : 0);
-		SetToolTip(item ? wxstr(item->getName()) : wxstr("Empty Slot"));
+		UpdateToolTip();
 	}
 
 	Item* getItem() const {
@@ -33,6 +33,14 @@ public:
 	}
 
 protected:
+	void UpdateToolTip() {
+		if (item) {
+			SetToolTip(wxstr(item->getName()) + wxString::Format("\nID: %d\nCount: %d", item->getID(), item->getCount()));
+		} else {
+			SetToolTip("Empty Slot");
+		}
+	}
+
 	uint32_t index;
 	Item* item;
 };

--- a/source/ui/properties/depot_properties_window.cpp
+++ b/source/ui/properties/depot_properties_window.cpp
@@ -61,6 +61,7 @@ DepotPropertiesWindow::DepotPropertiesWindow(wxWindow* parent, const Map* map, c
 		to_select_index = depot_id_field->GetCount() - 1;
 	}
 	depot_id_field->SetSelection(to_select_index);
+	depot_id_field->SetToolTip("Select the town this depot belongs to");
 
 	subsizer->Add(depot_id_field, wxSizerFlags(1).Expand());
 
@@ -70,9 +71,11 @@ DepotPropertiesWindow::DepotPropertiesWindow(wxWindow* parent, const Map* map, c
 	wxSizer* buttonsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Apply changes");
 	buttonsizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetToolTip("Discard changes");
 	buttonsizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 

--- a/source/ui/properties/podium_properties_window.cpp
+++ b/source/ui/properties/podium_properties_window.cpp
@@ -144,9 +144,11 @@ PodiumPropertiesWindow::PodiumPropertiesWindow(wxWindow* win_parent, const Map* 
 	wxSizer* std_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Apply changes");
 	std_sizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetToolTip("Discard changes");
 	std_sizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(std_sizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 

--- a/source/ui/properties/spawn_properties_window.cpp
+++ b/source/ui/properties/spawn_properties_window.cpp
@@ -25,7 +25,7 @@ SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* ma
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Spawn size"));
 	count_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_spawn->getSize()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, g_settings.getInteger(Config::MAX_SPAWN_RADIUS), edit_spawn->getSize());
-	count_field->SetToolTip("Radius of the spawn area");
+	count_field->SetToolTip("Radius of the spawn area in tiles");
 	subsizer->Add(count_field, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(subsizer, wxSizerFlags(1).Expand());
@@ -35,9 +35,11 @@ SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* ma
 	wxSizer* std_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Apply changes");
 	std_sizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetToolTip("Discard changes");
 	std_sizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(std_sizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 

--- a/source/ui/result_window.cpp
+++ b/source/ui/result_window.cpp
@@ -31,12 +31,12 @@ SearchResultWindow::SearchResultWindow(wxWindow* parent) :
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* exportBtn = newd wxButton(this, wxID_FILE, "Export");
 	exportBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
-	exportBtn->SetToolTip("Export results to text file");
+	exportBtn->SetToolTip("Save search results to a text file");
 	buttonsSizer->Add(exportBtn, wxSizerFlags(0).Center());
 
 	wxButton* clearBtn = newd wxButton(this, wxID_CLEAR, "Clear");
 	clearBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
-	clearBtn->SetToolTip("Clear search results");
+	clearBtn->SetToolTip("Remove all results from the list");
 	buttonsSizer->Add(clearBtn, wxSizerFlags(0).Center());
 	sizer->Add(buttonsSizer, wxSizerFlags(0).Center().DoubleBorder());
 	SetSizerAndFit(sizer);

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -364,10 +364,6 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 			break;
 		}
 	}
-	if (!hover_brush && prev_hover) {
-		UnsetToolTip();
-	}
-
 	// Sliders Interaction
 	if (evt.LeftDown()) {
 		if (interactables.size_slider_rect.Contains(m_hoverPos)) {
@@ -446,18 +442,33 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 		interactables.dragging_thickness = false;
 	}
 
-	// Hover states for checkboxes
-	if (interactables.preview_check_rect.Contains(m_hoverPos)) {
-		interactables.hover_preview = true;
-		hand_cursor = true;
-	}
-	if (interactables.lock_check_rect.Contains(m_hoverPos)) {
-		interactables.hover_lock = true;
-		hand_cursor = true;
-	}
+	// Hover states and tooltips
+	if (!hover_brush) {
+		bool tooltip_set = false;
 
-	if (interactables.size_slider_rect.Contains(m_hoverPos) || interactables.thickness_slider_rect.Contains(m_hoverPos)) {
-		hand_cursor = true;
+		if (interactables.preview_check_rect.Contains(m_hoverPos)) {
+			interactables.hover_preview = true;
+			SetToolTip("Toggle auto-border preview");
+			hand_cursor = true;
+			tooltip_set = true;
+		} else if (interactables.lock_check_rect.Contains(m_hoverPos)) {
+			interactables.hover_lock = true;
+			SetToolTip("Toggle door locking (Shift)");
+			hand_cursor = true;
+			tooltip_set = true;
+		} else if (interactables.size_slider_rect.Contains(m_hoverPos)) {
+			SetToolTip("Adjust brush size");
+			hand_cursor = true;
+			tooltip_set = true;
+		} else if (interactables.thickness_slider_rect.Contains(m_hoverPos)) {
+			SetToolTip("Adjust brush thickness/variability");
+			hand_cursor = true;
+			tooltip_set = true;
+		}
+
+		if (!tooltip_set) {
+			UnsetToolTip();
+		}
 	}
 
 	SetCursor(hand_cursor ? wxCursor(wxCURSOR_HAND) : wxCursor(wxCURSOR_ARROW));


### PR DESCRIPTION
This PR implements 10 micro-UX improvements as requested by the Palette agent. The changes focus on adding missing tooltips to various dialogs and controls to improve accessibility and usability.

Key changes:
1.  **`ContainerPropertiesWindow`**: Tooltips now show Item Name, Server ID, and Count/Charges.
2.  **`GotoPositionDialog`**: Added tooltips to OK/Cancel buttons.
3.  **`FindDialog`**: Added tooltip to Cancel button.
4.  **`SpawnPropertiesWindow`**: Added tooltips to OK/Cancel buttons and improved "Spawn size" tooltip.
5.  **`AddTilesetWindow`**: Added tooltips to item button and text fields.
6.  **`DialogUtil`**: Added tooltips to buttons in `ListDialog` and `ShowTextBox`.
7.  **`SearchResultWindow`**: Improved tooltips for Export and Clear buttons.
8.  **`DepotPropertiesWindow`**: Added tooltips to OK/Cancel buttons and Depot ID field.
9.  **`PodiumPropertiesWindow`**: Added tooltips to OK/Cancel buttons.
10. **`ToolOptionsSurface`**: Added hover tooltips for Size Slider, Thickness Slider, Preview Checkbox, and Lock Checkbox.

---
*PR created automatically by Jules for task [4532409152606435357](https://jules.google.com/task/4532409152606435357) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated and expanded tooltips across multiple dialog windows for clearer user guidance
  * Added descriptive tooltips to input fields and action buttons throughout the interface
  * Improved hover information to help users understand the purpose of each control

<!-- end of auto-generated comment: release notes by coderabbit.ai -->