### PR TITLE
🗝️ Keeper: Fix network use-after-free and modernize NanoVG caching

### DIFF
--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -203,9 +203,10 @@ void LiveClient::receive(uint32_t packetSize) {
 	});
 }
 
-void LiveClient::send(NetworkMessage& message) {
-	memcpy(&message.buffer[0], &message.size, 4);
-	boost::asio::async_write(*socket, boost::asio::buffer(message.buffer, message.size + 4), [this](const boost::system::error_code& error, size_t bytesTransferred) -> void {
+void LiveClient::send(const NetworkMessage& message) {
+	auto msg = std::make_shared<NetworkMessage>(message);
+	memcpy(&msg->buffer[0], &msg->size, 4);
+	boost::asio::async_write(*socket, boost::asio::buffer(msg->buffer, msg->size + 4), [this, msg](const boost::system::error_code& error, size_t bytesTransferred) -> void {
 		if (error) {
 			logMessage(wxString() + getHostName() + ": " + error.message());
 		}

--- a/source/live/live_client.h
+++ b/source/live/live_client.h
@@ -44,7 +44,7 @@ public:
 	//
 	void receiveHeader();
 	void receive(uint32_t packetSize);
-	void send(NetworkMessage& message);
+	void send(const NetworkMessage& message) override;
 
 	//
 	void updateCursor(const Position& position);

--- a/source/live/live_peer.cpp
+++ b/source/live/live_peer.cpp
@@ -95,9 +95,10 @@ void LivePeer::receive(uint32_t packetSize) {
 	});
 }
 
-void LivePeer::send(NetworkMessage& message) {
-	memcpy(&message.buffer[0], &message.size, 4);
-	boost::asio::async_write(socket, boost::asio::buffer(message.buffer, message.size + 4), [this](const boost::system::error_code& error, size_t bytesTransferred) -> void {
+void LivePeer::send(const NetworkMessage& message) {
+	auto msg = std::make_shared<NetworkMessage>(message);
+	memcpy(&msg->buffer[0], &msg->size, 4);
+	boost::asio::async_write(socket, boost::asio::buffer(msg->buffer, msg->size + 4), [this, msg](const boost::system::error_code& error, size_t bytesTransferred) -> void {
 		if (error) {
 			logMessage(wxString() + getHostName() + ": " + error.message());
 		}

--- a/source/live/live_peer.h
+++ b/source/live/live_peer.h
@@ -50,7 +50,7 @@ public:
 	//
 	void receiveHeader();
 	void receive(uint32_t packetSize);
-	void send(NetworkMessage& message);
+	void send(const NetworkMessage& message) override;
 
 	//
 	void updateCursor(const Position& position) { }

--- a/source/live/live_server.h
+++ b/source/live/live_server.h
@@ -42,7 +42,7 @@ public:
 	//
 	void receiveHeader() { }
 	void receive(uint32_t packetSize) { }
-	void send(NetworkMessage& message) { }
+	void send(const NetworkMessage& message) override { }
 
 	//
 	void updateCursor(const Position& position);

--- a/source/live/live_socket.h
+++ b/source/live/live_socket.h
@@ -62,7 +62,7 @@ public:
 	//
 	virtual void receiveHeader() = 0;
 	virtual void receive(uint32_t packetSize) = 0;
-	virtual void send(NetworkMessage& message) = 0;
+	virtual void send(const NetworkMessage& message) = 0;
 
 	//
 	virtual void updateCursor(const Position& position) = 0;

--- a/source/rendering/core/nanovg_image.h
+++ b/source/rendering/core/nanovg_image.h
@@ -1,0 +1,52 @@
+#ifndef RME_RENDERING_CORE_NANOVG_IMAGE_H_
+#define RME_RENDERING_CORE_NANOVG_IMAGE_H_
+
+#include <nanovg.h>
+
+class NanoVGImage {
+public:
+	NanoVGImage(NVGcontext* ctx, int handle) :
+		m_ctx(ctx), m_handle(handle) { }
+
+	~NanoVGImage() {
+		if (m_ctx && m_handle > 0) {
+			nvgDeleteImage(m_ctx, m_handle);
+		}
+	}
+
+	// Move-only
+	NanoVGImage(const NanoVGImage&) = delete;
+	NanoVGImage& operator=(const NanoVGImage&) = delete;
+
+	NanoVGImage(NanoVGImage&& other) noexcept :
+		m_ctx(other.m_ctx), m_handle(other.m_handle) {
+		other.m_ctx = nullptr;
+		other.m_handle = 0;
+	}
+
+	NanoVGImage& operator=(NanoVGImage&& other) noexcept {
+		if (this != &other) {
+			if (m_ctx && m_handle > 0) {
+				nvgDeleteImage(m_ctx, m_handle);
+			}
+			m_ctx = other.m_ctx;
+			m_handle = other.m_handle;
+			other.m_ctx = nullptr;
+			other.m_handle = 0;
+		}
+		return *this;
+	}
+
+	int getHandle() const {
+		return m_handle;
+	}
+	bool isValid() const {
+		return m_handle > 0;
+	}
+
+private:
+	NVGcontext* m_ctx = nullptr;
+	int m_handle = 0;
+};
+
+#endif

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -16,6 +16,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "rendering/ui/tooltip_drawer.h"
+#include "rendering/core/nanovg_image.h"
 #include "rendering/core/graphics.h"
 #include "rendering/core/text_renderer.h"
 #include <nanovg.h>
@@ -31,14 +32,6 @@ TooltipDrawer::TooltipDrawer() {
 
 TooltipDrawer::~TooltipDrawer() {
 	clear();
-	if (lastContext) {
-		for (auto& pair : spriteCache) {
-			if (pair.second > 0) {
-				nvgDeleteImage(lastContext, pair.second);
-			}
-		}
-		spriteCache.clear();
-	}
 }
 
 void TooltipDrawer::clear() {
@@ -124,22 +117,6 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 		return 0;
 	}
 
-	// Detect context change and clear cache
-	if (vg != lastContext) {
-		// If we had a previous context, we'd ideally delete images from it,
-		// but if the context pointer changed, the old one might be invalid.
-		// However, adhering to the request to clear cache with nvgDeleteImage:
-		if (lastContext) {
-			for (auto& pair : spriteCache) {
-				if (pair.second > 0) {
-					nvgDeleteImage(lastContext, pair.second);
-				}
-			}
-		}
-		spriteCache.clear();
-		lastContext = vg;
-	}
-
 	// Resolve Item ID
 	ItemType& it = g_items[itemId];
 	if (!it.sprite) {
@@ -149,7 +126,7 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 	// We use the item ID as the cache key since it's unique and stable
 	auto itCache = spriteCache.find(itemId);
 	if (itCache != spriteCache.end()) {
-		return itCache->second;
+		return itCache->second->getHandle();
 	}
 
 	// Use the sprite directly from ItemType
@@ -204,11 +181,7 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 					// nvgCreateImageRGBA failed
 				} else {
 					// Success
-					// Check if we are overwriting an existing valid image (shouldn't happen given find() above, but safest)
-					if (spriteCache.contains(itemId) && spriteCache[itemId] > 0) {
-						nvgDeleteImage(vg, spriteCache[itemId]);
-					}
-					spriteCache[itemId] = image;
+					spriteCache[itemId] = std::make_unique<NanoVGImage>(vg, image);
 					return image;
 				}
 			}

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -30,6 +30,7 @@
 
 class Item;
 class Waypoint;
+class NanoVGImage;
 struct NVGcontext;
 
 struct ContainerItem {
@@ -179,8 +180,7 @@ protected:
 	std::vector<TooltipData> tooltips;
 	size_t active_count = 0;
 
-	std::unordered_map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
-	NVGcontext* lastContext = nullptr;
+	std::unordered_map<uint32_t, std::unique_ptr<NanoVGImage>> spriteCache; // sprite_id -> nvg image handle
 
 	// Helper to get or load sprite image
 	int getSpriteImage(NVGcontext* vg, uint16_t itemId);


### PR DESCRIPTION
This PR addresses two main areas:
1.  **Memory Safety in Networking:** The `send` method in `LiveClient` and `LivePeer` was using a reference to a potentially stack-allocated `NetworkMessage` in an asynchronous operation. This could lead to use-after-free if the message went out of scope before the write completed. The fix involves creating a shared copy of the message for the async handler.
2.  **Resource Management in Rendering:** The `TooltipDrawer` was manually managing NanoVG image handles, leading to complex and potentially unsafe cleanup logic involving a raw `lastContext` pointer. A new RAII class `NanoVGImage` was introduced to handle image deletion automatically, and `TooltipDrawer` was updated to use `std::unique_ptr` for its cache.

---
*PR created automatically by Jules for task [12373187943735106745](https://jules.google.com/task/12373187943735106745) started by @karolak6612*