### PR TITLE
Throttle: Optimize Map Spawn List and Tile Rendering Tooltips

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -425,7 +425,14 @@ SpawnList Map::getSpawnList(Tile* where) {
 			int z = where->getZ();
 			int start_x = where->getX() - 1, end_x = where->getX() + 1;
 			int start_y = where->getY() - 1, end_y = where->getY() + 1;
+			int loop_count = 0;
 			while (found != tile_loc->getSpawnCount()) {
+				if (++loop_count > 4096) {
+					spdlog::warn("Map::getSpawnList infinite loop detected! Found {} of {} spawns at [{}, {}, {}]",
+								 found, tile_loc->getSpawnCount(), where->getX(), where->getY(), where->getZ());
+					break;
+				}
+
 				for (int x = start_x; x <= end_x; ++x) {
 					Tile* tile = getTile(x, start_y, z);
 					if (tile && tile->spawn) {

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -644,6 +644,10 @@ bool Tile::isContentEqual(const Tile* other) const {
 		return false;
 	}
 
+	if (this == other) {
+		return true;
+	}
+
 	// Compare ground
 	if (ground != nullptr && other->ground != nullptr) {
 		if (ground->getID() != other->ground->getID() || ground->getSubtype() != other->ground->getSubtype()) {

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -192,6 +192,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 
 	bool as_minimap = options.show_as_minimap;
 	bool only_colors = as_minimap || options.show_only_colors;
+	bool is_hovered = (map_x == view.mouse_map_x && map_y == view.mouse_map_y);
 
 	uint8_t r = 255, g = 255, b = 255;
 
@@ -223,7 +224,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (options.show_tooltips && is_hovered && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -271,7 +272,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				const ItemType& it = g_items[item->getID()];
 
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (options.show_tooltips && is_hovered && map_z == view.floor) {
 					TooltipData& itemData = tooltip_drawer->requestTooltipData();
 					if (FillItemTooltipData(itemData, item.get(), it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 						if (itemData.hasVisibleFields()) {


### PR DESCRIPTION
This PR implements three optimizations/fixes:
1.  **Robustness**: Added a safety break in `Map::getSpawnList` to prevent infinite loops if spawn counts are inconsistent.
2.  **Performance**: Modified `TileRenderer::DrawTile` to only calculate tooltip data for the tile currently under the mouse cursor. Previously, it was calculating tooltip data for all visible tiles if tooltips were enabled, which was unnecessary and expensive.
3.  **Optimization**: Added a pointer equality check in `Tile::isContentEqual` to avoid unnecessary content comparison when comparing a tile to itself.

---
*PR created automatically by Jules for task [9031250217965403646](https://jules.google.com/task/9031250217965403646) started by @karolak6612*