### PR TITLE
⚡ Bolt: Optimize Tile Rendering (House Colors & Pattern Calculation)

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -35,7 +35,19 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, ephemeral, red, green, blue, alpha, tile);
 }
 
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const SpritePatterns& patterns, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha) {
+	const Position& pos = tile->getPosition();
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, patterns, options, ephemeral, red, green, blue, alpha, tile);
+}
+
 void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
+	ItemType& it = g_items[item->getID()];
+	GameSprite* spr = it.sprite;
+	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, patterns, options, ephemeral, red, green, blue, alpha, tile);
+}
+
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const SpritePatterns& patterns, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
 	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
@@ -118,7 +130,6 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	draw_x -= spr->draw_height;
 	draw_y -= spr->draw_height;
 
-	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
 	int subtype = patterns.subtype;
 	int pattern_x = patterns.x;
 	int pattern_y = patterns.y;
@@ -281,4 +292,3 @@ void ItemDrawer::DrawDoorIndicator(bool locked, const Position& pos, bool south,
 		door_indicator_drawer->addDoor(pos, locked, south, east);
 	}
 }
-

--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -16,6 +16,7 @@ class Item;
 class ItemType;
 class HookIndicatorDrawer;
 class DoorIndicatorDrawer;
+struct SpritePatterns;
 
 struct DrawingOptions;
 class SpriteBatch;
@@ -27,6 +28,9 @@ public:
 
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const SpritePatterns& patterns, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const SpritePatterns& patterns, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -20,6 +20,7 @@ struct LightBuffer;
 class SpriteBatch;
 class PrimitiveRenderer;
 class ItemType;
+struct SpritePatterns;
 
 class TileRenderer {
 public:
@@ -29,7 +30,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item, const ItemType& it);
+	void PreloadItem(const Tile* tile, Item* item, const ItemType& it, const SpritePatterns& patterns);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This PR implements rendering optimizations identified by Bolt. 
1. House color and pulse intensity calculations (floating point math) are now performed once per tile instead of for every item on the tile.
2. `PatternCalculator::Calculate` (modulo operations) is now called once per item in `DrawTile`, and the result is passed to `PreloadItem` and `ItemDrawer::BlitItem`. Previously, `PreloadItem` would calculate it (if item needed loading) and `BlitItem` would calculate it again.
This change involves adding an overload to `ItemDrawer::BlitItem` and modifying `TileRenderer::PreloadItem`. Backwards compatibility for `BlitItem` is maintained via delegation.

---
*PR created automatically by Jules for task [6994701242852474775](https://jules.google.com/task/6994701242852474775) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Optimized item and tile rendering by precomputing sprite patterns once and reusing them throughout the rendering pipeline, reducing redundant calculations.
  * Streamlined house color calculations for items to compute adjustments once instead of per-item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->