### PR TITLE
⚡ Throttle: Optimize TooltipDrawer with LRU layout cache

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -17,6 +17,9 @@ class RMERecipe(ConanFile):
             # Only dependencies NOT available via apt
             self.requires("glad/0.1.36")
             self.requires("opengl/system")
+            self.requires("tomlplusplus/3.4.0")
+            self.requires("glm/1.0.1")
+            self.requires("spdlog/1.15.0")
             # Note: nanovg is in ext/nanovg
         else:
             # Full dependency tree for Windows/macOS

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <sstream>
 #include <unordered_map>
+#include <list>
 
 class Item;
 class Waypoint;
@@ -207,6 +208,24 @@ protected:
 	void drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip);
 	void drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize);
 	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout);
+
+private:
+	struct CachedFieldLine {
+		std::string label;
+		std::string value;
+		uint8_t r, g, b;
+		std::vector<std::string> wrappedLines;
+	};
+
+	struct CachedLayout {
+		LayoutMetrics metrics;
+		std::vector<CachedFieldLine> fields;
+	};
+
+	std::list<uint64_t> lruList;
+	std::unordered_map<uint64_t, std::pair<CachedLayout, std::list<uint64_t>::iterator>> layoutCache;
+
+	uint64_t computeHash(const TooltipData& data) const;
 };
 
 #endif


### PR DESCRIPTION
This PR implements a performance optimization for the `TooltipDrawer`. Previously, tooltip layouts (including text wrapping and string formatting) were recalculated every frame for every active tooltip. This caused significant CPU overhead when many tooltips were visible (e.g., "Viewport labels").

The optimization introduces an LRU cache that stores the calculated layout metrics and formatted text lines. The cache is keyed by a hash of the tooltip content, allowing identical tooltips (even at different positions) to share the layout calculation.

Key changes:
- `source/rendering/ui/tooltip_drawer.h`: Added cache structures and helper methods.
- `source/rendering/ui/tooltip_drawer.cpp`: Implemented `computeHash` and updated `draw` to use the cache.
- `conanfile.py`: Added missing Linux dependencies to fix build issues discovered during verification.


---
*PR created automatically by Jules for task [12565908323886421051](https://jules.google.com/task/12565908323886421051) started by @karolak6612*