### PR TITLE
Throttle: Migrate UI lists to NanoVG VirtualListCanvas

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -209,6 +209,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/item_buttons.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/virtual_list_canvas.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.h
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.h
@@ -511,6 +512,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/add_tileset_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/browse_tile_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/sortable_list_box.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/controls/virtual_list_canvas.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/controls/modern_button.cpp
 
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/goto_position_dialog.cpp

--- a/source/ui/controls/virtual_list_canvas.cpp
+++ b/source/ui/controls/virtual_list_canvas.cpp
@@ -1,0 +1,326 @@
+#include "ui/controls/virtual_list_canvas.h"
+#include "ui/theme.h"
+#include "rendering/core/graphics.h"
+#include "util/image_manager.h"
+#include "rendering/core/text_renderer.h"
+#include <wx/settings.h>
+#include <algorithm>
+
+VirtualListCanvas::VirtualListCanvas(wxWindow* parent, wxWindowID id, long style) :
+	NanoVGCanvas(parent, id, style | wxVSCROLL | wxWANTS_CHARS),
+	m_itemHeight(32),
+	m_selectionMode(SelectionMode::Single),
+	m_anchorIndex(-1),
+	m_hoverIndex(-1),
+	m_focusedIndex(-1) {
+
+	m_itemHeight = FromDIP(32);
+
+	// Initialize theme colors
+	wxColour selColor = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+	m_selectionColor = nvgRGBA(selColor.Red(), selColor.Green(), selColor.Blue(), 128); // 50% opacity
+
+	wxColour hoverColor = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT).ChangeLightness(150);
+	m_hoverColor = nvgRGBA(hoverColor.Red(), hoverColor.Green(), hoverColor.Blue(), 64); // 25% opacity
+
+	wxColour textColor = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
+	m_textColor = nvgRGBA(textColor.Red(), textColor.Green(), textColor.Blue(), 255);
+
+	Bind(wxEVT_LEFT_DOWN, &VirtualListCanvas::OnMouseDown, this);
+	Bind(wxEVT_LEFT_UP, &VirtualListCanvas::OnMouseUp, this);
+	Bind(wxEVT_MOTION, &VirtualListCanvas::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, &VirtualListCanvas::OnLeave, this);
+	Bind(wxEVT_KEY_DOWN, &VirtualListCanvas::OnKeyDown, this);
+	Bind(wxEVT_CHAR, &VirtualListCanvas::OnChar, this);
+	Bind(wxEVT_SIZE, &VirtualListCanvas::OnSize, this);
+
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+VirtualListCanvas::~VirtualListCanvas() {
+}
+
+void VirtualListCanvas::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int count = (int)GetItemCount();
+	if (count == 0) {
+		return;
+	}
+
+	int scrollY = GetScrollPosition();
+	int startIdx = std::max(0, scrollY / m_itemHeight);
+	int endIdx = std::min(count, (scrollY + height + m_itemHeight - 1) / m_itemHeight);
+
+	nvgScissor(vg, 0, 0, width, height);
+
+	for (int i = startIdx; i < endIdx; ++i) {
+		int y = i * m_itemHeight - scrollY;
+		wxRect rect(0, y, width, m_itemHeight);
+
+		// Selection
+		if (IsSelected(i)) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+			nvgFillColor(vg, m_selectionColor);
+			nvgFill(vg);
+		} else if (i == m_hoverIndex) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+			nvgFillColor(vg, m_hoverColor);
+			nvgFill(vg);
+		}
+
+		// Draw Item Content
+		OnDrawItem(vg, i, rect);
+	}
+
+	nvgResetScissor(vg);
+}
+
+void VirtualListCanvas::SetSelectionMode(SelectionMode mode) {
+	m_selectionMode = mode;
+	if (mode == SelectionMode::Single && m_selectedIndices.size() > 1) {
+		int first = *m_selectedIndices.begin();
+		m_selectedIndices.clear();
+		m_selectedIndices.insert(first);
+		Refresh();
+	}
+}
+
+void VirtualListCanvas::SetSelection(int index) {
+	if (index < 0 || index >= (int)GetItemCount()) {
+		DeselectAll();
+		return;
+	}
+
+	if (m_selectionMode == SelectionMode::Single) {
+		m_selectedIndices.clear();
+		m_selectedIndices.insert(index);
+	} else {
+		if (m_selectedIndices.find(index) == m_selectedIndices.end()) {
+			m_selectedIndices.insert(index);
+		}
+	}
+	m_focusedIndex = index;
+	m_anchorIndex = index;
+	EnsureVisible(index);
+	Refresh();
+	SendSelectionEvent();
+}
+
+void VirtualListCanvas::Select(int index, bool select) {
+	if (index < 0 || index >= (int)GetItemCount()) return;
+
+	if (select) {
+		if (m_selectionMode == SelectionMode::Single) {
+			m_selectedIndices.clear();
+		}
+		m_selectedIndices.insert(index);
+	} else {
+		m_selectedIndices.erase(index);
+	}
+	Refresh();
+}
+
+void VirtualListCanvas::Deselect(int index) {
+	Select(index, false);
+}
+
+void VirtualListCanvas::SelectAll() {
+	if (m_selectionMode == SelectionMode::Multiple) {
+		for (int i = 0; i < (int)GetItemCount(); ++i) {
+			m_selectedIndices.insert(i);
+		}
+		Refresh();
+		SendSelectionEvent();
+	}
+}
+
+void VirtualListCanvas::DeselectAll() {
+	m_selectedIndices.clear();
+	Refresh();
+	SendSelectionEvent();
+}
+
+bool VirtualListCanvas::IsSelected(int index) const {
+	return m_selectedIndices.find(index) != m_selectedIndices.end();
+}
+
+int VirtualListCanvas::GetSelection() const {
+	if (m_selectedIndices.empty()) return wxNOT_FOUND;
+	return *m_selectedIndices.begin();
+}
+
+size_t VirtualListCanvas::GetSelectedCount() const {
+	return m_selectedIndices.size();
+}
+
+std::vector<int> VirtualListCanvas::GetSelections() const {
+	std::vector<int> sels(m_selectedIndices.begin(), m_selectedIndices.end());
+	return sels;
+}
+
+void VirtualListCanvas::SetItemHeight(int height) {
+	m_itemHeight = FromDIP(height); // Ensure scaled
+	RefreshList();
+}
+
+int VirtualListCanvas::GetItemHeight(int index) const {
+	return m_itemHeight; // Simplified for now
+}
+
+void VirtualListCanvas::RefreshList() {
+	int count = (int)GetItemCount();
+	int totalHeight = count * m_itemHeight;
+	UpdateScrollbar(totalHeight);
+	Refresh();
+}
+
+void VirtualListCanvas::EnsureVisible(int index) {
+	if (index < 0 || index >= (int)GetItemCount()) return;
+
+	int itemTop = index * m_itemHeight;
+	int itemBottom = itemTop + m_itemHeight;
+	int viewTop = GetScrollPosition();
+	int viewBottom = viewTop + GetClientSize().GetHeight();
+
+	if (itemTop < viewTop) {
+		SetScrollPosition(itemTop);
+	} else if (itemBottom > viewBottom) {
+		SetScrollPosition(itemBottom - GetClientSize().GetHeight());
+	}
+}
+
+void VirtualListCanvas::SendSelectionEvent() {
+	wxCommandEvent event(wxEVT_LISTBOX, GetId());
+	event.SetEventObject(this);
+	event.SetInt(GetSelection());
+	GetEventHandler()->ProcessEvent(event);
+}
+
+void VirtualListCanvas::OnMouseDown(wxMouseEvent& event) {
+	SetFocus();
+	int index = HitTest(event.GetY());
+	if (index == wxNOT_FOUND) {
+		DeselectAll();
+		return;
+	}
+
+	if (m_selectionMode == SelectionMode::Multiple) {
+		if (event.ShiftDown() && m_anchorIndex != -1) {
+			RangeSelect(m_anchorIndex, index);
+		} else if (event.ControlDown()) {
+			if (IsSelected(index)) {
+				Deselect(index);
+			} else {
+				Select(index, true);
+				m_anchorIndex = index;
+			}
+		} else {
+			SetSelection(index);
+		}
+	} else {
+		SetSelection(index);
+	}
+	m_focusedIndex = index;
+}
+
+void VirtualListCanvas::OnMouseUp(wxMouseEvent& event) {
+	// Optional: Handle drag end
+}
+
+void VirtualListCanvas::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetY());
+	if (index != m_hoverIndex) {
+		m_hoverIndex = index;
+		Refresh();
+	}
+}
+
+void VirtualListCanvas::OnLeave(wxMouseEvent& event) {
+	if (m_hoverIndex != -1) {
+		m_hoverIndex = -1;
+		Refresh();
+	}
+}
+
+void VirtualListCanvas::OnKeyDown(wxKeyEvent& event) {
+	int count = (int)GetItemCount();
+	if (count == 0) {
+		event.Skip();
+		return;
+	}
+
+	int nextIndex = m_focusedIndex;
+	int pageSize = GetClientSize().GetHeight() / m_itemHeight;
+
+	switch (event.GetKeyCode()) {
+		case WXK_UP:
+			nextIndex = std::max(0, m_focusedIndex - 1);
+			break;
+		case WXK_DOWN:
+			nextIndex = std::min(count - 1, m_focusedIndex + 1);
+			break;
+		case WXK_PAGEUP:
+			nextIndex = std::max(0, m_focusedIndex - pageSize);
+			break;
+		case WXK_PAGEDOWN:
+			nextIndex = std::min(count - 1, m_focusedIndex + pageSize);
+			break;
+		case WXK_HOME:
+			nextIndex = 0;
+			break;
+		case WXK_END:
+			nextIndex = count - 1;
+			break;
+		default:
+			event.Skip();
+			return;
+	}
+
+	if (nextIndex != m_focusedIndex) {
+		if (m_selectionMode == SelectionMode::Multiple && event.ShiftDown()) {
+			if (m_anchorIndex == -1) m_anchorIndex = m_focusedIndex;
+			RangeSelect(m_anchorIndex, nextIndex);
+			m_focusedIndex = nextIndex;
+			EnsureVisible(nextIndex);
+			Refresh();
+			SendSelectionEvent();
+		} else {
+			SetSelection(nextIndex);
+		}
+	}
+}
+
+void VirtualListCanvas::OnChar(wxKeyEvent& event) {
+	// Optional: Type-to-search or other shortcuts
+	event.Skip();
+}
+
+void VirtualListCanvas::OnSize(wxSizeEvent& event) {
+	RefreshList(); // Update scrollbar
+	event.Skip();
+}
+
+wxSize VirtualListCanvas::DoGetBestClientSize() const {
+	return FromDIP(wxSize(200, 300));
+}
+
+int VirtualListCanvas::HitTest(int y) const {
+	int scrollY = GetScrollPosition();
+	int index = (scrollY + y) / m_itemHeight;
+	if (index >= 0 && index < (int)GetItemCount()) {
+		return index;
+	}
+	return wxNOT_FOUND;
+}
+
+void VirtualListCanvas::RangeSelect(int anchor, int current) {
+	m_selectedIndices.clear();
+	int start = std::min(anchor, current);
+	int end = std::max(anchor, current);
+	for (int i = start; i <= end; ++i) {
+		m_selectedIndices.insert(i);
+	}
+	Refresh();
+	SendSelectionEvent();
+}

