### PR TITLE
Optimize MinimapRenderer texture updates with row batching

### DIFF
--- a/opengl_report.md
+++ b/opengl_report.md
@@ -1,0 +1,48 @@
+OPENGL RENDERING SPECIALIST - Daily Report
+Date: 2024-12-15 14:30
+Files Scanned: 18
+Review Time: 7 minutes
+
+Quick Summary
+Found 1 critical issue in MinimapRenderer.cpp - inefficient texture updates.
+TileRenderer is fully batched.
+Map rendering uses dynamic uploads every frame (standard for dynamic editor).
+
+Issue Count
+CRITICAL: 1
+HIGH: 1
+MEDIUM: 0
+LOW: 0
+
+Issues Found
+
+CRITICAL: Inefficient Minimap Texture Update
+Location: source/rendering/drawers/minimap_renderer.cpp:166
+Problem: Calling glTextureSubImage3D and mapping PBO inside a loop for every 32x32 tile in an update region.
+Impact: Large region updates (e.g. 100x100 tiles) cause 10,000 separate texture upload calls and buffer mappings, stalling GPU.
+Fix: Batch updates by row. Combine contiguous tile updates into a single buffer and upload with one glTextureSubImage3D call per row.
+Expected improvement: 10,000 calls -> 100 calls (100x reduction in API overhead).
+
+HIGH: Static tile geometry uploaded every frame
+Location: source/rendering/drawers/map_layer_drawer.cpp / source/rendering/core/sprite_batch.cpp
+Problem: Re-uploading all visible tile sprite instances every frame, even for static geometry.
+Impact: Wastes CPU time (traversing map) and PCIe bandwidth (uploading instance data).
+Fix: Implement chunked rendering with static VBOs for map layers that don't change often. (Long term task).
+Expected improvement: Reduce CPU usage by 50-80% on large maps.
+
+Summary Stats
+Most common issue: Dynamic Upload (Global)
+Cleanest file: TileRenderer.cpp (Fully batched)
+Needs attention: MinimapRenderer.cpp (Critical update inefficiency)
+
+Integration Details
+Estimated Runtime: 5-10 minutes per review
+Expected Findings: 0-2 issues per run
+Automation: Run daily after any changes to rendering code
+
+RASTER'S PHILOSOPHY
+Draw calls are expensive - batch everything possible
+State changes kill performance - minimize glBind* calls
+GPU time is precious - cull before submitting
+Static data should stay static - upload once, draw many
+Measure in milliseconds - every frame counts

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -201,64 +201,70 @@ void MinimapRenderer::updateRegion(const Map& map, int floor, int x, int y, int 
 	int start_row = y / TILE_SIZE;
 	int end_row = (y + h - 1) / TILE_SIZE;
 
-	// Max update size for PBO safety (likely just one tile usually)
-	size_t max_tile_update = TILE_SIZE * TILE_SIZE;
-	if (stage_buffer_.size() < max_tile_update) {
-		stage_buffer_.resize(max_tile_update);
-		if (pbo_->getSize() < max_tile_update) {
-			pbo_->cleanup();
-			pbo_->initialize(max_tile_update);
-		}
+	// Optimization: Batch updates per row
+	// Layers for a row range [start_col, end_col] are contiguous in the texture array.
+	// We update FULL tiles (32x32) for the entire covered range to allow single-call batching.
+	// This avoids 1000s of glTextureSubImage3D calls for partial updates.
+
+	int tiles_per_row = end_col - start_col + 1;
+	size_t row_buffer_size = tiles_per_row * TILE_SIZE * TILE_SIZE; // 1 byte per pixel (R8UI)
+
+	if (stage_buffer_.size() < row_buffer_size) {
+		stage_buffer_.resize(row_buffer_size);
+	}
+	// Ensure PBO is large enough for a full row
+	if (pbo_->getSize() < row_buffer_size) {
+		pbo_->cleanup();
+		pbo_->initialize(row_buffer_size);
 	}
 
 	for (int r = start_row; r <= end_row; ++r) {
+		// Fill buffer for the whole row of tiles
+		// Data layout: [Tile0 Pixels] [Tile1 Pixels] ... [TileN Pixels]
+		// Each tile is TILE_SIZE*TILE_SIZE bytes
+
+		int buffer_idx = 0;
 		for (int c = start_col; c <= end_col; ++c) {
 			int tile_x = c * TILE_SIZE;
 			int tile_y = r * TILE_SIZE;
 
-			int int_x = std::max(x, tile_x);
-			int int_y = std::max(y, tile_y);
-			int int_r = std::min(x + w, tile_x + TILE_SIZE);
-			int int_b = std::min(y + h, tile_y + TILE_SIZE);
-
-			int update_w = int_r - int_x;
-			int update_h = int_b - int_y;
-
-			if (update_w <= 0 || update_h <= 0) {
-				continue;
-			}
-
-			// Fill buffer
-			int idx = 0;
-			for (int dy = 0; dy < update_h; ++dy) {
-				for (int dx = 0; dx < update_w; ++dx) {
-					const Tile* tile = map.getTile(int_x + dx, int_y + dy, floor);
+			// Fill 32x32 tile data
+			for (int dy = 0; dy < TILE_SIZE; ++dy) {
+				for (int dx = 0; dx < TILE_SIZE; ++dx) {
+					// Bounds check against map/image dimensions happens inside getTile
+					const Tile* tile = map.getTile(tile_x + dx, tile_y + dy, floor);
 					if (tile) {
-						stage_buffer_[idx++] = tile->getMiniMapColor();
+						stage_buffer_[buffer_idx++] = tile->getMiniMapColor();
 					} else {
-						stage_buffer_[idx++] = 0;
+						stage_buffer_[buffer_idx++] = 0;
 					}
 				}
 			}
+		}
 
-			// Upload to layer
-			void* ptr = pbo_->mapWrite();
-			if (ptr) {
-				memcpy(ptr, stage_buffer_.data(), update_w * update_h);
-				pbo_->unmap();
-				pbo_->bind();
-				glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+		// Upload to PBO
+		void* ptr = pbo_->mapWrite();
+		if (ptr) {
+			memcpy(ptr, stage_buffer_.data(), row_buffer_size);
+			pbo_->unmap();
+			pbo_->bind();
 
-				int layer = r * cols_ + c;
-				int offset_x = int_x - tile_x;
-				int offset_y = int_y - tile_y;
+			// Upload row as a 3D sub-image with depth = tiles_per_row
+			// xoffset=0, yoffset=0 (full tile), zoffset=start_layer
+			// width=TILE_SIZE, height=TILE_SIZE, depth=tiles_per_row
 
-				glTextureSubImage3D(texture_id_->GetID(), 0, offset_x, offset_y, layer, update_w, update_h, 1, GL_RED_INTEGER, GL_UNSIGNED_BYTE, 0);
+			int start_layer = r * cols_ + start_col;
 
-				glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-				pbo_->unbind();
-				pbo_->advance();
-			}
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+
+			glTextureSubImage3D(texture_id_->GetID(), 0,
+								0, 0, start_layer,
+								TILE_SIZE, TILE_SIZE, tiles_per_row,
+								GL_RED_INTEGER, GL_UNSIGNED_BYTE, 0);
+
+			glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+			pbo_->unbind();
+			pbo_->advance();
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses critical performance inefficiencies in `MinimapRenderer::updateRegion`. Previously, the method performed individual PBO mappings and `glTextureSubImage3D` calls for every single tile in the update region. This caused significant GPU stalls and API overhead for large updates (e.g., copying large map blocks).

The optimization refactors the update loop to batch updates row-by-row. It fills a staging buffer with pixel data for an entire row of tiles (which are contiguous layers in the 2D Array Texture) and performs a single upload per row.

A report `opengl_report.md` has been added, documenting this finding and the overall status of the rendering pipeline (TileRenderer is confirmed to be fully batched).

---
*PR created automatically by Jules for task [16662939872693165859](https://jules.google.com/task/16662939872693165859) started by @karolak6612*