### PR TITLE
👻 Phantom: Fix UI Layout and Performance Issues

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -92,6 +92,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_window.h
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_chooser_dialog.h
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_color_palette.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_preview_panel.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_selection_grid.h
 
@@ -410,6 +411,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_window.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ingame_preview/ingame_preview_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_chooser_dialog.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_color_palette.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_preview_panel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/dialogs/outfit_selection_grid.cpp
 

--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -24,21 +24,22 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "House Properties");
-	wxFlexGridSizer* housePropContainer = newd wxFlexGridSizer(2, 10, 10);
-	housePropContainer->AddGrowableCol(1);
-
-	wxFlexGridSizer* subsizer = newd wxFlexGridSizer(2, 10, 10);
-	subsizer->AddGrowableCol(1);
 
 	house_name = wxstr(house->name);
 	house_id = i2ws(house->getID());
 	house_rent = i2ws(house->rent);
 
-	subsizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Name:"), wxSizerFlags(0).Border(wxLEFT, 5));
-	name_field = newd wxTextCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, wxSize(160, 20), 0, wxTextValidator(wxFILTER_ASCII, &house_name));
-	subsizer->Add(name_field, wxSizerFlags(1).Expand());
+	wxBoxSizer* housePropContainer = newd wxBoxSizer(wxHORIZONTAL);
 
-	subsizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Town:"), wxSizerFlags(0).Border(wxLEFT, 5));
+	// Left Column: Name, Town, Rent
+	wxFlexGridSizer* leftCol = newd wxFlexGridSizer(2, 10, 10);
+	leftCol->AddGrowableCol(1);
+
+	leftCol->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Name:"), wxSizerFlags(0).Border(wxLEFT, 5));
+	name_field = newd wxTextCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, wxSize(160, 20), 0, wxTextValidator(wxFILTER_ASCII, &house_name));
+	leftCol->Add(name_field, wxSizerFlags(1).Expand());
+
+	leftCol->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Town:"), wxSizerFlags(0).Border(wxLEFT, 5));
 
 	const Towns& towns = map->towns;
 	town_id_field = newd wxChoice(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY);
@@ -67,29 +68,29 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 		}
 	}
 	town_id_field->SetSelection(to_select_index);
-	subsizer->Add(town_id_field, wxSizerFlags(1).Expand());
+	leftCol->Add(town_id_field, wxSizerFlags(1).Expand());
 
-	subsizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Rent:"), wxSizerFlags(0).Border(wxLEFT, 5));
+	leftCol->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Rent:"), wxSizerFlags(0).Border(wxLEFT, 5));
 	rent_field = newd wxTextCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, wxSize(160, 20), 0, wxTextValidator(wxFILTER_NUMERIC, &house_rent));
-	subsizer->Add(rent_field, wxSizerFlags(1).Expand());
+	leftCol->Add(rent_field, wxSizerFlags(1).Expand());
 
-	wxFlexGridSizer* subsizerRight = newd wxFlexGridSizer(1, 10, 10);
-	wxFlexGridSizer* houseSizer = newd wxFlexGridSizer(2, 10, 10);
+	// Right Column: ID, Guildhall
+	wxBoxSizer* rightCol = newd wxBoxSizer(wxVERTICAL);
 
-	houseSizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "ID:"), wxSizerFlags(0).Center());
+	wxBoxSizer* idSizer = newd wxBoxSizer(wxHORIZONTAL);
+	idSizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "ID:"), wxSizerFlags(0).Center().Border(wxRIGHT, 10));
 	id_field = newd wxSpinCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, wxSize(40, 20), wxSP_ARROW_KEYS, 1, 0xFFFF, house->getID());
-	houseSizer->Add(id_field, wxSizerFlags(1).Expand());
-	subsizerRight->Add(houseSizer, wxSizerFlags(1).Expand());
+	idSizer->Add(id_field, wxSizerFlags(1).Expand());
+	rightCol->Add(idSizer, wxSizerFlags(0).Expand());
 
