### PR TITLE
[WXWIDGETS] Fix 21 wxWidgets violations in UI dialogs

### DIFF
--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -12,22 +12,9 @@
 
 namespace IngamePreview {
 
-	enum {
-		ID_FOLLOW_SELECTION = 10001,
-		ID_ENABLE_LIGHTING,
-		ID_CHOOSE_OUTFIT,
-		ID_AMBIENT_SLIDER,
-		ID_INTENSITY_SLIDER,
-		ID_VIEWPORT_W_UP,
-		ID_VIEWPORT_W_DOWN,
-		ID_VIEWPORT_H_UP,
-		ID_VIEWPORT_H_DOWN,
-		ID_UPDATE_TIMER
-	};
-
 	IngamePreviewWindow::IngamePreviewWindow(wxWindow* parent) :
 		wxPanel(parent, wxID_ANY),
-		update_timer(this, ID_UPDATE_TIMER),
+		update_timer(this),
 		follow_selection(true) {
 
 		// Load initial preferences
@@ -36,17 +23,8 @@ namespace IngamePreview {
 		current_name = wxString::FromUTF8(g_preview_preferences.getName());
 		current_speed = g_preview_preferences.getSpeed();
 
-		// Bind Events
-		Bind(wxEVT_TIMER, &IngamePreviewWindow::OnUpdateTimer, this, ID_UPDATE_TIMER);
-		Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleFollow, this, ID_FOLLOW_SELECTION);
-		Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleLighting, this, ID_ENABLE_LIGHTING);
-		Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnAmbientSlider, this, ID_AMBIENT_SLIDER);
-		Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnIntensitySlider, this, ID_INTENSITY_SLIDER);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthUp, this, ID_VIEWPORT_W_UP);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthDown, this, ID_VIEWPORT_W_DOWN);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightUp, this, ID_VIEWPORT_H_UP);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightDown, this, ID_VIEWPORT_H_DOWN);
-		Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnChooseOutfit, this, ID_CHOOSE_OUTFIT);
+		// Bind Timer
+		Bind(wxEVT_TIMER, &IngamePreviewWindow::OnUpdateTimer, this);
 
 		wxBoxSizer* main_sizer = new wxBoxSizer(wxVERTICAL);
 
@@ -54,69 +32,78 @@ namespace IngamePreview {
 		wxBoxSizer* toolbar_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 		// Toggles
-		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, wxSize(28, 24));
-		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+		follow_btn = new wxToggleButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(76, 175, 80)));
 		follow_btn->SetValue(true);
 		follow_btn->SetToolTip("Follow Selection / Camera");
-		toolbar_sizer->Add(follow_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		follow_btn->Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleFollow, this);
+		toolbar_sizer->Add(follow_btn, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, wxSize(28, 24));
-		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SUNNY, wxSize(16, 16), wxColour(255, 235, 59)));
+		lighting_btn = new wxToggleButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SUNNY, wxColour(255, 235, 59)));
 		lighting_btn->SetValue(false);
 		lighting_btn->SetToolTip("Toggle Lighting");
-		toolbar_sizer->Add(lighting_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		lighting_btn->Bind(wxEVT_TOGGLEBUTTON, &IngamePreviewWindow::OnToggleLighting, this);
+		toolbar_sizer->Add(lighting_btn, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, wxSize(28, 24));
-		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ACCOUNT, wxSize(16, 16), wxColour(96, 125, 139)));
+		outfit_btn = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_ACCOUNT, wxColour(96, 125, 139)));
 		outfit_btn->SetToolTip("Change Preview Creature Outfit");
