### PR TITLE
Keeper: Memory Safety Refactoring

### DIFF
--- a/source/app/settings.cpp
+++ b/source/app/settings.cpp
@@ -51,8 +51,8 @@ bool Settings::getBoolean(uint32_t key) const {
 	}
 
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		return dv.intval != 0;
+	if (auto pval = std::get_if<int>(&dv.value)) {
+		return *pval != 0;
 	}
 	return false;
 }
@@ -62,8 +62,8 @@ int Settings::getInteger(uint32_t key) const {
 		return 0;
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		return dv.intval;
+	if (auto pval = std::get_if<int>(&dv.value)) {
+		return *pval;
 	}
 	return 0;
 }
@@ -73,8 +73,8 @@ float Settings::getFloat(uint32_t key) const {
 		return 0.0;
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_FLOAT) {
-		return dv.floatval;
+	if (auto pval = std::get_if<float>(&dv.value)) {
+		return *pval;
 	}
 	return 0.0;
 }
@@ -84,8 +84,8 @@ std::string Settings::getString(uint32_t key) const {
 		return "";
 	}
 	const DynamicValue& dv = store[key];
-	if (dv.type == TYPE_STR && dv.strval != nullptr) {
-		return *dv.strval;
+	if (auto pval = std::get_if<std::string>(&dv.value)) {
+		return *pval;
 	}
 	return "";
 }
