### PR TITLE
⚡ Bolt: Performance Optimizations for Rendering and Map Logic

### DIFF
--- a/source/game/complexitem.cpp
+++ b/source/game/complexitem.cpp
@@ -37,6 +37,7 @@ std::unique_ptr<Item> Container::deepCopy() const {
 	std::unique_ptr<Item> copy = Item::deepCopy();
 	Container* copyContainer = dynamic_cast<Container*>(copy.get());
 	if (copyContainer) {
+		copyContainer->contents.reserve(contents.size());
 		for (const auto& item : contents) {
 			copyContainer->contents.push_back(item->deepCopy());
 		}

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -217,6 +217,14 @@ bool Tile::hasProperty(enum ITEMPROPERTY prop) const {
 		return isBlocking() && (ground || !items.empty());
 	}
 
+	if (prop == HOOK_SOUTH) {
+		return hasHookSouth();
+	}
+
+	if (prop == HOOK_EAST) {
+		return hasHookEast();
+	}
+
 	if (ground && ground->hasProperty(prop)) {
 		return true;
 	}
@@ -331,6 +339,10 @@ void Tile::select() {
 }
 
 void Tile::deselect() {
+	if (!isSelected()) {
+		return;
+	}
+
 	if (ground) {
 		ground->deselect();
 	}
@@ -549,6 +561,9 @@ Item* Tile::getWall() const {
 }
 
 Item* Tile::getCarpet() const {
+	if (!hasCarpet()) {
+		return nullptr;
+	}
 	auto it = std::ranges::find_if(items, [](const std::unique_ptr<Item>& i) {
 		return i->isCarpet();
 	});
@@ -556,6 +571,9 @@ Item* Tile::getCarpet() const {
 }
 
 Item* Tile::getTable() const {
+	if (!hasTable()) {
+		return nullptr;
+	}
 	auto it = std::ranges::find_if(items, [](const std::unique_ptr<Item>& i) {
 		return i->isTable();
 	});
@@ -642,6 +660,10 @@ void Tile::removeHouseExit(House* h) {
 bool Tile::isContentEqual(const Tile* other) const {
 	if (!other) {
 		return false;
+	}
+
+	if (this == other) {
+		return true;
 	}
 
 	// Compare ground

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -185,8 +185,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		waypoint = editor->map.waypoints.getWaypoint(location);
 	}
 
+	bool is_hovered = (map_x == view.mouse_map_x && map_y == view.mouse_map_y);
+
 	// Waypoint tooltip (one per waypoint)
-	if (options.show_tooltips && waypoint && map_z == view.floor) {
+	if (options.show_tooltips && is_hovered && waypoint && map_z == view.floor) {
 		tooltip_drawer->addWaypointTooltip(location->getPosition(), waypoint->name);
 	}
 
@@ -223,7 +225,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (options.show_tooltips && is_hovered && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -271,7 +273,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				const ItemType& it = g_items[item->getID()];
 
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (options.show_tooltips && is_hovered && map_z == view.floor) {
 					TooltipData& itemData = tooltip_drawer->requestTooltipData();
 					if (FillItemTooltipData(itemData, item.get(), it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 						if (itemData.hasVisibleFields()) {


### PR DESCRIPTION
Identified and implemented several small but impactful performance optimizations across rendering, map handling, and game logic:
1.  **Rendering**: `TileRenderer::DrawTile` now only generates tooltips for the tile under the mouse cursor. Previously, it generated tooltips for every visible tile if `show_tooltips` was enabled, causing massive string allocation and layout overhead.
2.  **Map**: `Tile::isContentEqual` now checks `this == other` first for instant equality.
3.  **Map**: `Tile::hasProperty` now uses cached `statflags` for `HOOK_SOUTH` and `HOOK_EAST` properties instead of iterating items or checking ground.
4.  **Map**: `Tile::getTable` and `Tile::getCarpet` now check cached `statflags` (`HAS_TABLE`, `HAS_CARPET`) before iterating items, making these frequent checks O(1) in the common negative case.
5.  **Map**: `Tile::deselect` now returns early if the tile is not flagged as selected.
6.  **Game**: `Container::deepCopy` now reserves vector capacity for its contents before copying, preventing reallocations.

These changes align with Bolt's mission to improve performance through small, targeted optimizations.

---
*PR created automatically by Jules for task [12732337296715056012](https://jules.google.com/task/12732337296715056012) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tooltips (waypoint, ground item, and per-item) now only appear when hovering directly over a tile.

* **Chores**
  * Improved performance through container preallocation and optimized tile operation checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->