### PR TITLE
UX: Add tooltips to Replace Tool and Outfit Chooser controls

### DIFF
--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -165,12 +165,19 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
 	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
 	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(16, 16)));
+	head_btn->SetToolTip("Select Head Color");
+
 	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
 	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHIRT, wxSize(16, 16)));
+	body_btn->SetToolTip("Select Primary Color");
+
 	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
 	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SOCKS, wxSize(16, 16)));
+	legs_btn->SetToolTip("Select Secondary Color");
+
 	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
 	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHOE_PRINTS, wxSize(16, 16)));
+	feet_btn->SetToolTip("Select Detail Color");
 
 	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
 	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);
@@ -230,6 +237,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	outfit_search = new wxSearchCtrl(this, ID_SEARCH, wxEmptyString, wxDefaultPosition, wxSize(180, -1));
 	outfit_search->SetDescriptiveText("Search...");
+	outfit_search->SetToolTip("Search for outfits by name");
 	outfits_header_row->Add(outfit_search, 0, wxALIGN_BOTTOM | wxRIGHT, 4);
 
 	colorable_only_check = new wxCheckBox(this, wxID_ANY, "Template Only");

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -169,18 +169,21 @@ void ReplaceToolWindow::InitLayout() {
 	m_addRuleBtn->SetBackgroundColour(wxColour(40, 180, 40)); // Green
 	m_addRuleBtn->SetForegroundColour(*wxWHITE);
 	m_addRuleBtn->SetFont(Theme::GetFont(9, true));
+	m_addRuleBtn->SetToolTip("Add a new replacement rule");
 
 	m_editRuleBtn = new wxButton(actionsCard, wxID_ANY, "EDIT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	m_editRuleBtn->SetBackgroundColour(wxColour(80, 80, 80)); // Neutral Dark Gray
 	m_editRuleBtn->SetForegroundColour(*wxWHITE);
 	m_editRuleBtn->SetFont(Theme::GetFont(9, true));
+	m_editRuleBtn->SetToolTip("Rename selected rule set");
 
 	m_deleteRuleBtn = new wxButton(actionsCard, wxID_ANY, "DEL", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
 	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
 	m_deleteRuleBtn->SetBackgroundColour(wxColour(180, 40, 40)); // Red
 	m_deleteRuleBtn->SetForegroundColour(*wxWHITE);
 	m_deleteRuleBtn->SetFont(Theme::GetFont(9, true));
+	m_deleteRuleBtn->SetToolTip("Delete selected rule set");
 
 	manageBtnsSizer->Add(m_addRuleBtn, wxSizerFlags(1).Border(wxRIGHT, 2));
 	manageBtnsSizer->Add(m_editRuleBtn, wxSizerFlags(1).Border(wxLEFT | wxRIGHT, 2));
@@ -193,6 +196,7 @@ void ReplaceToolWindow::InitLayout() {
 	m_addVisibleBtn->SetBackgroundColour(wxColour(45, 120, 180)); // Sky Blue
 	m_addVisibleBtn->SetForegroundColour(*wxWHITE);
 	m_addVisibleBtn->SetFont(Theme::GetFont(9, true));
+	m_addVisibleBtn->SetToolTip("Add rules for all visible items in the current viewport");
 	actionsSizer->Add(m_addVisibleBtn, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, padding));
 
 	// Scope Selection
@@ -207,6 +211,7 @@ void ReplaceToolWindow::InitLayout() {
 	scopes.Add("ALL MAP");
 	m_scopeChoice = new wxChoice(actionsCard, wxID_ANY, wxDefaultPosition, FromDIP(wxSize(-1, 24)), scopes);
 	m_scopeChoice->SetSelection(0);
+	m_scopeChoice->SetToolTip("Choose where to apply replacements (Selection, Viewport, or Entire Map)");
 	if (editor && editor->selection.empty()) {
 		m_scopeChoice->SetSelection(1); // Default to Viewport if no selection
 	}
@@ -225,6 +230,7 @@ void ReplaceToolWindow::InitLayout() {
 	m_executeBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Blue
 	m_executeBtn->SetForegroundColour(*wxWHITE);
 	m_executeBtn->SetFont(Theme::GetFont(10, true));
+	m_executeBtn->SetToolTip("Run replacement on the selected scope");
 	actionsSizer->Add(m_executeBtn, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	// Close Button
@@ -233,6 +239,7 @@ void ReplaceToolWindow::InitLayout() {
 	closeBtn->SetBackgroundColour(wxColour(120, 120, 120)); // Gray
 	closeBtn->SetForegroundColour(*wxWHITE);
 	closeBtn->SetFont(Theme::GetFont(10, true));
+	closeBtn->SetToolTip("Close this window");
 	actionsSizer->Add(closeBtn, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	actionsCard->GetContentSizer()->Add(actionsSizer, wxSizerFlags(1).Expand());


### PR DESCRIPTION
This PR implements several micro-UX improvements identified by the Palette agent.
It adds tooltips to various interactive elements that were previously missing them, helping users understand the function of buttons and controls.

**Key Changes:**
*   **Replace Tool Window:** Added tooltips to all action buttons, the scope selector, and the "Add Visible" button.
*   **Outfit Chooser Dialog:** Added tooltips to the outfit part selection buttons (Head, Body, Legs, Feet) and the search field.

These changes are purely UI enhancements using standard wxWidgets `SetToolTip` calls and do not affect core logic.

---
*PR created automatically by Jules for task [4330394748084163090](https://jules.google.com/task/4330394748084163090) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added helpful tooltips to the outfit chooser dialog color buttons (Head, Primary, Secondary, Detail) and search control to guide users.
  * Added informative tooltips throughout the replace tool window to assist users, including guidance on rule management buttons (Add, Edit, Delete), viewport visibility toggle, scope selection dropdown, and execute/close action buttons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->