### PR TITLE
Profiler: Fix CPU bottleneck in tooltip generation

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -185,8 +185,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		waypoint = editor->map.waypoints.getWaypoint(location);
 	}
 
+	bool is_hovered = (map_x == view.mouse_map_x && map_y == view.mouse_map_y);
+
 	// Waypoint tooltip (one per waypoint)
-	if (options.show_tooltips && waypoint && map_z == view.floor) {
+	if (is_hovered && options.show_tooltips && waypoint && map_z == view.floor) {
 		tooltip_drawer->addWaypointTooltip(location->getPosition(), waypoint->name);
 	}
 
@@ -223,7 +225,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (is_hovered && options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -271,7 +273,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				const ItemType& it = g_items[item->getID()];
 
 				// item tooltip (one per item)
-				if (options.show_tooltips && map_z == view.floor) {
+				if (is_hovered && options.show_tooltips && map_z == view.floor) {
 					TooltipData& itemData = tooltip_drawer->requestTooltipData();
 					if (FillItemTooltipData(itemData, item.get(), it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 						if (itemData.hasVisibleFields()) {


### PR DESCRIPTION
This PR addresses a significant CPU bottleneck identified by the Profiler agent. Previously, `TileRenderer::DrawTile` would attempt to generate tooltip data (including string processing and container iteration) for every single tile and item visible in the viewport, regardless of whether the user was hovering over it.

This change introduces a check (`is_hovered`) to ensure that tooltip logic is only executed for the tile currently under the mouse cursor. This aligns with the expected behavior of tooltips and drastically reduces per-frame CPU usage.

**Changes:**
- Modified `source/rendering/drawers/tiles/tile_renderer.cpp`: Added `is_hovered` check before calling `tooltip_drawer->addWaypointTooltip` and `tooltip_drawer->requestTooltipData` for ground items and tile items.

**Impact:**
- Frame time improvement (CPU bound scenarios).
- Reduced memory allocations per frame.
- Compliant with Painter's Algorithm constraints.

---
*PR created automatically by Jules for task [15316499486181703750](https://jules.google.com/task/15316499486181703750) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tooltip display behavior so waypoint, ground/item, and item tooltips now only appear when directly hovering over specific tiles, rather than displaying based on other conditions. This provides clearer, more contextual information placement during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->