### PR TITLE
UX Improvements: 10 Micro-enhancements for DPI and Usability

### DIFF
--- a/source/ui/about_window.cpp
+++ b/source/ui/about_window.cpp
@@ -71,12 +71,12 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
-	okBtn->SetToolTip("Close this window");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, FROM_DIP(this, wxSize(16, 16))));
+	okBtn->SetToolTip("Close About dialog");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 
 	wxButton* copyBtn = newd wxButton(this, wxID_COPY, "Copy Version Info");
-	copyBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_COPY, wxSize(16, 16)));
+	copyBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_COPY, FROM_DIP(this, wxSize(16, 16))));
 	copyBtn->Bind(wxEVT_BUTTON, [about](wxCommandEvent&) {
 		if (wxTheClipboard->Open()) {
 			wxTheClipboard->SetData(new wxTextDataObject(about));
@@ -87,7 +87,7 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	choicesizer->Add(copyBtn, wxSizerFlags(1).Center().Border(wxLEFT, 10));
 
 	wxButton* websiteBtn = newd wxButton(this, wxID_ANY, "Visit Website");
-	websiteBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GLOBE, wxSize(16, 16)));
+	websiteBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GLOBE, FROM_DIP(this, wxSize(16, 16))));
 	websiteBtn->Bind(wxEVT_BUTTON, [](wxCommandEvent&) {
 		::wxLaunchDefaultBrowser(__SITE_URL__, wxBROWSER_NEW_WINDOW);
 	});
@@ -109,7 +109,7 @@ AboutWindow::AboutWindow(wxWindow* parent) :
 	Bind(wxEVT_MENU, &AboutWindow::OnClickOK, this, wxID_CANCEL);
 
 	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_INFO, wxSize(32, 32)));
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_INFO, FROM_DIP(this, wxSize(32, 32))));
 	SetIcon(icon);
 }
 

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -55,12 +55,12 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 
 	wxSizer* stdsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, FROM_DIP(this, wxSize(16, 16))));
 	okBtn->SetToolTip("Jump to selected item/brush");
 	stdsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
-	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	cancelBtn->SetToolTip("Close this window");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, FROM_DIP(this, wxSize(16, 16))));
+	cancelBtn->SetToolTip("Close search dialog");
 	stdsizer->Add(cancelBtn, wxSizerFlags(1).Center());
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
 
@@ -79,7 +79,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	// RefreshContents();
 
 	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(32, 32)));
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, FROM_DIP(this, wxSize(32, 32))));
 	SetIcon(icon);
 }
 
@@ -361,14 +361,14 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 		nvgFontSize(vg, 12.0f);
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "No matches for your search.", nullptr);
+		nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+		nvgText(vg, rect.x + rect.width / 2.0f, rect.y + rect.height / 2.0f, "No matches for your search.", nullptr);
 	} else if (cleared) {
 		nvgFontSize(vg, 12.0f);
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
+		nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+		nvgText(vg, rect.x + rect.width / 2.0f, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
 	} else {
 		ASSERT(n < brushlist.size());
 		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -23,19 +23,19 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 
 	posctrl = newd PositionCtrl(this, "Destination", map.getWidth() / 2, map.getHeight() / 2, GROUND_LAYER, map.getWidth(), map.getHeight());
-	sizer->Add(posctrl, 0, wxTOP | wxLEFT | wxRIGHT, 20);
+	sizer->Add(posctrl, 0, wxTOP | wxLEFT | wxRIGHT, FROM_DIP(this, 20));
 
 	// OK/Cancel buttons
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, FROM_DIP(this, wxSize(16, 16))));
 	okBtn->SetToolTip("Go to position");
 	tmpsizer->Add(okBtn, wxSizerFlags(1).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
-	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, FROM_DIP(this, wxSize(16, 16))));
 	cancelBtn->SetToolTip("Close this window");
 	tmpsizer->Add(cancelBtn, wxSizerFlags(1).Center());
-	sizer->Add(tmpsizer, 0, wxALL | wxCENTER, 20); // Border to top too
+	sizer->Add(tmpsizer, 0, wxALL | wxCENTER, FROM_DIP(this, 20)); // Border to top too
 
 	SetSizerAndFit(sizer);
 	Centre(wxBOTH);
