### PR TITLE
⚡ Throttle: Optimize Waypoint Lookup O(N) -> O(log N)

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -226,22 +226,8 @@ void Action::commit(DirtyList* dirty_list) {
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 
 				if (wp) {
-					// Change the tiles
-					TileLocation* oldtile = editor.map.getTileL(wp->pos);
-					TileLocation* newtile = editor.map.getTileL(p.pos);
-
-					// Only need to remove from old if it actually exists
-					if (p.pos != Position()) {
-						if (oldtile && oldtile->getWaypointCount() > 0) {
-							oldtile->decreaseWaypointCount();
-						}
-					}
-
-					newtile->increaseWaypointCount();
-
-					// Update shit
 					Position oldpos = wp->pos;
-					wp->pos = p.pos;
+					editor.map.waypoints.updateWaypointPosition(wp, p.pos);
 					p.pos = oldpos;
 				}
 				break;
@@ -354,24 +340,8 @@ void Action::undo(DirtyList* dirty_list) {
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 
 				if (wp) {
-					// Change the tiles
-					TileLocation* oldtile = editor.map.getTileL(wp->pos);
-					TileLocation* newtile = editor.map.getTileL(p.pos);
-
-					// Only need to remove from old if it actually exists
-					if (p.pos != Position()) {
-						if (oldtile && oldtile->getWaypointCount() > 0) {
-							oldtile->decreaseWaypointCount();
-						}
-					}
-
-					if (newtile) {
-						newtile->increaseWaypointCount();
-					}
-
-					// Update shit
 					Position oldpos = wp->pos;
-					wp->pos = p.pos;
+					editor.map.waypoints.updateWaypointPosition(wp, p.pos);
 					p.pos = oldpos;
 				}
 				break;

--- a/source/game/waypoints.h
+++ b/source/game/waypoints.h
@@ -19,6 +19,8 @@
 #define RME_WAYPOINTS_H_
 
 #include "map/position.h"
+#include <map>
+#include <memory>
 
 class Waypoint {
 public:
@@ -43,8 +45,10 @@ public:
 	Waypoint* getWaypoint(std::string name);
 	Waypoint* getWaypoint(TileLocation* location);
 	void removeWaypoint(std::string name);
+	void updateWaypointPosition(Waypoint* wp, const Position& newPos);
 
 	WaypointMap waypoints;
+	std::multimap<Position, Waypoint*> position_index;
 
 	WaypointMap::iterator begin() {
 		return waypoints.begin();

--- a/source/palette/palette_waypoints.cpp
+++ b/source/palette/palette_waypoints.cpp
@@ -102,9 +102,6 @@ void WaypointPalettePanel::OnUpdate() {
 	if (wxTextCtrl* tc = waypoint_list->GetEditControl()) {
 		Waypoint* wp = map->waypoints.getWaypoint(nstr(tc->GetValue()));
 		if (wp && wp->pos == Position()) {
-			if (map->getTile(wp->pos)) {
-				map->getTileL(wp->pos)->decreaseWaypointCount();
-			}
 			map->waypoints.removeWaypoint(wp->name);
 		}
 	}
@@ -180,9 +177,6 @@ void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
 
 				Waypoint* rwp = map->waypoints.getWaypoint(oldwpname);
 				if (rwp) {
-					if (map->getTile(rwp->pos)) {
-						map->getTileL(rwp->pos)->decreaseWaypointCount();
-					}
 					map->waypoints.removeWaypoint(rwp->name);
 				}
 
@@ -219,9 +213,6 @@ void WaypointPalettePanel::OnClickRemoveWaypoint(wxCommandEvent& event) {
 	if (item != -1) {
 		Waypoint* wp = map->waypoints.getWaypoint(nstr(waypoint_list->GetItemText(item)));
 		if (wp) {
-			if (map->getTile(wp->pos)) {
-				map->getTileL(wp->pos)->decreaseWaypointCount();
-			}
 			map->waypoints.removeWaypoint(wp->name);
 		}
 		waypoint_list->DeleteItem(item);


### PR DESCRIPTION
This PR optimizes waypoint lookup from O(N) to O(log N) by introducing a spatial index (`std::multimap<Position, Waypoint*>`) in the `Waypoints` class. This significantly improves performance when rendering many waypoints, as `TileRenderer::DrawTile` calls `getWaypoint` for every tile with a waypoint count > 0.

Additionally, this PR fixes a bug where removing a waypoint did not correctly decrease the `waypoint_count` on the tile, potentially leading to stale data and performance degradation (as `getWaypoint` would still be called).

The refactoring also centralizes waypoint position updates in `updateWaypointPosition`, simplifying `Action` (undo/redo) and `PaletteWaypoints` logic.


---
*PR created automatically by Jules for task [18392600306898613150](https://jules.google.com/task/18392600306898613150) started by @karolak6612*