### PR TITLE
[REFACTOR] Fix code smells in GameSprite

### DIFF
--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -266,6 +266,8 @@ public:
 	bool isSimpleAndLoaded() const;
 
 protected:
+	const AtlasRegion* tryGetSimpleAtlasRegion();
+
 	// Cache for default state (0,0,0,0) to avoid lookups/virtual calls for simple sprites
 	mutable const AtlasRegion* cached_default_region = nullptr;
 	uint32_t cached_generation_id = 0;


### PR DESCRIPTION
CODE SMELL: Duplicate Code, Long Method, Complex Conditional
LOCATION: source/rendering/core/game_sprite.cpp
SEVERITY: HIGH
PROBLEM: GameSprite::Decompress and NormalImage::getRGBData shared duplicated RLE decompression logic. Decompress was >100 lines. getAtlasRegion had complex nested optimization logic.
REFACTORING APPLIED: Extracted shared decompression logic into static DecompressCore template. Extracted simple sprite optimization into tryGetSimpleAtlasRegion.
CHANGES:
- Created DecompressCore helper for unified RLE decoding.
- Refactored Decompress and getRGBData to use DecompressCore.
- Extracted tryGetSimpleAtlasRegion from getAtlasRegion.
BEFORE: Decompress 120 lines, heavy duplication in getRGBData.
AFTER: Decompress 20 lines, getRGBData 20 lines, DecompressCore handles logic centrally.
BEHAVIOR: No functional changes, verified with fuzz test.
TESTED: Fuzz test passed.

---
*PR created automatically by Jules for task [316045286417811847](https://jules.google.com/task/316045286417811847) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated sprite decompression logic across RGB and RGBA image formats.
  * Enhanced atlas region caching and lookup optimization.
  * Improved sprite rendering architecture with streamlined boundary and color validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->