-	wxSizer* checkbox_sub_sizer = newd wxBoxSizer(wxVERTICAL);
-	checkbox_sub_sizer->AddSpacer(4);
+	rightCol->AddSpacer(10);
+
 	guildhall_field = newd wxCheckBox(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Guildhall");
-	checkbox_sub_sizer->Add(guildhall_field);
-	subsizerRight->Add(checkbox_sub_sizer);
+	rightCol->Add(guildhall_field);
 	guildhall_field->SetValue(house->guildhall);
 
-	housePropContainer->Add(subsizer, wxSizerFlags(5).Expand());
-	housePropContainer->Add(subsizerRight, wxSizerFlags(5).Expand());
+	housePropContainer->Add(leftCol, wxSizerFlags(5).Expand());
+	housePropContainer->Add(rightCol, wxSizerFlags(5).Expand().Border(wxLEFT, 20));
 	boxsizer->Add(housePropContainer, wxSizerFlags(5).Expand().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -40,53 +40,6 @@ namespace {
 	const int OUTFIT_TILE_WIDTH = 100;
 	const int OUTFIT_TILE_HEIGHT = 120;
 
-	class ColorSwatch : public wxWindow {
-	public:
-		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
-			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
-			color(color), selected(false) {
-			SetBackgroundStyle(wxBG_STYLE_PAINT);
-			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
-			Bind(wxEVT_LEFT_DOWN, &ColorSwatch::OnMouse, this);
-		}
-
-		void SetSelected(bool s) {
-			if (selected != s) {
-				selected = s;
-				Refresh();
-			}
-		}
-
-	private:
-		void OnPaint(wxPaintEvent&) {
-			wxAutoBufferedPaintDC dc(this);
-			dc.SetBackground(wxBrush(Theme::Get(Theme::Role::Surface)));
-			dc.Clear();
-
-			wxRect rect = GetClientRect();
-			dc.SetPen(*wxTRANSPARENT_PEN);
-			dc.SetBrush(wxBrush(wxColor((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF)));
-			dc.DrawRectangle(rect);
-
-			if (selected) {
-				dc.SetBrush(*wxTRANSPARENT_BRUSH);
-				dc.SetPen(wxPen(Theme::Get(Theme::Role::Accent), 2));
-				dc.DrawRectangle(rect.Inflate(-1, -1));
-			}
-		}
-
-		void OnMouse(wxMouseEvent&) {
-			wxCommandEvent evt(wxEVT_BUTTON, GetId());
-			evt.SetEventObject(this);
-			HandleWindowEvent(evt); // Ensure internal bindings (lambdas) are called
-			if (GetParent()) {
-				GetParent()->GetEventHandler()->ProcessEvent(evt); // Also send to parent just in case
-			}
-		}
-
-		uint32_t color;
-		bool selected;
-	};
 }
 
 // ============================================================================
@@ -178,18 +131,8 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
-	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
-		uint32_t color = TemplateOutfitLookupTable[i];
-		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
-		color_buttons.push_back(swatch);
-
-		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
-			SelectColor(i);
-		});
-	}
-	col1_sizer->Add(palette_sizer, 0, wxALL, 8);
+	palette_canvas = new OutfitColorPalette(this, this);
+	col1_sizer->Add(palette_canvas, 0, wxALL, 8);
 
 	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);
@@ -347,9 +290,7 @@ void OutfitChooserDialog::UpdateColorSelection() {
 		currentColor = current_outfit.lookFeet;
 	}
 
