### PR TITLE
Throttle: Tooltip Caching Optimization

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -219,10 +219,16 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground) {
-		TooltipData& groundData = tooltip_drawer->requestTooltipData();
-		if (FillItemTooltipData(groundData, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-			if (groundData.hasVisibleFields()) {
-				tooltip_drawer->commitTooltip();
+		uint64_t hash = TooltipDrawer::computeHash(tile->ground.get(), tile->isHouseTile(), view.zoom);
+		if (tooltip_drawer->hasTooltip(hash)) {
+			tooltip_drawer->addActiveTooltip(hash, location->getPosition());
+		} else {
+			TooltipData& groundData = tooltip_drawer->requestTooltipData();
+			if (FillItemTooltipData(groundData, tile->ground.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
+				if (groundData.hasVisibleFields()) {
+					tooltip_drawer->defineTooltip(hash, groundData);
+					tooltip_drawer->addActiveTooltip(hash, location->getPosition());
+				}
 			}
 		}
 	}
@@ -265,10 +271,16 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 			for (const auto& item : tile->items) {
 				// item tooltip (one per item)
 				if (options.show_tooltips && map_z == view.floor) {
-					TooltipData& itemData = tooltip_drawer->requestTooltipData();
-					if (FillItemTooltipData(itemData, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
-						if (itemData.hasVisibleFields()) {
-							tooltip_drawer->commitTooltip();
+					uint64_t hash = TooltipDrawer::computeHash(item.get(), tile->isHouseTile(), view.zoom);
+					if (tooltip_drawer->hasTooltip(hash)) {
+						tooltip_drawer->addActiveTooltip(hash, location->getPosition());
+					} else {
+						TooltipData& itemData = tooltip_drawer->requestTooltipData();
+						if (FillItemTooltipData(itemData, item.get(), location->getPosition(), tile->isHouseTile(), view.zoom)) {
+							if (itemData.hasVisibleFields()) {
+								tooltip_drawer->defineTooltip(hash, itemData);
+								tooltip_drawer->addActiveTooltip(hash, location->getPosition());
+							}
 						}
 					}
 				}

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -24,7 +24,29 @@
 #include <wx/wx.h>
 #include "game/items.h"
 #include "game/sprites.h"
+#include "game/item.h"
+#include "game/complexitem.h"
 #include "ui/gui.h"
+
+// Helper for hashing
+static inline void hash_combine(uint64_t& seed, uint64_t value) {
+	seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
+TooltipDrawer::CachedTooltipData::CachedTooltipData(const TooltipData& other) :
+	category(other.category),
+	itemId(other.itemId),
+	itemName(other.itemName),
+	actionId(other.actionId),
+	uniqueId(other.uniqueId),
+	doorId(other.doorId),
+	text(other.text),
+	description(other.description),
+	destination(other.destination),
+	waypointName(other.waypointName),
+	containerItems(other.containerItems),
+	containerCapacity(other.containerCapacity) {
+}
 
 TooltipDrawer::TooltipDrawer() {
 }
@@ -43,6 +65,7 @@ TooltipDrawer::~TooltipDrawer() {
 
 void TooltipDrawer::clear() {
 	active_count = 0;
+	active_tooltips.clear();
 }
 
 TooltipData& TooltipDrawer::requestTooltipData() {
@@ -87,6 +110,123 @@ void TooltipDrawer::addWaypointTooltip(Position pos, std::string_view name) {
 	commitTooltip();
 }
 
+uint64_t TooltipDrawer::computeHash(const Item* item, bool isHouseTile, float zoom) {
+	if (!item) {
+		return 0;
+	}
+
+	uint64_t hash = 0;
+	uint16_t id = item->getID();
+	hash_combine(hash, id);
+
+	if (isHouseTile) {
+		hash_combine(hash, 1);
+	}
+
+	// Zoom level affects container visibility (threshold 1.5)
+	if (zoom <= 1.5f) {
+		hash_combine(hash, 1);
+	} else {
+		hash_combine(hash, 0);
+	}
+
+	if (item->isComplex()) {
+		hash_combine(hash, item->getActionID());
+		hash_combine(hash, item->getUniqueID());
+
+		// Text/Desc hashing
+		std::string_view text = item->getText();
+		for (char c : text) {
+			hash_combine(hash, c);
+		}
+
+		std::string_view desc = item->getDescription();
+		for (char c : desc) {
+			hash_combine(hash, c);
+		}
+
+		// Door hashing
+		if (isHouseTile && item->isDoor()) {
+			if (const Door* door = item->asDoor()) {
+				if (door->isRealDoor()) {
+					hash_combine(hash, door->getDoorID());
+				}
+			}
+		}
+
+		// Teleport hashing
+		if (item->isTeleport()) {
+			Teleport* tp = static_cast<Teleport*>(const_cast<Item*>(item));
+			if (tp->hasDestination()) {
+				const Position& dest = tp->getDestination();
+				hash_combine(hash, dest.x);
+				hash_combine(hash, dest.y);
+				hash_combine(hash, dest.z);
+			}
+		}
+
+		// Container hashing
+		if (zoom <= 1.5f && g_items[id].isContainer()) {
+			if (const Container* container = item->asContainer()) {
+				const auto& items = container->getVector();
+				size_t count = 0;
+				for (const auto& subItem : items) {
+					if (subItem) {
+						hash_combine(hash, subItem->getID());
+						hash_combine(hash, subItem->getSubtype());
+						hash_combine(hash, subItem->getCount());
+						count++;
+						if (count >= 32) {
+							break;
+						}
+					}
+				}
+				hash_combine(hash, container->getVolume());
+			}
+		}
+	}
+
+	return hash;
+}
+
+bool TooltipDrawer::hasTooltip(uint64_t hash) const {
+	return cache.find(hash) != cache.end();
+}
+
+void TooltipDrawer::addActiveTooltip(uint64_t hash, const Position& pos) {
+	active_tooltips.push_back({ hash, pos });
+}
+
+void TooltipDrawer::defineTooltip(uint64_t hash, const TooltipData& data) {
+	if (hasTooltip(hash)) {
+		// Move to front of LRU
+		lru_list.remove(hash);
+		lru_list.push_front(hash);
+		return;
+	}
+
+	// Create new entry
+	CachedTooltip entry;
+	entry.data = CachedTooltipData(data); // Deep copy strings
+
+	// Pre-calculate fields
+	prepareCachedFields(entry);
+
+	// Layout will be calculated on first draw since we need NVGcontext
+	// Initialize with zero size to signal recalculation needed
+	entry.layout.width = 0;
+
+	// Cache management
+	if (cache.size() >= MAX_CACHE_SIZE) {
+		uint64_t victim = lru_list.back();
+		lru_list.pop_back();
+		cache.erase(victim);
+	}
+
+	cache[hash] = std::move(entry);
+	lru_list.push_front(hash);
+}
+
 void TooltipDrawer::getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const {
 	using namespace TooltipColors;
 	switch (cat) {
@@ -126,9 +266,6 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 
 	// Detect context change and clear cache
 	if (vg != lastContext) {
-		// If we had a previous context, we'd ideally delete images from it,
-		// but if the context pointer changed, the old one might be invalid.
-		// However, adhering to the request to clear cache with nvgDeleteImage:
 		if (lastContext) {
 			for (auto& pair : spriteCache) {
 				if (pair.second > 0) {
@@ -146,23 +283,18 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 		return 0;
 	}
 
-	// We use the item ID as the cache key since it's unique and stable
 	auto itCache = spriteCache.find(itemId);
 	if (itCache != spriteCache.end()) {
 		return itCache->second;
 	}
 
-	// Use the sprite directly from ItemType
 	GameSprite* gameSprite = it.sprite;
 
 	if (gameSprite && !gameSprite->spriteList.empty()) {
-		// Use the first frame/part of the sprite
 		GameSprite::NormalImage* img = gameSprite->spriteList[0];
 		if (img) {
 			std::unique_ptr<uint8_t[]> rgba;
 
-			// For legacy sprites (no transparency), use getRGBData + Magenta Masking
-			// This matches how WxWidgets/SpriteIconGenerator renders icons
 			if (!g_gui.gfx.hasTransparency()) {
 				std::unique_ptr<uint8_t[]> rgb = img->getRGBData();
 				if (rgb) {
@@ -171,8 +303,6 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 						uint8_t r = rgb[i * 3 + 0];
 						uint8_t g = rgb[i * 3 + 1];
 						uint8_t b = rgb[i * 3 + 2];
-
-						// Magic Pink (Magenta) is transparent for legacy sprites
 						if (r == 0xFF && g == 0x00 && b == 0xFF) {
 							rgba[i * 4 + 0] = 0;
 							rgba[i * 4 + 1] = 0;
@@ -185,26 +315,16 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 							rgba[i * 4 + 3] = 255;
 						}
 					}
-				} else {
-					// getRGBData failed, should ideally not happen if sprite exists logic is correct
 				}
 			}
 
-			// Fallback/Standard path for alpha sprites or if RGB failed
 			if (!rgba) {
 				rgba = img->getRGBAData();
-				if (!rgba) {
-					// getRGBAData failed
-				}
 			}
 
 			if (rgba) {
 				int image = nvgCreateImageRGBA(vg, 32, 32, 0, rgba.get());
-				if (image == 0) {
-					// nvgCreateImageRGBA failed
-				} else {
-					// Success
-					// Check if we are overwriting an existing valid image (shouldn't happen given find() above, but safest)
+				if (image > 0) {
 					if (spriteCache.contains(itemId) && spriteCache[itemId] > 0) {
 						nvgDeleteImage(vg, spriteCache[itemId]);
 					}
@@ -213,15 +333,13 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 				}
 			}
 		}
-	} else {
-		// GameSprite missing or empty list
 	}
 
 	return 0;
 }
 
 void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
-	// Build content lines with word wrapping support
+	// Legacy path for non-cached tooltips (e.g. Waypoints if not hashed)
 	using namespace TooltipColors;
 	scratch_fields_count = 0;
 	storage.clear();
@@ -276,14 +394,52 @@ void TooltipDrawer::prepareFields(const TooltipData& tooltip) {
 	}
 }
 
-TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize) {
-	LayoutMetrics lm = {};
+void TooltipDrawer::prepareCachedFields(CachedTooltip& cached) {
+	using namespace TooltipColors;
+	const auto& data = cached.data;
+	cached.fields.clear();
 
-	// Set up font for measurements
+	auto addField = [&](std::string label, std::string value, uint8_t r, uint8_t g, uint8_t b) {
+		CachedFieldLine field;
+		field.label = std::move(label);
+		field.value = std::move(value);
+		field.r = r;
+		field.g = g;
+		field.b = b;
+		cached.fields.push_back(std::move(field));
+	};
+
+	if (data.category == TooltipCategory::WAYPOINT) {
+		addField("Waypoint", data.waypointName, WAYPOINT_HEADER_R, WAYPOINT_HEADER_G, WAYPOINT_HEADER_B);
+	} else {
+		if (data.actionId > 0) {
+			addField("Action ID", std::to_string(data.actionId), ACTION_ID_R, ACTION_ID_G, ACTION_ID_B);
+		}
+		if (data.uniqueId > 0) {
+			addField("Unique ID", std::to_string(data.uniqueId), UNIQUE_ID_R, UNIQUE_ID_G, UNIQUE_ID_B);
+		}
+		if (data.doorId > 0) {
+			addField("Door ID", std::to_string(data.doorId), DOOR_ID_R, DOOR_ID_G, DOOR_ID_B);
+		}
+		if (data.destination.x > 0) {
+			std::string dest = std::format("{}, {}, {}", data.destination.x, data.destination.y, data.destination.z);
+			addField("Destination", std::move(dest), TELEPORT_DEST_R, TELEPORT_DEST_G, TELEPORT_DEST_B);
+		}
+		if (!data.description.empty()) {
+			addField("Description", data.description, BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B);
+		}
+		if (!data.text.empty()) {
+			addField("Text", "\"" + data.text + "\"", TEXT_R, TEXT_G, TEXT_B);
+		}
+	}
+}
+
+TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize) {
+	// Legacy layout calculation using scratch_fields
+	LayoutMetrics lm = {};
 	nvgFontSize(vg, fontSize);
 	nvgFontFace(vg, "sans");
 
-	// Measure label widths
 	float maxLabelWidth = 0.0f;
 	for (size_t i = 0; i < scratch_fields_count; ++i) {
 		const auto& field = scratch_fields[i];
@@ -295,10 +451,8 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 		}
 	}
 
-	lm.valueStartX = maxLabelWidth + 12.0f; // Gap between label and value
+	lm.valueStartX = maxLabelWidth + 12.0f;
 	float maxValueWidth = maxWidth - lm.valueStartX - padding * 2;
-
-	// Word wrap values that are too long
 	int totalLines = 0;
 	float actualMaxWidth = minWidth;
 
@@ -307,13 +461,11 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 		const char* start = field.value.data();
 		const char* end = start + field.value.length();
 
-		// Check if value fits on one line
 		float valueBounds[4];
 		nvgTextBounds(vg, 0, 0, start, end, valueBounds);
 		float valueWidth = valueBounds[2] - valueBounds[0];
 
 		if (valueWidth <= maxValueWidth) {
-			// Single line
 			field.wrappedLines.push_back(field.value);
 			totalLines++;
 			float lineWidth = lm.valueStartX + valueWidth + padding * 2;
@@ -321,51 +473,40 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 				actualMaxWidth = lineWidth;
 			}
 		} else {
-			// Need to wrap - use NanoVG text breaking
 			NVGtextRow rows[16];
 			int nRows = nvgTextBreakLines(vg, start, end, maxValueWidth, rows, 16);
-
-			for (int i = 0; i < nRows; i++) {
-				std::string_view line(rows[i].start, rows[i].end - rows[i].start);
+			for (int j = 0; j < nRows; j++) {
+				std::string_view line(rows[j].start, rows[j].end - rows[j].start);
 				field.wrappedLines.push_back(line);
 				totalLines++;
-
-				float lineWidth = lm.valueStartX + rows[i].width + padding * 2;
+				float lineWidth = lm.valueStartX + rows[j].width + padding * 2;
 				if (lineWidth > actualMaxWidth) {
 					actualMaxWidth = lineWidth;
 				}
 			}
-
 			if (nRows == 0) {
-				// Fallback if breaking failed
 				field.wrappedLines.push_back(field.value);
 				totalLines++;
 			}
 		}
 	}
 
-	// Calculate container grid dimensions
 	lm.containerCols = 0;
 	lm.containerRows = 0;
-	lm.gridSlotSize = 34.0f; // 32px + padding
+	lm.gridSlotSize = 34.0f;
 	lm.containerHeight = 0.0f;
-
 	lm.numContainerItems = static_cast<int>(tooltip.containerItems.size());
 	int capacity = static_cast<int>(tooltip.containerCapacity);
 	lm.emptyContainerSlots = std::max(0, capacity - lm.numContainerItems);
 	lm.totalContainerSlots = lm.numContainerItems;
-
 	if (lm.emptyContainerSlots > 0) {
-		lm.totalContainerSlots++; // Add one slot for the summary
+		lm.totalContainerSlots++;
 	}
-
-	// Apply a hard cap for visual safety
 	if (lm.totalContainerSlots > 33) {
 		lm.totalContainerSlots = 33;
 	}
 
 	if (capacity > 0 || lm.numContainerItems > 0) {
-		// Heuristic: try to keep it somewhat square but matching width
 		lm.containerCols = std::min(4, lm.totalContainerSlots);
 		if (lm.totalContainerSlots > 4) {
 			lm.containerCols = 5;
@@ -376,20 +517,16 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 		if (lm.totalContainerSlots > 15) {
 			lm.containerCols = 8;
 		}
-
 		if (lm.containerCols == 0 && lm.totalContainerSlots > 0) {
 			lm.containerCols = 1;
 		}
-
 		if (lm.containerCols > 0) {
 			lm.containerRows = (lm.totalContainerSlots + lm.containerCols - 1) / lm.containerCols;
-			lm.containerHeight = lm.containerRows * lm.gridSlotSize + 4.0f; // + top margin
+			lm.containerHeight = lm.containerRows * lm.gridSlotSize + 4.0f;
 		}
 	}
 
-	// Calculate final box dimensions
 	lm.width = std::min(maxWidth + padding * 2, std::max(minWidth, actualMaxWidth));
-
 	bool hasContainer = lm.totalContainerSlots > 0;
 	if (hasContainer) {
 		float gridWidth = lm.containerCols * lm.gridSlotSize;
@@ -405,14 +542,121 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 	return lm;
 }
 
-void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip) {
-	using namespace TooltipColors;
+TooltipDrawer::LayoutMetrics TooltipDrawer::calculateCachedLayout(NVGcontext* vg, const CachedTooltip& cached, float maxWidth, float minWidth, float padding, float fontSize) {
+	// Similar to calculateLayout but uses cached fields and updates wrappedLines in-place
+	LayoutMetrics lm = {};
+	nvgFontSize(vg, fontSize);
+	nvgFontFace(vg, "sans");
 
-	// Get border color based on category
+	float maxLabelWidth = 0.0f;
+	for (const auto& field : cached.fields) {
+		float labelBounds[4];
+		nvgTextBounds(vg, 0, 0, field.label.c_str(), nullptr, labelBounds);
+		float lw = labelBounds[2] - labelBounds[0];
+		if (lw > maxLabelWidth) {
+			maxLabelWidth = lw;
+		}
+	}
+
+	lm.valueStartX = maxLabelWidth + 12.0f;
+	float maxValueWidth = maxWidth - lm.valueStartX - padding * 2;
+	int totalLines = 0;
+	float actualMaxWidth = minWidth;
+
+	// Mutable access needed to update wrappedLines
+	CachedTooltip& mutableCached = const_cast<CachedTooltip&>(cached);
+
+	for (auto& field : mutableCached.fields) {
+		field.wrappedLines.clear();
+		const char* start = field.value.c_str();
+		const char* end = start + field.value.length();
+
+		float valueBounds[4];
+		nvgTextBounds(vg, 0, 0, start, end, valueBounds);
+		float valueWidth = valueBounds[2] - valueBounds[0];
+
+		if (valueWidth <= maxValueWidth) {
+			field.wrappedLines.push_back(field.value);
+			totalLines++;
+			float lineWidth = lm.valueStartX + valueWidth + padding * 2;
+			if (lineWidth > actualMaxWidth) {
+				actualMaxWidth = lineWidth;
+			}
+		} else {
+			NVGtextRow rows[16];
+			int nRows = nvgTextBreakLines(vg, start, end, maxValueWidth, rows, 16);
+			for (int j = 0; j < nRows; j++) {
+				std::string line(rows[j].start, rows[j].end - rows[j].start);
+				field.wrappedLines.push_back(line);
+				totalLines++;
+				float lineWidth = lm.valueStartX + rows[j].width + padding * 2;
+				if (lineWidth > actualMaxWidth) {
+					actualMaxWidth = lineWidth;
+				}
+			}
+			if (nRows == 0) {
+				field.wrappedLines.push_back(field.value);
+				totalLines++;
+			}
+		}
+	}
+
+	// Container metrics
+	lm.gridSlotSize = 34.0f;
+	lm.numContainerItems = static_cast<int>(cached.data.containerItems.size());
+	int capacity = static_cast<int>(cached.data.containerCapacity);
+	lm.emptyContainerSlots = std::max(0, capacity - lm.numContainerItems);
+	lm.totalContainerSlots = lm.numContainerItems;
+	if (lm.emptyContainerSlots > 0) {
+		lm.totalContainerSlots++;
+	}
+	if (lm.totalContainerSlots > 33) {
+		lm.totalContainerSlots = 33;
+	}
+
+	if (capacity > 0 || lm.numContainerItems > 0) {
+		lm.containerCols = std::min(4, lm.totalContainerSlots);
+		if (lm.totalContainerSlots > 4) {
+			lm.containerCols = 5;
+		}
+		if (lm.totalContainerSlots > 10) {
+			lm.containerCols = 6;
+		}
+		if (lm.totalContainerSlots > 15) {
+			lm.containerCols = 8;
+		}
+		if (lm.containerCols == 0 && lm.totalContainerSlots > 0) {
+			lm.containerCols = 1;
+		}
+		if (lm.containerCols > 0) {
+			lm.containerRows = (lm.totalContainerSlots + lm.containerCols - 1) / lm.containerCols;
+			lm.containerHeight = lm.containerRows * lm.gridSlotSize + 4.0f;
+		}
+	}
+
+	lm.width = std::min(maxWidth + padding * 2, std::max(minWidth, actualMaxWidth));
+	bool hasContainer = lm.totalContainerSlots > 0;
+	if (hasContainer) {
+		float gridWidth = lm.containerCols * lm.gridSlotSize;
+		lm.width = std::max(lm.width, gridWidth + padding * 2);
+	}
+
+	float lineHeight = fontSize * 1.4f;
+	lm.height = totalLines * lineHeight + padding * 2;
+	if (hasContainer) {
+		lm.height += lm.containerHeight + 4.0f;
+	}
+
+	return lm;
+}
+
+void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const CachedTooltipData& tooltip) {
+	// Re-use existing logic but with CachedTooltipData type
+	// Ideally we'd template this or extract category
+	using namespace TooltipColors;
 	uint8_t borderR, borderG, borderB;
 	getHeaderColor(tooltip.category, borderR, borderG, borderB);
 
-	// Shadow (multi-layer soft shadow)
 	for (int i = 3; i >= 0; i--) {
 		float alpha = 35.0f + (3 - i) * 20.0f;
 		float spread = i * 2.0f;
@@ -423,13 +667,11 @@ void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width
 		nvgFill(vg);
 	}
 
-	// Main background
 	nvgBeginPath(vg);
 	nvgRoundedRect(vg, x, y, width, height, cornerRadius);
 	nvgFillColor(vg, nvgRGBA(BODY_BG_R, BODY_BG_G, BODY_BG_B, 250));
 	nvgFill(vg);
 
-	// Full colored border around entire frame
 	nvgBeginPath(vg);
 	nvgRoundedRect(vg, x, y, width, height, cornerRadius);
 	nvgStrokeColor(vg, nvgRGBA(borderR, borderG, borderB, 255));
@@ -437,57 +679,50 @@ void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width
 	nvgStroke(vg);
 }
 
-void TooltipDrawer::drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize) {
+void TooltipDrawer::drawCachedFields(NVGcontext* vg, float x, float y, const CachedTooltip& cached, float lineHeight, float padding, float fontSize) {
 	using namespace TooltipColors;
-
 	float contentX = x + padding;
 	float cursorY = y + padding;
+	float valueStartX = cached.layout.valueStartX;
 
 	nvgFontSize(vg, fontSize);
 	nvgFontFace(vg, "sans");
 	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_TOP);
 
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		const auto& field = scratch_fields[i];
+	for (const auto& field : cached.fields) {
 		bool firstLine = true;
 		for (const auto& line : field.wrappedLines) {
 			if (firstLine) {
-				// Draw label on first line
 				nvgFillColor(vg, nvgRGBA(BODY_TEXT_R, BODY_TEXT_G, BODY_TEXT_B, 160));
-				nvgText(vg, contentX, cursorY, field.label.data(), field.label.data() + field.label.size());
+				nvgText(vg, contentX, cursorY, field.label.c_str(), nullptr);
 				firstLine = false;
 			}
-
-			// Draw value line in semantic color
 			nvgFillColor(vg, nvgRGBA(field.r, field.g, field.b, 255));
-			nvgText(vg, contentX + valueStartX, cursorY, line.data(), line.data() + line.size());
-
+			nvgText(vg, contentX + valueStartX, cursorY, line.c_str(), nullptr);
 			cursorY += lineHeight;
 		}
 	}
 }
 
-void TooltipDrawer::drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout) {
+// Redefined to take full cached object
+void TooltipDrawer::drawContainerGrid(NVGcontext* vg, float x, float y, const CachedTooltip& cached) {
 	using namespace TooltipColors;
+	const auto& layout = cached.layout;
+	const auto& tooltip = cached.data;
 
 	if (layout.totalContainerSlots <= 0) {
 		return;
 	}
 
-	// Calculate cursorY after text fields
-	// We need to re-calculate text height or pass it, but simpler to deduce from logic:
-	// The grid is at the bottom. We can just use the bottom of the box minus grid height minus padding.
-	// But let's calculate exact start Y based on text content for precision
 	float fontSize = 11.0f;
 	float lineHeight = fontSize * 1.4f;
 	float textBlockHeight = 0.0f;
-	for (size_t i = 0; i < scratch_fields_count; ++i) {
-		const auto& field = scratch_fields[i];
+	for (const auto& field : cached.fields) {
 		textBlockHeight += field.wrappedLines.size() * lineHeight;
 	}
 
-	float startY = y + 10.0f + textBlockHeight + 8.0f; // Padding + Text + Spacer
-	float startX = x + 10.0f; // Padding
+	float startY = y + 10.0f + textBlockHeight + 8.0f;
+	float startX = x + 10.0f;
 
 	for (int idx = 0; idx < layout.totalContainerSlots; ++idx) {
 		int col = idx % layout.containerCols;
@@ -496,38 +731,26 @@ void TooltipDrawer::drawContainerGrid(NVGcontext* vg, float x, float y, const To
 		float itemX = startX + col * layout.gridSlotSize;
 		float itemY = startY + row * layout.gridSlotSize;
 
-		// Draw slot background (always)
 		nvgBeginPath(vg);
 		nvgRect(vg, itemX, itemY, 32, 32);
-		nvgFillColor(vg, nvgRGBA(60, 60, 60, 100)); // Dark slot placeholder
-		nvgStrokeColor(vg, nvgRGBA(100, 100, 100, 100)); // Light border
+		nvgFillColor(vg, nvgRGBA(60, 60, 60, 100));
+		nvgStrokeColor(vg, nvgRGBA(100, 100, 100, 100));
 		nvgStrokeWidth(vg, 1.0f);
 		nvgFill(vg);
 		nvgStroke(vg);
 
-		// Check if this is the summary info slot (last slot if we have empty spaces)
 		bool isSummarySlot = (layout.emptyContainerSlots > 0 && idx == layout.totalContainerSlots - 1);
 
 		if (isSummarySlot) {
-			// Draw empty slots count: "+N"
 			std::string summary = "+" + std::to_string(layout.emptyContainerSlots);
-
 			nvgFontSize(vg, 12.0f);
 			nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
-
-			// Text shadow
 			nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
 			nvgText(vg, itemX + 17, itemY + 17, summary.c_str(), nullptr);
-
-			// Text
 			nvgFillColor(vg, nvgRGBA(COUNT_TEXT_R, COUNT_TEXT_G, COUNT_TEXT_B, 255));
 			nvgText(vg, itemX + 16, itemY + 16, summary.c_str(), nullptr);
-
 		} else if (idx < layout.numContainerItems) {
-			// Draw Actual Item
 			const auto& item = tooltip.containerItems[idx];
-
-			// Draw item sprite
 			int img = getSpriteImage(vg, item.id);
 			if (img > 0) {
 				nvgBeginPath(vg);
@@ -535,18 +758,12 @@ void TooltipDrawer::drawContainerGrid(NVGcontext* vg, float x, float y, const To
 				nvgFillPaint(vg, nvgImagePattern(vg, itemX, itemY, 32, 32, 0, img, 1.0f));
 				nvgFill(vg);
 			}
-
-			// Draw Count
 			if (item.count > 1) {
 				std::string countStr = std::to_string(item.count);
 				nvgFontSize(vg, 10.0f);
 				nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_BOTTOM);
-
-				// Text shadow
 				nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
 				nvgText(vg, itemX + 33, itemY + 33, countStr.c_str(), nullptr);
-
-				// Text
 				nvgFillColor(vg, nvgRGBA(COUNT_TEXT_R, COUNT_TEXT_G, COUNT_TEXT_B, 255));
 				nvgText(vg, itemX + 32, itemY + 32, countStr.c_str(), nullptr);
 			}
@@ -559,49 +776,129 @@ void TooltipDrawer::draw(NVGcontext* vg, const RenderView& view) {
 		return;
 	}
 
-	for (size_t i = 0; i < active_count; ++i) {
-		const auto& tooltip = tooltips[i];
+	// Constants
+	float fontSize = 11.0f;
+	float padding = 10.0f;
+	float minWidth = 120.0f;
+	float maxWidth = 220.0f;
+
+	// 1. Draw Active Cached Tooltips
+	for (const auto& active : active_tooltips) {
+		auto it = cache.find(active.hash);
+		if (it == cache.end()) {
+			continue;
+		}
+
+		CachedTooltip& cached = it->second;
+
+		// Calculate layout if needed (first run or context change)
+		if (cached.layout.width == 0) {
+			cached.layout = calculateCachedLayout(vg, cached, maxWidth, minWidth, padding, fontSize);
+		}
+
 		int unscaled_x, unscaled_y;
-		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
-
+		view.getScreenPosition(active.pos.x, active.pos.y, active.pos.z, unscaled_x, unscaled_y);
 		float zoom = view.zoom < 0.01f ? 1.0f : view.zoom;
-
 		float screen_x = unscaled_x / zoom;
 		float screen_y = unscaled_y / zoom;
 		float tile_size_screen = 32.0f / zoom;
 
-		// Center on tile
 		screen_x += tile_size_screen / 2.0f;
 		screen_y += tile_size_screen / 2.0f;
 
-		// Constants
-		float fontSize = 11.0f;
-		float padding = 10.0f;
-		float minWidth = 120.0f;
-		float maxWidth = 220.0f;
+		float tooltipX = screen_x - (cached.layout.width / 2.0f);
+		float tooltipY = screen_y - cached.layout.height - 12.0f;
 
-		// 1. Prepare Content
+		drawBackground(vg, tooltipX, tooltipY, cached.layout.width, cached.layout.height, 4.0f, cached.data);
+		drawCachedFields(vg, tooltipX, tooltipY, cached, fontSize * 1.4f, padding, fontSize);
+		drawContainerGrid(vg, tooltipX, tooltipY, cached);
+	}
+
+	// 2. Draw Legacy Tooltips (if any)
+	for (size_t i = 0; i < active_count; ++i) {
+		const auto& tooltip = tooltips[i];
+		int unscaled_x, unscaled_y;
+		view.getScreenPosition(tooltip.pos.x, tooltip.pos.y, tooltip.pos.z, unscaled_x, unscaled_y);
+		float zoom = view.zoom < 0.01f ? 1.0f : view.zoom;
+		float screen_x = unscaled_x / zoom;
+		float screen_y = unscaled_y / zoom;
+		float tile_size_screen = 32.0f / zoom;
+		screen_x += tile_size_screen / 2.0f;
+		screen_y += tile_size_screen / 2.0f;
+
 		prepareFields(tooltip);
-
-		// Skip if nothing to show
 		if (scratch_fields_count == 0 && tooltip.containerItems.empty()) {
 			continue;
 		}
 
-		// 2. Calculate Layout
 		LayoutMetrics layout = calculateLayout(vg, tooltip, maxWidth, minWidth, padding, fontSize);
-
-		// Position tooltip above tile
 		float tooltipX = screen_x - (layout.width / 2.0f);
 		float tooltipY = screen_y - layout.height - 12.0f;
 
-		// 3. Draw Background & Shadow
 		drawBackground(vg, tooltipX, tooltipY, layout.width, layout.height, 4.0f, tooltip);
-
-		// 4. Draw Text Fields
 		drawFields(vg, tooltipX, tooltipY, layout.valueStartX, fontSize * 1.4f, padding, fontSize);
+		// Legacy drawContainerGrid needs the old signature with TooltipData
+		// We can define it inline or add back the method, but let's overload
+		// Actually I defined overload in header but implementation was missing above.
+		// Let's just implement the legacy one locally here or duplicated.
+		// For brevity, I'll implement legacy drawContainerGrid here
 
-		// 5. Draw Container Grid
-		drawContainerGrid(vg, tooltipX, tooltipY, tooltip, layout);
+		auto legacyDrawGrid = [&](float x, float y, const TooltipData& t, const LayoutMetrics& l) {
+			using namespace TooltipColors;
+			if (l.totalContainerSlots <= 0) return;
+
+			float textBlockHeight = 0.0f;
+			float lh = fontSize * 1.4f;
+			for (size_t k = 0; k < scratch_fields_count; ++k) {
+				textBlockHeight += scratch_fields[k].wrappedLines.size() * lh;
+			}
+			float startY = y + 10.0f + textBlockHeight + 8.0f;
+			float startX = x + 10.0f;
+
+			for (int idx = 0; idx < l.totalContainerSlots; ++idx) {
+				int col = idx % l.containerCols;
+				int row = idx / l.containerCols;
+				float itemX = startX + col * l.gridSlotSize;
+				float itemY = startY + row * l.gridSlotSize;
+
+				nvgBeginPath(vg);
+				nvgRect(vg, itemX, itemY, 32, 32);
+				nvgFillColor(vg, nvgRGBA(60, 60, 60, 100));
+				nvgStrokeColor(vg, nvgRGBA(100, 100, 100, 100));
+				nvgStrokeWidth(vg, 1.0f);
+				nvgFill(vg);
+				nvgStroke(vg);
+
+				if (l.emptyContainerSlots > 0 && idx == l.totalContainerSlots - 1) {
+					std::string s = "+" + std::to_string(l.emptyContainerSlots);
+					nvgFontSize(vg, 12.0f);
+					nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+					nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+					nvgText(vg, itemX + 17, itemY + 17, s.c_str(), nullptr);
+					nvgFillColor(vg, nvgRGBA(COUNT_TEXT_R, COUNT_TEXT_G, COUNT_TEXT_B, 255));
+					nvgText(vg, itemX + 16, itemY + 16, s.c_str(), nullptr);
+				} else if (idx < l.numContainerItems) {
+					const auto& item = t.containerItems[idx];
+					int img = getSpriteImage(vg, item.id);
+					if (img > 0) {
+						nvgBeginPath(vg);
+						nvgRect(vg, itemX, itemY, 32, 32);
+						nvgFillPaint(vg, nvgImagePattern(vg, itemX, itemY, 32, 32, 0, img, 1.0f));
+						nvgFill(vg);
+					}
+					if (item.count > 1) {
+						std::string c = std::to_string(item.count);
+						nvgFontSize(vg, 10.0f);
+						nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_BOTTOM);
+						nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+						nvgText(vg, itemX + 33, itemY + 33, c.c_str(), nullptr);
+						nvgFillColor(vg, nvgRGBA(COUNT_TEXT_R, COUNT_TEXT_G, COUNT_TEXT_B, 255));
+						nvgText(vg, itemX + 32, itemY + 32, c.c_str(), nullptr);
+					}
+				}
+			}
+		};
+
+		legacyDrawGrid(tooltipX, tooltipY, tooltip, layout);
 	}
 }


### PR DESCRIPTION
Implemented a hash-based caching mechanism for tooltips in TooltipDrawer and TileRenderer. 
This optimization prevents redundant tooltip data generation and layout calculations every frame by hashing item properties and storing the resulting layout/content in an LRU cache.
TileRenderer now checks the cache before constructing full TooltipData, significantly reducing CPU overhead when rendering many visible items with tooltips enabled.
Refactored TooltipDrawer to support owning strings in cache entries, ensuring data safety across frames.

---
*PR created automatically by Jules for task [1132311211355896506](https://jules.google.com/task/1132311211355896506) started by @karolak6612*