### PR TITLE
[ICONS] Migrate WelcomeDialog to ImageManager and add missing icons

### DIFF
--- a/source/app/preferences/client_version_page.cpp
+++ b/source/app/preferences/client_version_page.cpp
@@ -3,6 +3,7 @@
 #include "app/settings.h"
 #include "ui/gui.h"
 #include "ui/dialog_util.h"
+#include "util/image_manager.h"
 #include <wx/tokenzr.h>
 #include <charconv>
 
@@ -26,7 +27,9 @@ ClientVersionPage::ClientVersionPage(wxWindow* parent) : PreferencesPage(parent)
 
 	wxSizer* btn_outer_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_client_btn = newd wxButton(left_panel, wxID_ANY, "+ Add");
+	add_client_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	delete_client_btn = newd wxButton(left_panel, wxID_ANY, "- Remove");
+	delete_client_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
 
 	// Equal width for buttons
 	btn_outer_sizer->AddStretchSpacer(1);
@@ -325,7 +328,7 @@ void ClientVersionPage::OnTreeContextMenu(wxTreeEvent& event) {
 	}
 
 	wxMenu menu;
-	menu.Append(wxID_COPY, "Duplicate");
+	menu.Append(wxID_COPY, "Duplicate")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_COPY, wxSize(16, 16)));
 	menu.Bind(wxEVT_MENU, &ClientVersionPage::OnDuplicateClient, this, wxID_COPY);
 
 	PopupMenu(&menu);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -1,7 +1,6 @@
 #include <wx/listctrl.h>
 #include <wx/imaglist.h>
 #include <wx/statline.h>
-#include <wx/artprov.h>
 #include <wx/filename.h>
 #include <wx/dcbuffer.h>
 
@@ -240,13 +239,13 @@ WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionT
 
 	// Image List for Icons
 	m_imageList = new wxImageList(16, 16);
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_NEW, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FIND, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_HARDDISK, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_NORMAL_FILE, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_TICK_MARK, wxART_OTHER, wxSize(16, 16)));
-	m_imageList->Add(wxArtProvider::GetBitmap(wxART_FOLDER, wxART_OTHER, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_HARD_DRIVE, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FILE, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FOLDER, wxSize(16, 16)));
 
 	wxBoxSizer* mainSizer = new wxBoxSizer(wxVERTICAL);
 
@@ -269,10 +268,10 @@ WelcomeDialog::~WelcomeDialog() {
 	delete m_imageList;
 }
 
-void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol) {
+void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const std::string& iconPath, const wxColour& valCol) {
 	wxBoxSizer* row = new wxBoxSizer(wxHORIZONTAL);
 
-	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, wxArtProvider::GetBitmap(artId, wxART_OTHER, wxSize(14, 14)));
+	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(iconPath, wxSize(14, 14)));
 	row->Add(icon, 0, wxCENTER | wxRIGHT, 4);
 
 	wxStaticText* lbl = new wxStaticText(parent, wxID_ANY, label);
@@ -304,7 +303,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 
 	// Icon Button - Align Left: 10px total
 	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : wxArtProvider::GetBitmap(wxART_HELP, wxART_OTHER, wxSize(32, 32))); // Fallback if logo invalid
+	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -325,7 +324,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	headerSizer->Add(titleSizer, 1, wxALL | wxEXPAND, 10);
 
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
-	prefBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_EDIT, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Right: 10px total
@@ -340,14 +339,14 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	wxBoxSizer* footerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
-	exitBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_QUIT, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
 
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
-	newBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_NEW, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
@@ -359,7 +358,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	footerSizer->AddStretchSpacer();
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
-	loadBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_BUTTON, FromDIP(wxSize(24, 24))));
+	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -388,13 +387,13 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
 	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_NEW, wxART_BUTTON, wxSize(24, 24)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(wxArtProvider::GetBitmap(wxART_FILE_OPEN, wxART_BUTTON, wxSize(24, 24)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
@@ -434,22 +433,22 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 
 	// Column 3: Selected Map Info
 	DarkCardPanel* col3 = new DarkCardPanel(contentPanel, "Selected Map Info");
-	AddInfoField(col3->GetSizer(), col3, "Map Name", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Client Version", "Placeholder", wxART_TICK_MARK);
-	AddInfoField(col3->GetSizer(), col3, "Dimensions", "Placeholder", wxART_LIST_VIEW);
+	AddInfoField(col3->GetSizer(), col3, "Map Name", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Client Version", "Placeholder", ICON_CHECK);
+	AddInfoField(col3->GetSizer(), col3, "Dimensions", "Placeholder", ICON_LIST);
 	col3->GetSizer()->Add(new wxStaticLine(col3), 0, wxEXPAND | wxALL, 4);
-	AddInfoField(col3->GetSizer(), col3, "House File", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Spawn File", "Placeholder", wxART_NORMAL_FILE);
-	AddInfoField(col3->GetSizer(), col3, "Description", "Placeholder", wxART_REPORT_VIEW);
+	AddInfoField(col3->GetSizer(), col3, "House File", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Spawn File", "Placeholder", ICON_FILE);
+	AddInfoField(col3->GetSizer(), col3, "Description", "Placeholder", ICON_FILE_LINES);
 	contentSizer->Add(col3, 1, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 5); // Add Column 3 (Center)
 
 	// Column 4: Client Info
 	DarkCardPanel* col4 = new DarkCardPanel(contentPanel, "Client Information");
-	AddInfoField(col4->GetSizer(), col4, "Client Name", "Placeholder", wxART_HARDDISK);
-	AddInfoField(col4->GetSizer(), col4, "Client Version", "Placeholder", wxART_TICK_MARK);
-	AddInfoField(col4->GetSizer(), col4, "Data Directory", "Placeholder", wxART_FOLDER);
+	AddInfoField(col4->GetSizer(), col4, "Client Name", "Placeholder", ICON_HARD_DRIVE);
+	AddInfoField(col4->GetSizer(), col4, "Client Version", "Placeholder", ICON_CHECK);
+	AddInfoField(col4->GetSizer(), col4, "Data Directory", "Placeholder", ICON_FOLDER);
 	col4->GetSizer()->Add(new wxStaticLine(col4), 0, wxEXPAND | wxALL, 4);
-	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", wxART_TICK_MARK, wxColour(0, 200, 0));
+	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", ICON_CHECK, wxColour(0, 200, 0));
 	contentSizer->Add(col4, 1, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 5); // Add Column 4
 
 	// Column 5: Available Clients


### PR DESCRIPTION
This PR updates the `WelcomeDialog` to use the project's centralized `ImageManager` and SVG icons instead of legacy `wxArtProvider` bitmaps. It also adds missing icons to the Client Version management buttons in the Preferences window.

**Changes:**
- `source/ui/welcome_dialog.cpp`: Replaced `wxArtProvider::GetBitmap` calls with `IMAGE_MANAGER.GetBitmap(ICON_*)`.
- `source/app/preferences/client_version_page.cpp`: Added icons to "Add Client" and "Remove Client" buttons.

**Verification:**
- Verified that all referenced `ICON_*` macros exist in `source/util/image_manager.h`.
- The changes are purely cosmetic and utilize existing infrastructure.

---
*PR created automatically by Jules for task [810733081787221520](https://jules.google.com/task/810733081787221520) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added icons to action buttons (Add, Remove, and Duplicate) throughout the application for improved visual clarity and consistency.
  * Enhanced icon presentation in welcome dialog and preferences pages for a more polished user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->