### PR TITLE
⚡ Bolt: Rendering optimizations (hoisting, lookups, spatial iteration)

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -27,6 +27,8 @@ public:
 
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	// Overload accepting ItemType& to avoid redundant lookup
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const ItemType& it, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/overlays/marker_drawer.cpp
+++ b/source/rendering/drawers/overlays/marker_drawer.cpp
@@ -21,7 +21,7 @@ void MarkerDrawer::draw(SpriteBatch& sprite_batch, SpriteDrawer* drawer, int dra
 
 	// house exit (blue splash)
 	if (tile->isHouseExit() && options.show_houses) {
-		if (tile->hasHouseExit(current_house_id)) {
+		if (current_house_id != 0 && tile->hasHouseExit(current_house_id)) {
 			drawer->BlitSprite(sprite_batch, draw_x, draw_y, SPRITE_HOUSE_EXIT, 64, 255, 255);
 		} else {
 			drawer->BlitSprite(sprite_batch, draw_x, draw_y, SPRITE_HOUSE_EXIT, 64, 64, 255);

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -13,6 +13,7 @@
 #include "editor/copybuffer.h"
 #include "editor/editor.h"
 #include "ui/map_tab.h"
+#include "game/items.h"
 
 PreviewDrawer::PreviewDrawer() {
 }
@@ -89,17 +90,19 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							g /= 2;
 						}
 						if (tile->ground) {
-							item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), options, true, r, g, b, 255);
+							const ItemType& groundType = g_items[tile->ground->getID()];
+							item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, tile->ground.get(), groundType, options, true, r, g, b, 255);
 						}
 					}
 
 					// Draw items on the tile
 					if (view.zoom <= 10.0 || !options.hide_items_when_zoomed) {
 						for (const auto& item : tile->items) {
+							const ItemType& it = g_items[item->getID()];
 							if (item->isBorder()) {
-								item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, true, 255, r, g, b);
+								item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), it, options, true, 255, r, g, b);
 							} else {
-								item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), options, true, 255, 255, 255, 255);
+								item_drawer->BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, tile, item.get(), it, options, true, 255, 255, 255, 255);
 							}
 						}
 						if (tile->creature && options.show_creatures) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -19,6 +19,9 @@ class TooltipDrawer;
 struct LightBuffer;
 class SpriteBatch;
 class PrimitiveRenderer;
+class Tile;
+class Item;
+struct ItemType;
 
 class TileRenderer {
 public:
@@ -28,7 +31,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item);
+	void PreloadItem(const Tile* tile, Item* item, const ItemType& it);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This PR implements several performance optimizations identified by the "Bolt" agent:
1.  **Rendering Math Hoisting:** House color and pulse effect calculations are now done once per tile instead of for every item on the tile.
2.  **Reduced Lookups:** `ItemType` is looked up once per item loop and passed by reference to drawing functions (`BlitItem`, `PreloadItem`), avoiding repeated array access/pointer arithmetic.
3.  **Pattern Calculation Skipping:** Simple static items (walls, grounds) now bypass the `PatternCalculator` logic completely.
4.  **Spatial Iteration:** `FloorDrawer` now uses `visitLeaves` (quadtree-like traversal) instead of iterating every coordinate in the viewport, significantly improving performance on sparse maps or large viewports.
5.  **Logic Pruning:** Redundant checks in `MarkerDrawer` and `CreatureNameDrawer` are removed for common cases (no house selected, different floor).

---
*PR created automatically by Jules for task [10939811998533112086](https://jules.google.com/task/10939811998533112086) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed house exit markers appearing when they shouldn't be visible.

* **Performance**
  * Optimized item rendering pipeline to reduce redundant lookups and skip expensive calculations for simple items.
  * Enhanced transparent floor rendering with improved batching and viewport bounds optimization for better performance when viewing higher floors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->