### PR TITLE
Profiler: Avoid redundant SpritePatterns calculation

### DIFF
--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -37,6 +37,14 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 
 void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
 	ItemType& it = g_items[item->getID()];
+	GameSprite* spr = it.sprite;
+	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
+
+	BlitItem(sprite_batch, sprite_drawer, creature_drawer, draw_x, draw_y, pos, item, options, patterns, ephemeral, red, green, blue, alpha, tile);
+}
+
+void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, const SpritePatterns& patterns, bool ephemeral, int red, int green, int blue, int alpha, const Tile* tile) {
+	ItemType& it = g_items[item->getID()];
 
 	// Locked door indicator
 	if (!options.ingame && options.highlight_locked_doors && it.isDoor()) {
@@ -118,7 +126,6 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	draw_x -= spr->draw_height;
 	draw_y -= spr->draw_height;
 
-	SpritePatterns patterns = PatternCalculator::Calculate(spr, it, item, tile, pos);
 	int subtype = patterns.subtype;
 	int pattern_x = patterns.x;
 	int pattern_y = patterns.y;
@@ -281,4 +288,3 @@ void ItemDrawer::DrawDoorIndicator(bool locked, const Position& pos, bool south,
 		door_indicator_drawer->addDoor(pos, locked, south, east);
 	}
 }
-

--- a/source/rendering/drawers/entities/item_drawer.h
+++ b/source/rendering/drawers/entities/item_drawer.h
@@ -18,6 +18,7 @@ class HookIndicatorDrawer;
 class DoorIndicatorDrawer;
 
 struct DrawingOptions;
+struct SpritePatterns;
 class SpriteBatch;
 
 class ItemDrawer {
@@ -27,6 +28,7 @@ public:
 
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Tile* tile, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255);
 	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
+	void BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, CreatureDrawer* creature_drawer, int& draw_x, int& draw_y, const Position& pos, Item* item, const DrawingOptions& options, const SpritePatterns& patterns, bool ephemeral = false, int red = 255, int green = 255, int blue = 255, int alpha = 255, const Tile* tile = nullptr);
 
 	void DrawRawBrush(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer, int screenx, int screeny, ItemType* itemType, uint8_t r, uint8_t g, uint8_t b, uint8_t alpha);
 	void DrawHookIndicator(const ItemType& type, const Position& pos);

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -20,6 +20,8 @@ struct LightBuffer;
 class SpriteBatch;
 class PrimitiveRenderer;
 class ItemType;
+class GameSprite;
+struct SpritePatterns;
 
 class TileRenderer {
 public:
@@ -29,7 +31,7 @@ public:
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:
-	void PreloadItem(const Tile* tile, Item* item, const ItemType& it);
+	void PreloadItem(GameSprite* spr, const SpritePatterns& patterns);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This change optimizes the rendering loop by calculating `SpritePatterns` only once per item (and skipping it for simple sprites) and passing it to both `PreloadItem` and `ItemDrawer::BlitItem`. Previously, `PatternCalculator::Calculate` was called twice for every item every frame (once in `PreloadItem` implicitly, and once in `BlitItem`), which involved redundant computations. This adheres to the painter's algorithm and preserves visual output while reducing CPU overhead.

---
*PR created automatically by Jules for task [3373085823528128553](https://jules.google.com/task/3373085823528128553) started by @karolak6612*