-		toolbar_sizer->Add(outfit_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		outfit_btn->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnChooseOutfit, this);
+		toolbar_sizer->Add(outfit_btn, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
 		// Sliders
-		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, wxSize(60, -1));
+		ambient_slider = new wxSlider(this, wxID_ANY, 128, 0, 255, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		ambient_slider->SetToolTip("Ambient Light");
-		toolbar_sizer->Add(ambient_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		ambient_slider->Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnAmbientSlider, this);
+		toolbar_sizer->Add(ambient_slider, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, wxSize(60, -1));
+		intensity_slider = new wxSlider(this, wxID_ANY, 100, 0, 200, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		intensity_slider->SetToolTip("Light Intensity");
-		toolbar_sizer->Add(intensity_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		intensity_slider->Bind(wxEVT_SLIDER, &IngamePreviewWindow::OnIntensitySlider, this);
+		toolbar_sizer->Add(intensity_slider, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
 		// Spacer
 		toolbar_sizer->AddSpacer(4);
-		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "|"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "|"), wxSizerFlags().Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
 		toolbar_sizer->AddSpacer(4);
 
 		// Viewport Controls
 		// Width
-		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_w_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_w_down = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_MINUS, wxColour(0, 150, 136)));
+		viewport_w_down->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthDown, this);
+		toolbar_sizer->Add(viewport_w_down, wxSizerFlags().Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
-		toolbar_sizer->Add(viewport_x_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
+		toolbar_sizer->Add(viewport_x_text, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_w_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_w_up = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS, wxColour(0, 150, 136)));
+		viewport_w_up->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportWidthUp, this);
+		toolbar_sizer->Add(viewport_w_up, wxSizerFlags().Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), wxSizerFlags().Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
 
 		// Height
-		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_h_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_h_down = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_MINUS, wxColour(0, 150, 136)));
+		viewport_h_down->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightDown, this);
+		toolbar_sizer->Add(viewport_h_down, wxSizerFlags().Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
-		toolbar_sizer->Add(viewport_y_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
+		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
+		toolbar_sizer->Add(viewport_y_text, wxSizerFlags().Border(wxALL, 1).Align(wxALIGN_CENTER_VERTICAL));
 
-		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
-		toolbar_sizer->Add(viewport_h_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
+		viewport_h_up = new wxButton(this, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS, wxColour(0, 150, 136)));
+		viewport_h_up->Bind(wxEVT_BUTTON, &IngamePreviewWindow::OnViewportHeightUp, this);
+		toolbar_sizer->Add(viewport_h_up, wxSizerFlags().Border(wxALL, 0).Align(wxALIGN_CENTER_VERTICAL));
 
-		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
+		main_sizer->Add(toolbar_sizer, wxSizerFlags().Expand().Border(wxALL, 2));
 
 		// Canvas
-		canvas = std::make_unique<IngamePreviewCanvas>(this);
-		main_sizer->Add(canvas.get(), 1, wxEXPAND);
+		canvas = new IngamePreviewCanvas(this);
+		main_sizer->Add(canvas, wxSizerFlags(1).Expand());
 
 		// Sync UI State to Canvas
 		canvas->SetLightingEnabled(lighting_btn->GetValue());
@@ -184,9 +171,9 @@ namespace IngamePreview {
 	void IngamePreviewWindow::SetFollowSelection(bool follow) {
 		follow_selection = follow;
 		if (follow_selection) {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(76, 175, 80)));
 		} else {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(158, 158, 158)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_LOCATION, wxColour(158, 158, 158)));
 		}
 		follow_btn->SetValue(follow_selection);
 	}

