### PR TITLE
🎨 Palette: UX Improvements & Linux Build Fix

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,7 @@ class RMERecipe(ConanFile):
             # Only dependencies NOT available via apt
             self.requires("glad/0.1.36")
             self.requires("opengl/system")
+            self.requires("tomlplusplus/3.3.0")
             # Note: nanovg is in ext/nanovg
         else:
             # Full dependency tree for Windows/macOS

--- a/source/app/client_version.cpp
+++ b/source/app/client_version.cpp
@@ -15,7 +15,7 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //////////////////////////////////////////////////////////////////////
 
-#include <toml++/toml.hpp>
+#include <toml++/toml.h>
 #include <charconv>
 #include <string>
 #include "app/main.h"

--- a/source/editor/managers/editor_manager.cpp
+++ b/source/editor/managers/editor_manager.cpp
@@ -177,6 +177,7 @@ bool EditorManager::ShouldSave() {
 }
 
 void EditorManager::SaveCurrentMap(FileName fileName, bool showdialog) {
+	wxBusyCursor wait;
 	MapTab* mapTab = GetCurrentMapTab();
 	if (mapTab) {
 		Editor* editor = mapTab->GetEditor();
@@ -274,6 +275,7 @@ void EditorManager::SaveMapAs() {
 }
 
 bool EditorManager::LoadMap(const FileName& fileName) {
+	wxBusyCursor wait;
 	spdlog::info("EditorManager::LoadMap - Loading map: {}", nstr(fileName.GetFullPath()));
 	g_status.SetStatusText("Loading map...");
 	if (g_gui.root) {

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -164,12 +164,16 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
 	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
 	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(16, 16)));
+	head_btn->SetToolTip("Change head color");
 	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
 	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHIRT, wxSize(16, 16)));
+	body_btn->SetToolTip("Change primary color");
 	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
 	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SOCKS, wxSize(16, 16)));
+	legs_btn->SetToolTip("Change secondary color");
 	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
 	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHOE_PRINTS, wxSize(16, 16)));
+	feet_btn->SetToolTip("Change detail color");
 
 	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
 	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -45,6 +45,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
 	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
+	options_radio_box->SetToolTip("Select search criteria");
 	options_radio_box->SetSelection(SearchMode::ServerIDs);
 	options_box_sizer->Add(options_radio_box, 0, wxALL | wxEXPAND, 5);
 

--- a/source/ui/managers/recent_files_manager.cpp
+++ b/source/ui/managers/recent_files_manager.cpp
@@ -1,5 +1,5 @@
 #include "ui/managers/recent_files_manager.h"
-#include <toml++/toml.hpp>
+#include <toml++/toml.h>
 #include "app/settings.h"
 
 RecentFilesManager::RecentFilesManager() :

--- a/source/ui/map_window.cpp
+++ b/source/ui/map_window.cpp
@@ -220,6 +220,11 @@ void MapWindow::ScrollRelative(int x, int y) {
 
 void MapWindow::OnGem(wxCommandEvent& WXUNUSED(event)) {
 	g_gui.SwitchMode();
+	if (g_gui.IsDrawingMode()) {
+		g_gui.SetStatusText("Switched to Drawing Mode");
+	} else {
+		g_gui.SetStatusText("Switched to Selection Mode");
+	}
 }
 
 void MapWindow::OnSize(wxSizeEvent& event) {

--- a/source/ui/menubar/navigation_menu_handler.cpp
+++ b/source/ui/menubar/navigation_menu_handler.cpp
@@ -63,6 +63,7 @@ void NavigationMenuHandler::OnJumpToBrush(wxCommandEvent& WXUNUSED(event)) {
 	const Brush* brush = dlg->getResult();
 	if (brush) {
 		g_gui.SelectBrush(brush, TILESET_UNKNOWN);
+		g_gui.SetStatusText("Jumped to brush: " + wxstr(brush->getName()));
 	}
 	dlg->Destroy();
 }
@@ -80,6 +81,7 @@ void NavigationMenuHandler::OnJumpToItemBrush(wxCommandEvent& WXUNUSED(event)) {
 		const Brush* brush = dialog.getResult();
 		if (brush) {
 			g_gui.SelectBrush(brush, TILESET_RAW);
+			g_gui.SetStatusText("Jumped to item: " + wxstr(brush->getName()));
 		}
 		g_settings.setInteger(Config::JUMP_TO_ITEM_MODE, (int)dialog.getSearchMode());
 	}

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -129,6 +129,11 @@ void BrushToolBar::OnToolbarClick(wxCommandEvent& event) {
 		return;
 	}
 
+	wxString help = toolbar->GetToolShortHelp(event.GetId());
+	if (!help.IsEmpty()) {
+		g_gui.SetStatusText("Selected " + help);
+	}
+
 	switch (event.GetId()) {
 		case PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL:
 			g_gui.SelectBrush(g_brush_manager.optional_brush);

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -114,12 +114,15 @@ void StandardToolBar::OnButtonClick(wxCommandEvent& event) {
 			break;
 		case wxID_CUT:
 			g_gui.DoCut();
+			g_gui.SetStatusText("Cut selection to clipboard");
 			break;
 		case wxID_COPY:
 			g_gui.DoCopy();
+			g_gui.SetStatusText("Copied selection to clipboard");
 			break;
 		case wxID_PASTE:
 			g_gui.PreparePaste();
+			g_gui.SetStatusText("Paste mode active. Click on map to paste.");
 			break;
 		default:
 			event.Skip();


### PR DESCRIPTION
- Added status bar feedback for map mode switching, clipboard operations, brush selection, and jump-to-brush/item.
- Added tooltips to Outfit Chooser color buttons and Find Item Dialog radio box.
- Added busy cursor for long-running LoadMap and SaveCurrentMap operations.
- Added `tomlplusplus` dependency to `conanfile.py` for Linux builds.
- Fixed `tomlplusplus` include paths to `#include <toml++/toml.h>` for consistency and correctness with Conan package layout.

---
*PR created automatically by Jules for task [15040591346314547596](https://jules.google.com/task/15040591346314547596) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added visual busy indicator during map save and load operations.
  * Enhanced status bar feedback for user actions including mode switching, brush/item selection, and clipboard operations.
  * Added tooltips to outfit color buttons and search criteria options for improved usability.

* **Chores**
  * Updated library dependencies and includes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->