### PR TITLE
[UB FIX] Fix critical undefined behavior, race conditions, and recursion crash vectors

### DIFF
--- a/source/game/items.cpp
+++ b/source/game/items.cpp
@@ -308,7 +308,8 @@ ItemType& ItemDatabase::getItemType(int id) {
 			return *it;
 		}
 	}
-	static ItemType dummyItemType; // use this for invalid ids
+	static thread_local ItemType dummyItemType; // use this for invalid ids
+	dummyItemType = ItemType(); // Reset to clean state
 	return dummyItemType;
 }
 

--- a/source/game/items.h
+++ b/source/game/items.h
@@ -280,12 +280,15 @@ struct writeableBlock3 {
 #pragma pack()
 
 class ItemType {
-private:
-	ItemType(const ItemType&) { }
-
 public:
 	ItemType();
 	~ItemType();
+
+	ItemType(const ItemType&) = delete;
+	ItemType& operator=(const ItemType&) = delete;
+
+	ItemType(ItemType&&) = default;
+	ItemType& operator=(ItemType&&) = default;
 
 	bool isGroundTile() const {
 		return (group == ITEM_GROUP_GROUND);

--- a/source/io/otbm/item_serialization_otbm.cpp
+++ b/source/io/otbm/item_serialization_otbm.cpp
@@ -224,7 +224,11 @@ bool ItemSerializationOTBM::readAttribute(const IOMap& maphandle, OTBM_ItemAttri
 	return true;
 }
 
-bool ItemSerializationOTBM::serializeItemNode(const IOMap& maphandle, NodeFileWriteHandle& f, const Item& item) {
+bool ItemSerializationOTBM::serializeItemNode(const IOMap& maphandle, NodeFileWriteHandle& f, const Item& item, int depth) {
+	if (depth >= MAX_CONTAINER_DEPTH) {
+		return false;
+	}
+
 	f.addNode(OTBM_ITEM);
 	f.addU16(item.getID());
 	if (maphandle.version.otbm == MAP_OTBM_1) {
@@ -237,7 +241,7 @@ bool ItemSerializationOTBM::serializeItemNode(const IOMap& maphandle, NodeFileWr
 
 	if (auto container = item.asContainer()) {
 		for (const auto& child : container->getVector()) {
-			if (!serializeItemNode(maphandle, f, *child)) {
+			if (!serializeItemNode(maphandle, f, *child, depth + 1)) {
 				return false;
 			}
 		}

--- a/source/io/otbm/item_serialization_otbm.h
+++ b/source/io/otbm/item_serialization_otbm.h
@@ -27,7 +27,7 @@ public:
 	static bool readAttribute(const IOMap& maphandle, OTBM_ItemAttribute attr, BinaryNode* stream, Item& item);
 
 	// Writing
-	static bool serializeItemNode(const IOMap& maphandle, NodeFileWriteHandle& f, const Item& item);
+	static bool serializeItemNode(const IOMap& maphandle, NodeFileWriteHandle& f, const Item& item, int depth = 0);
 	static void serializeItemCompact(const IOMap& /*maphandle*/, NodeFileWriteHandle& f, const Item& item);
 	static void serializeItemAttributes(const IOMap& maphandle, NodeFileWriteHandle& f, const Item& item);
 };

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -39,6 +39,9 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
+	if (position + length > buffer.size()) {
+		throw std::runtime_error("Buffer underflow");
+	}
 	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
 	position += length;
 	return std::string(strBuffer, length);

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,8 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <cstring>
+#include <stdexcept>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -36,7 +38,11 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		if (position + sizeof(T) > buffer.size()) {
+			throw std::runtime_error("Buffer underflow");
+		}
+		T value;
+		std::memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}


### PR DESCRIPTION
This PR addresses three critical issues identified during a deep scan for undefined behavior and bugs:

1.  **Network Security & Safety**:
    -   `NetworkMessage::read<T>` previously used `reinterpret_cast` on a raw buffer, causing Strict Aliasing Violations (UB) and potential alignment issues. It also lacked bounds checking.
    -   Fix: Implemented `std::memcpy` for safe type punning and added `position + sizeof(T) > buffer.size()` checks, throwing `std::runtime_error` on underflow. This prevents potential RCE or crashes from malicious packets.

2.  **Thread Safety & Logic Integrity**:
    -   `ItemDatabase::getItemType(int id)` returned a reference to a static `dummyItemType` for invalid IDs. This object was shared across all callers and threads, leading to state pollution (modifications persisted) and race conditions.
    -   Fix: Changed `dummyItemType` to `static thread_local` and reset it to a fresh state (`ItemType()`) before returning. Added move semantics to `ItemType` to support this efficient reset.

3.  **Crash Prevention (Stack Overflow)**:
    -   `ItemSerializationOTBM::serializeItemNode` lacked recursion depth limits, making it vulnerable to stack overflow if map data contained cycles or extreme nesting.
    -   Fix: Added `depth` parameter and check against `MAX_CONTAINER_DEPTH` (256).

Verification:
-   Verified compilation of `net_connection.cpp`, `items.cpp`, and `item_serialization_otbm.cpp`.
-   Verified header changes in `items.h`, `net_connection.h`, `item_serialization_otbm.h`.
-   Ran limited compilation tests (full link timed out but individual units passed).

---
*PR created automatically by Jules for task [11766848074196482862](https://jules.google.com/task/11766848074196482862) started by @karolak6612*