### PR TITLE
🗝️ Keeper: Modernize ownership in RMEProcessClient, WelcomeDialog and fix IngamePreviewWindow double-free

### DIFF
--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -115,8 +115,8 @@ namespace IngamePreview {
 		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
 
 		// Canvas
-		canvas = std::make_unique<IngamePreviewCanvas>(this);
-		main_sizer->Add(canvas.get(), 1, wxEXPAND);
+		canvas = new IngamePreviewCanvas(this);
+		main_sizer->Add(canvas, 1, wxEXPAND);
 
 		// Sync UI State to Canvas
 		canvas->SetLightingEnabled(lighting_btn->GetValue());

--- a/source/ingame_preview/ingame_preview_window.h
+++ b/source/ingame_preview/ingame_preview_window.h
@@ -32,7 +32,7 @@ namespace IngamePreview {
 		void UpdateState();
 
 	private:
-		std::unique_ptr<IngamePreviewCanvas> canvas;
+		IngamePreviewCanvas* canvas;
 		wxTimer update_timer;
 
 		// UI Controls

--- a/source/net/process_com.cpp
+++ b/source/net/process_com.cpp
@@ -49,11 +49,12 @@ RMEProcessClient::RMEProcessClient() :
 }
 
 RMEProcessClient::~RMEProcessClient() {
-	delete proc;
+	//
 }
 
 wxConnectionBase* RMEProcessClient::OnMakeConnection() {
-	return proc = newd RMEProcessConnection();
+	proc = std::make_unique<RMEProcessConnection>();
+	return proc.get();
 }
 
 // Connection

--- a/source/net/process_com.h
+++ b/source/net/process_com.h
@@ -21,6 +21,7 @@
 		#define RME_PROCESS_COMMUNICATION_H_
 
 		#include "wx/ipc.h"
+		#include <memory>
 
 class RMEProcessConnection : public wxConnection {
 public:
@@ -39,7 +40,7 @@ public:
 };
 
 class RMEProcessClient : public wxClient {
-	wxConnectionBase* proc;
+	std::unique_ptr<wxConnectionBase> proc;
 
 public:
 	RMEProcessClient();

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -238,7 +238,7 @@ WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionT
 	SetForegroundColour(Theme::Get(Theme::Role::Text));
 
 	// Image List for Icons
-	m_imageList = new wxImageList(16, 16);
+	m_imageList = std::make_unique<wxImageList>(16, 16);
 	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(16, 16)));
 	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(16, 16)));
 	m_imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
@@ -265,7 +265,6 @@ WelcomeDialog::~WelcomeDialog() {
 	if (m_clientList) {
 		m_clientList->SetImageList(nullptr, wxIMAGE_LIST_SMALL);
 	}
-	delete m_imageList;
 }
 
 void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, const wxString& artId, const wxColour& valCol) {
@@ -403,7 +402,7 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 2: Recent Maps
 	DarkCardPanel* col2 = new DarkCardPanel(contentPanel, "Recent Maps");
 	m_recentList = new wxListCtrl(col2, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_NO_HEADER | wxBORDER_NONE);
-	m_recentList->SetImageList(m_imageList, wxIMAGE_LIST_SMALL);
+	m_recentList->SetImageList(m_imageList.get(), wxIMAGE_LIST_SMALL);
 	m_recentList->InsertColumn(0, "Icon", wxLIST_FORMAT_LEFT, 24);
 	m_recentList->InsertColumn(1, "Map Info", wxLIST_FORMAT_LEFT, 250); // Wider
 	m_recentList->InsertColumn(2, "Date Modified", wxLIST_FORMAT_LEFT, 150);
@@ -454,7 +453,7 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 5: Available Clients
 	DarkCardPanel* col5 = new DarkCardPanel(contentPanel, "Available Clients");
 	m_clientList = new wxListCtrl(col5, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxLC_REPORT | wxLC_NO_HEADER | wxBORDER_NONE);
-	m_clientList->SetImageList(m_imageList, wxIMAGE_LIST_SMALL);
+	m_clientList->SetImageList(m_imageList.get(), wxIMAGE_LIST_SMALL);
 	m_clientList->InsertColumn(0, "Icon", wxLIST_FORMAT_LEFT, 24);
 	m_clientList->InsertColumn(1, "Name", wxLIST_FORMAT_LEFT, 150);
 

--- a/source/ui/welcome_dialog.h
+++ b/source/ui/welcome_dialog.h
@@ -4,6 +4,7 @@
 #include <wx/wx.h>
 #include <wx/listctrl.h>
 #include <vector>
+#include <memory>
 
 // Forward declarations
 class wxListCtrl;
@@ -28,7 +29,7 @@ private:
 	wxPanel* CreateContentPanel(wxWindow* parent, const std::vector<wxString>& recentFiles);
 	wxPanel* CreateFooterPanel(wxWindow* parent, const wxString& versionText);
 
-	wxImageList* m_imageList = nullptr;
+	std::unique_ptr<wxImageList> m_imageList;
 	wxListCtrl* m_recentList = nullptr;
 	wxListCtrl* m_clientList = nullptr;
 };


### PR DESCRIPTION
This PR addresses memory ownership issues identified by the Keeper agent:
1.  **`IngamePreviewWindow` Double-Free Fix:** Changed `canvas` from `std::unique_ptr` to a raw pointer. Since `IngamePreviewCanvas` is a `wxWindow` child of `IngamePreviewWindow`, it is automatically deleted by the parent. Using `std::unique_ptr` caused a double deletion (one by the smart pointer, one by the wxWidgets framework).
2.  **`RMEProcessClient` Modernization:** Replaced manual `new`/`delete` for the `proc` connection object with `std::unique_ptr`, ensuring exception safety and automatic cleanup.
3.  **`WelcomeDialog` Modernization:** Replaced manual `new`/`delete` for `m_imageList` with `std::unique_ptr`, simplifying the destructor and preventing leaks.

---
*PR created automatically by Jules for task [18278280254766346895](https://jules.google.com/task/18278280254766346895) started by @karolak6612*