### PR TITLE
UX Improvements: Enhanced status text and tooltips

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -88,6 +88,39 @@ uint32_t Change::memsize() const {
 	return mem;
 }
 
+std::string GetActionName(ActionIdentifier ident) {
+	switch (ident) {
+		case ACTION_MOVE:
+			return "Move";
+		case ACTION_REMOTE:
+			return "Remote Action";
+		case ACTION_SELECT:
+			return "Select";
+		case ACTION_DELETE_TILES:
+			return "Delete";
+		case ACTION_CUT_TILES:
+			return "Cut";
+		case ACTION_PASTE_TILES:
+			return "Paste";
+		case ACTION_RANDOMIZE:
+			return "Randomize";
+		case ACTION_BORDERIZE:
+			return "Borderize";
+		case ACTION_DRAW:
+			return "Draw";
+		case ACTION_SWITCHDOOR:
+			return "Switch Door";
+		case ACTION_ROTATE_ITEM:
+			return "Rotate Item";
+		case ACTION_REPLACE_ITEMS:
+			return "Replace Items";
+		case ACTION_CHANGE_PROPERTIES:
+			return "Change Properties";
+		default:
+			return "Action";
+	}
+}
+
 Action::Action(Editor& editor, ActionIdentifier ident) :
 	commited(false),
 	editor(editor),

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -102,6 +102,8 @@ enum ActionIdentifier {
 	ACTION_CHANGE_PROPERTIES,
 };
 
