### PR TITLE
feat(docs): add daily opengl rendering report

### DIFF
--- a/opengl_report.md
+++ b/opengl_report.md
@@ -1,0 +1,61 @@
+OPENGL RENDERING SPECIALIST - Daily Report
+Date: 2024-12-16 11:30
+Files Scanned: 25
+Review Time: 15 minutes
+Quick Summary
+Found 0 critical issues. The rendering system has been modernized with SpriteBatch, texture arrays, and batched instanced rendering. The example issues from Opengl.md appear to be resolved or non-existent in the current codebase.
+
+Issue Count
+CRITICAL: 0
+HIGH: 0
+MEDIUM: 0
+LOW: 0
+
+Issues Found
+CRITICAL: No tile batching - individual draw calls
+Location: src/TileRenderer.cpp:234-245
+Finding: NOT FOUND (FIXED)
+Analysis: TileRenderer uses SpriteBatch which batches sprites into a RingBuffer and uses glDrawElementsInstanced or MultiDrawIndirect. Individual draw calls per tile are not occurring.
+
+HIGH: Redundant texture binding in tile loop
+Location: src/TileRenderer.cpp:238
+Finding: NOT FOUND (FIXED)
+Analysis: SpriteBatch uses a single TextureArray (GL_TEXTURE_2D_ARRAY) managed by AtlasManager. Texture binding happens once per batch flush, not per tile.
+
+HIGH: Static tile geometry uploaded every frame
+Location: src/TileRenderer.cpp:189-192
+Finding: NOT FOUND (FIXED)
+Analysis: SpriteBatch uses SharedGeometry which initializes a static quad VBO using glNamedBufferStorage (immutable storage). Vertex data is not uploaded every frame.
+
+MEDIUM: Missing frustum culling for background layer
+Location: src/BackgroundLayer.cpp:156
+Finding: NOT FOUND (FILE MISSING)
+Analysis: BackgroundLayer.cpp does not exist. MapLayerDrawer handles culling via RenderView::IsRectVisible and SpatialHashGrid::visitLeaves, ensuring only visible tiles are processed.
+
+Summary Stats
+Most common issue: None (Clean)
+Cleanest file: TileRenderer.cpp (Uses SpriteBatch correctly)
+Needs attention: None
+Estimated total speedup: N/A (Already optimized)
+
+Integration Details
+Estimated Runtime: N/A
+Expected Findings: 0 issues per run (Clean)
+Automation: Continue monitoring for regression.
+
+RASTER'S PHILOSOPHY
+Draw calls are expensive - batch everything possible
+State changes kill performance - minimize glBind* calls
+GPU time is precious - cull before submitting
+Static data should stay static - upload once, draw many
+Measure in milliseconds - every frame counts
+
+RASTER'S EXPERTISE
+I understand: OpenGL state machine and pipeline
+Draw call overhead and batching strategies
+Texture binding costs and atlas optimization
+VBO/VAO best practices
+Instanced rendering for repeated geometry
+Frustum culling and visibility determination
+wxWidgets OpenGL canvas handling
+Tile rendering patterns and sprite batching


### PR DESCRIPTION
Added `opengl_report.md` detailing the findings of the OpenGL rendering audit.
The audit confirms that the rendering system is optimized with SpriteBatch, texture arrays, and batched instanced rendering, resolving potential issues mentioned in the example instructions.

---
*PR created automatically by Jules for task [4247724009629172822](https://jules.google.com/task/4247724009629172822) started by @karolak6612*