--- a/source/ingame_preview/ingame_preview_window.h
+++ b/source/ingame_preview/ingame_preview_window.h
@@ -32,7 +32,7 @@ namespace IngamePreview {
 		void UpdateState();
 
 	private:
-		std::unique_ptr<IngamePreviewCanvas> canvas;
+		IngamePreviewCanvas* canvas;
 		wxTimer update_timer;
 
 		// UI Controls

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -42,7 +42,7 @@ namespace {
 	class ColorSwatch : public wxWindow {
 	public:
 		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
-			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
+			wxWindow(parent, id, wxDefaultPosition, FromDIP(wxSize(16, 16)), wxBORDER_NONE),
 			color(color), selected(false) {
 			SetBackgroundStyle(wxBG_STYLE_PAINT);
 			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
@@ -93,7 +93,7 @@ namespace {
 // ============================================================================
 
 OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current_outfit) :
-	wxDialog(parent, wxID_ANY, "Customise Character", wxDefaultPosition, wxSize(1200, 850), wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
+	wxDialog(parent, wxID_ANY, "Customise Character", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
 	current_outfit(current_outfit),
 	current_speed(220),
 	current_name("You"),
@@ -101,6 +101,8 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	selection_panel = new OutfitSelectionGrid(this, this, false);
 	favorites_panel = new OutfitSelectionGrid(this, this, true);
+
+	SetSize(FromDIP(wxSize(1200, 850)));
 
 	// Load preferences on startup
 	g_preview_preferences.load();
@@ -160,27 +162,27 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	col1_sizer->Add(new wxStaticLine(this, wxID_ANY), 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 8);
 
-	col1_sizer->Add(CreateHeader("Appearance"), 0, wxLEFT | wxTOP, 8);
+	col1_sizer->Add(CreateHeader("Appearance"), wxSizerFlags().Border(wxLEFT | wxTOP, 8));
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
-	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
-	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(16, 16)));
-	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
-	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHIRT, wxSize(16, 16)));
-	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
-	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SOCKS, wxSize(16, 16)));
-	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
-	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHOE_PRINTS, wxSize(16, 16)));
+	head_btn = new wxButton(this, wxID_ANY, "Head", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_USER_SOLID));
+	body_btn = new wxButton(this, wxID_ANY, "Primary", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SHIRT));
+	legs_btn = new wxButton(this, wxID_ANY, "Secondary", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SOCKS));
+	feet_btn = new wxButton(this, wxID_ANY, "Detail", wxDefaultPosition, FromDIP(wxSize(50, -1)));
+	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SHOE_PRINTS));
 
-	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
-	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);
-	part_sizer->Add(legs_btn, 1, wxEXPAND | wxRIGHT, 2);
-	part_sizer->Add(feet_btn, 1, wxEXPAND);
-	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
+	part_sizer->Add(head_btn, wxSizerFlags(1).Expand().Border(wxRIGHT, 2));
+	part_sizer->Add(body_btn, wxSizerFlags(1).Expand().Border(wxRIGHT, 2));
+	part_sizer->Add(legs_btn, wxSizerFlags(1).Expand().Border(wxRIGHT, 2));
+	part_sizer->Add(feet_btn, wxSizerFlags(1).Expand());
+	col1_sizer->Add(part_sizer, wxSizerFlags().Expand().Border(wxTOP | wxLEFT | wxRIGHT, 8));
 
 	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
-		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
+		ColorSwatch* swatch = new ColorSwatch(this, wxID_ANY, color);
 		palette_sizer->Add(swatch, 0);
 		color_buttons.push_back(swatch);
 
@@ -188,34 +190,34 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 			SelectColor(i);
 		});
 	}
-	col1_sizer->Add(palette_sizer, 0, wxALL, 8);
+	col1_sizer->Add(palette_sizer, wxSizerFlags().Border(wxALL, 8));
 
-	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
+	col1_sizer->Add(CreateHeader("Configuration"), wxSizerFlags().Border(wxLEFT | wxTOP, 8));
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);
-	addon1 = new wxCheckBox(this, ID_ADDON1, "Addon 1");
+	addon1 = new wxCheckBox(this, wxID_ANY, "Addon 1");
 	addon1->SetToolTip("Toggle Addon 1");
 	addon1->SetValue((current_outfit.lookAddon & 1) != 0);
-	addon2 = new wxCheckBox(this, ID_ADDON2, "Addon 2");
+	addon2 = new wxCheckBox(this, wxID_ANY, "Addon 2");
 	addon2->SetToolTip("Toggle Addon 2");
 	addon2->SetValue((current_outfit.lookAddon & 2) != 0);
 
