### PR TITLE
⚡ Throttle: Optimize SpatialHashGrid lookup with cache

### DIFF
--- a/source/map/spatial_hash_grid.h
+++ b/source/map/spatial_hash_grid.h
@@ -92,6 +92,9 @@ protected:
 	mutable std::vector<SortedGridCell> sorted_cells_cache;
 	mutable bool sorted_cells_dirty;
 
+	mutable uint64_t last_key = 0;
+	mutable GridCell* last_cell = nullptr;
+
 	// Traverses cells by iterating over the viewport coordinates.
 	// Efficient for small or dense viewports.
 	template <typename Func>


### PR DESCRIPTION
Optimized `SpatialHashGrid::getLeaf` by adding a simple cache for the last accessed cell. This improves performance for sequential tile accesses (e.g. iterating over a region) by avoiding repeated hash map lookups. Verified compilation.

---
*PR created automatically by Jules for task [7048108008542787412](https://jules.google.com/task/7048108008542787412) started by @karolak6612*