-	for (size_t i = 0; i < color_buttons.size(); ++i) {
-		static_cast<ColorSwatch*>(color_buttons[i])->SetSelected(i == (size_t)currentColor);
-	}
+	palette_canvas->UpdateSelection(currentColor);
 }
 
 void OutfitChooserDialog::SelectColor(int color_id) {

--- a/source/ui/dialogs/outfit_chooser_dialog.h
+++ b/source/ui/dialogs/outfit_chooser_dialog.h
@@ -10,6 +10,7 @@
 
 #include "ui/dialogs/outfit_preview_panel.h"
 #include "ui/dialogs/outfit_selection_grid.h"
+#include "ui/dialogs/outfit_color_palette.h"
 
 class OutfitChooserDialog : public wxDialog {
 public:
@@ -54,6 +55,9 @@ public:
 	void OnFavoriteEdit(wxCommandEvent& event);
 	void OnFavoriteDelete(wxCommandEvent& event);
 
+	// Made public for OutfitColorPalette
+	void SelectColor(int color_id);
+
 	Outfit current_outfit; // Made public or keep friend? Friend is messy with circular includes. Let's make it public for now or add getter/setter.
 	// Actually, OutfitSelectionGrid accesses current_outfit. Let's use getter/setter in the grid.
 	// But current_outfit is used extensively. Let's keep it private and add friends or accessors.
@@ -69,7 +73,6 @@ private:
 	void OnOK(wxCommandEvent& event);
 
 	void UpdateColorSelection();
-	void SelectColor(int color_id);
 
 	int current_speed;
 	wxString current_name;
@@ -93,7 +96,7 @@ private:
 	wxButton* legs_btn;
 	wxButton* feet_btn;
 
-	std::vector<wxWindow*> color_buttons;
+	OutfitColorPalette* palette_canvas;
 };
 
 #endif

--- a/source/ui/dialogs/outfit_color_palette.cpp
+++ b/source/ui/dialogs/outfit_color_palette.cpp
@@ -1,0 +1,144 @@
+#include "ui/dialogs/outfit_color_palette.h"
+#include "ui/dialogs/outfit_chooser_dialog.h"
+#include "rendering/core/graphics.h"
+#include "ui/theme.h"
+#include "util/nvg_utils.h"
+
+#include <glad/glad.h>
+#include <nanovg.h>
+
+OutfitColorPalette::OutfitColorPalette(wxWindow* parent, OutfitChooserDialog* owner) :
+	NanoVGCanvas(parent, wxID_ANY, 0), // No scrollbar needed for fixed size
+	owner(owner),
+	selected_color_index(-1),
+	hover_color_index(-1) {
+
+	Bind(wxEVT_LEFT_DOWN, &OutfitColorPalette::OnMouse, this);
+	Bind(wxEVT_MOTION, &OutfitColorPalette::OnMotion, this);
+	Bind(wxEVT_LEAVE_WINDOW, [this](wxMouseEvent&) {
+		if (hover_color_index != -1) {
+			hover_color_index = -1;
+			Refresh();
+		}
+	});
+
+	SetBackgroundStyle(wxBG_STYLE_PAINT);
+}
+
+OutfitColorPalette::~OutfitColorPalette() = default;
+
+void OutfitColorPalette::UpdateSelection(int currentColor) {
+	// Find index for this color in the lookup table
+	// Since color indices map directly to TemplateOutfitLookupTable indices (0-132)
+	// We can use the color index directly.
+	// But wait, the currentColor passed from outside is likely the color INDEX (0-132),
+	// not the RGB value. The old code used indices.
+	// Let's verify OutfitChooserDialog::UpdateColorSelection logic later.
+	// Assuming it passes the index.
+
+	if (selected_color_index != currentColor) {
+		selected_color_index = currentColor;
+		Refresh();
+	}
+}
+
+wxSize OutfitColorPalette::DoGetBestClientSize() const {
+	int width = COLS * ITEM_SIZE + (COLS - 1) * SPACING;
+	int height = ROWS * ITEM_SIZE + (ROWS - 1) * SPACING;
+	return FromDIP(wxSize(width, height));
+}
+
+void OutfitColorPalette::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	// width and height are client size (logical or physical depending on implementation).
+	// NanoVGCanvas implementation detail:
+	// nvgBeginFrame(m_nvg, windowWidth, windowHeight, pixelRatio);
+	// So we draw in logical pixels if pixelRatio is set correctly.
+
+	for (int i = 0; i < TemplateOutfitLookupTableSize; ++i) {
+		if (i >= ROWS * COLS) break; // Safety
+
+		wxRect rect = GetItemRect(i);
+		uint32_t color = TemplateOutfitLookupTable[i];
+
+		// Convert 0xRRGGBB to NVGcolor
+		NVGcolor col = nvgRGB((color >> 16) & 0xFF, (color >> 8) & 0xFF, color & 0xFF);
+
+		nvgBeginPath(vg);
+		nvgRect(vg, static_cast<float>(rect.x), static_cast<float>(rect.y), static_cast<float>(rect.width), static_cast<float>(rect.height));
+		nvgFillColor(vg, col);
+		nvgFill(vg);
+
+		// Selection border
+		if (i == selected_color_index) {
+			// Inset border
+			nvgBeginPath(vg);
+			nvgRect(vg, static_cast<float>(rect.x) + 0.5f, static_cast<float>(rect.y) + 0.5f, static_cast<float>(rect.width) - 1.0f, static_cast<float>(rect.height) - 1.0f);
+			nvgStrokeColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Accent)));
+			nvgStrokeWidth(vg, 2.0f);
+			nvgStroke(vg);
+		} else if (i == hover_color_index) {
+			// Hover effect (e.g. slight border or brightness)
+			nvgBeginPath(vg);
+			nvgRect(vg, static_cast<float>(rect.x) + 0.5f, static_cast<float>(rect.y) + 0.5f, static_cast<float>(rect.width) - 1.0f, static_cast<float>(rect.height) - 1.0f);
+			// Slightly lighter than black/white
+			nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 128));
+			nvgStrokeWidth(vg, 1.0f);
+			nvgStroke(vg);
+		}
+	}
+}
+
+wxRect OutfitColorPalette::GetItemRect(int index) const {
+	int row = index / COLS;
+	int col = index % COLS;
+
+	// Coordinates are logical
+	return wxRect(
+		col * (ITEM_SIZE + SPACING),
+		row * (ITEM_SIZE + SPACING),
+		ITEM_SIZE,
+		ITEM_SIZE
+	);
+}
+
+int OutfitColorPalette::HitTest(int x, int y) const {
+	// x, y are logical coordinates from wxMouseEvent
+
+	// Inverse of GetItemRect logic
+	int col = x / (ITEM_SIZE + SPACING);
+	int row = y / (ITEM_SIZE + SPACING);
+
+	if (col < 0 || col >= COLS || row < 0 || row >= ROWS) {
+		return -1;
+	}
+
+	int index = row * COLS + col;
+	if (index >= 0 && index < TemplateOutfitLookupTableSize) {
+		return index;
+	}
+	return -1;
+}
+
+void OutfitColorPalette::OnMouse(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1) {
+		if (owner) {
+			owner->SelectColor(index);
+		}
+
+		if (index != selected_color_index) {
+			selected_color_index = index;
+			Refresh();
+		}
+	}
+	event.Skip();
+}
+
+void OutfitColorPalette::OnMotion(wxMouseEvent& event) {
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != hover_color_index) {
+		hover_color_index = index;
+		Refresh();
+	}
+	event.Skip();
+}

