### PR TITLE
[ICONS] Add SVG icons to House Palette and Dialog

### DIFF
--- a/find_missing_icons.py
+++ b/find_missing_icons.py
@@ -1,0 +1,58 @@
+import os
+import re
+
+def find_missing_icons(root_dir):
+    # Regex to capture variable name in assignment: var = new(d) wxButton
+    # Handles *var = ...
+    button_regex = re.compile(r'(\w+)\s*=\s*newd?\s*wxButton\s*\(')
+    # Regex to capture SetBitmap calls: var->SetBitmap
+    bitmap_regex = re.compile(r'(\w+)->SetBitmap\s*\(')
+
+    missing_icons = []
+
+    for root, dirs, files in os.walk(root_dir):
+        for file in files:
+            if file.endswith('.cpp') or file.endswith('.h'):
+                filepath = os.path.join(root, file)
+                try:
+                    with open(filepath, 'r', encoding='utf-8', errors='ignore') as f:
+                        content = f.read()
+
+                        # Find all buttons created
+                        buttons = {} # name -> line_number
+                        # We use finditer to locate all occurrences
+                        for match in button_regex.finditer(content):
+                            # Check if line is commented out (simplistic check)
+                            line_start = content.rfind('\n', 0, match.start()) + 1
+                            line_content = content[line_start:match.start()]
+                            if '//' in line_content:
+                                continue
+
+                            btn_name = match.group(1)
+                            buttons[btn_name] = content.count('\n', 0, match.start()) + 1
+
+                        if not buttons:
+                            continue
+
+                        # Check if SetBitmap is called for them
+                        # We need to find SetBitmap for THESE buttons
+                        # But wait, SetBitmap might be called on a member variable not captured here if definition is separate.
+                        # This script only checks local variables or members assigned in this file.
+
+                        # Find all SetBitmap calls in the file
+                        bitmaps_set = set()
+                        for match in bitmap_regex.finditer(content):
+                            bitmaps_set.add(match.group(1))
+
+                        for btn, line in buttons.items():
+                            if btn not in bitmaps_set:
+                                missing_icons.append(f"{filepath}:{line} - {btn}")
+                except Exception as e:
+                    print(f"Error reading {filepath}: {e}")
+
+    return missing_icons
+
+if __name__ == "__main__":
+    missing = find_missing_icons("source")
+    for m in missing:
+        print(m)

--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -12,6 +12,7 @@
 #include "map/map.h"
 #include "game/house.h"
 #include "game/town.h"
+#include "util/image_manager.h"
 
 #include <sstream>
 
@@ -94,8 +95,13 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -15,6 +15,7 @@
 #include "brushes/managers/brush_manager.h"
 #include "brushes/house/house_brush.h"
 #include "brushes/house/house_exit_brush.h"
+#include "util/image_manager.h"
 
 #include <algorithm>
 
@@ -59,8 +60,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);
@@ -72,7 +76,9 @@ HousePalette::HousePalette(wxWindow* parent) :
 	wxStaticBoxSizer* brush_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Brushes");
 
 	house_brush_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_HOUSE_BRUSH, "House tiles");
+	house_brush_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
 	select_exit_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_EXIT_BRUSH, "Select Exit");
+	select_exit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, wxSize(16, 16)));
 
 	brush_sizer->Add(house_brush_button, 0, wxEXPAND | wxBOTTOM, 2);
 	brush_sizer->Add(select_exit_button, 0, wxEXPAND);


### PR DESCRIPTION
Added standard SVG icons to buttons in `HousePalette` and `EditHouseDialog`.
- `HousePalette`: Add (+), Edit (Pen), Remove (Trash), House Brush (House), Select Exit (Door Open).
- `EditHouseDialog`: OK (Check), Cancel (XMark).
Used `IMAGE_MANAGER` for consistent icon usage.

---
*PR created automatically by Jules for task [15217793899372033736](https://jules.google.com/task/15217793899372033736) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added icon graphics to action buttons (Add, Edit, Remove) in the house palette interface.
  * Added icon graphics to dialog buttons and toggle controls for improved visual clarity and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->