### PR TITLE
[REFACTOR] Fix Long Method smells in Map, TileRenderer, and IOMapOTBM

### DIFF
--- a/source/io/iomap_otbm.cpp
+++ b/source/io/iomap_otbm.cpp
@@ -182,6 +182,12 @@ bool IOMapOTBM::loadMapFromDisk(Map& map, const FileName& filename) {
 		}
 	}
 
+	loadAuxiliaryFiles(map, filename);
+
+	return true;
+}
+
+void IOMapOTBM::loadAuxiliaryFiles(Map& map, const FileName& filename) {
 	// Read auxiliary files
 	auto loadAux = [&](bool (*func)(Map&, const FileName&), const std::string& suffix, std::string& target) {
 		std::string defaultFile = nstr(filename.GetName()) + "-" + suffix + ".xml";
@@ -293,8 +299,6 @@ bool IOMapOTBM::loadMapFromDisk(Map& map, const FileName& filename) {
 			map.waypointfile = nstr(filename.GetName()) + "-waypoint.xml";
 		}
 	}
-
-	return true;
 }
 
 bool IOMapOTBM::loadMap(Map& map, const FileName& filename) {

--- a/source/io/iomap_otbm.h
+++ b/source/io/iomap_otbm.h
@@ -99,6 +99,7 @@ protected:
 	void readTileArea(Map& map, BinaryNode* mapNode);
 	void readTowns(Map& map, BinaryNode* mapNode);
 	void readWaypoints(Map& map, BinaryNode* mapNode);
+	void loadAuxiliaryFiles(Map& map, const FileName& identifier);
 
 	bool saveMapToDisk(Map& map, const FileName& identifier);
 

--- a/source/map/map.h
+++ b/source/map/map.h
@@ -18,6 +18,10 @@
 #ifndef RME_MAP_H_
 #define RME_MAP_H_
 
+#include <vector>
+#include <unordered_map>
+#include <unordered_set>
+
 #include "map/basemap.h"
 #include "map/tile.h"
 #include "game/town.h"
@@ -137,6 +141,7 @@ protected:
 
 protected:
 	void removeSpawnInternal(Tile* tile);
+	void convertTile(Tile* tile, const ConversionMap& rm, const std::unordered_map<const std::vector<uint16_t>*, std::unordered_set<uint16_t>>& mtm_lookups, std::vector<uint16_t>& id_list);
 
 	std::vector<std::string> warnings;
 	wxString error;

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 class TileLocation;
+class Tile;
 struct RenderView;
 struct DrawingOptions;
 class Editor;
@@ -30,6 +31,8 @@ public:
 
 private:
 	void PreloadItem(const Tile* tile, Item* item, const ItemType& it);
+	void DrawHouseHighlight(SpriteBatch& sprite_batch, int draw_x, int draw_y, const Tile* tile, uint32_t current_house_id, const DrawingOptions& options, int map_z, int view_floor);
+	void DrawItems(SpriteBatch& sprite_batch, int draw_x, int draw_y, const Tile* tile, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int map_z, uint8_t r, uint8_t g, uint8_t b);
 
 	ItemDrawer* item_drawer;
 	SpriteDrawer* sprite_drawer;


### PR DESCRIPTION
This PR addresses three critical code smells identified as "Long Method" in the RME codebase.

1.  **`Map::convert` in `source/map/map.cpp`**: The logic for converting a single tile was extracted into a private helper method `convertTile`. This reduces the complexity of the main loop and makes the conversion logic more isolated. An optimization was applied to reuse the `id_list` vector to avoid reallocation per tile.

2.  **`TileRenderer::DrawTile` in `source/rendering/drawers/tiles/tile_renderer.cpp`**: The rendering logic was split into helper methods: `DrawHouseHighlight` and `DrawItems`. This makes the main `DrawTile` method easier to read and maintain, separating different rendering phases.

3.  **`IOMapOTBM::loadMapFromDisk` in `source/io/iomap_otbm.cpp`**: The loading of auxiliary files (houses, spawns, waypoints) was extracted into `loadAuxiliaryFiles`. This simplifies the main loading function and encapsulates the auxiliary file handling logic.

These changes improve code readability and maintainability without altering the functional behavior of the application. verified by successful compilation.

---
*PR created automatically by Jules for task [11634340991538386016](https://jules.google.com/task/11634340991538386016) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced map loading with improved auxiliary file handling (houses, spawns, waypoints) for better data integrity.

* **Improvements**
  * Optimized progress feedback during map conversion with more frequent UI updates.

* **Refactor**
  * Reorganized internal tile rendering logic and map conversion processes for improved code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->