### PR TITLE
Fix critical UB and race conditions in Network and DirtyList

### DIFF
--- a/source/editor/dirty_list.cpp
+++ b/source/editor/dirty_list.cpp
@@ -29,16 +29,16 @@ DirtyList::~DirtyList() {
 }
 
 void DirtyList::AddPosition(int x, int y, int z) {
-	uint32_t m = ((x >> 2) << 18) | ((y >> 2) << 4);
+	uint32_t m = ((uint32_t(x) >> 2) << 18) | ((uint32_t(y) >> 2) << 4);
 	ValueType fi = { m, 0 };
 	SetType::iterator s = iset.find(fi);
 	if (s != iset.end()) {
 		ValueType v = *s;
 		iset.erase(s);
-		v.floors = (1 << z) | v.floors;
+		v.floors = (1u << z) | v.floors;
 		iset.insert(v);
 	} else {
-		ValueType v = { m, (uint32_t)(1 << z) };
+		ValueType v = { m, (uint32_t)(1u << z) };
 		iset.insert(v);
 	}
 }

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,8 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <cstring>
+#include <atomic>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -36,7 +38,8 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		T value;
+		memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}
@@ -81,7 +84,7 @@ public:
 private:
 	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
-	bool stopped;
+	std::atomic<bool> stopped;
 };
 
 #endif


### PR DESCRIPTION
Addressed 3 critical bugs identified by the "Bugger" agent instructions:
1.  **Undefined Behavior / Strict Aliasing**: `NetworkMessage::read` was using `reinterpret_cast` on a byte buffer, which violates strict aliasing and can cause unaligned access. Fixed by using `memcpy`.
2.  **Race Condition**: `NetworkConnection` used a raw `bool` for thread termination signaling. Fixed by using `std::atomic<bool>`.
3.  **Signed Integer Overflow**: `DirtyList::AddPosition` performed bitwise shifts on signed integers that could overflow or shift into the sign bit. Fixed by casting to `uint32_t` for defined unsigned arithmetic.

Verified fixes with a standalone reproduction script `source/ub_verification_test.cpp`.

---
*PR created automatically by Jules for task [15983499405582571901](https://jules.google.com/task/15983499405582571901) started by @karolak6612*