### PR TITLE
Modernize window persistence using wxPersistentWindow

### DIFF
--- a/source/app/application.cpp
+++ b/source/app/application.cpp
@@ -53,6 +53,11 @@
 
 #include "../brushes/icon/editor_icon.xpm"
 
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
+#include <wx/config.h>
+#include <wx/fileconf.h>
+
 wxIMPLEMENT_APP_NO_MAIN(Application);
 
 int main(int argc, char** argv) {
@@ -87,6 +92,13 @@ bool Application::OnInit() {
 	spdlog::info("This is free software: you are free to change and redistribute it.");
 	spdlog::info("There is NO WARRANTY, to the extent permitted by law.");
 	spdlog::info("Review COPYING in RME distribution for details.");
+
+	// Configure persistence manager
+	// Use a separate file for UI persistence to avoid cluttering system config
+	auto* config = new wxFileConfig("", "",
+		wxStandardPaths::Get().GetUserConfigDir() + "/.rme_persistence"
+	);
+	wxConfigBase::Set(config);
 
 	// Load settings early for theme support
 	g_settings.load();

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -6,6 +6,8 @@
 #include "ui/theme.h"
 #include "brushes/raw/raw_brush.h"
 #include "util/image_manager.h"
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
 #include <glad/glad.h>
 #include <nanovg.h>
 #include <algorithm>
@@ -65,7 +67,11 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	sizer->Add(stdsizer, wxSizerFlags(0).Center().Border());
 
 	SetSizerAndFit(sizer);
-	Centre(wxBOTH);
+
+	SetName("FindDialog");
+	if (!wxPersistenceManager::Get().RegisterAndRestore(this)) {
+		Centre(wxBOTH);
+	}
 
 	Bind(wxEVT_TIMER, &FindDialog::OnTextIdle, this, wxID_ANY);
 	Bind(wxEVT_TEXT, &FindDialog::OnTextChange, this, JUMP_DIALOG_TEXT);

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -30,6 +30,8 @@
 #include "ui/theme.h"
 #include "util/json.h"
 #include "util/image_manager.h"
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
 #include <fstream>
 #include <nlohmann/json.hpp>
 #include <format>
@@ -248,6 +250,9 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 	wxIcon icon;
 	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(32, 32)));
 	SetIcon(icon);
+
+	SetName("OutfitChooserDialog");
+	wxPersistenceManager::Get().RegisterAndRestore(this);
 }
 
 OutfitChooserDialog::~OutfitChooserDialog() { }

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -24,6 +24,8 @@
 #include "brushes/brush.h"
 #include "brushes/raw/raw_brush.h"
 #include "util/image_manager.h"
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
 
 FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onlyPickupables /* = false*/) :
 	wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600), wxDEFAULT_DIALOG_STYLE),
@@ -198,6 +200,9 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	wxIcon icon;
 	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(32, 32)));
 	SetIcon(icon);
+
+	SetName("FindItemDialog");
+	wxPersistenceManager::Get().RegisterAndRestore(this);
 
 	// Connect Events
 	options_radio_box->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, &FindItemDialog::OnOptionChange, this);

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -19,7 +19,8 @@
 #include <wx/srchctrl.h>
 #include <wx/msgdlg.h>
 #include <wx/textdlg.h>
-#include <wx/artprov.h>
+#include <wx/persist.h>
+#include <wx/persist/toplevel.h>
 
 // Brush includes
 #include "brushes/brush.h"
@@ -46,35 +47,13 @@ ReplaceToolWindow::ReplaceToolWindow(wxWindow* parent, Editor* editor) : wxDialo
 
 	UpdateSavedRulesList();
 
-	Bind(wxEVT_CLOSE_WINDOW, &ReplaceToolWindow::OnClose, this);
-
-	// Restore window size (Physical pixels)
-	int w = g_settings.getInteger(Config::REPLACE_TOOL_WINDOW_WIDTH);
-	int h = g_settings.getInteger(Config::REPLACE_TOOL_WINDOW_HEIGHT);
-
-	if (w < 600 || h < 400) {
-		// Default size (Logical -> Physical)
+	SetName("ReplaceToolWindow");
+	if (!wxPersistenceManager::Get().RegisterAndRestore(this)) {
 		SetSize(FromDIP(wxSize(1400, 850)));
-	} else {
-		// Restored size (Already Physical)
-		SetSize(wxSize(w, h));
 	}
 }
 
 ReplaceToolWindow::~ReplaceToolWindow() {
-	// Unbind to be safe, though destructor usually handles cleanup
-	Unbind(wxEVT_CLOSE_WINDOW, &ReplaceToolWindow::OnClose, this);
-}
-
-void ReplaceToolWindow::OnClose(wxCloseEvent& event) {
-	if (!IsMaximized()) {
-		// GetSize returns Physical pixels on Windows
-		wxSize size = GetSize();
-		g_settings.setInteger(Config::REPLACE_TOOL_WINDOW_WIDTH, size.GetWidth());
-		g_settings.setInteger(Config::REPLACE_TOOL_WINDOW_HEIGHT, size.GetHeight());
-		g_settings.save();
-	}
-	event.Skip(); // Allow window to close
 }
 
 void ReplaceToolWindow::InitializeWithIDs(const std::vector<uint16_t>& ids) {

--- a/source/ui/replace_tool/replace_tool_window.h
+++ b/source/ui/replace_tool/replace_tool_window.h
@@ -38,8 +38,6 @@ public:
 	// ItemGridPanel::Listener
 	virtual void OnItemSelected(ItemGridPanel* source, uint16_t itemId) override;
 
-	void OnClose(wxCloseEvent& event);
-
 private:
 	void InitLayout();
 	void UpdateSavedRulesList();


### PR DESCRIPTION
This change modernizes the window geometry saving mechanism by utilizing `wxPersistenceManager`.
Previously, some windows (like `ReplaceToolWindow`) implemented manual saving/restoring of size and position using `g_settings`.
Others (`OutfitChooserDialog`, `FindDialog`, `FindItemDialog`) did not save their geometry at all.

By using `wxPersistentWindow`, we standardize this behavior and remove boilerplate code.
A dedicated configuration file `.rme_persistence` is used to store UI state, keeping the main `settings.toml` clean.
Each affected dialog now calls `SetName()` and `RegisterAndRestore()` in its constructor.

---
*PR created automatically by Jules for task [2628366182494954349](https://jules.google.com/task/2628366182494954349) started by @karolak6612*