### PR TITLE
Refactor ItemDatabase loading logic

### DIFF
--- a/source/game/items.h
+++ b/source/game/items.h
@@ -475,10 +475,6 @@ protected:
 	bool loadFromOtbGeneric(BinaryNode* itemNode, OtbFileFormatVersion version, wxString& error, std::vector<std::string>& warnings);
 
 private:
-	static void parseItemTypeAttribute(ItemType& it, std::string_view value);
-	static void parseSlotTypeAttribute(ItemType& it, std::string_view value);
-	static void parseWeaponTypeAttribute(ItemType& it, std::string_view value);
-	static void parseFloorChangeAttribute(ItemType& it, std::string_view value);
 	void updateAllTooltipableFlags();
 
 protected:


### PR DESCRIPTION
This PR refactors `source/game/items.cpp` to address "Long Method" and "Bloater" code smells in `ItemDatabase::loadFromOtbGeneric` and `ItemDatabase::loadItemFromGameXml`.

Changes:
1.  **Extraction of Attribute Handlers**: The logic for parsing individual OTB and XML attributes, previously defined as inline lambdas within the loading methods, has been moved to named static functions within an anonymous namespace in `items.cpp`.
2.  **Dispatch Table Simplification**: The `handlers` (for OTB) and `parsers` (for XML) maps/arrays are now initialized with references to these static functions, making the dispatch logic clean and concise.
3.  **Header Cleanup**: Private static helper methods (`parseItemTypeAttribute`, etc.) were removed from `ItemDatabase` in `items.h` and converted to free functions in `items.cpp`, reducing the class interface surface area.
4.  **Logic Separation**: The update of `max_item_id` was moved out of the specific server ID handler to the main loop, allowing the handlers to be independent of `ItemDatabase` internals.

This change aims to make the item loading code easier to read, test, and maintain by separating the "what" (dispatching) from the "how" (parsing logic).

---
*PR created automatically by Jules for task [14350768656578326720](https://jules.google.com/task/14350768656578326720) started by @karolak6612*