### PR TITLE
Refactor UI list boxes to use NanoVG

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -14,9 +14,12 @@ class RMERecipe(ConanFile):
         # On Linux, most dependencies come from apt - only need glad from Conan
         # On other platforms, use full Conan dependency tree
         if self.settings.os == "Linux":
-            # Only dependencies NOT available via apt
+            # Only dependencies NOT available via apt (or too old)
             self.requires("glad/0.1.36")
             self.requires("opengl/system")
+            self.requires("tomlplusplus/3.4.0")
+            self.requires("glm/1.0.1")
+            self.requires("spdlog/1.15.0")
             # Note: nanovg is in ext/nanovg
         else:
             # Full dependency tree for Windows/macOS

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -311,6 +311,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/util/common.h
     ${CMAKE_CURRENT_LIST_DIR}/util/json.h
     ${CMAKE_CURRENT_LIST_DIR}/util/nanovg_canvas.h
+    ${CMAKE_CURRENT_LIST_DIR}/util/nanovg_listbox.h
     ${CMAKE_CURRENT_LIST_DIR}/util/virtual_item_grid.h
 )
 
@@ -620,6 +621,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ui/menubar_loader.cpp
     ${CMAKE_CURRENT_LIST_DIR}/util/common.cpp
     ${CMAKE_CURRENT_LIST_DIR}/util/nanovg_canvas.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/util/nanovg_listbox.cpp
     ${CMAKE_CURRENT_LIST_DIR}/util/virtual_item_grid.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/tool_options_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/tool_options_surface.cpp

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -3,7 +3,7 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
-#include <wx/vlbox.h>
+#include "util/nanovg_listbox.h"
 #include <vector>
 
 class Brush;
@@ -19,7 +19,7 @@ public:
 	void OnKeyDown(wxKeyEvent&);
 };
 
