### PR TITLE
[TILE/WXWIDGETS] Fix inefficient tile selection traversal

### DIFF
--- a/source/editor/selection_util.h
+++ b/source/editor/selection_util.h
@@ -1,0 +1,33 @@
+#ifndef RME_SELECTION_UTIL_H
+#define RME_SELECTION_UTIL_H
+
+#include "editor/editor.h"
+#include "map/map.h"
+#include "editor/selection.h"
+
+template <typename ForeachType>
+inline void foreach_ItemInSelection(Editor& editor, ForeachType& foreach) {
+	long long done = 0;
+	const auto& tiles = editor.selection.getTiles();
+	std::vector<Container*> containers;
+	containers.reserve(32);
+	for (Tile* tile : tiles) {
+		++done;
+		foreach_ItemOnTile(editor.map, tile, foreach, done, containers);
+	}
+}
+
+template <typename RemoveIfType>
+inline int64_t RemoveItemInSelection(Editor& editor, RemoveIfType& condition) {
+	int64_t done = 0;
+	int64_t removed = 0;
+	const auto& tiles = editor.selection.getTiles();
+
+	for (Tile* tile : tiles) {
+		++done;
+		RemoveItemOnTile(editor.map, tile, condition, removed, done);
+	}
+	return removed;
+}
+
+#endif

--- a/source/ui/menubar/search_handler.cpp
+++ b/source/ui/menubar/search_handler.cpp
@@ -12,6 +12,7 @@
 #include "editor/operations/clean_operations.h"
 #include "map/map.h"
 #include "editor/action_queue.h"
+#include "editor/selection_util.h"
 
 SearchHandler::SearchHandler(MainFrame* frame) :
 	frame(frame) {
@@ -115,7 +116,7 @@ void SearchHandler::OnSearchForItemOnSelection(wxCommandEvent& WXUNUSED(event)) 
 		EditorOperations::ItemSearcher finder(dialog.getResultID(), (uint32_t)g_settings.getInteger(Config::REPLACE_SIZE));
 		g_gui.CreateLoadBar("Searching on selected area...");
 
-		foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, true);
+		foreach_ItemInSelection(*g_gui.GetCurrentEditor(), finder);
 		std::vector<std::pair<Tile*, Item*>>& result = finder.result;
 
 		g_gui.DestroyLoadBar();
@@ -162,7 +163,7 @@ void SearchHandler::OnRemoveItemOnSelection(wxCommandEvent& WXUNUSED(event)) {
 		g_gui.GetCurrentEditor()->actionQueue->clear();
 		g_gui.CreateLoadBar("Searching item on selection to remove...");
 		EditorOperations::RemoveItemCondition condition(dialog.getResultID());
-		int64_t count = RemoveItemOnMap(g_gui.GetCurrentMap(), condition, true);
+		int64_t count = RemoveItemInSelection(*g_gui.GetCurrentEditor(), condition);
 		g_gui.DestroyLoadBar();
 
 		wxString msg;
@@ -202,7 +203,11 @@ void SearchHandler::SearchItems(bool unique, bool action, bool container, bool w
 	finder.search_container = container;
 	finder.search_writeable = writable;
 
-	foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, onSelection);
+	if (onSelection) {
+		foreach_ItemInSelection(*g_gui.GetCurrentEditor(), finder);
+	} else {
+		foreach_ItemOnMap(g_gui.GetCurrentMap(), finder, false);
+	}
 	finder.sort();
 
 	std::vector<SearchResult> found;

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -19,6 +19,7 @@
 #include "ui/replace_items_window.h"
 #include "ui/find_item_window.h"
 #include "editor/action_queue.h"
+#include "editor/selection_util.h"
 #include "rendering/core/graphics.h"
 #include "ui/gui.h"
 #include "util/image_manager.h"
@@ -357,7 +358,11 @@ void ReplaceItemsDialog::OnExecuteButtonClicked(wxCommandEvent& WXUNUSED(event))
 		ItemFinder finder(info.replaceId, (uint32_t)g_settings.getInteger(Config::REPLACE_SIZE));
 
 		// search on map
-		foreach_ItemOnMap(editor->map, finder, selectionOnly);
+		if (selectionOnly) {
+			foreach_ItemInSelection(*editor, finder);
+		} else {
+			foreach_ItemOnMap(editor->map, finder, false);
+		}
 
 		uint32_t total = 0;
 		std::vector<std::pair<Tile*, Item*>>& result = finder.result;


### PR DESCRIPTION
ISSUE: Operations on selected tiles (e.g. Find Item on Selection, Replace Item on Selection) were inefficiently iterating over the entire map (O(MapSize)) to find selected tiles, instead of iterating only the selected tiles (O(SelectionSize)). This caused significant lag on large maps even for small selections.
IMPACT: Improved performance of selection-based operations from linear to map size to linear to selection size.
FIX: Introduced `foreach_ItemInSelection` and `RemoveItemInSelection` helpers in `source/editor/selection_util.h` that iterate `editor.selection.getTiles()`. Refactored `map.h` to expose `foreach_ItemOnTile` logic. Updated `SearchHandler` and `ReplaceItemsDialog` to use optimized traversal.
DOMAIN CONTEXT: Selection operations are frequent in tile editing. O(N) lookup where N is 30000x30000 is unacceptable.
PERFORMANCE: Selection iteration is now O(K) where K is number of selected tiles.
TESTED: Verified compilation. Verified logic correctness by code review.

---
*PR created automatically by Jules for task [9964747396668318152](https://jules.google.com/task/9964747396668318152) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search and replace operations now support selection-scoped searches, enabling users to narrow operations to selected items and tiles rather than searching the entire map.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->