### PR TITLE
[TILE/WXWIDGETS] Fix nested container editing and properties grid resizing

### DIFF
--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -44,6 +44,12 @@ public:
 	void OnNotebookPageChanged(wxNotebookEvent&);
 	void OnGridValueChanged(wxGridEvent&);
 
+	void OnContainerItemClick(wxCommandEvent& event);
+	void OnContainerItemRightClick(wxMouseEvent& event);
+	void OnAddItem(wxCommandEvent& event);
+	void OnEditItem(wxCommandEvent& event);
+	void OnRemoveItem(wxCommandEvent& event);
+
 	void Update();
 
 protected:
@@ -53,6 +59,7 @@ protected:
 
 	// Container pane
 	std::vector<ContainerItemButton*> container_items;
+	ContainerItemButton* last_clicked_button;
 	wxWindow* createContainerPanel(wxWindow* parent);
 	void saveContainerPanel();
 


### PR DESCRIPTION
This PR addresses two issues in `PropertiesWindow`:
1.  **Missing Event Bindings**: Container items displayed in `PropertiesWindow` (used for nested containers and generic items in newer maps) were not interactive. Clicking them did nothing. This PR adds event bindings for left-click (edit/add) and right-click (context menu), enabling full container management (Add, Edit, Remove).
2.  **Sizer Mismanagement**: The attributes grid had fixed column widths and did not resize with the window. This PR implements `OnResize` to dynamically adjust the 'Value' column width.

These changes improve the UX for editing nested containers and general item properties.

---
*PR created automatically by Jules for task [16099179992441419437](https://jules.google.com/task/16099179992441419437) started by @karolak6612*