### PR TITLE
[ICONS] Modernize toolbars and add missing UI icons

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -12,6 +12,7 @@
 #include "map/map.h"
 #include "game/house.h"
 #include "game/town.h"
+#include "util/image_manager.h"
 
 #include <sstream>
 
@@ -94,8 +95,12 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -15,6 +15,7 @@
 #include "brushes/managers/brush_manager.h"
 #include "brushes/house/house_brush.h"
 #include "brushes/house/house_exit_brush.h"
+#include "util/image_manager.h"
 
 #include <algorithm>
 
@@ -59,8 +60,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -18,21 +18,21 @@ const wxString BrushToolBar::PANE_NAME = "brush_toolbar";
 BrushToolBar::BrushToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_OPTIONAL_BORDER_SMALL, icon_size);
-	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_ERASER_SMALL, icon_size);
-	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PROTECTION_ZONE_SMALL, icon_size);
-	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_PVP_ZONE_SMALL, icon_size);
-	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_LOGOUT_ZONE_SMALL, icon_size);
-	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PVP_ZONE_SMALL, icon_size);
-	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_SMALL, icon_size);
-	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_LOCKED_SMALL, icon_size);
-	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_MAGIC_SMALL, icon_size);
-	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_QUEST_SMALL, icon_size);
-	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_ALT_SMALL, icon_size);
-	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_ARCHWAY_SMALL, icon_size);
+	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(ICON_BORDER_ALL, icon_size);
+	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ERASER, icon_size);
+	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SHIELD_HEART, icon_size);
+	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOVE, icon_size);
+	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ANCHOR, icon_size);
+	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SKULL_CROSSBONES, icon_size);
+	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, icon_size);
+	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCK, icon_size);
+	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WAND_MAGIC, icon_size);
+	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(ICON_KEY, icon_size);
+	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, icon_size);
+	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ARCHWAY, icon_size);
 
-	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_HATCH_SMALL, icon_size);
-	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_NORMAL_SMALL, icon_size);
+	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MINIMIZE, icon_size);
+	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MAXIMIZE, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_BRUSHES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);

--- a/source/ui/toolbar/size_toolbar.cpp
+++ b/source/ui/toolbar/size_toolbar.cpp
@@ -17,13 +17,13 @@ SizeToolBar::SizeToolBar(wxWindow* parent) {
 
 	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size);
 	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size);
-	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size);
-	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size);
-	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size);
-	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size);
-	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size);
+	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(ICON_1, icon_size);
+	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(ICON_2, icon_size);
+	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(ICON_3, icon_size);
+	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(ICON_4, icon_size);
+	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(ICON_5, icon_size);
+	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(ICON_6, icon_size);
+	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(ICON_7, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_SIZES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
@@ -69,27 +69,9 @@ void SizeToolBar::UpdateBrushSize(BrushShape shape, int size) {
 	if (shape == BRUSHSHAPE_CIRCLE) {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, true);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, false);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_7_SMALL, icon_size));
 	} else {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, false);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, true);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size));
 	}
 
 	toolbar->ToggleTool(TOOLBAR_SIZES_1, size == 0);


### PR DESCRIPTION
This PR modernizes the application's UI by replacing legacy PNG icons with scalable SVG icons in the `SizeToolBar` and `BrushToolBar`. It also adds missing icons to the `HousePalette` and `EditHouseDialog` to improve UI consistency.

Key changes:
- `source/ui/toolbar/size_toolbar.cpp`: Switched to `ICON_1` through `ICON_7` SVGs, removing dynamic shape-based icon swapping.
- `source/ui/toolbar/brush_toolbar.cpp`: Replaced all PNG brush icons with corresponding `ICON_*` SVGs from `image_manager.h`.
- `source/palette/house/house_palette.cpp`: Added icons to Add/Edit/Remove buttons.
- `source/palette/house/edit_house_dialog.cpp`: Added icons to OK/Cancel buttons.

This addresses the goal of adding/modernizing icons across the UI.

---
*PR created automatically by Jules for task [11140143877063403794](https://jules.google.com/task/11140143877063403794) started by @karolak6612*