### PR TITLE
Sentinel: Modernize Minimap and Preview Context Management

### DIFF
--- a/source/ingame_preview/ingame_preview_canvas.h
+++ b/source/ingame_preview/ingame_preview_canvas.h
@@ -12,6 +12,7 @@ class Editor;
 #include <deque>
 #include <string>
 #include "rendering/core/graphics.h"
+#include "util/nanovg_canvas.h"
 
 struct NVGcontext;
 
@@ -19,12 +20,16 @@ namespace IngamePreview {
 
 	class IngamePreviewRenderer;
 
-	class IngamePreviewCanvas : public wxGLCanvas {
+	class IngamePreviewCanvas : public NanoVGCanvas {
 	public:
 		IngamePreviewCanvas(wxWindow* parent);
 		~IngamePreviewCanvas();
 
-		void OnPaint(wxPaintEvent& event);
+		// Hooks from NanoVGCanvas
+		void OnGLPaint() override;
+		void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+		bool ShouldClearBackground() const override { return false; } // Renderer clears or fills
+
 		void OnSize(wxSizeEvent& event);
 		void OnMouseMove(wxMouseEvent& event);
 		void OnKeyDown(wxKeyEvent& event);
@@ -52,15 +57,14 @@ namespace IngamePreview {
 			Refresh();
 		}
 
-		void Render(Editor* current_editor);
 		bool IsWalking() const {
 			return is_walking;
 		}
 
 	private:
+		void Render(Editor* current_editor);
+
 		std::unique_ptr<IngamePreviewRenderer> renderer;
-		std::unique_ptr<wxGLContext> m_glContext;
-		std::unique_ptr<NVGcontext, NVGDeleter> m_nvg;
 		const void* last_tile_renderer;
 
 		Position camera_pos;

--- a/source/rendering/drawers/minimap_drawer.cpp
+++ b/source/rendering/drawers/minimap_drawer.cpp
@@ -20,7 +20,7 @@ MinimapDrawer::MinimapDrawer() :
 MinimapDrawer::~MinimapDrawer() {
 }
 
-void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanvas* canvas) {
+void MinimapDrawer::Draw(const wxSize& size, Editor& editor, MapCanvas* canvas) {
 	// We no longer use wxDC for drawing the map content, as we render via OpenGL.
 	// However, we might need to conform to existing architecture.
 	// The caller likely sets up GL context if we are in GLCanvas?

--- a/source/rendering/drawers/minimap_drawer.h
+++ b/source/rendering/drawers/minimap_drawer.h
@@ -17,7 +17,7 @@ public:
 	MinimapDrawer();
 	~MinimapDrawer();
 
-	void Draw(wxDC& dc, const wxSize& size, Editor& editor, MapCanvas* canvas);
+	void Draw(const wxSize& size, Editor& editor, MapCanvas* canvas);
 
 	void ScreenToMap(int screen_x, int screen_y, int& map_x, int& map_y);
 

--- a/source/rendering/ui/minimap_window.h
+++ b/source/rendering/ui/minimap_window.h
@@ -18,18 +18,22 @@
 #ifndef RME_MINIMAP_WINDOW_H_
 #define RME_MINIMAP_WINDOW_H_
 
-#include <wx/glcanvas.h>
+#include "util/nanovg_canvas.h"
 #include <memory>
 
 #include "rendering/core/graphics.h"
 
 class MinimapDrawer;
-class MinimapWindow : public wxGLCanvas {
+class MinimapWindow : public NanoVGCanvas {
 public:
 	MinimapWindow(wxWindow* parent);
 	~MinimapWindow() override;
 
-	void OnPaint(wxPaintEvent&);
+	// Hooks from NanoVGCanvas
+	void OnGLPaint() override;
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	bool ShouldClearBackground() const override;
+
 	void OnEraseBackground(wxEraseEvent&) { }
 	void OnMouseClick(wxMouseEvent&);
 	void OnSize(wxSizeEvent&);
@@ -42,8 +46,6 @@ public:
 protected:
 	std::unique_ptr<MinimapDrawer> drawer;
 	wxTimer update_timer;
-	std::unique_ptr<wxGLContext> context;
-	std::unique_ptr<NVGcontext, NVGDeleter> nvg;
 };
 
 #endif

--- a/source/util/nanovg_canvas.h
+++ b/source/util/nanovg_canvas.h
@@ -56,12 +56,23 @@ class NanoVGCanvas : public wxGLCanvas {
 
 public:
 	/**
-	 * @brief Constructs a NanoVGCanvas control.
+	 * @brief Constructs a NanoVGCanvas control with default legacy attributes.
 	 * @param parent Parent window
 	 * @param id Window ID (default: wxID_ANY)
 	 * @param style Additional window styles (default includes vertical scrollbar)
+	 * @param sharedContext Context to share resources with (optional)
 	 */
-	NanoVGCanvas(wxWindow* parent, wxWindowID id = wxID_ANY, long style = wxVSCROLL | wxWANTS_CHARS);
+	NanoVGCanvas(wxWindow* parent, wxWindowID id = wxID_ANY, long style = wxVSCROLL | wxWANTS_CHARS, wxGLContext* sharedContext = nullptr);
+
+	/**
+	 * @brief Constructs a NanoVGCanvas control with specific GL attributes (e.g. Core Profile).
+	 * @param parent Parent window
+	 * @param dispAttrs GL Attributes
+	 * @param id Window ID
+	 * @param style Additional window styles
+	 * @param sharedContext Context to share resources with (optional)
+	 */
+	NanoVGCanvas(wxWindow* parent, const wxGLAttributes& dispAttrs, wxWindowID id = wxID_ANY, long style = wxVSCROLL | wxWANTS_CHARS, wxGLContext* sharedContext = nullptr);
 
 	/**
 	 * @brief Destructor - cleans up OpenGL and NanoVG resources.
@@ -117,6 +128,21 @@ protected:
 	 * Use GetScrollPosition() if you need the raw scroll value.
 	 */
 	virtual void OnNanoVGPaint(NVGcontext* vg, int width, int height) = 0;
+
+	/**
+	 * @brief Override this to implement custom raw OpenGL drawing before NanoVG frame starts.
+	 * Useful for hybrid rendering (e.g. Minimap, 3D Viewport).
+	 * Context is current and viewport is set to (0, 0, w, h).
+	 */
+	virtual void OnGLPaint() {}
+
+	/**
+	 * @brief Override to control whether NanoVGCanvas should clear the background.
+	 * @return true to clear with theme surface color (default), false to skip clearing.
+	 */
+	virtual bool ShouldClearBackground() const {
+		return true;
+	}
 
 	/**
 	 * @brief Override to return preferred control size.
@@ -189,6 +215,7 @@ private:
 	void OnScroll(wxScrollWinEvent& evt);
 
 	std::unique_ptr<wxGLContext> m_glContext;
+	wxGLContext* m_sharedContext = nullptr;
 	std::unique_ptr<NVGcontext, NVGDeleter> m_nvg;
 	bool m_glInitialized = false;
 


### PR DESCRIPTION
Refactored `MinimapWindow` and `IngamePreviewCanvas` to inherit from `NanoVGCanvas`.
This standardizes OpenGL context management, context sharing, and NanoVG initialization.
Enhanced `NanoVGCanvas` to support hybrid rendering (raw GL + NanoVG) via `OnGLPaint` hook.
Removed duplicate and manual context handling code.
Ensured `IngamePreviewCanvas` shares context with main GUI to access textures.
Removed unused `wxDC` parameter from `MinimapDrawer::Draw`.

---
*PR created automatically by Jules for task [5525426923389706978](https://jules.google.com/task/5525426923389706978) started by @karolak6612*