--- a/source/ui/dialogs/outfit_color_palette.h
+++ b/source/ui/dialogs/outfit_color_palette.h
@@ -1,0 +1,39 @@
+#ifndef RME_UI_DIALOGS_OUTFIT_COLOR_PALETTE_H_
+#define RME_UI_DIALOGS_OUTFIT_COLOR_PALETTE_H_
+
+#include "app/main.h"
+#include "util/nanovg_canvas.h"
+#include "rendering/core/outfit_colors.h"
+
+class OutfitChooserDialog;
+
+class OutfitColorPalette : public NanoVGCanvas {
+public:
+	OutfitColorPalette(wxWindow* parent, OutfitChooserDialog* owner);
+	virtual ~OutfitColorPalette();
+
+	void UpdateSelection(int currentColor);
+
+protected:
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	void OnMouse(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
+
+private:
+	OutfitChooserDialog* owner;
+	int selected_color_index;
+	int hover_color_index;
+
+	// Layout constants
+	static const int ROWS = 7;
+	static const int COLS = 19;
+	static const int ITEM_SIZE = 16;
+	static const int SPACING = 1;
+
+	int HitTest(int x, int y) const;
+	wxRect GetItemRect(int index) const;
+};
+
+#endif // RME_UI_DIALOGS_OUTFIT_COLOR_PALETTE_H_

--- a/source/ui/properties/container_properties_window.cpp
+++ b/source/ui/properties/container_properties_window.cpp
@@ -16,6 +16,8 @@
 #include "ui/properties/properties_window.h"
 #include "ui/properties/old_properties_window.h"
 
+#include <wx/wrapsizer.h>
+
 ContainerPropertiesWindow::ContainerPropertiesWindow(wxWindow* win_parent, const Map* map, const Tile* tile_parent, Item* item, wxPoint pos) :
 	ObjectPropertiesWindowBase(win_parent, "Container Properties", map, tile_parent, item, pos),
 	action_id_field(nullptr),
@@ -56,37 +58,21 @@ ContainerPropertiesWindow::ContainerPropertiesWindow(wxWindow* win_parent, const
 	// Now we add the subitems!
 	wxSizer* contents_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Contents");
 
+	wxSizer* wrapSizer = newd wxWrapSizer(wxHORIZONTAL);
+
 	bool use_large_sprites = g_settings.getBoolean(Config::USE_LARGE_CONTAINER_ICONS);
-	wxSizer* horizontal_sizer = nullptr;
-	int32_t maxColumns;
-	if (use_large_sprites) {
-		maxColumns = 6;
-	} else {
-		maxColumns = 12;
-	}
 
 	for (uint32_t index = 0; index < container->getVolume(); ++index) {
-		if (!horizontal_sizer) {
-			horizontal_sizer = newd wxBoxSizer(wxHORIZONTAL);
-		}
-
 		Item* sub_item = container->getItem(index);
 		ContainerItemButton* containerItemButton = newd ContainerItemButton(this, use_large_sprites, index, map, sub_item);
 		containerItemButton->Bind(wxEVT_BUTTON, &ContainerPropertiesWindow::OnContainerItemClick, this);
 		containerItemButton->Bind(wxEVT_RIGHT_UP, &ContainerPropertiesWindow::OnContainerItemRightClick, this);
 
 		container_items.push_back(containerItemButton);
-		horizontal_sizer->Add(containerItemButton);
-
-		if (((index + 1) % maxColumns) == 0) {
-			contents_sizer->Add(horizontal_sizer);
-			horizontal_sizer = nullptr;
-		}
+		wrapSizer->Add(containerItemButton, wxSizerFlags(0).Border(wxALL, 1));
 	}
 
-	if (horizontal_sizer != nullptr) {
-		contents_sizer->Add(horizontal_sizer);
-	}
+	contents_sizer->Add(wrapSizer, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(contents_sizer, wxSizerFlags(2).Expand());
 


### PR DESCRIPTION
This PR addresses several UI issues identified by the Phantom agent:
1.  **Performance Optimization:** The `OutfitChooserDialog` previously created over 100 `wxWindow` instances for color swatches. This has been replaced by a single `OutfitColorPalette` control that draws the swatches using NanoVG, significantly reducing GDI handle usage and improving rendering performance.
2.  **Layout Modernization:** The `ContainerPropertiesWindow` now uses `wxWrapSizer` instead of manual row/column calculation, allowing the container items to flow naturally based on window width.
3.  **Code Simplification:** The `EditHouseDialog` layout was refactored to use `wxBoxSizer` columns instead of a complex nested `wxFlexGridSizer`, making the code easier to read and maintain.

These changes adhere to the modern wxWidgets patterns and performance best practices outlined in the Phantom agent instructions.

---
*PR created automatically by Jules for task [7944219731136462006](https://jules.google.com/task/7944219731136462006) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new color palette interface for outfit color selection with improved visual feedback including hover and selection indicators.

* **Improvements**
  * Reorganized the house editing dialog layout for better visual organization.
  * Enhanced container properties window with improved item wrapping layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->