--- a/source/ui/controls/virtual_list_canvas.h
+++ b/source/ui/controls/virtual_list_canvas.h
@@ -1,0 +1,97 @@
+#ifndef RME_UI_CONTROLS_VIRTUAL_LIST_CANVAS_H_
+#define RME_UI_CONTROLS_VIRTUAL_LIST_CANVAS_H_
+
+#include "util/nanovg_canvas.h"
+#include <vector>
+#include <set>
+
+/**
+ * @class VirtualListCanvas
+ * @brief A high-performance, virtual list control using NanoVG rendering.
+ *
+ * Replaces wxVListBox for lists with many items or custom rendering requirements.
+ * Supports:
+ * - Virtual scrolling (millions of items)
+ * - Custom item drawing via NanoVG
+ * - Single and Multiple selection modes
+ * - Keyboard navigation
+ * - Hover effects
+ */
+class VirtualListCanvas : public NanoVGCanvas {
+public:
+	enum class SelectionMode {
+		Single,
+		Multiple
+	};
+
+	VirtualListCanvas(wxWindow* parent, wxWindowID id = wxID_ANY, long style = wxVSCROLL | wxWANTS_CHARS);
+	virtual ~VirtualListCanvas();
+
+	// Data Provider Interface
+	virtual size_t GetItemCount() const = 0;
+
+	// Drawing Interface
+	/**
+	 * @brief Draw a single item.
+	 * @param vg NanoVG context.
+	 * @param index Item index.
+	 * @param rect Item rectangle in local coordinates (already scrolled).
+	 */
+	virtual void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) = 0;
+
+	// Selection Management
+	void SetSelectionMode(SelectionMode mode);
+	SelectionMode GetSelectionMode() const { return m_selectionMode; }
+
+	void SetSelection(int index); // Clears others if Single
+	void Select(int index, bool select = true);
+	void Deselect(int index);
+	void SelectAll();
+	void DeselectAll();
+	bool IsSelected(int index) const;
+	int GetSelection() const; // Returns first selected index or wxNOT_FOUND
+	size_t GetSelectedCount() const;
+	std::vector<int> GetSelections() const;
+
+	// Layout & Scrolling
+	void SetItemHeight(int height);
+	int GetItemHeight(int index) const;
+	void RefreshList(); // Recalculate layout and repaint
+	void EnsureVisible(int index);
+
+	// Event handling
+	void SendSelectionEvent();
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Event handlers
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMouseUp(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+	void OnLeave(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void OnSize(wxSizeEvent& event);
+	void OnChar(wxKeyEvent& event);
+
+	int HitTest(int y) const;
+	void ToggleSelection(int index);
+	void RangeSelect(int anchor, int current);
+
+protected:
+	int m_itemHeight;
+	SelectionMode m_selectionMode;
+
+	std::set<int> m_selectedIndices;
+	int m_anchorIndex; // For range selection (Shift+Click)
+	int m_hoverIndex;
+	int m_focusedIndex; // For keyboard navigation
+
+	// Style colors (can be customized by subclasses or theme)
+	NVGcolor m_selectionColor;
+	NVGcolor m_hoverColor;
+	NVGcolor m_textColor;
+};
+
+#endif

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,7 +3,7 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
+#include "ui/controls/virtual_list_canvas.h"
 #include <vector>
 
 class Brush;
@@ -19,7 +19,7 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogListBox : public VirtualListCanvas {
 public:
 	FindDialogListBox(wxWindow* parent, wxWindowID id);
 	~FindDialogListBox();
@@ -29,8 +29,8 @@ public:
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	size_t GetItemCount() const override;
+	void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect) override;
 
 protected:
 	bool cleared;

--- a/source/ui/welcome_dialog.h
+++ b/source/ui/welcome_dialog.h
@@ -16,7 +16,6 @@ public:
 	// Event Handlers
 	void OnButtonClicked(wxCommandEvent& event);
 	void OnCheckboxClicked(wxCommandEvent& event);
-	void OnRecentFileClicked(wxCommandEvent& event);
 
 private:
 	// Implementation details


### PR DESCRIPTION
This change introduces `VirtualListCanvas`, a reusable NanoVG-based control for high-performance lists, and migrates existing `wxVListBox` usages (`FindDialogListBox`, `BrowseTileListBox`) and the `WelcomeDialog` recent files list to use it. This aligns with the project's goal to modernize UI rendering and improve performance.

---
*PR created automatically by Jules for task [9515005741759275172](https://jules.google.com/task/9515005741759275172) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced VirtualListCanvas, a virtual list component supporting configurable selection modes, keyboard navigation, hover feedback, and range selection.

* **Refactor**
  * Modernized rendering pipeline for list components in the tile browser, search dialogs, and welcome screen with an updated graphics system.
  * Enhanced selection state management and visual feedback across list controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->