### PR TITLE
Refactor wxWidgets layout, threading, and performance violations

### DIFF
--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -39,6 +39,9 @@ public:
 	~UpdateChecker();
 
 	void connect(wxEvtHandler* receiver);
+
+private:
+	std::jthread m_worker;
 };
 
 	#endif

--- a/source/palette/palette_waypoints.h
+++ b/source/palette/palette_waypoints.h
@@ -23,6 +23,18 @@
 #include "game/waypoints.h"
 #include "palette/palette_common.h"
 
+class VirtualWaypointListCtrl : public wxListCtrl {
+public:
+	VirtualWaypointListCtrl(wxWindow* parent, wxWindowID id, const wxPoint& pos, const wxSize& size, long style) :
+		wxListCtrl(parent, id, pos, size, style | wxLC_VIRTUAL) {
+	}
+	wxString OnGetItemText(long item, long column) const override;
+	void UpdateWaypoints(std::vector<wxString> waypoints);
+
+private:
+	std::vector<wxString> m_waypoints;
+};
+
 class WaypointPalettePanel : public PalettePanel {
 public:
 	WaypointPalettePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
@@ -59,7 +71,7 @@ public:
 
 protected:
 	Map* map;
-	wxListCtrl* waypoint_list;
+	VirtualWaypointListCtrl* waypoint_list;
 	wxButton* add_waypoint_button;
 	wxButton* remove_waypoint_button;
 };

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -178,18 +178,18 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	part_sizer->Add(feet_btn, 1, wxEXPAND);
 	col1_sizer->Add(part_sizer, 0, wxEXPAND | wxTOP | wxLEFT | wxRIGHT, 8);
 
-	wxFlexGridSizer* palette_sizer = new wxFlexGridSizer(COLOR_ROWS, COLOR_COLUMNS, 1, 1);
+	wxWrapSizer* palette_sizer = new wxWrapSizer(wxHORIZONTAL);
 	for (size_t i = 0; i < TemplateOutfitLookupTableSize; ++i) {
 		uint32_t color = TemplateOutfitLookupTable[i];
 		ColorSwatch* swatch = new ColorSwatch(this, ID_COLOR_START + static_cast<int>(i), color);
-		palette_sizer->Add(swatch, 0);
+		palette_sizer->Add(swatch, 0, wxRIGHT | wxBOTTOM, 1);
 		color_buttons.push_back(swatch);
 
 		swatch->Bind(wxEVT_BUTTON, [this, i](wxCommandEvent&) {
 			SelectColor(i);
 		});
 	}
-	col1_sizer->Add(palette_sizer, 0, wxALL, 8);
+	col1_sizer->Add(palette_sizer, 0, wxEXPAND | wxALL, 8);
 
 	col1_sizer->Add(CreateHeader("Configuration"), 0, wxLEFT | wxTOP, 8);
 	wxWrapSizer* check_sizer = new wxWrapSizer(wxHORIZONTAL);


### PR DESCRIPTION
This PR addresses three specific wxWidgets violations identified by the Phantom agent:
1.  **Layout Violation**: `OutfitChooserDialog` used a fixed-grid `wxFlexGridSizer` for the color palette. This has been replaced with `wxWrapSizer` to allow the palette to flow naturally.
2.  **Threading Violation**: `UpdateChecker` used a detached thread with a raw pointer to `wxEvtHandler`, which is unsafe. This has been refactored to use `std::jthread` as a member variable, ensuring the thread is joined and stopped safely before destruction.
3.  **Performance Anti-Pattern**: `WaypointPalettePanel` rebuilt the entire `wxListCtrl` item-by-item on every update. This has been optimized by implementing a `VirtualWaypointListCtrl` subclass that uses `wxLC_VIRTUAL` style and a cached `std::vector` of strings, significantly improving update performance for large lists.

---
*PR created automatically by Jules for task [4685629596658709976](https://jules.google.com/task/4685629596658709976) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Color palette in outfit chooser now wraps horizontally with better spacing between items

* **Performance**
  * Waypoint list rendering optimized for better responsiveness with large lists

* **Stability**
  * Improved reliability of the update checker mechanism

<!-- end of auto-generated comment: release notes by coderabbit.ai -->