### PR TITLE
Refactor UI components to fix wxWidgets violations and optimize rendering

### DIFF
--- a/source/palette/controls/virtual_brush_grid.cpp
+++ b/source/palette/controls/virtual_brush_grid.cpp
@@ -19,7 +19,7 @@ VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _til
 	columns(1),
 	item_size(0),
 	padding(4),
-	m_animTimer(new wxTimer(this)) {
+	m_animTimer(this) {
 
 	if (icon_size == RENDER_SIZE_16x16) {
 		item_size = 18;
@@ -36,8 +36,7 @@ VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _til
 }
 
 VirtualBrushGrid::~VirtualBrushGrid() {
-	m_animTimer->Stop();
-	delete m_animTimer;
+	m_animTimer.Stop();
 }
 
 void VirtualBrushGrid::SetDisplayMode(DisplayMode mode) {

--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -80,7 +80,7 @@ protected:
 	mutable std::unordered_map<const Brush*, std::string> m_utf8NameCache;
 
 	// Animation state
-	wxTimer* m_animTimer;
+	wxTimer m_animTimer;
 	void OnTimer(wxTimerEvent& event);
 };
 

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -128,6 +128,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 		} else {
 			item.name = wxString::Format("Outfit %d", i);
 		}
+		item.name_utf8 = item.name.ToUTF8().data();
 
 		GameSprite* spr = g_gui.gfx.getCreatureSprite(i);
 		item.layers = spr ? spr->layers : 1;
@@ -177,18 +178,18 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
+	wxWrapSizer* palette_sizer = new wxWrapSizer(wxHORIZONTAL);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
 		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
+		palette_sizer->Add(swatch, 0, wxRIGHT | wxBOTTOM, 1);
 		color_buttons.push_back(swatch);
 
 		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
 			SelectColor(i);
 		});
 	}
-	col1_sizer->Add(palette_sizer, 0, wxALL, 8);
+	col1_sizer->Add(palette_sizer, 0, wxEXPAND | wxALL, 8);
 
 	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);

--- a/source/ui/dialogs/outfit_selection_grid.cpp
+++ b/source/ui/dialogs/outfit_selection_grid.cpp
@@ -174,7 +174,7 @@ void OutfitSelectionGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 		wxRect rect = GetItemRect(i);
 
 		int lookType = is_favorites ? favorite_items[i].outfit.lookType : filtered_outfits[i].lookType;
-		wxString name = is_favorites ? favorite_items[i].label : filtered_outfits[i].name;
+		const std::string& name = is_favorites ? favorite_items[i].label : filtered_outfits[i].name_utf8;
 
 		// Card background
 		nvgBeginPath(vg);
@@ -228,10 +228,15 @@ void OutfitSelectionGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 
 		// Name
 		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
-		if (name.length() > 14) {
-			name = name.Mid(0, 12) + "..";
+		std::string displayName = name;
+		if (displayName.length() > 14) {
+			size_t cut = 12;
+			while (cut > 0 && (displayName[cut] & 0xC0) == 0x80) {
+				cut--;
+			}
+			displayName = displayName.substr(0, cut) + "..";
 		}
-		nvgText(vg, rect.x + rect.width / 2, rect.y + 75, name.ToUTF8().data(), nullptr);
+		nvgText(vg, rect.x + rect.width / 2, rect.y + 75, displayName.c_str(), nullptr);
 
 		// ID
 		const std::string idStr = std::format("#{}", lookType);

--- a/source/ui/dialogs/outfit_selection_grid.h
+++ b/source/ui/dialogs/outfit_selection_grid.h
@@ -13,6 +13,7 @@ class OutfitChooserDialog; // Forward declaration
 struct OutfitItem {
 	int lookType;
 	wxString name;
+	std::string name_utf8;
 	int layers;
 };
 


### PR DESCRIPTION
This change addresses several wxWidgets violations and optimizations identified by the Phantom agent:

1.  **Resource Management**: Fixed a memory management issue in `VirtualBrushGrid` where `wxTimer` was managed via a raw pointer. Converted it to a member object to ensure proper RAII cleanup.
2.  **Layout Improvement**: Replaced the rigid `wxFlexGridSizer` in `OutfitChooserDialog`'s color palette with `wxWrapSizer`. This allows the color swatches to flow naturally when the dialog is resized, improving responsiveness.
3.  **Performance Optimization**: In `OutfitSelectionGrid`, `wxString` to UTF-8 conversion was happening every frame for every visible item during NanoVG painting. Introduced `name_utf8` cache in `OutfitItem` to perform this conversion once during population.
4.  **Rendering Safety**: Added a UTF-8 aware string truncation algorithm in `OutfitSelectionGrid::OnNanoVGPaint` to ensure that truncating names (e.g., "Outfit Name...") does not split multi-byte characters, which could lead to rendering artifacts.

---
*PR created automatically by Jules for task [960513977230318172](https://jules.google.com/task/960513977230318172) started by @karolak6612*