-	check_sizer->Add(addon1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
-	check_sizer->Add(addon2, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
+	check_sizer->Add(addon1, wxSizerFlags().Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
+	check_sizer->Add(addon2, wxSizerFlags().Border(wxALL, 2).Align(wxALIGN_CENTER_VERTICAL));
 
-	wxButton* rand_btn = new wxButton(this, ID_RANDOMIZE, "Random");
-	rand_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHUFFLE, wxSize(16, 16)));
+	wxButton* rand_btn = new wxButton(this, wxID_ANY, "Random");
+	rand_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SHUFFLE));
 	rand_btn->SetToolTip("Randomize outfit colors");
-	check_sizer->Add(rand_btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 5);
+	check_sizer->Add(rand_btn, wxSizerFlags().Border(wxLEFT, 5).Align(wxALIGN_CENTER_VERTICAL));
 
-	col1_sizer->Add(check_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, 8);
+	col1_sizer->Add(check_sizer, wxSizerFlags().Expand().Border(wxLEFT | wxRIGHT, 8));
 
 	wxFlexGridSizer* text_fields = new wxFlexGridSizer(2, 2, 4, 8);
 	text_fields->Add(new wxStaticText(this, wxID_ANY, "Speed:"), 0, wxALIGN_CENTER_VERTICAL);
-	speed_ctrl = new wxSpinCtrl(this, ID_SPEED, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 50, 3000, current_speed);
+	speed_ctrl = new wxSpinCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 50, 3000, current_speed);
 	text_fields->Add(speed_ctrl, 1, wxEXPAND);
 
 	text_fields->Add(new wxStaticText(this, wxID_ANY, "Name:"), 0, wxALIGN_CENTER_VERTICAL);
-	name_ctrl = new wxTextCtrl(this, ID_NAME, current_name);
+	name_ctrl = new wxTextCtrl(this, wxID_ANY, current_name);
 	text_fields->Add(name_ctrl, 1, wxEXPAND);
 	text_fields->AddGrowableCol(1);
 	col1_sizer->Add(text_fields, 0, wxEXPAND | wxALL, 8);
@@ -225,30 +227,30 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	// Column 2: Available Outfits
 	wxBoxSizer* outfits_sizer = new wxBoxSizer(wxVERTICAL);
 	wxBoxSizer* outfits_header_row = new wxBoxSizer(wxHORIZONTAL);
-	outfits_header_row->Add(CreateHeader("Available Outfits"), 1, wxALIGN_BOTTOM | wxLEFT, 4);
+	outfits_header_row->Add(CreateHeader("Available Outfits"), wxSizerFlags(1).Align(wxALIGN_BOTTOM).Border(wxLEFT, 4));
 
-	outfit_search = new wxSearchCtrl(this, ID_SEARCH, wxEmptyString, wxDefaultPosition, wxSize(180, -1));
+	outfit_search = new wxSearchCtrl(this, wxID_ANY, wxEmptyString, wxDefaultPosition, FromDIP(wxSize(180, -1)));
 	outfit_search->SetDescriptiveText("Search...");
-	outfits_header_row->Add(outfit_search, 0, wxALIGN_BOTTOM | wxRIGHT, 4);
+	outfits_header_row->Add(outfit_search, wxSizerFlags().Align(wxALIGN_BOTTOM).Border(wxRIGHT, 4));
 
 	colorable_only_check = new wxCheckBox(this, wxID_ANY, "Template Only");
 	colorable_only_check->SetToolTip("Show only colorable outfits");
-	outfits_header_row->Add(colorable_only_check, 0, wxALIGN_BOTTOM | wxRIGHT | wxBOTTOM, 4);
+	outfits_header_row->Add(colorable_only_check, wxSizerFlags().Align(wxALIGN_BOTTOM).Border(wxRIGHT | wxBOTTOM, 4));
 