@@ -44,7 +44,7 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 	cancelBtn->Bind(wxEVT_BUTTON, &GotoPositionDialog::OnClickCancel, this);
 
 	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(32, 32)));
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, FROM_DIP(this, wxSize(32, 32))));
 	SetIcon(icon);
 }
 

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -1,4 +1,5 @@
 #include "ui/dialogs/outfit_chooser_dialog.h"
+#include "app/main.h"
 #include <wx/statline.h>
 #include <wx/sizer.h>
 #include <wx/wrapsizer.h>
@@ -43,7 +44,7 @@ namespace {
 	class ColorSwatch : public wxWindow {
 	public:
 		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
-			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
+			wxWindow(parent, id, wxDefaultPosition, FROM_DIP(parent, wxSize(16, 16)), wxBORDER_NONE),
 			color(color), selected(false) {
 			SetBackgroundStyle(wxBG_STYLE_PAINT);
 			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
@@ -204,8 +205,8 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	check_sizer->Add(addon2, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
 	wxButton* rand_btn = new wxButton(this, ID_RANDOMIZE, "Random");
-	rand_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHUFFLE, wxSize(16, 16)));
-	rand_btn->SetToolTip("Randomize outfit colors");
+	rand_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHUFFLE, FROM_DIP(this, wxSize(16, 16))));
+	rand_btn->SetToolTip("Surprise me! (Randomize colors)");
 	check_sizer->Add(rand_btn, 0, wxLEFT | wxALIGN_CENTER_VERTICAL, 5);
 
 	col1_sizer->Add(check_sizer, 0, wxEXPAND | wxLEFT | wxRIGHT, 8);

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -14,6 +14,7 @@
 #include "util/image_manager.h"
 
 #include <wx/wx.h>
+#include <wx/clipbrd.h>
 #include <sstream>
 
 extern GUI g_gui;
@@ -87,18 +88,30 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 
 	wxDialog* dg = newd wxDialog(parent, wxID_ANY, "Map Statistics", wxDefaultPosition, wxDefaultSize, wxRESIZE_BORDER | wxCAPTION | wxCLOSE_BOX);
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
-	wxTextCtrl* text_field = newd wxTextCtrl(dg, wxID_ANY, wxstr(os.str()), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
-	text_field->SetMinSize(wxSize(400, 300));
+	std::string statsStr = os.str();
+	wxTextCtrl* text_field = newd wxTextCtrl(dg, wxID_ANY, wxstr(statsStr), wxDefaultPosition, wxDefaultSize, wxTE_MULTILINE | wxTE_READONLY);
+	text_field->SetMinSize(FROM_DIP(dg, wxSize(400, 300)));
 	topsizer->Add(text_field, wxSizerFlags(5).Expand());
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* export_button = newd wxButton(dg, wxID_OK, "Export as XML");
-	export_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
+	export_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, FROM_DIP(dg, wxSize(16, 16))));
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
 	export_button->SetToolTip("Not implemented yet");
 	export_button->Enable(false);
+
+	wxButton* copy_button = newd wxButton(dg, wxID_ANY, "Copy to Clipboard");
+	copy_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_COPY, FROM_DIP(dg, wxSize(16, 16))));
+	copy_button->SetToolTip("Copy statistics to clipboard");
+	copy_button->Bind(wxEVT_BUTTON, [statsStr](wxCommandEvent&) {
+		if (wxTheClipboard->Open()) {
+			wxTheClipboard->SetData(new wxTextDataObject(wxstr(statsStr)));
+			wxTheClipboard->Close();
+		}
+	});
+	choicesizer->Add(copy_button, wxSizerFlags(1).Center().Border(wxLEFT, FROM_DIP(dg, 5)));
 	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, FROM_DIP(dg, wxSize(16, 16))));
 	okBtn->SetToolTip("Close this window");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());