-class FindDialogListBox : public wxVListBox {
+class FindDialogListBox : public NanoVGListBox {
 public:
 	FindDialogListBox(wxWindow* parent, wxWindowID id);
 	~FindDialogListBox();
@@ -29,8 +29,8 @@ public:
 	void AddBrush(Brush*);
 	Brush* GetSelectedBrush();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, int index) const override;
+	int OnMeasureItem(int index) const override;
 
 protected:
 	bool cleared;

--- a/source/ui/replace_items_window.h
+++ b/source/ui/replace_items_window.h
@@ -21,6 +21,7 @@
 #include "app/main.h"
 #include "ui/controls/item_buttons.h"
 #include "editor/editor.h"
+#include "util/nanovg_listbox.h"
 
 struct ReplacingItem {
 	ReplacingItem() :
@@ -57,7 +58,7 @@ private:
 // ============================================================================
 // ReplaceItemsListBox
 
-class ReplaceItemsListBox : public wxVListBox {
+class ReplaceItemsListBox : public NanoVGListBox {
 public:
 	ReplaceItemsListBox(wxWindow* parent);
 
@@ -66,8 +67,8 @@ public:
 	void RemoveSelected();
 	bool CanAdd(uint16_t replaceId, uint16_t withId) const;
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, int index) const override;
+	int OnMeasureItem(int index) const override;
 
 	const std::vector<ReplacingItem>& GetItems() const {
 		return m_items;
@@ -78,8 +79,6 @@ public:
 
 private:
 	std::vector<ReplacingItem> m_items;
-	wxBitmap m_arrow_bitmap;
-	wxBitmap m_flag_bitmap;
 };
 
 // ============================================================================

--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -1,0 +1,267 @@
+#include "util/nanovg_listbox.h"
+#include <wx/wx.h>
+#include <nanovg.h>
+#include <algorithm>
+
+NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
+	NanoVGCanvas(parent, id, wxVSCROLL | wxWANTS_CHARS),
+	m_count(0),
+	m_style(style),
+	m_totalHeight(0),
+	m_lastSelection(-1) {
+	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnLeftDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &NanoVGListBox::OnLeftDClick, this);
+	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
+}
+
+NanoVGListBox::~NanoVGListBox() {
+	//
+}
+
+void NanoVGListBox::SetItemCount(int count) {
+	m_count = count;
+	RecalculateLayout();
+	m_selections.clear();
+	m_lastSelection = -1;
+	Refresh();
+}
+
+void NanoVGListBox::RecalculateLayout() {
+	m_itemY.clear();
+	m_itemY.reserve(m_count + 1);
+	m_totalHeight = 0;
+	for (int i = 0; i < m_count; ++i) {
+		m_itemY.push_back(m_totalHeight);
+		m_totalHeight += OnMeasureItem(i);
+	}
+	m_itemY.push_back(m_totalHeight);
+	UpdateScrollbar(m_totalHeight);
+}
+
+void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int startY = GetScrollPosition();
+	int endY = startY + height;
+
+	// Find first visible item
+	auto it = std::lower_bound(m_itemY.begin(), m_itemY.end(), startY);
+	int first = std::distance(m_itemY.begin(), it);
+	if (first > 0 && m_itemY[first] > startY) {
+		first--;
+	}
+
+	for (int i = first; i < m_count; ++i) {
+		int y = m_itemY[i];
+		if (y > endY) {
+			break;
+		}
+
+		int h = m_itemY[i + 1] - y;
+		wxRect rect(0, y, width, h);
+
+		// Draw selection background
+		if (IsSelected(i)) {
+			nvgBeginPath(vg);
+			nvgRect(vg, 0, y, width, h);
+			nvgFillColor(vg, nvgRGBA(50, 100, 200, 255)); // Blueish selection
+			nvgFill(vg);
+		}
+
+		OnDrawItem(vg, rect, i);
+	}
+}
+
+int NanoVGListBox::OnMeasureItem(int index) const {
+	return 20;
+}
+
+int NanoVGListBox::HitTest(const wxPoint& point) const {
+	int y = point.y + GetScrollPosition();
+	auto it = std::upper_bound(m_itemY.begin(), m_itemY.end(), y);
+	int index = std::distance(m_itemY.begin(), it) - 1;
+	if (index >= 0 && index < m_count) {
+		return index;
+	}
+	return wxNOT_FOUND;
+}
+
+void NanoVGListBox::EnsureVisible(int n) {
+	if (n < 0 || n >= m_count) {
+		return;
+	}
+
+	int y = m_itemY[n];
+	int h = m_itemY[n + 1] - y;
+	int viewY = GetScrollPosition();
+	int viewH = GetClientSize().y;
+
+	if (y < viewY) {
+		SetScrollPosition(y);
+	} else if (y + h > viewY + viewH) {
+		SetScrollPosition(y + h - viewH);
+	}
+}
+
+void NanoVGListBox::SetSelection(int n) {
+	if (n < 0 || n >= m_count) {
+		return;
+	}
+	m_selections.clear();
+	m_selections.insert(n);
+	m_lastSelection = n;
+	EnsureVisible(n);
+	Refresh();
+
+	wxCommandEvent event(wxEVT_LISTBOX, GetId());
+	event.SetEventObject(this);
+	event.SetInt(n);
+	GetEventHandler()->ProcessEvent(event);
+}
+
+int NanoVGListBox::GetSelection() const {
+	if (m_selections.empty()) {
+		return wxNOT_FOUND;
+	}
+	return *m_selections.begin(); // Not deterministic if multiple, but consistent with single
+}
+
+bool NanoVGListBox::IsSelected(int n) const {
+	return m_selections.count(n) > 0;
+}
+
+void NanoVGListBox::Select(int n) {
+	if (n < 0 || n >= m_count) {
+		return;
+	}
+	if ((m_style & wxLB_MULTIPLE) || (m_style & wxLB_EXTENDED)) {
+		m_selections.insert(n);
+	} else {
+		m_selections.clear();
+		m_selections.insert(n);
+	}
+	m_lastSelection = n;
+	Refresh();
+}
+
+void NanoVGListBox::Deselect(int n) {
+	m_selections.erase(n);
+	Refresh();
+}
+
+void NanoVGListBox::DeselectAll() {
+	m_selections.clear();
+	Refresh();
+}
+
+void NanoVGListBox::OnLeftDown(wxMouseEvent& event) {
+	SetFocus();
+	int index = HitTest(event.GetPosition());
+	if (index == wxNOT_FOUND) {
+		return;
+	}
+
+	if ((m_style & wxLB_MULTIPLE) || (m_style & wxLB_EXTENDED)) {
+		if (event.ControlDown()) {
+			if (IsSelected(index)) {
+				Deselect(index);
+			} else {
+				Select(index);
+			}
+		} else if (event.ShiftDown() && m_lastSelection != -1) {
+			int start = std::min(m_lastSelection, index);
+			int end = std::max(m_lastSelection, index);
+			if (!event.ControlDown()) {
+				m_selections.clear();
+			}
+			for (int i = start; i <= end; ++i) {
+				m_selections.insert(i);
+			}
+		} else {
+			// Click without modifiers in multiple selection listbox usually toggles (simple multiple)
+			// or selects only one (extended).
+			// wxLB_MULTIPLE: Toggles the item at the position of the click.
+			// wxLB_EXTENDED: Selects the item... Ctrl toggles...
+			if (m_style & wxLB_MULTIPLE) {
+				if (IsSelected(index)) {
+					Deselect(index);
+				} else {
+					Select(index);
+				}
+			} else {
+				// Extended: Click selects only one
+				m_selections.clear();
+				Select(index);
+			}
+		}
+	} else {
+		// Single selection
+		SetSelection(index);
+	}
+
+	m_lastSelection = index;
+	Refresh();
+
+	wxCommandEvent evt(wxEVT_LISTBOX, GetId());
+	evt.SetEventObject(this);
+	evt.SetInt(index);
+	GetEventHandler()->ProcessEvent(evt);
+
+	// Double click handled by parent?
+	// We need to forward double click?
+	// NanoVGCanvas receives double click?
+	// Check Bind in NanoVGCanvas or NanoVGListBox?
+	// We bind LEFT_DOWN.
+}
+
+void NanoVGListBox::OnLeftDClick(wxMouseEvent& event) {
+	int index = HitTest(event.GetPosition());
+	if (index != wxNOT_FOUND) {
+		wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(index);
+		GetEventHandler()->ProcessEvent(evt);
+	}
+}
+
+void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
+	int sel = GetSelection();
+	if (sel == wxNOT_FOUND) {
+		sel = 0;
+	}
+
+	switch (event.GetKeyCode()) {
+		case WXK_UP:
+			if (sel > 0) {
+				SetSelection(sel - 1);
+			}
+			break;
+		case WXK_DOWN:
+			if (sel < m_count - 1) {
+				SetSelection(sel + 1);
+			}
+			break;
+		case WXK_HOME:
+			if (m_count > 0) {
+				SetSelection(0);
+			}
+			break;
+		case WXK_END:
+			if (m_count > 0) {
+				SetSelection(m_count - 1);
+			}
+			break;
+		case WXK_PAGEUP:
+			if (m_count > 0) {
+				int visibleCount = GetClientSize().y / 20; // Approx
+				SetSelection(std::max(0, sel - visibleCount));
+			}
+			break;
+		case WXK_PAGEDOWN:
+			if (m_count > 0) {
+				int visibleCount = GetClientSize().y / 20; // Approx
+				SetSelection(std::min(m_count - 1, sel + visibleCount));
+			}
+			break;
+		default:
+			event.Skip();
+	}
+}

