### PR TITLE
[MODERNIZE] Use range-based loops and std::ranges in materials.cpp, town.cpp, otml.cpp

### DIFF
--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -40,12 +40,12 @@ Materials::~Materials() {
 }
 
 void Materials::clear() {
-	for (TilesetContainer::iterator iter = tilesets.begin(); iter != tilesets.end(); ++iter) {
-		delete iter->second;
+	for (auto& [name, tileset] : tilesets) {
+		delete tileset;
 	}
 
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		delete *iter;
+	for (auto* extension : extensions) {
+		delete extension;
 	}
 
 	tilesets.clear();
@@ -58,9 +58,9 @@ const MaterialsExtensionList& Materials::getExtensions() {
 
 MaterialsExtensionList Materials::getExtensionsByVersion(uint16_t version_id) {
 	MaterialsExtensionList ret_list;
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		if ((*iter)->isForVersion(version_id)) {
-			ret_list.push_back(*iter);
+	for (auto* extension : extensions) {
+		if (extension->isForVersion(version_id)) {
+			ret_list.push_back(extension);
 		}
 	}
 	return ret_list;
@@ -233,7 +233,7 @@ void Materials::createOtherTileset() {
 	Tileset* others;
 	Tileset* npc_tileset;
 
-	if (tilesets.find("Others") != tilesets.end()) {
+	if (tilesets.contains("Others")) {
 		others = tilesets["Others"];
 		others->clear();
 	} else {
@@ -241,7 +241,7 @@ void Materials::createOtherTileset() {
 		tilesets["Others"] = others;
 	}
 
-	if (tilesets.find("NPCs") != tilesets.end()) {
+	if (tilesets.contains("NPCs")) {
 		npc_tileset = tilesets["NPCs"];
 		npc_tileset->clear();
 	} else {
@@ -277,9 +277,7 @@ void Materials::createOtherTileset() {
 		}
 	}
 
-	for (CreatureMap::iterator iter = g_creatures.begin(); iter != g_creatures.end(); ++iter) {
-		CreatureType* type = iter->second;
-
+	for (auto& [id, type] : g_creatures) {
 		if (type->brush == nullptr) {
 			type->brush = newd CreatureBrush(type);
 			g_brushes.addBrush(type->brush);

--- a/source/game/town.cpp
+++ b/source/game/town.cpp
@@ -45,18 +45,18 @@ bool Towns::addTown(std::unique_ptr<Town> town) {
 
 uint32_t Towns::getEmptyID() {
 	uint32_t empty = 0;
-	for (TownMap::iterator it = begin(); it != end(); ++it) {
-		if (it->second->getID() > empty) {
-			empty = it->second->getID();
+	for (const auto& [id, town] : *this) {
+		if (town->getID() > empty) {
+			empty = town->getID();
 		}
 	}
 	return empty + 1;
 }
 
 Town* Towns::getTown(std::string& name) {
-	for (TownMap::iterator it = begin(); it != end(); ++it) {
-		if (it->second->getName() == name) {
-			return it->second.get();
+	for (const auto& [id, town] : *this) {
+		if (town->getName() == name) {
+			return town.get();
 		}
 	}
 	return nullptr;

--- a/source/map/otml.cpp
+++ b/source/map/otml.cpp
@@ -113,7 +113,7 @@ void OTMLNode::addChild(const OTMLNodePtr& newChild) {
 }
 
 bool OTMLNode::removeChild(const OTMLNodePtr& oldChild) {
-	OTMLNodeList::iterator it = std::find(m_children.begin(), m_children.end(), oldChild);
+	auto it = std::ranges::find(m_children, oldChild);
 	if (it != m_children.end()) {
 		m_children.erase(it);
 		oldChild->setParent(OTMLNodePtr());
@@ -123,7 +123,7 @@ bool OTMLNode::removeChild(const OTMLNodePtr& oldChild) {
 }
 
 bool OTMLNode::replaceChild(const OTMLNodePtr& oldChild, const OTMLNodePtr& newChild) {
-	OTMLNodeList::iterator it = std::find(m_children.begin(), m_children.end(), oldChild);
+	auto it = std::ranges::find(m_children, oldChild);
 	if (it != m_children.end()) {
 		oldChild->setParent(OTMLNodePtr());
 		newChild->setParent(shared_from_this());


### PR DESCRIPTION
[MODERNIZE] Use range-based loops and std::ranges in materials.cpp, town.cpp, otml.cpp

BEFORE: 
- Manual iterator loops in `Materials::clear`, `Materials::getExtensionsByVersion`, `Materials::createOtherTileset`.
- Manual `find() != end()` checks in `Materials::createOtherTileset`.
- Manual iterator loops in `Towns::getEmptyID`, `Towns::getTown`.
- `std::find` in `OTMLNode::removeChild`, `OTMLNode::replaceChild`.

AFTER: 
- Range-based for loops using `auto` and structured bindings.
- `contains()` method for map existence checks.
- `std::ranges::find` for clearer algorithm usage.

BENEFITS: 
- Improved readability and conciseness.
- Reduced risk of iterator invalidation or misuse.
- Modern C++20 style compliance.

STANDARD: C++20

CHANGES:
source/game/materials.cpp: Replaced loops and map lookups.
source/game/town.cpp: Replaced loops.
source/map/otml.cpp: Replaced std::find with std::ranges::find.

TESTED:
Compiles with C++20 (GCC 13 via build_linux.sh).

---
*PR created automatically by Jules for task [15005693591818387585](https://jules.google.com/task/15005693591818387585) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized internal code structure to improve maintainability and align with current best practices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->