### PR TITLE
Refactor UI lists to virtual wxListCtrl

### DIFF
--- a/source/palette/palette_waypoints.cpp
+++ b/source/palette/palette_waypoints.cpp
@@ -28,21 +28,61 @@
 #include "map/map.h"
 #include "util/image_manager.h"
 
+#include <algorithm>
+#include <vector>
+
+class WaypointListCtrl : public wxListCtrl {
+public:
+	WaypointListCtrl(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) :
+		wxListCtrl(parent, id, pos, size, style | wxLC_VIRTUAL) {
+	}
+
+	wxString OnGetItemText(long item, long column) const override {
+		if (item >= 0 && item < static_cast<long>(m_waypoints.size())) {
+			return wxstr(m_waypoints[item]);
+		}
+		return "";
+	}
+
+	void SetWaypoints(std::vector<std::string> waypoints) {
+		m_waypoints = std::move(waypoints);
+		SetItemCount(m_waypoints.size());
+		Refresh();
+	}
+
+	const std::string& GetWaypointName(long item) const {
+		return m_waypoints.at(item);
+	}
+
+	long FindWaypoint(const std::string& name) const {
+		auto it = std::find(m_waypoints.begin(), m_waypoints.end(), name);
+		if (it != m_waypoints.end()) {
+			return std::distance(m_waypoints.begin(), it);
+		}
+		return -1;
+	}
+
+private:
+	std::vector<std::string> m_waypoints;
+};
+
 WaypointPalettePanel::WaypointPalettePanel(wxWindow* parent, wxWindowID id) :
 	PalettePanel(parent, id),
 	map(nullptr) {
 	wxSizer* sidesizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Waypoints");
 
-	waypoint_list = newd wxListCtrl(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_WAYPOINT_LISTBOX, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_EDIT_LABELS | wxLC_NO_HEADER);
+	waypoint_list = newd WaypointListCtrl(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_WAYPOINT_LISTBOX, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_SINGLE_SEL | wxLC_EDIT_LABELS | wxLC_NO_HEADER);
 	waypoint_list->InsertColumn(0, "UNNAMED", wxLIST_FORMAT_LEFT, 200);
 	sidesizer->Add(waypoint_list, 1, wxEXPAND);
 
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_waypoint_button = newd wxButton(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_WAYPOINT_ADD_WAYPOINT, "Add", wxDefaultPosition, wxSize(50, -1));
 	add_waypoint_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+	add_waypoint_button->SetToolTip("Add Waypoint");
 	tmpsizer->Add(add_waypoint_button, 1, wxEXPAND);
 	remove_waypoint_button = newd wxButton(static_cast<wxStaticBoxSizer*>(sidesizer)->GetStaticBox(), PALETTE_WAYPOINT_REMOVE_WAYPOINT, "Remove", wxDefaultPosition, wxSize(70, -1));
 	remove_waypoint_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
+	remove_waypoint_button->SetToolTip("Remove Waypoint");
 	tmpsizer->Add(remove_waypoint_button, 1, wxEXPAND);
 	sidesizer->Add(tmpsizer, 0, wxEXPAND);
 
@@ -75,9 +115,14 @@ void WaypointPalettePanel::SelectFirstBrush() {
 
 Brush* WaypointPalettePanel::GetSelectedBrush() const {
 	long item = waypoint_list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
-	g_brush_manager.waypoint_brush->setWaypoint(
-		item == -1 ? nullptr : map->waypoints.getWaypoint(nstr(waypoint_list->GetItemText(item)))
-	);
+	if (item != -1) {
+		WaypointListCtrl* vlist = static_cast<WaypointListCtrl*>(waypoint_list);
+		g_brush_manager.waypoint_brush->setWaypoint(
+			map->waypoints.getWaypoint(vlist->GetWaypointName(item))
+		);
+	} else {
+		g_brush_manager.waypoint_brush->setWaypoint(nullptr);
+	}
 	return g_brush_manager.waypoint_brush;
 }
 
@@ -99,19 +144,10 @@ wxString WaypointPalettePanel::GetName() const {
 }
 
 void WaypointPalettePanel::OnUpdate() {
-	if (wxTextCtrl* tc = waypoint_list->GetEditControl()) {
-		Waypoint* wp = map->waypoints.getWaypoint(nstr(tc->GetValue()));
-		if (wp && wp->pos == Position()) {
-			if (map->getTile(wp->pos)) {
-				map->getTileL(wp->pos)->decreaseWaypointCount();
-			}
-			map->waypoints.removeWaypoint(wp->name);
-		}
-	}
 	waypoint_list->Freeze();
-	waypoint_list->DeleteAllItems();
 
 	if (!map) {
+		static_cast<WaypointListCtrl*>(waypoint_list)->SetWaypoints({});
 		waypoint_list->Enable(false);
 		add_waypoint_button->Enable(false);
 		remove_waypoint_button->Enable(false);
@@ -123,11 +159,15 @@ void WaypointPalettePanel::OnUpdate() {
 	add_waypoint_button->Enable(true);
 	remove_waypoint_button->Enable(true);
 
-	Waypoints& waypoints = map->waypoints;
-
-	for (const auto& [name, wp] : waypoints) {
-		waypoint_list->InsertItem(0, wxstr(wp->name));
+	std::vector<std::string> wp_names;
+	wp_names.reserve(map->waypoints.size());
+	for (const auto& [name, wp] : map->waypoints) {
+		wp_names.push_back(name);
 	}
+	// Sort to keep consistent order
+	std::sort(wp_names.begin(), wp_names.end());
+
+	static_cast<WaypointListCtrl*>(waypoint_list)->SetWaypoints(std::move(wp_names));
 	waypoint_list->Thaw();
 }
 
@@ -136,7 +176,9 @@ void WaypointPalettePanel::OnClickWaypoint(wxListEvent& event) {
 		return;
 	}
 
-	std::string wpname = nstr(event.GetText());
+	WaypointListCtrl* vlist = static_cast<WaypointListCtrl*>(waypoint_list);
+	std::string wpname = vlist->GetWaypointName(event.GetIndex());
+
 	Waypoint* wp = map->waypoints.getWaypoint(wpname);
 	if (wp) {
 		g_gui.SetScreenCenterPosition(wp->pos);
@@ -150,8 +192,10 @@ void WaypointPalettePanel::OnBeginEditWaypointLabel(wxListEvent& event) {
 }
 
 void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
+	WaypointListCtrl* vlist = static_cast<WaypointListCtrl*>(waypoint_list);
+	std::string oldwpname = vlist->GetWaypointName(event.GetIndex());
 	std::string wpname = nstr(event.GetLabel());
-	std::string oldwpname = nstr(waypoint_list->GetItemText(event.GetIndex()));
+
 	Waypoint* wp = map->waypoints.getWaypoint(oldwpname);
 
 	if (event.IsEditCancelled()) {
@@ -160,6 +204,7 @@ void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
 
 	if (wpname == "") {
 		map->waypoints.removeWaypoint(oldwpname);
+		OnUpdate(); // Refresh list
 		g_gui.RefreshPalettes();
 	} else if (wp) {
 		if (wpname == oldwpname) {
@@ -169,8 +214,12 @@ void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
 				// Already exists a waypoint with this name!
 				g_gui.SetStatusText("There already is a waypoint with this name.");
 				event.Veto();
+				// If we were creating a new waypoint (empty name originally), and failed to rename,
+				// we should probably remove it?
+				// But here oldwpname is likely "" if it was just added.
 				if (oldwpname == "") {
 					map->waypoints.removeWaypoint(oldwpname);
+					OnUpdate();
 					g_gui.RefreshPalettes();
 				}
 			} else {
@@ -189,6 +238,16 @@ void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
 				map->waypoints.addWaypoint(std::move(nwp_ptr));
 				g_brush_manager.waypoint_brush->setWaypoint(nwp);
 
+				// Refresh list to show new name and resorts
+				OnUpdate();
+
+				// Re-select the renamed item
+				long new_idx = vlist->FindWaypoint(wpname);
+				if (new_idx != -1) {
+					waypoint_list->SetItemState(new_idx, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+					waypoint_list->EnsureVisible(new_idx);
+				}
+
 				// Refresh other palettes
 				refresh_timer.Start(300, true);
 			}
@@ -202,10 +261,19 @@ void WaypointPalettePanel::OnEditWaypointLabel(wxListEvent& event) {
 
 void WaypointPalettePanel::OnClickAddWaypoint(wxCommandEvent& event) {
 	if (map) {
+		// Add empty waypoint
 		map->waypoints.addWaypoint(std::make_unique<Waypoint>());
-		long i = waypoint_list->InsertItem(0, "");
-		waypoint_list->EditLabel(i);
 
+		OnUpdate(); // Refresh list
+
+		// Find the empty waypoint
+		WaypointListCtrl* vlist = static_cast<WaypointListCtrl*>(waypoint_list);
+		long i = vlist->FindWaypoint("");
+		if (i != -1) {
+			waypoint_list->SetItemState(i, wxLIST_STATE_SELECTED, wxLIST_STATE_SELECTED);
+			waypoint_list->EnsureVisible(i);
+			waypoint_list->EditLabel(i);
+		}
 		// g_gui.RefreshPalettes();
 	}
 }
@@ -217,14 +285,18 @@ void WaypointPalettePanel::OnClickRemoveWaypoint(wxCommandEvent& event) {
 
 	long item = waypoint_list->GetNextItem(-1, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
 	if (item != -1) {
-		Waypoint* wp = map->waypoints.getWaypoint(nstr(waypoint_list->GetItemText(item)));
+		WaypointListCtrl* vlist = static_cast<WaypointListCtrl*>(waypoint_list);
+		std::string name = vlist->GetWaypointName(item);
+
+		Waypoint* wp = map->waypoints.getWaypoint(name);
 		if (wp) {
 			if (map->getTile(wp->pos)) {
 				map->getTileL(wp->pos)->decreaseWaypointCount();
 			}
 			map->waypoints.removeWaypoint(wp->name);
 		}
-		waypoint_list->DeleteItem(item);
+
+		OnUpdate();
 		refresh_timer.Start(300, true);
 	}
 }

--- a/source/ui/map/towns_window.h
+++ b/source/ui/map/towns_window.h
@@ -3,6 +3,7 @@
 
 #include "app/main.h"
 #include <wx/wx.h>
+#include <wx/listctrl.h>
 #include <vector>
 #include <memory>
 
@@ -15,7 +16,7 @@ public:
 	EditTownsDialog(wxWindow* parent, Editor& editor);
 	virtual ~EditTownsDialog();
 
-	void OnListBoxChange(wxCommandEvent&);
+	void OnListSelected(wxListEvent&);
 	void OnClickSelectTemplePosition(wxCommandEvent&);
 	void OnClickAdd(wxCommandEvent&);
 	void OnClickRemove(wxCommandEvent&);
@@ -24,14 +25,14 @@ public:
 
 protected:
 	void BuildListBox(bool doselect);
-	void UpdateSelection(int new_selection);
+	void UpdateSelection(long new_selection);
 
 	Editor& editor;
 
 	std::vector<std::unique_ptr<Town>> town_list;
 	uint32_t max_town_id;
 
-	wxListBox* town_listbox;
+	wxListCtrl* town_list_ctrl;
 	wxString town_name, town_id;
 
 	wxTextCtrl* name_field;


### PR DESCRIPTION
This PR refactors `WaypointPalettePanel`, `EditTownsDialog`, and `WelcomeDialog` to use virtual `wxListCtrl` implementations. This improves performance for large lists and modernizes the UI code by replacing deprecated or less flexible controls like `wxListBox` with more capable alternatives. It also adds missing tooltips and improves data handling.

---
*PR created automatically by Jules for task [8147110566698625442](https://jules.google.com/task/8147110566698625442) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tooltips to waypoint palette Add and Remove buttons.
  * Waypoint list now displays in sorted order for consistent organization.
  * Towns dialog enhanced with two-column layout showing ID and Name.

* **UI/UX Improvements**
  * Improved list selection and refresh behavior across waypoint and towns dialogs.
  * Better handling of empty entries and list state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->