### PR TITLE
[WXWIDGETS] Fix missing double-click event in NanoVGListBox and FindItemDialog

### DIFF
--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -227,6 +227,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	invalid_item->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
 
 	input_timer.Bind(wxEVT_TIMER, &FindItemDialog::OnInputTimer, this);
+	items_list->Bind(wxEVT_LISTBOX_DCLICK, &FindItemDialog::OnClickOK, this);
 	ok_button->Bind(wxEVT_BUTTON, &FindItemDialog::OnClickOK, this);
 	cancel_button->Bind(wxEVT_BUTTON, &FindItemDialog::OnClickCancel, this);
 }

--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -16,6 +16,7 @@ NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
 
 	Bind(wxEVT_SIZE, &NanoVGListBox::OnSize, this);
 	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnMouseDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &NanoVGListBox::OnDoubleClick, this);
 	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
 	Bind(wxEVT_MOTION, &NanoVGListBox::OnMotion, this);
 	Bind(wxEVT_LEAVE_WINDOW, &NanoVGListBox::OnLeave, this);
@@ -277,6 +278,29 @@ void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
 		Refresh();
 	}
 	SetFocus(); // Ensure we get key events
+}
+
+void NanoVGListBox::OnDoubleClick(wxMouseEvent& event) {
+	int scrollPos = GetScrollPosition();
+	int index = HitTest(event.GetX(), event.GetY() + scrollPos);
+
+	if (index != -1) {
+		// Ensure selection
+		if (m_style & wxLB_MULTIPLE) {
+			// In multiple selection, double click usually acts on the item under cursor
+			// But we should ensure it's selected first? OnMouseDown already happened.
+			if (!IsSelected(index)) {
+				Select(index, true);
+			}
+		} else {
+			Select(index, true);
+		}
+
+		wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+		evt.SetEventObject(this);
+		evt.SetInt(index);
+		ProcessWindowEvent(evt);
+	}
 }
 
 void NanoVGListBox::OnMotion(wxMouseEvent& event) {

--- a/source/util/nanovg_listbox.h
+++ b/source/util/nanovg_listbox.h
@@ -49,6 +49,7 @@ protected:
 	void UpdateScrollbar();
 	void OnSize(wxSizeEvent& event);
 	void OnMouseDown(wxMouseEvent& event);
+	void OnDoubleClick(wxMouseEvent& event);
 	void OnKeyDown(wxKeyEvent& event);
 	void OnMotion(wxMouseEvent& event);
 	void OnLeave(wxMouseEvent& event);


### PR DESCRIPTION
Implemented `wxEVT_LEFT_DCLICK` handling in `NanoVGListBox` to emit `wxEVT_LISTBOX_DCLICK`.
Bound this event in `FindItemDialog` to allow confirming selection with a double click, improving UX.
`FindDialog` already had the binding but it was non-functional until now.

This addresses "Pattern 1: Missing Event Bindings" by ensuring list box interactions (double click) are properly handled.

---
*PR created automatically by Jules for task [2459093486965826131](https://jules.google.com/task/2459093486965826131) started by @karolak6612*