@@ -95,12 +95,7 @@ void Settings::setInteger(uint32_t key, int newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_INT) {
-		dv.intval = newval;
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_INT;
-		dv.intval = newval;
-	}
+	dv.value = newval;
 }
 
 void Settings::setFloat(uint32_t key, float newval) {
@@ -108,12 +103,7 @@ void Settings::setFloat(uint32_t key, float newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_FLOAT) {
-		dv.floatval = newval;
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_FLOAT;
-		dv.floatval = newval;
-	}
+	dv.value = newval;
 }
 
 void Settings::setString(uint32_t key, std::string newval) {
@@ -121,27 +111,20 @@ void Settings::setString(uint32_t key, std::string newval) {
 		return;
 	}
 	DynamicValue& dv = store[key];
-	if (dv.type == TYPE_STR) {
-		delete dv.strval;
-		dv.strval = newd std::string(newval);
-	} else if (dv.type == TYPE_NONE) {
-		dv.type = TYPE_STR;
-		dv.strval = newd std::string(newval);
-	}
+	dv.value = newval;
 }
 
 std::string Settings::DynamicValue::str() {
-	switch (type) {
-		case TYPE_FLOAT:
-			return f2s(floatval);
-		case TYPE_STR:
-			return std::string(*strval);
-		case TYPE_INT:
-			return i2s(intval);
-		default:
-		case TYPE_NONE:
-			return "";
+	if (auto pval = std::get_if<int>(&value)) {
+		return i2s(*pval);
 	}
+	if (auto pval = std::get_if<float>(&value)) {
+		return f2s(*pval);
+	}
+	if (auto pval = std::get_if<std::string>(&value)) {
+		return *pval;
+	}
+	return "";
 }
 
 static std::string toLower(std::string s) {

--- a/source/app/settings.h
+++ b/source/app/settings.h
@@ -21,6 +21,7 @@
 #include "app/main.h"
 
 #include <toml++/toml.h>
+#include <variant>
 
 namespace Config {
 	enum Key {
@@ -235,59 +236,18 @@ public:
 	void save(bool endoftheworld = false);
 
 public:
-	enum DynamicType {
-		TYPE_NONE,
-		TYPE_STR,
-		TYPE_INT,
-		TYPE_FLOAT,
-	};
 	class DynamicValue {
 	public:
-		DynamicValue() :
-			type(TYPE_NONE) {
-			intval = 0;
-		};
-		DynamicValue(DynamicType t) :
-			type(t) {
-			if (t == TYPE_STR) {
-				strval = nullptr;
-			} else if (t == TYPE_INT) {
-				intval = 0;
-			} else if (t == TYPE_FLOAT) {
-				floatval = 0.0;
-			} else {
-				intval = 0;
-			}
-		};
-		~DynamicValue() {
-			if (type == TYPE_STR) {
-				delete strval;
-			}
-		}
-		DynamicValue(const DynamicValue& dv) :
-			type(dv.type) {
-			if (dv.type == TYPE_STR) {
-				strval = newd std::string(*dv.strval);
-			} else if (dv.type == TYPE_INT) {
-				intval = dv.intval;
-			} else if (dv.type == TYPE_FLOAT) {
-				floatval = dv.floatval;
-			} else {
-				intval = 0;
-			}
-		};
+		DynamicValue() = default;
+		~DynamicValue() = default;
+		DynamicValue(const DynamicValue&) = default;
+		DynamicValue(DynamicValue&&) = default;
+		DynamicValue& operator=(const DynamicValue&) = default;
+		DynamicValue& operator=(DynamicValue&&) = default;
 
 		std::string str();
 
-	private:
-		DynamicType type;
-		union {
-			int intval;
-			std::string* strval;
-			float floatval;
-		};
-
-		friend class Settings;
+		std::variant<std::monostate, int, float, std::string> value;
 	};
 
 private:

--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -115,8 +115,8 @@ namespace IngamePreview {
 		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
 
 		// Canvas
-		canvas = std::make_unique<IngamePreviewCanvas>(this);
-		main_sizer->Add(canvas.get(), 1, wxEXPAND);
+		canvas = new IngamePreviewCanvas(this);
+		main_sizer->Add(canvas, 1, wxEXPAND);
 
 		// Sync UI State to Canvas
 		canvas->SetLightingEnabled(lighting_btn->GetValue());

--- a/source/ingame_preview/ingame_preview_window.h
+++ b/source/ingame_preview/ingame_preview_window.h
@@ -32,7 +32,7 @@ namespace IngamePreview {
 		void UpdateState();
 
 	private:
-		std::unique_ptr<IngamePreviewCanvas> canvas;
+		IngamePreviewCanvas* canvas;
 		wxTimer update_timer;
 
 		// UI Controls

--- a/source/net/process_com.cpp
+++ b/source/net/process_com.cpp
@@ -49,11 +49,12 @@ RMEProcessClient::RMEProcessClient() :
 }
 
 RMEProcessClient::~RMEProcessClient() {
-	delete proc;
+	////
 }
 
 wxConnectionBase* RMEProcessClient::OnMakeConnection() {
-	return proc = newd RMEProcessConnection();
+	proc.reset(newd RMEProcessConnection());
+	return proc.get();
 }
 
 // Connection

--- a/source/net/process_com.h
+++ b/source/net/process_com.h
@@ -21,6 +21,7 @@
 		#define RME_PROCESS_COMMUNICATION_H_
 
 		#include "wx/ipc.h"
+		#include <memory>
 
 class RMEProcessConnection : public wxConnection {
 public:
@@ -39,7 +40,7 @@ public:
 };
 
 class RMEProcessClient : public wxClient {
-	wxConnectionBase* proc;
+	std::unique_ptr<wxConnectionBase> proc;
 
 public:
 	RMEProcessClient();


### PR DESCRIPTION
This change addresses memory safety issues identified by the Keeper agent.

1.  **`source/app/settings.h` / `.cpp`**: The `DynamicValue` class used a raw `union` and manual `new`/`delete` for `std::string`. This has been replaced with `std::variant<std::monostate, int, float, std::string>`, which is safer, cleaner, and handles destruction automatically.
2.  **`source/ingame_preview/ingame_preview_window.h` / `.cpp`**: The `canvas` member was a `std::unique_ptr<IngamePreviewCanvas>`, but `IngamePreviewCanvas` is a `wxWindow` child of `IngamePreviewWindow`. When the parent window is destroyed, it destroys its children. `std::unique_ptr` would then try to destroy it again, causing a double-free. This was fixed by using a raw pointer, relying on wxWidgets ownership semantics.
3.  **`source/net/process_com.h` / `.cpp`**: The `proc` member (connection) was a raw pointer manually deleted in the destructor. This has been modernized to use `std::unique_ptr`, enforcing RAII.

---
*PR created automatically by Jules for task [15722191604629251192](https://jules.google.com/task/15722191604629251192) started by @karolak6612*