### PR TITLE
📊 Profiler: Fix CPU bottleneck in container tooltip generation

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -120,29 +120,7 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const ItemType& i
 		if (const Container* container = item->asContainer()) {
 			// Set capacity for rendering empty slots
 			data.containerCapacity = static_cast<uint8_t>(container->getVolume());
-
-			const auto& items = container->getVector();
-			data.containerItems.clear();
-			data.containerItems.reserve(items.size());
-			for (const auto& subItem : items) {
-				if (subItem) {
-					ContainerItem ci;
-					ci.id = subItem->getID();
-					ci.subtype = subItem->getSubtype();
-					ci.count = subItem->getCount();
-					// Sanity check for count
-					if (ci.count == 0) {
-						ci.count = 1;
-					}
-
-					data.containerItems.push_back(ci);
-
-					// Limit preview items to avoid massive tooltips
-					if (data.containerItems.size() >= 32) {
-						break;
-					}
-				}
-			}
+			data.container = container;
 		}
 	}
 

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -29,14 +29,9 @@
 #include <unordered_map>
 
 class Item;
+class Container;
 class Waypoint;
 struct NVGcontext;
-
-struct ContainerItem {
-	uint16_t id;
-	uint8_t count;
-	uint8_t subtype;
-};
 
 // Tooltip category determines header color and icon
 enum class TooltipCategory {
@@ -68,7 +63,7 @@ struct TooltipData {
 	std::string_view waypointName;
 
 	// Container contents
-	std::vector<ContainerItem> containerItems;
+	const Container* container = nullptr;
 	uint8_t containerCapacity = 0;
 
 	TooltipData() = default;
@@ -98,7 +93,7 @@ struct TooltipData {
 
 	// Check if this tooltip has any visible fields
 	bool hasVisibleFields() const {
-		return !waypointName.empty() || actionId > 0 || uniqueId > 0 || doorId > 0 || !text.empty() || !description.empty() || destination.x > 0 || !containerItems.empty();
+		return !waypointName.empty() || actionId > 0 || uniqueId > 0 || doorId > 0 || !text.empty() || !description.empty() || destination.x > 0 || container != nullptr;
 	}
 
 	void clear() {
@@ -115,7 +110,7 @@ struct TooltipData {
 		description = {};
 		destination = Position();
 		waypointName = {};
-		containerItems.clear();
+		container = nullptr;
 		containerCapacity = 0;
 	}
 };


### PR DESCRIPTION
This PR optimizes the tooltip rendering pipeline by eliminating unnecessary memory allocations and vector copies when displaying container contents. Previously, `FillItemTooltipData` would iterate through a container's contents and populate a `std::vector<ContainerItem>` in the `TooltipData` struct every frame for every visible container (if tooltips were enabled). This refactor changes `TooltipData` to hold a direct pointer to the `Container` object (`const Container*`). The `TooltipDrawer` now accesses items directly from the container during the layout and drawing phases, respecting the existing limit of 32 displayed items. This approach significantly reduces heap allocations and improves performance in scenes with many containers.

---
*PR created automatically by Jules for task [5675422415112934030](https://jules.google.com/task/5675422415112934030) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved container item tooltip rendering by optimizing the internal data structure and access patterns. These changes enhance performance and simplify the underlying implementation while preserving all existing functionality and maintaining the exact appearance and behavior of container contents displayed in tooltips.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->