### PR TITLE
Fix Critical UB and Infinite Loop Bugs

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -26,6 +26,7 @@
 #include <stdio.h>
 #include <memory>
 #include <vector>
+#include <cstring>
 
 #ifndef FORCEINLINE
 	#ifdef _MSV_VER
@@ -185,7 +186,7 @@ protected:
 			read_offset = data.size();
 			return false;
 		}
-		ref = *(T*)(data.data() + read_offset);
+		std::memcpy(&ref, data.data() + read_offset, sizeof(ref));
 
 		read_offset += sizeof(ref);
 		return true;

--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -425,7 +425,16 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int z = where->getZ();
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
+
+			int loop_limit = std::max(width, height) + 100;
+			int loop_count = 0;
+
 			while (found != tile_loc->getSpawnCount()) {
+				if (++loop_count > loop_limit) {
+					spdlog::warn("Map::getSpawnList: Infinite loop detected. Spawn count mismatch at {},{},{}", where->getX(), where->getY(), where->getZ());
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -39,6 +39,9 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
+	if (position + length > buffer.size()) {
+		throw std::out_of_range("NetworkMessage::read<std::string>: buffer underflow");
+	}
 	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
 	position += length;
 	return std::string(strBuffer, length);

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,8 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <cstring>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -36,7 +38,11 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::out_of_range("NetworkMessage::read: buffer underflow");
+		}
+		T value;
+		std::memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}


### PR DESCRIPTION
BUG TYPE: [Undefined Behavior / Race Condition / Logic Bug]
SEVERITY: [CRITICAL/HIGH]

ISSUES FIXED:
1.  **NetworkMessage::read (UB / Security)**: Replaced `reinterpret_cast` with `std::memcpy` to fix strict aliasing violations and potential unaligned access crashes. Added `position + sizeof(T) > buffer.size()` check to prevent buffer over-read (security vulnerability). This applies to both the generic `read<T>` and `read<std::string>`.
2.  **Map::getSpawnList (Logic Bug)**: Added a safety loop limit (`std::max(width, height) + 100`) to prevent infinite loops if the map's spawn count metadata desynchronizes from actual spawn items.
3.  **BinaryNode::getType (UB)**: Replaced `reinterpret_cast` with `std::memcpy` when reading from `std::string` buffer to fix strict aliasing violations.

TESTED:
-   Verified code logic for bounds checks and strict aliasing compliance.
-   Compiles with standard C++ (using `std::memcpy` and `<cstring>`).

PREVENTION:
-   Always use `std::memcpy` for binary deserialization.
-   Always validate buffer bounds before reading.
-   Always add safety breakers to `while` loops dependent on external data counts.

---
*PR created automatically by Jules for task [15778412449747027705](https://jules.google.com/task/15778412449747027705) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Added loop prevention safeguards to prevent infinite loops when aggregating spawn information
* Implemented buffer boundary validation on network message reads to prevent underflow conditions with improved error reporting  
* Enhanced memory safety with improved copying and data access mechanisms

<!-- end of auto-generated comment: release notes by coderabbit.ai -->