### PR TITLE
Chunk-based Rendering Optimization

### DIFF
--- a/source/map/map_allocator.h
+++ b/source/map/map_allocator.h
@@ -41,7 +41,7 @@ public:
 
 	//
 	std::unique_ptr<Floor> allocateFloor(int x, int y, int z) {
-		return std::make_unique<Floor>(x, y, z);
+		return std::make_unique<Floor>(x, y, z, nullptr);
 	}
 
 	//

--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -23,6 +23,7 @@
 #include "map/spatial_hash_grid.h"
 #include <utility>
 #include <unordered_map>
+#include <atomic>
 
 class Tile;
 class Floor;
@@ -45,6 +46,7 @@ protected:
 	size_t waypoint_count;
 	size_t town_count;
 	std::unique_ptr<HouseExitList> house_exits; // Any house exits pointing here
+	MapNode* parent_node;
 
 public:
 	// Access tile
@@ -111,6 +113,8 @@ public:
 		return house_exits.get();
 	}
 
+	void notifyChange();
+
 	friend class Floor;
 	friend class MapNode;
 	friend class Waypoints;
@@ -118,7 +122,7 @@ public:
 
 class Floor {
 public:
-	Floor(int x, int y, int z);
+	Floor(int x, int y, int z, MapNode* node);
 	TileLocation locs[MAP_LAYERS];
 };
 
@@ -156,6 +160,11 @@ public:
 		REQUESTED_UNDERGROUND = 1 << 2,
 		REQUESTED_OVERGROUND = 1 << 3,
 	};
+
+	std::atomic<uint64_t> last_modified = 0;
+	void notifyChange() {
+		last_modified++;
+	}
 
 protected:
 	BaseMap& map;

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -380,6 +380,9 @@ std::vector<std::unique_ptr<Item>> Tile::popSelectedItems(bool ignoreTileSelecte
 	items.erase(split_point, items.end());
 
 	statflags &= ~TILESTATE_SELECTED;
+	if (location) {
+		location->notifyChange();
+	}
 	return pop_items;
 }
 
@@ -521,6 +524,10 @@ void Tile::update() {
 			statflags |= TILESTATE_BLOCKING;
 		}
 	}