--- a/source/ui/positionctrl.cpp
+++ b/source/ui/positionctrl.cpp
@@ -22,20 +22,23 @@
 
 PositionCtrl::PositionCtrl(wxWindow* parent, const wxString& label, int x, int y, int z, int maxx /*= MAP_MAX_WIDTH*/, int maxy /*= MAP_MAX_HEIGHT*/, int maxz /*= MAP_MAX_LAYER*/) :
 	wxStaticBoxSizer(wxHORIZONTAL, parent, label) {
-	x_field = newd NumberTextCtrl(parent, wxID_ANY, x, 0, maxx, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, wxSize(60, 20));
+	Add(newd wxStaticText(parent, wxID_ANY, "X:"), 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxBOTTOM, FROM_DIP(parent, 5));
+	x_field = newd NumberTextCtrl(parent, wxID_ANY, x, 0, maxx, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
 	x_field->SetToolTip("X Coordinate");
 	x_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
-	Add(x_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
+	Add(x_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, FROM_DIP(parent, 5));
 
-	y_field = newd NumberTextCtrl(parent, wxID_ANY, y, 0, maxy, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, wxSize(60, 20));
+	Add(newd wxStaticText(parent, wxID_ANY, "Y:"), 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxBOTTOM, FROM_DIP(parent, 5));
+	y_field = newd NumberTextCtrl(parent, wxID_ANY, y, 0, maxy, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
 	y_field->SetToolTip("Y Coordinate");
 	y_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
-	Add(y_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
+	Add(y_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, FROM_DIP(parent, 5));
 
-	z_field = newd NumberTextCtrl(parent, wxID_ANY, z, 0, maxz, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, wxSize(35, 20));
+	Add(newd wxStaticText(parent, wxID_ANY, "Z:"), 0, wxALIGN_CENTER_VERTICAL | wxLEFT | wxBOTTOM, FROM_DIP(parent, 5));
+	z_field = newd NumberTextCtrl(parent, wxID_ANY, z, 0, maxz, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, FROM_DIP(parent, wxSize(35, 20)));
 	z_field->SetToolTip("Z Coordinate (Layer)");
 	z_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
-	Add(z_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
+	Add(z_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FROM_DIP(parent, 5));
 
 	maxWidth = maxx;
 	maxHeight = maxy;

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -67,11 +67,11 @@ void StandardToolBar::Update() {
 		toolbar->SetToolShortHelp(wxID_PASTE, canPaste ? "Paste (Ctrl+V)" : "Paste (Ctrl+V) - Clipboard empty");
 	} else {
 		toolbar->EnableTool(wxID_UNDO, false);
-		toolbar->SetToolShortHelp(wxID_UNDO, "Undo (Ctrl+Z) - No editor open");
+		toolbar->SetToolShortHelp(wxID_UNDO, "Undo (Ctrl+Z) - No map open");
 		toolbar->EnableTool(wxID_REDO, false);
-		toolbar->SetToolShortHelp(wxID_REDO, "Redo (Ctrl+Shift+Z) - No editor open");
+		toolbar->SetToolShortHelp(wxID_REDO, "Redo (Ctrl+Shift+Z) - No map open");
 		toolbar->EnableTool(wxID_PASTE, false);
-		toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - No editor open");
+		toolbar->SetToolShortHelp(wxID_PASTE, "Paste (Ctrl+V) - No map open");
 	}
 
 	bool has_map = editor != nullptr;
@@ -88,6 +88,8 @@ void StandardToolBar::Update() {
 
 	toolbar->EnableTool(wxID_COPY, has_map);
 	toolbar->SetToolShortHelp(wxID_COPY, has_map ? "Copy (Ctrl+C)" : "Copy (Ctrl+C) - No map open");
+
+	toolbar->SetToolShortHelp(MAIN_FRAME_MENU + MenuBar::JUMP_TO_BRUSH, "Search for brushes and items (J)");
 
 	toolbar->Refresh();
 }


### PR DESCRIPTION
Implemented 10 micro-UX improvements focused on High DPI support, accessibility, and visual polish:
- Wrapped hardcoded pixel sizes in `FROM_DIP` for `PositionCtrl`, `GotoPositionDialog`, `FindDialog`, `OutfitChooserDialog`, `MapStatisticsDialog`, and `AboutWindow` to fix High DPI scaling issues.
- Added visible "X:", "Y:", "Z:" labels to `PositionCtrl` inputs for better clarity.
- Centered "No matches" text in `FindDialogListBox` using `NVG_ALIGN_CENTER`.
- Added "Copy to Clipboard" button to `MapStatisticsDialog`.
- Updated `JUMP_TO_BRUSH` toolbar tooltip to "Search for brushes and items (J)".
- Standardized "No map open" tooltips for Undo/Redo/Paste actions.
- Clarified "Cancel" tooltip in Find Dialog and "OK" tooltip in About Window.
- Improved "Random" button tooltip in Outfit Chooser.

---
*PR created automatically by Jules for task [4132270260868347313](https://jules.google.com/task/4132270260868347313) started by @karolak6612*