### PR TITLE
[UB FIX] Fix integer overflows, truncation and division by zero

### DIFF
--- a/source/io/filehandle.cpp
+++ b/source/io/filehandle.cpp
@@ -126,11 +126,19 @@ bool FileReadHandle::getLongString(std::string& str) {
 }
 
 bool FileReadHandle::seek(size_t offset) {
-	return fseek(file.get(), long(offset), SEEK_SET) == 0;
+#ifdef _MSC_VER
+	return _fseeki64(file.get(), static_cast<__int64>(offset), SEEK_SET) == 0;
+#else
+	return fseeko(file.get(), static_cast<off_t>(offset), SEEK_SET) == 0;
+#endif
 }
 
 bool FileReadHandle::seekRelative(size_t offset) {
-	return fseek(file.get(), long(offset), SEEK_CUR) == 0;
+#ifdef _MSC_VER
+	return _fseeki64(file.get(), static_cast<__int64>(offset), SEEK_CUR) == 0;
+#else
+	return fseeko(file.get(), static_cast<off_t>(offset), SEEK_CUR) == 0;
+#endif
 }
 
 //=============================================================================

--- a/source/io/loaders/dat_loader.cpp
+++ b/source/io/loaders/dat_loader.cpp
@@ -467,7 +467,21 @@ bool DatLoader::ReadSpriteGroup(GraphicManager* manager, FileReadHandle& file, G
 		}
 	}
 
-	uint32_t numsprites = static_cast<uint32_t>(width) * static_cast<uint32_t>(height) * static_cast<uint32_t>(layers) * static_cast<uint32_t>(pattern_x) * static_cast<uint32_t>(pattern_y) * static_cast<uint32_t>(pattern_z) * static_cast<uint32_t>(frames);
+	uint64_t numsprites_u64 = static_cast<uint64_t>(width) * static_cast<uint64_t>(height) * static_cast<uint64_t>(layers) * static_cast<uint64_t>(pattern_x) * static_cast<uint64_t>(pattern_y) * static_cast<uint64_t>(pattern_z) * static_cast<uint64_t>(frames);
+
+	if (numsprites_u64 > UINT32_MAX) {
+#if defined(__cpp_lib_format) && __cpp_lib_format >= 201907L
+		warnings.push_back(std::format("Sprite group {} for id {}: numsprites overflow (value: {})", group_index, sType->id, numsprites_u64));
+#else
+		wxString err;
+		err.Printf("Sprite group %u for id %u: numsprites overflow", group_index, sType->id);
+		warnings.push_back(err.ToStdString());
+#endif
+		return false;
+	}
+
+	uint32_t numsprites = static_cast<uint32_t>(numsprites_u64);
+
 	if (group_index == 0) {
 		sType->numsprites = numsprites;
 		sType->spriteList.reserve(numsprites);

--- a/source/rendering/core/game_sprite.cpp
+++ b/source/rendering/core/game_sprite.cpp
@@ -169,15 +169,19 @@ const AtlasRegion* GameSprite::getAtlasRegion(int _x, int _y, int _layer, int _c
 		}
 	}
 
-	uint32_t v;
+	uint64_t v;
 	if (_count >= 0 && height <= 1 && width <= 1) {
-		v = _count;
+		v = static_cast<uint64_t>(_count);
 	} else {
-		v = ((((((_frame)*pattern_y + _pattern_y) * pattern_x + _pattern_x) * layers + _layer) * height + _y) * width + _x);
+		v = (((((static_cast<uint64_t>(_frame) * pattern_y + _pattern_y) * pattern_x + _pattern_x) * layers + _layer) * height + _y) * width + _x);
 	}
+
 	if (v >= numsprites) {
-		if (numsprites == 1) {
+		if (numsprites <= 1) {
 			v = 0;
+			if (numsprites == 0) {
+				return nullptr;
+			}
 		} else {
 			v %= numsprites;
 		}


### PR DESCRIPTION
This PR addresses critical undefined behaviors and potential crashes:
- `source/io/loaders/dat_loader.cpp`: Changed `numsprites` calculation to `uint64_t` and added a check against `UINT32_MAX` to prevent overflow on malicious/large inputs.
- `source/io/filehandle.cpp`: Replaced `fseek` (which takes `long` and can fail/truncate on offsets > 2GB on Windows) with `_fseeki64` on Windows and `fseeko` on POSIX systems.
- `source/rendering/core/game_sprite.cpp`: Changed sprite index calculation to `uint64_t` to avoid intermediate overflow, and added a check for `numsprites == 0` to prevent division by zero crash.

---
*PR created automatically by Jules for task [16574916706998387229](https://jules.google.com/task/16574916706998387229) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file seeking operations with enhanced support for large files and better cross-platform compatibility
  * Added overflow detection in sprite data loading to prevent crashes
  * Enhanced sprite rendering calculations for improved stability and accuracy

<!-- end of auto-generated comment: release notes by coderabbit.ai -->