### PR TITLE
[UB FIX] Fix buffer overflow, integer overflow, and division by zero

### DIFF
--- a/source/game/items.cpp
+++ b/source/game/items.cpp
@@ -343,7 +343,9 @@ bool ItemDatabase::loadFromOtbGeneric(BinaryNode* itemNode, OtbFileFormatVersion
 					warnings.push_back("Invalid item type property (weight)");
 					return true;
 				}
-				memcpy(&it.weight, raw_weight, sizeof(double));
+				double weight_val;
+				memcpy(&weight_val, raw_weight, sizeof(double));
+				it.weight = static_cast<float>(weight_val);
 				return true;
 			};
 

--- a/source/game/outfit.h
+++ b/source/game/outfit.h
@@ -38,11 +38,11 @@ struct Outfit {
 	int lookMountFeet;
 
 	uint32_t getColorHash() const {
-		return lookHead << 24 | lookBody << 16 | lookLegs << 8 | lookFeet;
+		return static_cast<uint32_t>(lookHead) << 24 | static_cast<uint32_t>(lookBody) << 16 | static_cast<uint32_t>(lookLegs) << 8 | static_cast<uint32_t>(lookFeet);
 	}
 
 	uint32_t getMountColorHash() const {
-		return lookMountHead << 24 | lookMountBody << 16 | lookMountLegs << 8 | lookMountFeet;
+		return static_cast<uint32_t>(lookMountHead) << 24 | static_cast<uint32_t>(lookMountBody) << 16 | static_cast<uint32_t>(lookMountLegs) << 8 | static_cast<uint32_t>(lookMountFeet);
 	}
 };
 

--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -286,7 +286,9 @@ void IOMapOTBM::readMapNodes(Map& map, NodeFileReadHandle& f, BinaryNode* mapHea
 
 	for (BinaryNode* mapNode = mapHeaderNode->getChild(); mapNode != nullptr; mapNode = mapNode->advance()) {
 		if (++nodes_loaded % 2048 == 0) {
-			g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			if (f.size() > 0) {
+				g_gui.SetLoadDone(static_cast<int32_t>(100.0 * f.tell() / f.size()));
+			}
 		}
 
 		uint8_t node_type;


### PR DESCRIPTION
**Problem:**
1.  `ItemDatabase::loadFromOtbGeneric` reads `ITEM_ATTR_WEIGHT` as a double (8 bytes) and uses `memcpy` to write it into `ItemType::weight`, which is a `float` (4 bytes). This causes a stack buffer overflow or corrupts the `ItemType` struct layout.
2.  `Outfit::getColorHash` performs left shifts on `int` members. If the value is large enough to shift into the sign bit, it invokes undefined behavior (signed integer overflow).
3.  `IOMapOTBM::readMapNodes` divides `f.tell()` by `f.size()` to update the progress bar. If `f.size()` is 0 (e.g., empty or corrupted file), it causes a division by zero exception/crash.

**Solution:**
1.  Read the weight into a local `double` variable first, then static_cast it to `float` and assign it to `it.weight`.
2.  Cast `lookHead`, `lookBody`, etc., to `uint32_t` before performing bitwise shift operations.
3.  Add a conditional check `if (f.size() > 0)` before performing the division for the progress bar update.

**Testing:**
- Verified syntax and compilation of header files.
- Code logic verified by inspection and adherence to standard C++ practices.
- The changes are defensive and local, minimizing regression risk.

---
*PR created automatically by Jules for task [1434356515752986806](https://jules.google.com/task/1434356515752986806) started by @karolak6612*