### PR TITLE
Palette: Implement micro-UX improvements

### DIFF
--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -159,7 +159,7 @@ void MapPopupMenu::Update() {
 					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
+				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select as RAW Brush", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 
 				if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
 					Append(MAP_POPUP_MENU_MOVE_TO_TILESET, "Move To Tileset", "Move this item to any tileset")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHARE_FROM_SQUARE, wxSize(16, 16)));
@@ -209,7 +209,7 @@ void MapPopupMenu::Update() {
 					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
+				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select as RAW Brush", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 				if (hasWall) {
 					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
@@ -233,7 +233,7 @@ void MapPopupMenu::Update() {
 
 			AppendSeparator();
 
-			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "Browse Field", "Navigate from tile items");
+			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "Navigate Field Items", "Navigate from tile items");
 			browseTile->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
 			browseTile->Enable(anything_selected);
 		}

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -229,7 +229,7 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 
 	wxButton* removeBtn = newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute");
 	removeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
-	removeBtn->SetToolTip("Remove selected custom attribute");
+	removeBtn->SetToolTip("Remove selected custom attribute (Select a row first)");
 	optSizer->Add(removeBtn, wxSizerFlags(0).Center());
 
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());

--- a/source/ui/toolbar/position_toolbar.cpp
+++ b/source/ui/toolbar/position_toolbar.cpp
@@ -30,7 +30,7 @@ PositionToolBar::PositionToolBar(wxWindow* parent) {
 
 	go_button = newd wxButton(toolbar, TOOLBAR_POSITION_GO, wxEmptyString, wxDefaultPosition, parent->FromDIP(wxSize(22, 20)));
 	go_button->SetBitmap(go_bitmap);
-	go_button->SetToolTip("Go To Position");
+	go_button->SetToolTip("Go to position (Enter)");
 
 	toolbar->AddControl(x_control);
 	toolbar->AddControl(y_control);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -326,6 +326,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
 	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	prefBtn->SetToolTip("Configure editor preferences");
 
 	// Align Right: 10px total
 	headerSizer->Add(prefBtn, 0, wxCENTER | wxALL, 8);
@@ -341,6 +342,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
 	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	exitBtn->SetToolTip("Close the application");
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
@@ -348,6 +350,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
 	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	newBtn->SetToolTip("Create a new map (Ctrl+N)");
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
 	footerSizer->AddStretchSpacer();
@@ -370,6 +373,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 			QueueEvent(newEvent);
 		}
 	});
+	loadBtn->SetToolTip("Load an existing map (Ctrl+O)");
 
 	// Align Right: 10px total
 	footerSizer->Add(loadBtn, 0, wxALL, 8);
@@ -389,12 +393,14 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
 	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	newMapBtn->SetToolTip("Create a new map (Ctrl+N)");
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
 	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	browseBtn->SetToolTip("Browse for a map file (Ctrl+O)");
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	// Add Column 1 to Sizer FIRST (Explicit LEFTmost placement)


### PR DESCRIPTION
This PR implements several micro-UX improvements identified by the Palette agent:
1.  **Welcome Dialog:** Added tooltips to the header and footer buttons to improve accessibility and discoverability of keyboard shortcuts (Ctrl+N, Ctrl+O).
2.  **Map Popup Menu:** Renamed ambiguous menu items "Select RAW" and "Browse Field" to be more descriptive ("Select as RAW Brush", "Navigate Field Items").
3.  **Properties Window:** Improved the tooltip for the "Remove Attribute" button to guide users to select a row before clicking.
4.  **Position Toolbar:** Added a keyboard shortcut hint to the "Go" button tooltip.

These changes are purely cosmetic and additive, aimed at reducing user friction and improving clarity.

---
*PR created automatically by Jules for task [15194470888513686933](https://jules.google.com/task/15194470888513686933) started by @karolak6612*