-	outfits_sizer->Add(outfits_header_row, 0, wxEXPAND | wxBOTTOM, 4);
+	outfits_sizer->Add(outfits_header_row, wxSizerFlags().Expand().Border(wxBOTTOM, 4));
 	outfits_sizer->Add(selection_panel, 1, wxEXPAND);
-	main_sizer->Add(outfits_sizer, 1, wxEXPAND | wxLEFT | wxRIGHT, 5);
+	main_sizer->Add(outfits_sizer, wxSizerFlags(1).Expand().Border(wxLEFT | wxRIGHT, 5));
 
 	// Column 3: Favorites
 	wxBoxSizer* favs_sizer = new wxBoxSizer(wxVERTICAL);
-	favs_sizer->Add(CreateHeader("Favorites"), 0, wxBOTTOM | wxLEFT, 4);
+	favs_sizer->Add(CreateHeader("Favorites"), wxSizerFlags().Border(wxBOTTOM | wxLEFT, 4));
 
-	favorites_panel->SetMinSize(wxSize(430, -1)); // Force width for 4 columns of 100px
+	favorites_panel->SetMinSize(FromDIP(wxSize(430, -1))); // Force width for 4 columns of 100px
 	favs_sizer->Add(favorites_panel, 1, wxEXPAND);
 
-	wxButton* fav_btn = new wxButton(this, ID_ADD_FAVORITE, "Save Current Outfit as Favorite", wxDefaultPosition, wxSize(-1, 28));
-	fav_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_STAR, wxSize(16, 16)));
-	favs_sizer->Add(fav_btn, 0, wxEXPAND | wxTOP, 8);
+	wxButton* fav_btn = new wxButton(this, wxID_ANY, "Save Current Outfit as Favorite", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
+	fav_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_STAR));
+	favs_sizer->Add(fav_btn, wxSizerFlags().Expand().Border(wxTOP, 8));
 
 	main_sizer->Add(favs_sizer, 0, wxEXPAND | wxLEFT, 5);
 
@@ -261,14 +263,14 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* bottom_sizer = new wxBoxSizer(wxHORIZONTAL);
 	bottom_sizer->AddStretchSpacer();
 
-	wxButton* ok_btn = new wxButton(this, wxID_OK, "OK", wxDefaultPosition, wxSize(90, 30));
-	ok_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	wxButton* ok_btn = new wxButton(this, wxID_OK, "OK", wxDefaultPosition, FromDIP(wxSize(90, 30)));
+	ok_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
 	ok_btn->SetToolTip("Confirm outfit selection");
-	wxButton* cancel_btn = new wxButton(this, wxID_CANCEL, "Cancel", wxDefaultPosition, wxSize(90, 30));
-	cancel_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	wxButton* cancel_btn = new wxButton(this, wxID_CANCEL, "Cancel", wxDefaultPosition, FromDIP(wxSize(90, 30)));
+	cancel_btn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
 	cancel_btn->SetToolTip("Cancel outfit selection");
-	bottom_sizer->Add(ok_btn, 0, wxALL, 8);
-	bottom_sizer->Add(cancel_btn, 0, wxALL, 8);
+	bottom_sizer->Add(ok_btn, wxSizerFlags().Border(wxALL, 8));
+	bottom_sizer->Add(cancel_btn, wxSizerFlags().Border(wxALL, 8));
 
 	outer_sizer->Add(bottom_sizer, 0, wxEXPAND);
 
@@ -292,30 +294,32 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	Bind(wxEVT_BUTTON, &OutfitChooserDialog::OnOK, this, wxID_OK);
 
 	// Update initial part selection highlight
-	wxCommandEvent dummy;
-	dummy.SetId(ID_COLOR_HEAD);
-	OnColorPartChange(dummy);
-
+	selected_color_part = 0;
 	UpdateColorSelection();
