### PR TITLE
📊 Profiler: Fix CPU bottleneck in item rendering

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -7,6 +7,8 @@
 
 #include "app/definitions.h"
 #include "map/position.h"
+#include <optional>
+#include "rendering/utilities/sprite_patterns.h"
 
 // Forward declarations
 class SpriteDrawer;
@@ -25,8 +27,8 @@ public:
 	ItemDrawer();
 	~ItemDrawer();
 
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
-	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, std::optional<SpritePatterns> cached_patterns = std::nullopt);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr, std::optional<SpritePatterns> cached_patterns = std::nullopt);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -209,8 +209,8 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		}
 	} else {
 		if (tile->ground) {
-			PreloadItem(tile, tile->ground.get());
-			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b);
+			auto patterns = PreloadItem(tile, tile->ground.get());
+			item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, false, r, g, b, 255, patterns);
 		} else if (options.always_show_zones && (r != 255 || g != 255 || b != 255)) {
 			ItemType* zoneItem = &g_items[SPRITE_ZONE];
 			item_drawer->DrawRawBrush(sprite_batch, sprite_drawer, draw_x, draw_y, zoneItem, r, g, b, 60);
@@ -273,11 +273,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 					}
 				}
 
-				PreloadItem(tile, item.get());
+				auto patterns = PreloadItem(tile, item.get());
 
 				// item sprite
 				if (item->isBorder()) {
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, r, g, b, 255, patterns);
 				} else {
 					uint8_t ir = 255, ig = 255, ib = 255;
 
@@ -297,7 +297,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 							}
 						}
 					}
-					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib);
+					item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, false, ir, ig, ib, 255, patterns);
 				}
 			}
 			// monster/npc on tile
@@ -316,9 +316,9 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 }
 
-void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
+std::optional<SpritePatterns> TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (!item) {
-		return;
+		return std::nullopt;
 	}
 
 	const ItemType& it = g_items[item->getID()];
@@ -326,7 +326,9 @@ void TileRenderer::PreloadItem(const Tile* tile, Item* item) {
 	if (spr && !spr->isSimpleAndLoaded()) {
 		SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, tile->getPosition());
 		rme::collectTileSprites(spr, patterns.x, patterns.y, patterns.z, patterns.frame);
+		return patterns;
 	}
+	return std::nullopt;
 }
 
 void TileRenderer::AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -4,6 +4,8 @@
 #include <memory>
 #include <sstream>
 #include <stdint.h>
+#include <optional>
+#include "rendering/utilities/sprite_patterns.h"
 
 class TileLocation;
 struct RenderView;
@@ -28,7 +30,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item);
+	std::optional<SpritePatterns> PreloadItem(const Tile* tile, Item* item);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;

--- a/source/rendering/utilities/pattern_calculator.h
+++ b/source/rendering/utilities/pattern_calculator.h
@@ -5,14 +5,7 @@
 #include "game/items.h"
 #include "game/item.h"
 #include "map/tile.h"
-
-struct SpritePatterns {
-	int x = 0;
-	int y = 0;
-	int z = 0;
-	int frame = 0;
-	int subtype = -1;
-};
+#include "rendering/utilities/sprite_patterns.h"
 
 class PatternCalculator {
 public:

--- a/source/rendering/utilities/sprite_patterns.h
+++ b/source/rendering/utilities/sprite_patterns.h
@@ -1,0 +1,12 @@
+#ifndef RME_RENDERING_UTILITIES_SPRITE_PATTERNS_H_
+#define RME_RENDERING_UTILITIES_SPRITE_PATTERNS_H_
+
+struct SpritePatterns {
+	int x = 0;
+	int y = 0;
+	int z = 0;
+	int frame = 0;
+	int subtype = -1;
+};
+
+#endif


### PR DESCRIPTION
Implemented an optimization to cache `SpritePatterns` calculated during `TileRenderer::PreloadItem` and reuse them in `ItemDrawer::BlitItem`. This avoids redundant calculations and memory access, reducing CPU usage in the rendering hot path.

Changes:
- Extracted `SpritePatterns` struct to `source/rendering/utilities/sprite_patterns.h`.
- Updated `source/rendering/utilities/pattern_calculator.h` to use the new header.
- Modified `TileRenderer::PreloadItem` to return `std::optional<SpritePatterns>`.
- Modified `ItemDrawer::BlitItem` to accept `std::optional<SpritePatterns>` and use it if available, or skip calculation for simple sprites.
- Updated `TileRenderer::DrawTile` to pass the cached patterns.

---
*PR created automatically by Jules for task [9728351627701731646](https://jules.google.com/task/9728351627701731646) started by @karolak6612*