### PR TITLE
feat(ui): add 10 micro-UX improvements

### DIFF
--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -39,11 +39,12 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	wxDialog(g_gui.root, wxID_ANY, title, wxDefaultPosition, wxDefaultSize, wxRESIZE_BORDER | wxCAPTION | wxCLOSE_BOX),
 	idle_input_timer(this),
 	result_brush(nullptr),
-	result_id(0) {
+	result_id(0),
+	baseTitle(title) {
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 
 	search_field = newd KeyForwardingTextCtrl(this, JUMP_DIALOG_TEXT, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
-	search_field->SetHint("Type to search...");
+	search_field->SetHint("Type to search items/brushes...");
 	search_field->SetToolTip("Type at least 2 characters to search for brushes or items.");
 	search_field->SetFocus();
 	sizer->Add(search_field, 0, wxEXPAND);
@@ -302,6 +303,7 @@ void FindBrushDialog::RefreshContentsInternal() {
 		}
 	}
 	item_list->CommitUpdates();
+	SetTitle(wxString::Format("%s (%zu matches)", baseTitle, item_list->GetResultCount()));
 }
 
 // ============================================================================

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -29,6 +29,9 @@ public:
 	void AddBrush(Brush*);
 	void CommitUpdates();
 	Brush* GetSelectedBrush();
+	size_t GetResultCount() const {
+		return brushlist.size();
+	}
 
 	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
 	int OnMeasureItem(size_t index) const override;
@@ -69,6 +72,7 @@ protected:
 	wxTimer idle_input_timer;
 	const Brush* result_brush;
 	int result_id;
+	wxString baseTitle;
 };
 
 class FindBrushDialog : public FindDialog {

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -9,6 +9,7 @@
 #include "ui/positionctrl.h"
 #include "ui/gui.h"
 #include "util/image_manager.h"
+#include "ui/theme.h"
 
 // ============================================================================
 // Go To Position Dialog
@@ -24,6 +25,19 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 
 	posctrl = newd PositionCtrl(this, "Destination", map.getWidth() / 2, map.getHeight() / 2, GROUND_LAYER, map.getWidth(), map.getHeight());
 	sizer->Add(posctrl, 0, wxTOP | wxLEFT | wxRIGHT, 20);
+
+	wxStaticText* pasteHint = newd wxStaticText(this, wxID_ANY, "Tip: You can paste coordinates (x,y,z)");
+	pasteHint->SetForegroundColour(Theme::Get(Theme::Role::TextSubtle));
+	sizer->Add(pasteHint, 0, wxALIGN_CENTER | wxTOP, 5);
+
+	MapTab* currentTab = g_gui.GetCurrentMapTab();
+	if (currentTab) {
+		Position currentPos = currentTab->GetScreenCenterPosition();
+		wxString currentPosStr = wxString::Format("Current Position: %d, %d, %d", currentPos.x, currentPos.y, currentPos.z);
+		wxStaticText* currentPosLbl = newd wxStaticText(this, wxID_ANY, currentPosStr);
+		currentPosLbl->SetForegroundColour(Theme::Get(Theme::Role::Text));
+		sizer->Add(currentPosLbl, 0, wxALIGN_CENTER | wxTOP, 10);
+	}
 
 	// OK/Cancel buttons
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -42,10 +42,11 @@ namespace {
 
 	class ColorSwatch : public wxWindow {
 	public:
-		ColorSwatch(wxWindow* parent, int id, uint32_t color) :
+		ColorSwatch(wxWindow* parent, int id, uint32_t color, int colorIndex) :
 			wxWindow(parent, id, wxDefaultPosition, wxSize(16, 16), wxBORDER_NONE),
 			color(color), selected(false) {
 			SetBackgroundStyle(wxBG_STYLE_PAINT);
+			SetToolTip(wxString::Format("Color %d", colorIndex));
 			Bind(wxEVT_PAINT, &ColorSwatch::OnPaint, this);
 			Bind(wxEVT_LEFT_DOWN, &ColorSwatch::OnMouse, this);
 		}
@@ -181,7 +182,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
-		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
+		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color, i);
 		palette_sizer->Add(swatch, 0);
 		color_buttons.push_back(swatch);
 
@@ -194,10 +195,10 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);
 	addon1 = new wxCheckBox(this, ID_ADDON1, "Addon 1");
-	addon1->SetToolTip("Toggle Addon 1");
+	addon1->SetToolTip("Toggle Addon 1 (Accessory)");
 	addon1->SetValue((current_outfit.lookAddon & 1) != 0);
 	addon2 = new wxCheckBox(this, ID_ADDON2, "Addon 2");
-	addon2->SetToolTip("Toggle Addon 2");
+	addon2->SetToolTip("Toggle Addon 2 (Accessory)");
 	addon2->SetValue((current_outfit.lookAddon & 2) != 0);
 
 	check_sizer->Add(addon1, 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
@@ -230,6 +231,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	outfit_search = new wxSearchCtrl(this, ID_SEARCH, wxEmptyString, wxDefaultPosition, wxSize(180, -1));
 	outfit_search->SetDescriptiveText("Search...");
+	outfit_search->SetToolTip("Search by outfit name");
 	outfits_header_row->Add(outfit_search, 0, wxALIGN_BOTTOM | wxRIGHT, 4);
 
 	colorable_only_check = new wxCheckBox(this, wxID_ANY, "Template Only");

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -30,7 +30,8 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	input_timer(this),
 	result_brush(nullptr),
 	result_id(0),
-	only_pickupables(onlyPickupables) {
+	only_pickupables(onlyPickupables),
+	baseTitle(title) {
 	this->SetSizeHints(wxDefaultSize, wxDefaultSize);
 
 	wxBoxSizer* box_sizer = newd wxBoxSizer(wxHORIZONTAL);
@@ -415,6 +416,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	}
 
 	items_list->Refresh();
+	SetTitle(wxString::Format("%s (%zu matches)", baseTitle, items_list->GetResultCount()));
 }
 
 void FindItemDialog::OnOptionChange(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -111,6 +111,7 @@ private:
 	Brush* result_brush;
 	uint16_t result_id;
 	bool only_pickupables;
+	wxString baseTitle;
 };
 
 #endif // RME_FIND_ITEM_WINDOW_H_

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -325,6 +325,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
 	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
+	prefBtn->SetToolTip("Configure editor settings (Ctrl+P)");
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Right: 10px total
@@ -340,6 +341,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
 	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
+	exitBtn->SetToolTip("Exit the application (Alt+F4)");
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Left: 10px total
@@ -347,6 +349,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
 	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
+	newBtn->SetToolTip("Create a new map (Ctrl+N)");
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
@@ -359,6 +362,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
 	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
+	loadBtn->SetToolTip("Load selected recent map");
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -388,12 +392,14 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 
 	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
 	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	newMapBtn->SetToolTip("Create a new empty map (Ctrl+N)");
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
 	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	browseBtn->SetToolTip("Open an existing map file (Ctrl+O)");
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 


### PR DESCRIPTION
Implemented 10 micro-UX improvements across 4 dialogs:
1.  **Welcome Dialog**: Added tooltips and keyboard shortcut hints to "New Map", "Open Map", "Preferences", and "Exit" buttons.
2.  **Find Dialog**: Updated window title to show result count and improved search field hint.
3.  **Goto Position Dialog**: Added "Current: X, Y, Z" label and "Paste coordinates" hint.
4.  **Outfit Chooser Dialog**: Added tooltips to color swatches, search field, and improved addon tooltips.
5.  **Find Item Dialog**: Updated window title to show result count.

These changes make the interface more intuitive and informative.

---
*PR created automatically by Jules for task [16269150151317154013](https://jules.google.com/task/16269150151317154013) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search dialogs now display the number of matches in the title bar.
  * Go To Position dialog includes a paste hint and current map center position indicator.
  * Added helpful tooltips throughout the application: button shortcuts, accessory labels, outfit search guidance, and color palette indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->