### PR TITLE
Refactor: Modernize C++ loops in client_version, materials, and creatures

### DIFF
--- a/source/app/client_version.cpp
+++ b/source/app/client_version.cpp
@@ -355,9 +355,9 @@ ClientVersion* ClientVersion::get(ClientVersionID id) {
 }
 
 ClientVersion* ClientVersion::get(std::string id) {
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->getName() == id) {
-			return i->second.get();
+	for (const auto& [versionId, version] : client_versions) {
+		if (version->getName() == id) {
+			return version.get();
 		}
 	}
 	return nullptr;
@@ -365,17 +365,17 @@ ClientVersion* ClientVersion::get(std::string id) {
 
 ClientVersionList ClientVersion::getAll() {
 	ClientVersionList l;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		l.push_back(i->second.get());
+	for (const auto& [versionId, version] : client_versions) {
+		l.push_back(version.get());
 	}
 	return l;
 }
 
 ClientVersionList ClientVersion::getAllVisible() {
 	ClientVersionList l;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->isVisible()) {
-			l.push_back(i->second.get());
+	for (const auto& [versionId, version] : client_versions) {
+		if (version->isVisible()) {
+			l.push_back(version.get());
 		}
 	}
 	return l;
@@ -383,11 +383,11 @@ ClientVersionList ClientVersion::getAllVisible() {
 
 ClientVersionList ClientVersion::getAllForOTBMVersion(MapVersionID id) {
 	ClientVersionList list;
-	for (VersionMap::iterator i = client_versions.begin(); i != client_versions.end(); ++i) {
-		if (i->second->isVisible()) {
-			for (std::vector<MapVersionID>::iterator v = i->second->map_versions_supported.begin(); v != i->second->map_versions_supported.end(); ++v) {
-				if (*v == id) {
-					list.push_back(i->second.get());
+	for (const auto& [versionId, version] : client_versions) {
+		if (version->isVisible()) {
+			for (const auto& supportedVersion : version->map_versions_supported) {
+				if (supportedVersion == id) {
+					list.push_back(version.get());
 				}
 			}
 		}
@@ -522,9 +522,9 @@ bool ClientVersion::loadValidPaths() {
 }
 
 DatFormat ClientVersion::getDatFormatForSignature(uint32_t signature) const {
-	for (std::vector<ClientData>::const_iterator iter = data_versions.begin(); iter != data_versions.end(); ++iter) {
-		if (iter->datSignature == signature) {
-			return iter->datFormat;
+	for (const auto& clientData : data_versions) {
+		if (clientData.datSignature == signature) {
+			return clientData.datFormat;
 		}
 	}
 

--- a/source/game/creatures.cpp
+++ b/source/game/creatures.cpp
@@ -233,8 +233,8 @@ CreatureDatabase::~CreatureDatabase() {
 }
 
 void CreatureDatabase::clear() {
-	for (CreatureMap::iterator iter = creature_map.begin(); iter != creature_map.end(); ++iter) {
-		delete iter->second;
+	for (auto& [name, type] : creature_map) {
+		delete type;
 	}
 	creature_map.clear();
 }
@@ -279,8 +279,8 @@ CreatureType* CreatureDatabase::addCreatureType(const std::string& name, bool is
 }
 
 bool CreatureDatabase::hasMissing() const {
-	for (CreatureMap::const_iterator iter = creature_map.begin(); iter != creature_map.end(); ++iter) {
-		if (iter->second->missing) {
+	for (const auto& [name, type] : creature_map) {
+		if (type->missing) {
 			return true;
 		}
 	}

--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -40,12 +40,12 @@ Materials::~Materials() {
 }
 
 void Materials::clear() {
-	for (TilesetContainer::iterator iter = tilesets.begin(); iter != tilesets.end(); ++iter) {
-		delete iter->second;
+	for (auto& [name, tileset] : tilesets) {
+		delete tileset;
 	}
 
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		delete *iter;
+	for (auto& extension : extensions) {
+		delete extension;
 	}
 
 	tilesets.clear();
@@ -58,9 +58,9 @@ const MaterialsExtensionList& Materials::getExtensions() {
 
 MaterialsExtensionList Materials::getExtensionsByVersion(uint16_t version_id) {
 	MaterialsExtensionList ret_list;
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		if ((*iter)->isForVersion(version_id)) {
-			ret_list.push_back(*iter);
+	for (const auto& extension : extensions) {
+		if (extension->isForVersion(version_id)) {
+			ret_list.push_back(extension);
 		}
 	}
 	return ret_list;
@@ -277,9 +277,7 @@ void Materials::createOtherTileset() {
 		}
 	}
 
-	for (CreatureMap::iterator iter = g_creatures.begin(); iter != g_creatures.end(); ++iter) {
-		CreatureType* type = iter->second;
-
+	for (auto& [name, type] : g_creatures) {
 		if (type->brush == nullptr) {
 			type->brush = newd CreatureBrush(type);
 			g_brushes.addBrush(type->brush);


### PR DESCRIPTION
This PR modernizes legacy C++ iterator loops in `client_version.cpp`, `materials.cpp`, and `creatures.cpp` by replacing them with range-based for loops and structured bindings.

Changes:
- `source/app/client_version.cpp`: Replaced `for (VersionMap::iterator ...)` with `for (const auto& [id, version] : client_versions)`.
- `source/game/materials.cpp`: Replaced `for (TilesetContainer::iterator ...)` with `for (auto& [name, tileset] : tilesets)`.
- `source/game/creatures.cpp`: Replaced `for (CreatureMap::iterator ...)` with `for (auto& [name, type] : creature_map)`.

These changes improve code readability and maintainability while preserving existing logic.

---
*PR created automatically by Jules for task [7074929138881229381](https://jules.google.com/task/7074929138881229381) started by @karolak6612*