+
+	if (location) {
+		location->notifyChange();
+	}
 }
 
 void Tile::addBorderItem(std::unique_ptr<Item> item) {
@@ -608,10 +615,16 @@ void Tile::deselectGround() {
 
 void Tile::setHouse(House* _house) {
 	house_id = (_house ? _house->getID() : 0);
+	if (location) {
+		location->notifyChange();
+	}
 }
 
 void Tile::setHouseID(uint32_t newHouseId) {
 	house_id = newHouseId;
+	if (location) {
+		location->notifyChange();
+	}
 }
 
 bool Tile::isTownExit(Map& map) const {
@@ -624,6 +637,7 @@ void Tile::addHouseExit(House* h) {
 	}
 	HouseExitList* house_exits = location->createHouseExits();
 	house_exits->push_back(h->getID());
+	location->notifyChange();
 }
 
 void Tile::removeHouseExit(House* h) {
@@ -637,6 +651,7 @@ void Tile::removeHouseExit(House* h) {
 	}
 
 	std::erase(*house_exits, h->getID());
+	location->notifyChange();
 }
 
 bool Tile::isContentEqual(const Tile* other) const {

--- a/source/rendering/core/chunk_manager.cpp
+++ b/source/rendering/core/chunk_manager.cpp
@@ -1,0 +1,17 @@
+#include "rendering/core/chunk_manager.h"
+#include "map/map_region.h"
+
+RenderChunk* ChunkManager::GetChunk(MapNode* node, int z) {
+	if (!node) {
+		return nullptr;
+	}
+
+	// Simple key packing using pointer address and Z-layer
+	// Since MapNode size > 16, adding z (0-15) is collision-free
+	uint64_t key = reinterpret_cast<uint64_t>(node) + z;
+	return &chunks[key];
+}
+
+void ChunkManager::Clear() {
+	chunks.clear();
+}

--- a/source/rendering/core/chunk_manager.h
+++ b/source/rendering/core/chunk_manager.h
@@ -1,0 +1,23 @@
+#ifndef RME_RENDERING_CORE_CHUNK_MANAGER_H_
+#define RME_RENDERING_CORE_CHUNK_MANAGER_H_
+
+#include "rendering/core/render_chunk.h"
+#include <unordered_map>
+#include <cstdint>
+
+class MapNode;
+
+class ChunkManager {
+public:
+	ChunkManager() = default;
+	~ChunkManager() = default;
+
+	RenderChunk* GetChunk(MapNode* node, int z);
+	void Clear();
+
+private:
+	// Key: Unique ID derived from MapNode pointer and Z-layer
+	std::unordered_map<uint64_t, RenderChunk> chunks;
+};
+
+#endif

--- a/source/rendering/core/render_chunk.cpp
+++ b/source/rendering/core/render_chunk.cpp
@@ -1,0 +1,58 @@
+#include "rendering/core/render_chunk.h"
+#include "rendering/drawers/tiles/tile_renderer.h"
+#include "rendering/core/sprite_batch.h"
+#include "rendering/core/render_view.h"
+#include "app/definitions.h"
+#include <glm/glm.hpp>
+#include "rendering/core/light_buffer.h"
+
+RenderChunk::RenderChunk() {
+	instances.reserve(256);
+}
+
+void RenderChunk::Rebuild(MapNode* node, int map_z, TileRenderer* renderer, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id) {
+	if (!node) {
+		return;
+	}
+
+	is_dynamic = false;
+
+	// Use temporary SpriteBatch to capture instances
+	// We don't need to initialize GL resources for this batch as we only use it to accumulate instances
+	SpriteBatch temp_batch;
+	temp_batch.begin(glm::mat4(1.0f));
+
+	LightBuffer temp_light_buffer;
+
+	Floor* floor = node->getFloor(map_z);
+	if (floor) {
+		TileLocation* location = floor->locs;
+		// Iterate 4x4 tiles in the node
+		for (int i = 0; i < 16; ++i) {
+			TileLocation* loc = &floor->locs[i];
+
+			Position pos = loc->getPosition();
+
+			// Use World Coordinates for caching
+			int world_x = pos.x * TILE_SIZE;
+			int world_y = pos.y * TILE_SIZE;
+
+			bool dynamic_tile = false;
+			// Pass explicit coordinates to bypass visibility culling in DrawTile
+			renderer->DrawTile(temp_batch, loc, view, options, current_house_id, world_x, world_y, &dynamic_tile);
+
+			if (dynamic_tile) {
+				is_dynamic = true;
+			}
+
+			renderer->AddLight(loc, view, options, temp_light_buffer);
+		}
+	}
+
+	instances = temp_batch.stealInstances();
+	lights = std::move(temp_light_buffer.lights);
+
+	// Update timestamp
+	// Use relaxed ordering as exact synchronization isn't critical for visual cache
+	last_rendered = node->last_modified.load(std::memory_order_relaxed);
+}

--- a/source/rendering/core/render_chunk.h
+++ b/source/rendering/core/render_chunk.h
@@ -1,0 +1,43 @@
+#ifndef RME_RENDERING_CORE_RENDER_CHUNK_H_
+#define RME_RENDERING_CORE_RENDER_CHUNK_H_
+
+#include "rendering/core/sprite_instance.h"
+#include "map/map_region.h"
+#include "rendering/core/drawing_options.h"
+#include "rendering/core/light_buffer.h"
+#include <vector>
+#include <cstdint>
+
+class SpriteBatch;
+class TileRenderer;
+class RenderView;
+
+class RenderChunk {
+public:
+	RenderChunk();
+	~RenderChunk() = default;
+
+	// Rebuilds the chunk geometry if necessary
+	void Rebuild(MapNode* node, int map_z, TileRenderer* renderer, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id);
+
+	const std::vector<SpriteInstance>& getInstances() const {
+		return instances;
+	}
+	const std::vector<LightBuffer::Light>& getLights() const {
+		return lights;
+	}
+	uint64_t getLastRendered() const {
+		return last_rendered;
+	}
+	bool isDynamic() const {
+		return is_dynamic;
+	}
+
+private:
+	std::vector<SpriteInstance> instances;
+	std::vector<LightBuffer::Light> lights;
+	uint64_t last_rendered = 0;
+	bool is_dynamic = false;
+};
+
+#endif

--- a/source/rendering/core/sprite_batch.cpp
+++ b/source/rendering/core/sprite_batch.cpp
@@ -347,3 +347,17 @@ void SpriteBatch::end(const AtlasManager& atlas_manager) {
 	// blend_capability_ was constructed first, so destroy it last
 	blend_capability_.reset();
 }
+
+std::vector<SpriteInstance> SpriteBatch::stealInstances() {
+	std::vector<SpriteInstance> instances = std::move(pending_sprites_);
+	pending_sprites_.clear();
+	pending_sprites_.reserve(MAX_SPRITES_PER_BATCH);
+	return instances;
+}
+
+void SpriteBatch::append(const std::vector<SpriteInstance>& instances) {
+	if (!in_batch_) {
+		return;
+	}
+	pending_sprites_.insert(pending_sprites_.end(), instances.begin(), instances.end());
+}

--- a/source/rendering/core/sprite_batch.h
+++ b/source/rendering/core/sprite_batch.h
@@ -100,6 +100,18 @@ public:
 		return sprite_count_;
 	}
 
+	/**
+	 * Steals the pending sprites vector. Clears the batch.
+	 * Used for caching generated instances.
+	 */
+	std::vector<SpriteInstance> stealInstances();
+
+	/**
+	 * Appends a vector of instances to the pending batch.
+	 * Used for replaying cached instances.
+	 */
+	void append(const std::vector<SpriteInstance>& instances);
+
 private:
 	void flush(const AtlasManager& atlas_manager);
 

--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -19,6 +19,7 @@
 #define RME_MAP_LAYER_DRAWER_H
 
 #include <iosfwd>
+#include "rendering/core/chunk_manager.h"
 
 class Editor;
 class TileRenderer;
@@ -40,6 +41,8 @@ private:
 	TileRenderer* tile_renderer;
 	GridDrawer* grid_drawer;
 	Editor* editor;
+	ChunkManager chunk_manager;
+	uint64_t last_options_hash = 0;
 };
 
 #endif

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -25,7 +25,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, bool* out_is_dynamic = nullptr);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:


