### PR TITLE
📊 Profiler: Fix CPU bottleneck in tooltip generation

### DIFF
--- a/.jules/profiler.md
+++ b/.jules/profiler.md
@@ -12,3 +12,8 @@ Learning: Single-entry caching in nested loops must respect the iteration order.
 Finding: `GraphicManager::getSpriteFile()` returned `std::string` by value, causing a heap allocation and copy for every item in the render loop during sprite preloading checks.
 Impact: Reduced memory allocations per frame significantly (thousands of allocations avoided per frame).
 Learning: Returning `std::string` by value from a getter called in a hot loop is a major performance killer. Always use `const std::string&` or `std::string_view` for members.
+
+## 2024-10-27 - Optimization of Tooltip Generation in Render Loop
+Finding: `TileRenderer::DrawTile` generated full tooltip data (string allocations, layout calculations) for *every* item on a tile, causing massive CPU overhead (esp. `FillItemTooltipData`) even for items completely covered by others.
+Impact: Reduced tooltip generation overhead from O(items_per_tile) to O(1) per tile. Eliminated thousands of redundant string allocations and layout passes per frame.
+Learning: Even if a function (like `FillItemTooltipData`) is efficient, calling it inside a hot loop for invisible items is a major bottleneck. Pre-checking visibility/relevance (e.g. "is this the top item?") is crucial before doing expensive UI data preparation.


### PR DESCRIPTION
**Optimized Tooltip Generation in Map Rendering**

This change addresses a critical CPU bottleneck identified during profiling where tooltip data was being generated for *every* item on a tile, regardless of whether it was visible (covered by other items).

**Changes:**
- Refactored `TileRenderer::DrawTile` to track the `top_tooltip_item` and `top_tooltip_it` during the item rendering loop.
- Removed inline calls to `FillItemTooltipData` and `commitTooltip` inside the loop.
- Added a single `FillItemTooltipData` call at the end of the tile processing for the identified top-most item.

**Performance Impact:**
- Reduced tooltip generation complexity from O(N) to O(1) per tile (where N is the number of items on the tile).
- Eliminated redundant string allocations and NanoVG layout calculations for hidden items.
- Maintains Painter's Algorithm compliance for sprite rendering.


---
*PR created automatically by Jules for task [12626574283871353124](https://jules.google.com/task/12626574283871353124) started by @karolak6612*