+std::string GetActionName(ActionIdentifier ident);
+
 class Action {
 public:
 	virtual ~Action();

--- a/source/editor/action_queue.cpp
+++ b/source/editor/action_queue.cpp
@@ -136,3 +136,17 @@ void ActionQueue::clear() {
 	actions.clear();
 	current = 0;
 }
+
+std::string ActionQueue::getLastUndoActionName() {
+	if (current > 0) {
+		return GetActionName(actions[current - 1]->getType());
+	}
+	return "Action";
+}
+
+std::string ActionQueue::getLastRedoActionName() {
+	if (current < actions.size()) {
+		return GetActionName(actions[current]->getType());
+	}
+	return "Action";
+}

--- a/source/editor/action_queue.h
+++ b/source/editor/action_queue.h
@@ -47,6 +47,9 @@ public:
 	void redo();
 	void clear();
 
+	std::string getLastUndoActionName();
+	std::string getLastRedoActionName();
+
 	bool canUndo() {
 		return current > 0;
 	}

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -423,11 +423,12 @@ bool EditorManager::CanRedo() {
 bool EditorManager::DoUndo() {
 	Editor* editor = GetCurrentEditor();
 	if (editor && editor->actionQueue->canUndo()) {
+		std::string actionName = editor->actionQueue->getLastUndoActionName();
 		editor->actionQueue->undo();
 		if (!editor->selection.empty()) {
 			g_gui.SetSelectionMode();
 		}
-		g_status.SetStatusText("Undo action");
+		g_status.SetStatusText("Undid " + wxstr(actionName));
 		g_gui.UpdateMinimap();
 		g_gui.root->UpdateMenubar();
 		g_gui.root->Refresh();
@@ -439,11 +440,12 @@ bool EditorManager::DoUndo() {
 bool EditorManager::DoRedo() {
 	Editor* editor = GetCurrentEditor();
 	if (editor && editor->actionQueue->canRedo()) {
+		std::string actionName = editor->actionQueue->getLastRedoActionName();
 		editor->actionQueue->redo();
 		if (!editor->selection.empty()) {
 			g_gui.SetSelectionMode();
 		}
-		g_status.SetStatusText("Redo action");
+		g_status.SetStatusText("Redid " + wxstr(actionName));
 		g_gui.UpdateMinimap();
 		g_gui.root->UpdateMenubar();
 		g_gui.root->Refresh();

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -53,6 +53,8 @@ void GotoPositionDialog::OnClickCancel(wxCommandEvent&) {
 }
 
 void GotoPositionDialog::OnClickOK(wxCommandEvent&) {
-	g_gui.SetScreenCenterPosition(posctrl->GetPosition());
+	Position pos = posctrl->GetPosition();
+	g_gui.SetScreenCenterPosition(pos);
+	g_gui.SetStatusText(std::format("Jumped to position {}, {}, {}", pos.x, pos.y, pos.z));
 	EndModal(1);
 }

--- a/source/ui/menubar/view_settings_handler.cpp
+++ b/source/ui/menubar/view_settings_handler.cpp
@@ -77,6 +77,11 @@ void ViewSettingsHandler::OnChangeViewSettings(wxCommandEvent& event) {
 
 	bool old_grid = g_settings.getBoolean(Config::SHOW_GRID);
 	bool old_ghost = g_settings.getBoolean(Config::TRANSPARENT_ITEMS);
+	bool old_all_floors = g_settings.getBoolean(Config::SHOW_ALL_FLOORS);
+	bool old_creatures = g_settings.getBoolean(Config::SHOW_CREATURES);
+	bool old_spawns = g_settings.getBoolean(Config::SHOW_SPAWNS);
+	bool old_houses = g_settings.getBoolean(Config::SHOW_HOUSES);
+	bool old_highlight = g_settings.getBoolean(Config::HIGHLIGHT_ITEMS);
 
 	g_settings.setInteger(Config::SHOW_ALL_FLOORS, menuBar->IsItemChecked(SHOW_ALL_FLOORS));
 	if (menuBar->IsItemChecked(SHOW_ALL_FLOORS)) {
@@ -126,6 +131,22 @@ void ViewSettingsHandler::OnChangeViewSettings(wxCommandEvent& event) {
 	bool new_ghost = g_settings.getBoolean(Config::TRANSPARENT_ITEMS);
 	if (old_ghost != new_ghost) {
 		g_gui.SetStatusText(std::format("Ghost Mode: {}", new_ghost ? "On" : "Off"));
+	}
+
+	if (old_all_floors != g_settings.getBoolean(Config::SHOW_ALL_FLOORS)) {
+		g_gui.SetStatusText(std::format("Show All Floors: {}", g_settings.getBoolean(Config::SHOW_ALL_FLOORS) ? "On" : "Off"));
+	}
+	if (old_creatures != g_settings.getBoolean(Config::SHOW_CREATURES)) {
+		g_gui.SetStatusText(std::format("Show Creatures: {}", g_settings.getBoolean(Config::SHOW_CREATURES) ? "On" : "Off"));
+	}
+	if (old_spawns != g_settings.getBoolean(Config::SHOW_SPAWNS)) {
+		g_gui.SetStatusText(std::format("Show Spawns: {}", g_settings.getBoolean(Config::SHOW_SPAWNS) ? "On" : "Off"));
+	}
+	if (old_houses != g_settings.getBoolean(Config::SHOW_HOUSES)) {
+		g_gui.SetStatusText(std::format("Show Houses: {}", g_settings.getBoolean(Config::SHOW_HOUSES) ? "On" : "Off"));
+	}
+	if (old_highlight != g_settings.getBoolean(Config::HIGHLIGHT_ITEMS)) {
+		g_gui.SetStatusText(std::format("Highlight Items: {}", g_settings.getBoolean(Config::HIGHLIGHT_ITEMS) ? "On" : "Off"));
 	}
 
 	g_gui.RefreshView();

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -450,14 +450,19 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 	if (interactables.preview_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_preview = true;
 		hand_cursor = true;
-	}
-	if (interactables.lock_check_rect.Contains(m_hoverPos)) {
+		if (!prev_preview) SetToolTip("Toggle border preview");
+	} else if (interactables.lock_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_lock = true;
 		hand_cursor = true;
-	}
-
-	if (interactables.size_slider_rect.Contains(m_hoverPos) || interactables.thickness_slider_rect.Contains(m_hoverPos)) {
+		if (!prev_lock) SetToolTip("Toggle door lock (Shift)");
+	} else if (interactables.size_slider_rect.Contains(m_hoverPos)) {
 		hand_cursor = true;
+		SetToolTip("Adjust brush size");
+	} else if (interactables.thickness_slider_rect.Contains(m_hoverPos)) {
+		hand_cursor = true;
+		SetToolTip("Adjust brush thickness");
+	} else if (!hover_brush) {
+		UnsetToolTip();
 	}
 
 	SetCursor(hand_cursor ? wxCursor(wxCURSOR_HAND) : wxCursor(wxCURSOR_ARROW));


### PR DESCRIPTION
Implemented 10 micro-UX improvements as requested.
1. Undo status text with action name.
2. Redo status text with action name.
3. Tooltip for Brush Size slider.
4. Tooltip for Brush Thickness slider.
5. Tooltip for Preview Border checkbox.
6. Tooltip for Lock Doors checkbox.
7. Status text for Goto Position success.
8. Status text for Show All Floors toggle.
9. Status text for Show Creatures toggle.
10. Status text for Show Spawns toggle.
11. Status text for Show Houses toggle.
12. Status text for Highlight Items toggle.

---
*PR created automatically by Jules for task [11991232550048160813](https://jules.google.com/task/11991232550048160813) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo/Redo operations now display the specific action name being undone or redone in the status bar.
  * Jump to position feature now displays the coordinates of your destination.
  * View setting toggles now provide status feedback when changed.
  * Enhanced tooltips for tool options including border preview, door lock, and brush size controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->