--- a/source/util/nanovg_listbox.h
+++ b/source/util/nanovg_listbox.h
@@ -1,0 +1,60 @@
+#ifndef RME_UTIL_NANOVG_LISTBOX_H_
+#define RME_UTIL_NANOVG_LISTBOX_H_
+
+#include "util/nanovg_canvas.h"
+#include <unordered_set>
+#include <vector>
+
+class NanoVGListBox : public NanoVGCanvas {
+public:
+	NanoVGListBox(wxWindow* parent, wxWindowID id, long style = 0);
+	virtual ~NanoVGListBox();
+
+	// ListBox methods
+	void SetItemCount(int count);
+	int GetItemCount() const {
+		return m_count;
+	}
+
+	// Selection
+	void SetSelection(int n); // Selects only n, deselects others
+	int GetSelection() const; // Returns first selected item, or wxNOT_FOUND
+	bool IsSelected(int n) const;
+	void Select(int n); // Adds n to selection (if multiple)
+	void Deselect(int n);
+	void DeselectAll();
+	int GetSelectedCount() const {
+		return m_selections.size();
+	}
+	bool HasSelection() const {
+		return !m_selections.empty();
+	}
+
+	// Virtual methods to implement
+	virtual void OnDrawItem(NVGcontext* vg, const wxRect& rect, int index) const = 0;
+	virtual int OnMeasureItem(int index) const; // Default returns 20
+
+	// Helper
+	int HitTest(const wxPoint& point) const;
+	void EnsureVisible(int n);
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	void OnLeftDown(wxMouseEvent& event);
+	void OnLeftDClick(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+	void RecalculateLayout();
+
+	int m_count;
+	long m_style;
+	std::unordered_set<int> m_selections;
+
+	// Cached Y positions for variable height items.
+	// m_itemY[i] is the Y coordinate of the top of item i.
+	// m_itemY[m_count] is the total height.
+	std::vector<int> m_itemY;
+	int m_totalHeight;
+	int m_lastSelection; // For Shift-click range selection
+};
+
+#endif


### PR DESCRIPTION
This PR refactors `BrowseTileListBox`, `FindDialogListBox`, and `ReplaceItemsListBox` to inherit from `NanoVGListBox` instead of `wxVListBox`.
`NanoVGListBox` is a new class implementing a virtual list box using `NanoVGCanvas` for rendering, providing hardware acceleration.
This addresses performance issues with GDI+ rendering for list boxes and aligns with the project's goal of modernizing the UI.
Also updates `conanfile.py` to fix Linux build dependencies.

---
*PR created automatically by Jules for task [10866843629318816697](https://jules.google.com/task/10866843629318816697) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded internal rendering system for list boxes to use NanoVG technology for enhanced graphics performance and visual quality across the application.

* **Chores**
  * Updated Linux dependencies: added tomlplusplus (3.4.0), glm (1.0.1), and spdlog (1.15.0).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->