### PR TITLE
[ICONS] Add SVG icons to Welcome Dialog and House Palette

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -12,6 +12,7 @@
 #include "map/map.h"
 #include "game/house.h"
 #include "game/town.h"
+#include "util/image_manager.h"
 
 #include <sstream>
 
@@ -94,11 +95,19 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(32, 32)));
+	SetIcon(icon);
 
 	Bind(wxEVT_SET_FOCUS, &EditHouseDialog::OnFocusChange, this);
 	Bind(wxEVT_BUTTON, &EditHouseDialog::OnClickOK, this, wxID_OK);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -15,6 +15,7 @@
 #include "brushes/managers/brush_manager.h"
 #include "brushes/house/house_brush.h"
 #include "brushes/house/house_exit_brush.h"
+#include "util/image_manager.h"
 
 #include <algorithm>
 
@@ -59,8 +60,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);
@@ -72,7 +76,9 @@ HousePalette::HousePalette(wxWindow* parent) :
 	wxStaticBoxSizer* brush_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Brushes");
 
 	house_brush_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_HOUSE_BRUSH, "House tiles");
+	house_brush_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
 	select_exit_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_EXIT_BRUSH, "Select Exit");
+	select_exit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, wxSize(16, 16)));
 
 	brush_sizer->Add(house_brush_button, 0, wxEXPAND | wxBOTTOM, 2);
 	brush_sizer->Add(select_exit_button, 0, wxEXPAND);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -240,13 +240,13 @@ WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionT
 
 	// Image List for Icons
 	m_imageList = new wxImageList(16, 16);
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_NEW, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FIND, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_HARDDISK, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_NORMAL_FILE, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_TICK_MARK, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FOLDER, wxART_OTHER, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FOLDER_OPEN, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_HARD_DRIVE, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FILE, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FOLDER, wxSize(16, 16)));
 
 	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
@@ -269,10 +269,10 @@ WelcomeDialog::~WelcomeDialog() {
 	delete m_imageList;
 }
 
-void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol) {
+void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const std::string& iconName, const wxColour& valCol) {
 	wxBoxSizer* row = new wxBoxSizer(wxHORIZONTAL);
 
-	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, wxArtProvider::GetBitmap(artId, wxART_OTHER, wxSize(14, 14)));
+	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(iconName, wxSize(14, 14)));
 	row->Add(icon, 0, wxCENTER | wxRIGHT, 4);
 
 	wxStaticText* lbl = new wxStaticText(parent, wxID_ANY, label);
@@ -304,7 +304,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 
 	// Icon Button - Align Left: 10px total
 	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : wxArtProvider::GetBitmap(wxART_HELP, wxART_OTHER, wxSize(32, 32))); // Fallback if logo invalid
+	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -325,7 +325,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	headerSizer->Add(titleSizer, 1, wxALL | wxEXPAND, 10);
 
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
-	prefBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_EDIT, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Right: 10px total
@@ -340,14 +340,14 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	wxBoxSizer* footerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
-	exitBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_QUIT, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
 
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
-	newBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_NEW, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
@@ -359,7 +359,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	footerSizer->AddStretchSpacer();
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
-	loadBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FOLDER_OPEN, FromDIP(wxSize(24, 24))));
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -388,13 +388,13 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
 	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_NEW, wxART_BUTTON, wxSize(24, 24)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_BUTTON, wxSize(24, 24)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FOLDER_OPEN, wxSize(24, 24)));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
@@ -434,22 +434,22 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 
 	// Column 3: Selected Map Info
 	DarkCardPanel* col3 = new DarkCardPanel(contentPanel, "Selected Map Info");
