### PR TITLE
Palette: Implement 10 micro-UX improvements

### DIFF
--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -116,12 +116,16 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxBoxSizer* part_sizer = new wxBoxSizer(wxHORIZONTAL);
 	head_btn = new wxButton(this, ID_COLOR_HEAD, "Head", wxDefaultPosition, wxSize(50, -1));
 	head_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(16, 16)));
+	head_btn->SetToolTip("Change head color");
 	body_btn = new wxButton(this, ID_COLOR_BODY, "Primary", wxDefaultPosition, wxSize(50, -1));
 	body_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHIRT, wxSize(16, 16)));
+	body_btn->SetToolTip("Change primary color");
 	legs_btn = new wxButton(this, ID_COLOR_LEGS, "Secondary", wxDefaultPosition, wxSize(50, -1));
 	legs_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SOCKS, wxSize(16, 16)));
+	legs_btn->SetToolTip("Change secondary color");
 	feet_btn = new wxButton(this, ID_COLOR_FEET, "Detail", wxDefaultPosition, wxSize(50, -1));
 	feet_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHOE_PRINTS, wxSize(16, 16)));
+	feet_btn->SetToolTip("Change detail color");
 
 	part_sizer->Add(head_btn, 1, wxEXPAND | wxRIGHT, 2);
 	part_sizer->Add(body_btn, 1, wxEXPAND | wxRIGHT, 2);
@@ -193,6 +197,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	wxButton* fav_btn = new wxButton(this, ID_ADD_FAVORITE, "Save Current Outfit as Favorite", wxDefaultPosition, wxSize(-1, 28));
 	fav_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_STAR, wxSize(16, 16)));
+	fav_btn->SetToolTip("Add the current outfit configuration to your favorites list");
 	favs_sizer->Add(fav_btn, 0, wxEXPAND | wxTOP, 8);
 
 	main_sizer->Add(favs_sizer, 0, wxEXPAND | wxLEFT, 5);

--- a/source/ui/dialogs/outfit_selection_grid.cpp
+++ b/source/ui/dialogs/outfit_selection_grid.cpp
@@ -331,6 +331,14 @@ void OutfitSelectionGrid::OnMotion(wxMouseEvent& event) {
 	if (index != hover_index) {
 		hover_index = index;
 		Refresh();
+
+		if (index != -1) {
+			wxString name = is_favorites ? wxString::FromUTF8(favorite_items[index].label) : filtered_outfits[index].name;
+			int lookType = is_favorites ? favorite_items[index].outfit.lookType : filtered_outfits[index].lookType;
+			SetToolTip(name + wxString::Format(" (#%d)", lookType));
+		} else {
+			UnsetToolTip();
+		}
 	}
 
 	if (index != -1) {

--- a/source/ui/extension_window.cpp
+++ b/source/ui/extension_window.cpp
@@ -41,7 +41,7 @@ ExtensionsDialog::ExtensionsDialog(wxWindow* parent) :
 	buttonSizer->Add(okBtn, wxSizerFlags(1).Center());
 	auto openBtn = newd wxButton(this, EXTENSIONS_OPEN_FOLDER_BUTTON, "Open Extensions Folder");
 	openBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FOLDER_OPEN, wxSize(16, 16)));
-	openBtn->SetToolTip("Open the extensions directory in file explorer");
+	openBtn->SetToolTip("Open: " + FileSystem::GetExtensionsDirectory());
 	buttonSizer->Add(openBtn, wxSizerFlags(1).Center());
 	topSizer->Add(buttonSizer, 0, wxCENTER | wxLEFT | wxRIGHT | wxBOTTOM, 20);
 

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -456,6 +456,7 @@ void FindItemDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 		if (brush) {
 			result_brush = brush;
 			result_id = brush->as<RAWBrush>()->getItemID();
+			g_gui.SetStatusText("Selected item: " + brush->getName());
 			EndModal(wxID_OK);
 		}
 	}

