### PR TITLE
🎨 Palette: Micro-UX improvements for Properties, Welcome Dialog, and Menus

### DIFF
--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -227,7 +227,7 @@ void MainMenuBar::OnImportMonsterData(wxCommandEvent& event) {
 }
 
 void MainMenuBar::OnImportMinimap(wxCommandEvent& event) {
-	fileMenuHandler->OnImportMinimap(event);
+	DialogUtil::PopupDialog("Not implemented", "This feature is not yet implemented.", wxOK | wxICON_INFORMATION);
 }
 
 void MainMenuBar::OnExportTilesets(wxCommandEvent& event) {
@@ -409,11 +409,11 @@ void MainMenuBar::OnMapEditTowns(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void MainMenuBar::OnMapEditItems(wxCommandEvent& WXUNUSED(event)) {
-	;
+	DialogUtil::PopupDialog("Not implemented", "This feature is not yet implemented.", wxOK | wxICON_INFORMATION);
 }
 
 void MainMenuBar::OnMapEditMonsters(wxCommandEvent& WXUNUSED(event)) {
-	;
+	DialogUtil::PopupDialog("Not implemented", "This feature is not yet implemented.", wxOK | wxICON_INFORMATION);
 }
 
 void MainMenuBar::OnMapStatistics(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/map_tab.cpp
+++ b/source/ui/map_tab.cpp
@@ -111,7 +111,9 @@ void MapTab::OnSwitchEditorMode(EditorMode mode) {
 	gem->SetSprite(mode == DRAWING_MODE ? EDITOR_SPRITE_DRAWING_GEM : EDITOR_SPRITE_SELECTION_GEM);
 	if (mode == SELECTION_MODE) {
 		canvas->EnterSelectionMode();
+		g_gui.SetStatusText("Switched to Selection Mode");
 	} else {
 		canvas->EnterDrawingMode();
+		g_gui.SetStatusText("Switched to Drawing Mode");
 	}
 }

--- a/source/ui/menubar/file_menu_handler.cpp
+++ b/source/ui/menubar/file_menu_handler.cpp
@@ -91,6 +91,10 @@ void FileMenuHandler::OnReloadDataFiles(wxCommandEvent& WXUNUSED(event)) {
 	g_version.LoadVersion(g_version.GetCurrentVersionID(), error, warnings, true);
 	DialogUtil::PopupDialog("Error", error, wxOK);
 	DialogUtil::ListDialog("Warnings", warnings);
+
+	if (error.empty() && warnings.empty()) {
+		DialogUtil::PopupDialog("Reload Data Files", "Data files reloaded successfully.", wxOK);
+	}
 }
 
 void FileMenuHandler::OnPreferences(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/menubar/map_actions_handler.cpp
+++ b/source/ui/menubar/map_actions_handler.cpp
@@ -134,23 +134,7 @@ void MapActionsHandler::OnClearModifiedState(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void MapActionsHandler::OnMapCleanHouseItems(wxCommandEvent& WXUNUSED(event)) {
-	Editor* editor = g_gui.GetCurrentEditor();
-	if (!editor) {
-		return;
-	}
-
-	int ret = DialogUtil::PopupDialog(
-		"Clear Moveable House Items",
-		"Are you sure you want to remove all items inside houses that can be moved (this action cannot be undone)?",
-		wxYES | wxNO
-	);
-
-	if (ret == wxID_YES) {
-		// Editor will do the work
-		// editor->removeHouseItems(true);
-	}
-
-	g_gui.RefreshView();
+	DialogUtil::PopupDialog("Not implemented", "This feature is not yet implemented.", wxOK | wxICON_INFORMATION);
 }
 
 void MapActionsHandler::OnBorderizeSelection(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/properties/properties_window.h
+++ b/source/ui/properties/properties_window.h
@@ -29,6 +29,7 @@ class ItemAttribute;
 class wxSpinCtrl;
 class wxFlexGridSizer;
 class wxPanel;
+class wxGridRangeSelectEvent;
 
 class PropertiesWindow : public ObjectPropertiesWindowBase {
 public:
@@ -43,6 +44,8 @@ public:
 	void OnResize(wxSizeEvent&);
 	void OnNotebookPageChanged(wxNotebookEvent&);
 	void OnGridValueChanged(wxGridEvent&);
+	void OnGridSelectCell(wxGridEvent&);
+	void OnGridRangeSelect(wxGridRangeSelectEvent&);
 
 	void Update();
 
@@ -58,6 +61,7 @@ protected:
 
 	// Advanced pane
 	wxGrid* attributesGrid;
+	wxButton* removeAttributeBtn;
 	wxWindow* createAttributesPanel(wxWindow* parent);
 	void saveAttributesPanel();
 	void SetGridValue(wxGrid* grid, int rowIndex, std::string name, const ItemAttribute& attr);

--- a/source/ui/welcome_dialog.h
+++ b/source/ui/welcome_dialog.h
@@ -4,6 +4,7 @@
 #include <wx/wx.h>
 #include <wx/listctrl.h>
 #include <vector>
+#include <map>
 
 // Forward declarations
 class wxListCtrl;
@@ -22,7 +23,7 @@ private:
 	void OnRecentFileActivated(wxListEvent& event);
 	void OnRecentFileSelected(wxListEvent& event);
 
-	void AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol = wxNullColour);
+	void AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol = wxNullColour, const wxString& key = "");
 
 	wxPanel* CreateHeaderPanel(wxWindow* parent, const wxString& titleText, const wxBitmap& rmeLogo);
 	wxPanel* CreateContentPanel(wxWindow* parent, const std::vector<wxString>& recentFiles);
@@ -31,6 +32,7 @@ private:
 	wxImageList* m_imageList = nullptr;
 	wxListCtrl* m_recentList = nullptr;
 	wxListCtrl* m_clientList = nullptr;
+	std::map<wxString, wxStaticText*> m_infoFields;
 };
 
 #endif // WELCOME_DIALOG_H


### PR DESCRIPTION
* 💡 **What**:
    *   **Properties Window**:
        *   Automatically focus new attribute row when adding an attribute.
        *   Disable "Remove Attribute" button when no attribute is selected.
        *   Add `Ctrl+Enter` shortcut to confirm/close (OK).
    *   **Welcome Dialog**:
        *   Populate "Selected Map Info" with file stats (name, size, date) when a recent file is selected.
        *   Show "No clients found" instead of placeholder text in "Available Clients" list.
    *   **Main Menu**:
        *   Show "Not implemented" dialog for: Edit Items, Edit Monsters, Clean House Items, Import Minimap.
        *   Show "Reload successful" message after reloading data files.
    *   **Map Tab**:
        *   Show status bar message when switching between Drawing and Selection modes.

* 🎯 **Why**: Improves usability by providing visual feedback, reducing confusion on missing features, and streamlining common workflows (like adding attributes).
* 📸 **Before/After**: (Visual changes in dialogs and status bar).
* ♿ **Accessibility**: Keyboard shortcut `Ctrl+Enter` improves keyboard navigation. Focus management in Properties Window helps keyboard users.
* 🎨 **Features**: Uses `wxAcceleratorTable` for shortcuts, `wxGrid` events for state management, and `DialogUtil` for feedback.

---
*PR created automatically by Jules for task [13976030426644491476](https://jules.google.com/task/13976030426644491476) started by @karolak6612*