### PR TITLE
UX: Add tooltips and shortcut hints to various dialogs

### DIFF
--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -53,11 +53,11 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	okBtn->SetToolTip("Jump to selected item/brush");
+	okBtn->SetToolTip("Jump to selected item/brush (Enter)");
 	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancelBtn->SetToolTip("Close this window");
+	cancelBtn->SetToolTip("Close this window (Esc)");
 	stdsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
 

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -29,11 +29,11 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	okBtn->SetToolTip("Go to position");
+	okBtn->SetToolTip("Go to position (Enter)");
 	tmpsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancelBtn->SetToolTip("Close this window");
+	cancelBtn->SetToolTip("Close this window (Esc)");
 	tmpsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(tmpsizer, 0, wxALL | wxCENTER, 20); // Border to top too
 

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -46,6 +46,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
 	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
 	options_radio_box->SetSelection(SearchMode::ServerIDs);
+	options_radio_box->SetToolTip("Choose how you want to search for items");
 	options_box_sizer->Add(options_radio_box, 0, wxALL | wxEXPAND, 5);
 
 	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
@@ -79,11 +80,11 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	buttons_box_sizer = newd wxStdDialogButtonSizer();
 	ok_button = newd wxButton(this, wxID_OK);
 	ok_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	ok_button->SetToolTip("Select an item to confirm");
+	ok_button->SetToolTip("Confirm selection (Enter)");
 	buttons_box_sizer->AddButton(ok_button);
 	cancel_button = newd wxButton(this, wxID_CANCEL);
 	cancel_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancel_button->SetToolTip("Cancel selection");
+	cancel_button->SetToolTip("Cancel selection (Esc)");
 	buttons_box_sizer->AddButton(cancel_button);
 	buttons_box_sizer->Realize();
 	options_box_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
@@ -409,7 +410,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	if (found_search_results) {
 		items_list->SetSelection(0);
 		ok_button->Enable(true);
-		ok_button->SetToolTip("Confirm selection");
+		ok_button->SetToolTip("Confirm selection (Enter)");
 	} else {
 		items_list->SetNoMatches();
 	}

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -95,11 +95,11 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 	wxButton* export_button = newd wxButton(dg, wxID_OK, "Export as XML");
 	export_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
-	export_button->SetToolTip("Not implemented yet");
+	export_button->SetToolTip("Coming soon: Export statistics to XML");
 	export_button->Enable(false);
 	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	okBtn->SetToolTip("Close this window");
+	okBtn->SetToolTip("Close this window (Esc)");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());
 	dg->SetSizerAndFit(topsizer);

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -183,6 +183,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	items_sizer->SetMinSize(wxSize(-1, FromDIP(40)));
 
 	replace_button = new ReplaceItemsButton(this);
+	replace_button->SetToolTip("Click to select item");
 	items_sizer->Add(replace_button, 0, wxALL, 5);
 
 	wxBitmap bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCATION_ARROW, FromDIP(wxSize(16, 16)));
@@ -190,6 +191,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	items_sizer->Add(arrow_bitmap, 0, wxTOP, 15);
 
 	with_button = new ReplaceItemsButton(this);
+	with_button->SetToolTip("Click to select item");
 	items_sizer->Add(with_button, 0, wxALL, 5);
 
 	items_sizer->Add(0, 0, 1, wxEXPAND, 5);
@@ -224,7 +226,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 
 	close_button = new wxButton(this, wxID_ANY, "Close");
 	close_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	close_button->SetToolTip("Close this window");
+	close_button->SetToolTip("Close this window (Esc)");
 	buttons_sizer->Add(close_button, 0, wxALL, 5);
 
 	sizer->Add(buttons_sizer, 1, wxALL | wxLEFT | wxRIGHT | wxSHAPED, 5);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -18,6 +18,7 @@ public:
 		m_path(path), m_date(date), m_isHover(false), m_isPressed(false) {
 		SetBackgroundStyle(wxBG_STYLE_PAINT);
 		SetMinSize(wxSize(-1, FromDIP(45))); // Slightly more compact
+		SetToolTip(m_path);
 
 		Bind(wxEVT_PAINT, &RecentFileItem::OnPaint, this);
 		Bind(wxEVT_ENTER_WINDOW, [this](wxMouseEvent&) { m_isHover = true; Refresh(); });
@@ -108,20 +109,23 @@ public:
 		sideSizer->Add(version, 0, wxALIGN_CENTER_HORIZONTAL | wxBOTTOM, FromDIP(25));
 
 		// Actions (Nav-style)
-		auto addButton = [&](const wxString& label, int id, const char* icon) {
+		auto addButton = [&](const wxString& label, int id, const char* icon, const wxString& tooltip = "") {
 			ModernButton* btn = new ModernButton(sidebar, id, label);
 			btn->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_BTNTEXT));
 			btn->SetMinSize(wxSize(-1, FromDIP(35))); // More compact nav height
 			if (icon) {
 				btn->SetBitmap(IMAGE_MANAGER.GetBitmap(icon, wxSize(16, 16)));
 			}
+			if (!tooltip.IsEmpty()) {
+				btn->SetToolTip(tooltip);
+			}
 			sideSizer->Add(btn, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(8));
 			btn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, parent);
 		};
 
-		addButton("New Project", wxID_NEW, ICON_NEW);
-		addButton("Open Project", wxID_OPEN, ICON_OPEN);
-		addButton("Preferences", wxID_PREFERENCES, ICON_GEAR);
+		addButton("New Project", wxID_NEW, ICON_NEW, "Start a new map project (Ctrl+N)");
+		addButton("Open Project", wxID_OPEN, ICON_OPEN, "Open an existing map project (Ctrl+O)");
+		addButton("Preferences", wxID_PREFERENCES, ICON_GEAR, "Configure editor settings (Ctrl+P)");
 
 		sideSizer->AddStretchSpacer();
 


### PR DESCRIPTION
Implemented 10+ micro-UX improvements as per Palette agent instructions.
Changes include:
1.  **Welcome Dialog**: Added (Ctrl+N/O/P) hints and file path tooltips.
2.  **Goto Position Dialog**: Added (Enter/Esc) hints to OK/Cancel.
3.  **Find Item Dialog**: Added (Enter/Esc) hints, and radio box tooltip.
4.  **Find Dialog**: Added (Enter/Esc) hints.
5.  **Replace Items Window**: Added usage tooltips for selection buttons and (Esc) hint for close.
6.  **Map Statistics Dialog**: Added (Esc) hint and improved export button tooltip.

---
*PR created automatically by Jules for task [17943947416272943527](https://jules.google.com/task/17943947416272943527) started by @karolak6612*