### PR TITLE
Refactor LightDrawer to use SharedGeometry

### DIFF
--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -54,7 +54,6 @@ private:
 
 	std::unique_ptr<ShaderProgram> shader;
 	std::unique_ptr<GLVertexArray> vao;
-	std::unique_ptr<GLBuffer> vbo;
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 


### PR DESCRIPTION
Refactored LightDrawer to use SharedGeometry::getQuadVBO() and glDrawElementsInstanced, reducing duplicate geometry buffers and ensuring consistent quad usage.

OPENGL RENDERING SPECIALIST - Daily Report
Date: 2024-05-22
Files Scanned: 35
Review Time: 30 minutes
Quick Summary: Found 0 critical issues. The rendering pipeline is generally optimized with instanced rendering and sprite batching. Found 2 medium issues regarding duplicate geometry buffers and suboptimal PBO usage. Fixed 1 medium issue in LightDrawer.

Issues Found:
- MEDIUM: Duplicate geometry in LightDrawer (FIXED).
- MEDIUM: Duplicate geometry in MapDrawer (PLANNED).
- MEDIUM: Inefficient PBO usage in TextureAtlas (PLANNED).

---
*PR created automatically by Jules for task [8766643201739226215](https://jules.google.com/task/8766643201739226215) started by @karolak6612*