### PR DESCRIPTION
This PR implements a chunk-based caching system for the map renderer. It significantly reduces the CPU overhead of rendering static map geometry by caching the `SpriteInstance` and light data in `RenderChunk` objects managed by a `ChunkManager`.

Key changes:
1.  **Modification Tracking**: `MapNode` now tracks a `last_modified` timestamp. `TileLocation` stores a pointer to its parent `MapNode`, allowing `Tile` modifications to trigger notifications and update the timestamp.
2.  **Render Chunks**: `RenderChunk` captures the geometry (sprite instances) and lights for a map node. It rebuilds only when the node is modified or contains dynamic content (animations, pulsing selection).
3.  **World-Space Caching**: Cached geometry uses world-space coordinates. `MapLayerDrawer` applies a view matrix to `SpriteBatch` to handle camera scrolling, allowing the cache to persist while panning.
4.  **SpriteBatch Enhancements**: Added `stealInstances` and `append` to `SpriteBatch` to facilitate efficient data transfer between the batcher and the cache.
5.  **Option Invalidation**: The cache is automatically cleared if relevant drawing options (e.g., `show_blocking`, `current_house_id`) change.

---
*PR created automatically by Jules for task [16468239697500747489](https://jules.google.com/task/16468239697500747489) started by @karolak6612*