### PR TITLE
⚡ Bolt: Implement TooltipDrawer caching to optimize rendering

### DIFF
--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -141,6 +141,8 @@ struct TooltipData {
 		containerItems.clear();
 		containerCapacity = 0;
 	}
+
+	size_t computeHash() const;
 };
 
 class TooltipDrawer {
@@ -182,13 +184,13 @@ protected:
 	std::unordered_map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
 	NVGcontext* lastContext = nullptr;
 
-	// Helper to get or load sprite image
-	int getSpriteImage(NVGcontext* vg, uint16_t itemId);
+	struct CachedFieldLine {
+		std::string label;
+		std::string value;
+		uint8_t r, g, b;
+		std::vector<std::string> wrappedLines;
+	};
 
-	// Helper to get header color based on category
-	void getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const;
-
-	// Refactored drawing helpers
 	struct LayoutMetrics {
 		float width;
 		float height;
@@ -202,11 +204,27 @@ protected:
 		int numContainerItems;
 	};
 
+	struct CachedTooltipEntry {
+		LayoutMetrics layout;
+		std::vector<CachedFieldLine> fields;
+		uint64_t last_frame_used;
+	};
+
+	std::unordered_map<size_t, CachedTooltipEntry> layoutCache;
+	uint64_t frame_counter = 0;
+
+	// Helper to get or load sprite image
+	int getSpriteImage(NVGcontext* vg, uint16_t itemId);
+
+	// Helper to get header color based on category
+	void getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const;
+
+	// Refactored drawing helpers
 	void prepareFields(const TooltipData& tooltip);
 	LayoutMetrics calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize);
 	void drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip);
-	void drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize);
-	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout);
+	void drawFields(NVGcontext* vg, const std::vector<FieldLine>& fields, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize);
+	void drawContainerGrid(NVGcontext* vg, const std::vector<FieldLine>& fields, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout);
 };
 
 #endif


### PR DESCRIPTION
💡 What: Implemented a caching system for the `TooltipDrawer`.
🎯 Why: Rendering tooltips for all visible items caused significant CPU overhead due to redundant text measurement (`nvgTextBounds`) and string formatting every frame.
📊 Impact: Expected to reduce CPU usage and draw time significantly when "Show Tooltips" is enabled, especially on dense maps.
🔬 Measurement: Verify by enabling "Show Tooltips" on a large map and observing frame times/responsiveness. Code includes hash validation to ensure correctness.

---
*PR created automatically by Jules for task [18204912048047362971](https://jules.google.com/task/18204912048047362971) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tooltip rendering performance through caching and memory management improvements. Tooltip display remains visually unchanged while reducing rendering overhead and improving responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->