### PR TITLE
[TILE/WXWIDGETS] Fix missing double click event in NanoVGListBox

### DIFF
--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -16,6 +16,7 @@ NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
 
 	Bind(wxEVT_SIZE, &NanoVGListBox::OnSize, this);
 	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnMouseDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &NanoVGListBox::OnMouseDoubleClick, this);
 	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
 	Bind(wxEVT_MOTION, &NanoVGListBox::OnMotion, this);
 	Bind(wxEVT_LEAVE_WINDOW, &NanoVGListBox::OnLeave, this);
@@ -277,6 +278,30 @@ void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
 		Refresh();
 	}
 	SetFocus(); // Ensure we get key events
+}
+
+void NanoVGListBox::OnMouseDoubleClick(wxMouseEvent& event) {
+	int scrollPos = GetScrollPosition();
+	int index = HitTest(event.GetX(), event.GetY() + scrollPos);
+
+	if (index != -1) {
+		if (m_style & wxLB_MULTIPLE) {
+			// For multiple selection, ensure clicked item is selected and focused
+			if (!IsSelected(index)) {
+				Select(index, true);
+				m_focusIndex = index;
+			}
+		} else {
+			if (m_selection != index) {
+				Select(index, true);
+			}
+		}
+
+		wxCommandEvent cmdEvent(wxEVT_LISTBOX_DCLICK, GetId());
+		cmdEvent.SetEventObject(this);
+		cmdEvent.SetInt(index);
+		ProcessWindowEvent(cmdEvent);
+	}
 }
 
 void NanoVGListBox::OnMotion(wxMouseEvent& event) {

--- a/source/util/nanovg_listbox.h
+++ b/source/util/nanovg_listbox.h
@@ -49,6 +49,7 @@ protected:
 	void UpdateScrollbar();
 	void OnSize(wxSizeEvent& event);
 	void OnMouseDown(wxMouseEvent& event);
+	void OnMouseDoubleClick(wxMouseEvent& event);
 	void OnKeyDown(wxKeyEvent& event);
 	void OnMotion(wxMouseEvent& event);
 	void OnLeave(wxMouseEvent& event);


### PR DESCRIPTION
Implemented `OnMouseDoubleClick` in `NanoVGListBox` to fix missing double click events in derived controls like `FindDialogListBox`.


---
*PR created automatically by Jules for task [13318809997689552510](https://jules.google.com/task/13318809997689552510) started by @karolak6612*