+
+	// Initial font update
+	wxCommandEvent dummy;
+	dummy.SetEventObject(head_btn);
+	OnColorPartChange(dummy);
 
 	CenterOnParent();
 
 	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(32, 32)));
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_USER_SOLID).GetBitmap(FromDIP(wxSize(32, 32))));
 	SetIcon(icon);
 }
 
 OutfitChooserDialog::~OutfitChooserDialog() { }
 
 void OutfitChooserDialog::OnColorPartChange(wxCommandEvent& event) {
-	int id = event.GetId();
-	if (id == ID_COLOR_HEAD) {
+	wxObject* obj = event.GetEventObject();
+	if (obj == head_btn) {
 		selected_color_part = 0;
-	} else if (id == ID_COLOR_BODY) {
+	} else if (obj == body_btn) {
 		selected_color_part = 1;
-	} else if (id == ID_COLOR_LEGS) {
+	} else if (obj == legs_btn) {
 		selected_color_part = 2;
-	} else if (id == ID_COLOR_FEET) {
+	} else if (obj == feet_btn) {
 		selected_color_part = 3;
 	}
 

--- a/source/ui/dialogs/outfit_chooser_dialog.h
+++ b/source/ui/dialogs/outfit_chooser_dialog.h
@@ -14,23 +14,9 @@
 class OutfitChooserDialog : public wxDialog {
 public:
 	enum {
-		ID_SEARCH = 30000,
-		ID_ADDON1,
-		ID_ADDON2,
-		ID_COLOR_HEAD,
-		ID_COLOR_BODY,
-		ID_COLOR_LEGS,
-		ID_COLOR_FEET,
-		ID_COLOR_START,
-		ID_SPEED,
-		ID_NAME,
-		ID_RANDOMIZE,
-		ID_ADD_FAVORITE,
-		ID_FAVORITE_RENAME,
+		ID_FAVORITE_RENAME = wxID_HIGHEST + 1,
 		ID_FAVORITE_EDIT,
-		ID_FAVORITE_DELETE,
-		ID_OUTFIT_START = 31000,
-		ID_FAVORITE_START = 32000
+		ID_FAVORITE_DELETE
 	};
 
 	OutfitChooserDialog(wxWindow* parent, const Outfit& current_outfit);

--- a/source/ui/dialogs/outfit_preview_panel.cpp
+++ b/source/ui/dialogs/outfit_preview_panel.cpp
@@ -5,12 +5,8 @@
 #include <wx/dcbuffer.h>
 #include <wx/graphics.h>
 
-namespace {
-	const int PREVIEW_SIZE = 192;
-}
-
 OutfitPreviewPanel::OutfitPreviewPanel(wxWindow* parent, const Outfit& outfit) :
-	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(PREVIEW_SIZE, PREVIEW_SIZE), wxBORDER_NONE),
+	wxPanel(parent, wxID_ANY, wxDefaultPosition, parent->FromDIP(wxSize(192, 192)), wxBORDER_NONE),
 	preview_outfit(outfit),
 	preview_direction(0) {
 	SetBackgroundStyle(wxBG_STYLE_PAINT);
@@ -53,14 +49,18 @@ void OutfitPreviewPanel::OnPaint(wxPaintEvent& event) {
 				int sw = bmp.GetWidth();
 				int sh = bmp.GetHeight();
 
-				double scale = std::min<double>((double)PREVIEW_SIZE / sw, (double)PREVIEW_SIZE / sh);
+				wxSize clientSize = GetClientSize();
+				int w = clientSize.GetWidth();
+				int h = clientSize.GetHeight();
+
+				double scale = std::min<double>((double)w / sw, (double)h / sh);
 				// Hero scale - make it fit nicely
 				scale *= 0.9;
 
 				double drawW = sw * scale;
 				double drawH = sh * scale;
-				double x = (PREVIEW_SIZE - drawW) / 2.0;
-				double y = (PREVIEW_SIZE - drawH) / 2.0;
+				double x = (w - drawW) / 2.0;
+				double y = (h - drawH) / 2.0;
 
 				gc->DrawBitmap(bmp, x, y, drawW, drawH);
 			} else {

--- a/source/ui/dialogs/outfit_selection_grid.cpp
+++ b/source/ui/dialogs/outfit_selection_grid.cpp
@@ -14,19 +14,14 @@
 #include <format>
 #include <string>
 
-namespace {
-	const int OUTFIT_TILE_WIDTH = 100;
-	const int OUTFIT_TILE_HEIGHT = 120;
-}
-
 OutfitSelectionGrid::OutfitSelectionGrid(wxWindow* parent, OutfitChooserDialog* owner, bool is_favorites) :
 	NanoVGCanvas(parent, wxID_ANY, wxVSCROLL | wxWANTS_CHARS),
 	is_favorites(is_favorites),
 	selected_index(-1),
 	owner(owner),
 	columns(1),
-	item_width(OUTFIT_TILE_WIDTH),
-	item_height(OUTFIT_TILE_HEIGHT),
+	item_width(FromDIP(100)),
+	item_height(FromDIP(120)),
 	padding(4),
 	hover_index(-1) {
 
@@ -93,7 +88,7 @@ void OutfitSelectionGrid::OnSize(wxSizeEvent& event) {
 }
 
 wxSize OutfitSelectionGrid::DoGetBestClientSize() const {
-	return wxSize(430, 300); // Reasonable default
+	return FromDIP(wxSize(430, 300)); // Reasonable default
 }
 
 int OutfitSelectionGrid::GetOrCreateOutfitImage(NVGcontext* vg, int lookType, const Outfit& outfit) {
@@ -320,9 +315,9 @@ void OutfitSelectionGrid::OnContextMenu(wxContextMenuEvent& event) {
 	}
 
 	wxMenu menu;
-	menu.Append(OutfitChooserDialog::ID_FAVORITE_RENAME, "Rename...")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
-	menu.Append(OutfitChooserDialog::ID_FAVORITE_EDIT, "Update with Current")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SYNC, wxSize(16, 16)));
-	menu.Append(OutfitChooserDialog::ID_FAVORITE_DELETE, "Delete")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
+	menu.Append(OutfitChooserDialog::ID_FAVORITE_RENAME, "Rename...")->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PEN_TO_SQUARE));
+	menu.Append(OutfitChooserDialog::ID_FAVORITE_EDIT, "Update with Current")->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SYNC));
+	menu.Append(OutfitChooserDialog::ID_FAVORITE_DELETE, "Delete")->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_TRASH_CAN));
 
 	PopupMenu(&menu);
 }