-	AddInfoField(col3->GetSizer(), col3, "Map Name", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Client Version", "Placeholder", wxART_TICK_MARK);
-	AddInfoField(col3->GetSizer(), col3, "Dimensions", "Placeholder", wxART_LIST_VIEW);
+	AddInfoField(col3->GetSizer(), col3, "Map Name", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Client Version", "Placeholder", ICON_CHECK);
+	AddInfoField(col3->GetSizer(), col3, "Dimensions", "Placeholder", ICON_TABLE);
 	col3->GetSizer()->Add(new wxStaticLine(col3), 0, wxEXPAND | wxALL, 4);
-	AddInfoField(col3->GetSizer(), col3, "House File", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Spawn File", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Description", "Placeholder", wxART_REPORT_VIEW);
+	AddInfoField(col3->GetSizer(), col3, "House File", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Spawn File", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Description", "Placeholder", ICON_LIST);
 	contentSizer->Add(col3, 1, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 5); // Add Column 3 (Center)
 
 	// Column 4: Client Info
 	DarkCardPanel* col4 = new DarkCardPanel(contentPanel, "Client Information");
-	AddInfoField(col4->GetSizer(), col4, "Client Name", "Placeholder", wxART_HARDDISK);
-	AddInfoField(col4->GetSizer(), col4, "Client Version", "Placeholder", wxART_TICK_MARK);
-	AddInfoField(col4->GetSizer(), col4, "Data Directory", "Placeholder", wxART_FOLDER);
+	AddInfoField(col4->GetSizer(), col4, "Client Name", "Placeholder", ICON_HARD_DRIVE);
+	AddInfoField(col4->GetSizer(), col4, "Client Version", "Placeholder", ICON_CHECK);
+	AddInfoField(col4->GetSizer(), col4, "Data Directory", "Placeholder", ICON_FOLDER);
 	col4->GetSizer()->Add(new wxStaticLine(col4), 0, wxEXPAND | wxALL, 4);
-	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", wxART_TICK_MARK, wxColour(0, 200, 0));
+	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", ICON_CHECK, wxColour(0, 200, 0));
 	contentSizer->Add(col4, 1, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 5); // Add Column 4
 
 	// Column 5: Available Clients

--- a/source/ui/welcome_dialog.h
+++ b/source/ui/welcome_dialog.h
@@ -4,6 +4,7 @@
 #include <wx/wx.h>
 #include <wx/listctrl.h>
 #include <vector>
+#include <string>
 
 // Forward declarations
 class wxListCtrl;
@@ -22,7 +23,7 @@ private:
 	void OnRecentFileActivated(wxListEvent& event);
 	void OnRecentFileSelected(wxListEvent& event);
 
-	void AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol = wxNullColour);
+	void AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const std::string& iconName, const wxColour& valCol = wxNullColour);
 
 	wxPanel* CreateHeaderPanel(wxWindow* parent, const wxString& titleText, const wxBitmap& rmeLogo);
 	wxPanel* CreateContentPanel(wxWindow* parent, const std::vector<wxString>& recentFiles);


### PR DESCRIPTION
This PR modernizes the icon usage in the Welcome Dialog and House Palette.
It replaces legacy `wxArtProvider` calls with the centralized `ImageManager` system, ensuring consistent SVG icons are used throughout the application.
It also adds missing icons to buttons in the House Palette and House Editor dialog.

Changes:
- `source/ui/welcome_dialog.cpp`: Replaced `wxArtProvider` with `IMAGE_MANAGER`.
- `source/ui/welcome_dialog.h`: Updated `AddInfoField` signature.
- `source/palette/house/house_palette.cpp`: Added icons to buttons.
- `source/palette/house/edit_house_dialog.cpp`: Added icons to buttons and set dialog icon.


---
*PR created automatically by Jules for task [10614920075258052214](https://jules.google.com/task/10614920075258052214) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icons to action buttons (Add, Edit, Remove) throughout the UI.
  * House editing dialog now displays a house icon.
  * Welcome dialog enhanced with visual indicators for various options and settings.

* **Style**
  * Updated button and dialog appearance with improved visual presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->