--- a/source/ui/positionctrl.cpp
+++ b/source/ui/positionctrl.cpp
@@ -23,17 +23,17 @@
 PositionCtrl::PositionCtrl(wxWindow* parent, const wxString& label, int x, int y, int z, int maxx /*= MAP_MAX_WIDTH*/, int maxy /*= MAP_MAX_HEIGHT*/, int maxz /*= MAP_MAX_LAYER*/) :
 	wxStaticBoxSizer(wxHORIZONTAL, parent, label) {
 	x_field = newd NumberTextCtrl(GetStaticBox(), wxID_ANY, x, 0, maxx, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, wxSize(60, 20));
-	x_field->SetToolTip("X Coordinate");
+	x_field->SetToolTip(wxString::Format("X Coordinate (0-%d)", maxx));
 	x_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(x_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
 
 	y_field = newd NumberTextCtrl(GetStaticBox(), wxID_ANY, y, 0, maxy, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, wxSize(60, 20));
-	y_field->SetToolTip("Y Coordinate");
+	y_field->SetToolTip(wxString::Format("Y Coordinate (0-%d)", maxy));
 	y_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(y_field, 2, wxEXPAND | wxLEFT | wxBOTTOM, 5);
 
 	z_field = newd NumberTextCtrl(GetStaticBox(), wxID_ANY, z, 0, maxz, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, wxSize(35, 20));
-	z_field->SetToolTip("Z Coordinate (Layer)");
+	z_field->SetToolTip(wxString::Format("Z Coordinate (0-%d)", maxz));
 	z_field->Bind(wxEVT_TEXT_PASTE, &PositionCtrl::OnClipboardText, this);
 	Add(z_field, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, 5);
 

--- a/source/ui/properties/depot_properties_window.cpp
+++ b/source/ui/properties/depot_properties_window.cpp
@@ -11,6 +11,7 @@
 #include "map/map.h"
 #include "ui/dialog_util.h"
 #include "ui/properties/depot_properties_window.h"
+#include "ui/gui.h"
 #include "util/image_manager.h"
 
 // ============================================================================
@@ -70,9 +71,11 @@ DepotPropertiesWindow::DepotPropertiesWindow(wxWindow* parent, const Map* map, c
 	wxSizer* buttonsizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Apply changes and close");
 	buttonsizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetToolTip("Discard changes and close");
 	buttonsizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
@@ -92,6 +95,7 @@ void DepotPropertiesWindow::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 	if (Depot* depot = dynamic_cast<Depot*>(edit_item)) {
 		int new_depotid = static_cast<int>(reinterpret_cast<intptr_t>(depot_id_field->GetClientData(depot_id_field->GetSelection())));
 		depot->setDepotID(new_depotid);
+		g_gui.SetStatusText("Depot properties saved.");
 	}
 	EndModal(1);
 }

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -19,6 +19,7 @@
 
 #include "ui/properties/properties_window.h"
 
+#include "ui/gui.h"
 #include "util/image_manager.h"
 #include "ui/gui_ids.h"
 #include "game/complexitem.h"
@@ -308,6 +309,7 @@ void PropertiesWindow::OnClickOK(wxCommandEvent&) {
 
 	saveGeneralPanel();
 	saveAttributesPanel();
+	g_gui.SetStatusText("Item properties saved.");
 	EndModal(1);
 }
 

--- a/source/ui/properties/spawn_properties_window.cpp
+++ b/source/ui/properties/spawn_properties_window.cpp
@@ -5,6 +5,7 @@
 #include "app/main.h"
 #include "ui/properties/spawn_properties_window.h"
 
+#include "ui/gui.h"
 #include "map/map.h"
 #include "app/application.h"
 #include "util/image_manager.h"
@@ -24,8 +25,9 @@ SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* ma
 	subsizer->AddGrowableCol(1);
 
 	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Spawn size"));
-	count_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_spawn->getSize()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, g_settings.getInteger(Config::MAX_SPAWN_RADIUS), edit_spawn->getSize());
-	count_field->SetToolTip("Radius of the spawn area");
+	int max_radius = g_settings.getInteger(Config::MAX_SPAWN_RADIUS);
+	count_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_spawn->getSize()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, max_radius, edit_spawn->getSize());
+	count_field->SetToolTip(wxString::Format("Radius of the spawn area (1-%d)", max_radius));
 	subsizer->Add(count_field, wxSizerFlags(1).Expand());
 
 	boxsizer->Add(subsizer, wxSizerFlags(1).Expand());
@@ -35,9 +37,11 @@ SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* ma
 	wxSizer* std_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetToolTip("Apply changes and close");
 	std_sizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetToolTip("Discard changes and close");
 	std_sizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(std_sizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
@@ -56,6 +60,7 @@ SpawnPropertiesWindow::~SpawnPropertiesWindow() {
 void SpawnPropertiesWindow::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 	int new_spawnsize = count_field->GetValue();
 	edit_spawn->setSize(new_spawnsize);
+	g_gui.SetStatusText("Spawn properties saved.");
 	EndModal(1);
 }
 


### PR DESCRIPTION
Implemented 10 micro-UX improvements as requested by the Palette agent instructions.
These improvements focus on adding tooltips, clarifying ranges, and providing status bar feedback for actions.

1.  **OutfitChooserDialog**: Added tooltips to Head, Body, Legs, Feet, and Favorite buttons.
2.  **OutfitSelectionGrid**: Added dynamic hover tooltips showing outfit name and ID.
3.  **ExtensionsDialog**: Updated "Open Extensions Folder" tooltip to show the directory path.
4.  **PositionCtrl**: Updated X/Y/Z tooltips to show the valid coordinate range (0-Max).
5.  **PropertiesWindow**: Added "Item properties saved." status message on OK.
6.  **FindItemDialog**: Added "Selected item: [Name]" status message on OK.
7.  **SpawnPropertiesWindow**: Added tooltips to OK/Cancel buttons.
8.  **SpawnPropertiesWindow**: Added "Spawn properties saved." status message on OK.
9.  **SpawnPropertiesWindow**: Updated radius tooltip to show range (1-Max).
10. **DepotPropertiesWindow**: Added tooltips to OK/Cancel buttons.
11. **DepotPropertiesWindow**: Added "Depot properties saved." status message on OK.


---
*PR created automatically by Jules for task [9840078094561026390](https://jules.google.com/task/9840078094561026390) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface Improvements**
  * Enhanced tooltips across multiple dialogs (color pickers, outfit selection, coordinate fields, spawn settings) to provide better guidance
  * Added contextual hover information for outfit selection
  * Dynamically display valid ranges for coordinate and spawn radius fields
  * Added confirmation messages when saving changes to depot, item, and spawn properties
  * Improved tooltips to show actual file paths and action descriptions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->