### PR DESCRIPTION
This PR addresses over 20 wxWidgets violations identified in `ingame_preview_window.cpp`, `outfit_chooser_dialog.cpp`, and related files.

Key changes:
- **Event Handling:** Removed `enum` based IDs and replaced them with `wxID_ANY` and direct object binding using `Bind`.
- **Memory Management:** Replaced `std::unique_ptr<IngamePreviewCanvas>` with raw pointer to align with wxWidgets parent-child ownership model.
- **High DPI:** Replaced hardcoded pixel sizes with `FromDIP` and used `GetBitmapBundle` for icons.
- **Layout:** Modernized `wxBoxSizer` usage with `wxSizerFlags`.
- **Safety:** Fixed potential undefined behavior where `FromDIP` was called on `this` in constructor initializer lists.

Violations fixed: V001-V021 covering IDs, Sizing, Object Deletion, High DPI, and Sizer Syntax.

---
*PR created automatically by Jules for task [13577250131898746421](https://jules.google.com/task/13577250131898746421) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved DPI scaling support across outfit selection and preview dialogs for better display consistency on high-resolution monitors.
  * Enhanced dynamic UI sizing to adapt responsively to window dimensions and content changes.

* **Refactor**
  * Modernized internal event binding and UI construction mechanisms for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->