### PR TITLE
⚡ Throttle: Optimize tooltip generation in render loop

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -186,8 +186,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		waypoint = editor->map.waypoints.getWaypoint(location);
 	}
 
+	// Tooltip optimization: Only calculate tooltips for the tile under the mouse
+	bool is_under_mouse = (map_x == view.mouse_map_x && map_y == view.mouse_map_y);
+
 	// Waypoint tooltip (one per waypoint)
-	if (options.show_tooltips && waypoint && map_z == view.floor) {
+	if (is_under_mouse && options.show_tooltips && waypoint && map_z == view.floor) {
 		tooltip_drawer->addWaypointTooltip(location->getPosition(), waypoint->name);
 	}
 
@@ -233,7 +236,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (is_under_mouse && options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -273,7 +276,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				}
 			}
 
-			bool process_tooltips = options.show_tooltips && map_z == view.floor;
+			bool process_tooltips = is_under_mouse && options.show_tooltips && map_z == view.floor;
 
 			// items on tile
 			for (const auto& item : tile->items) {


### PR DESCRIPTION
Optimize map rendering by throttling tooltip generation

Restricts expensive tooltip data generation (`FillItemTooltipData` and `addWaypointTooltip`) in `TileRenderer::DrawTile` to only run for the tile currently under the mouse cursor.

This significantly reduces CPU usage during the render loop when `show_tooltips` is enabled, as it avoids processing string formatting and data collection for every visible tile every frame.

This change adheres to the instruction to optimize `TileRenderer::DrawTile` for performance while respecting that "Viewport labels" (handled separately) must remain visible for all entities.

---
*PR created automatically by Jules for task [12507762445723436670](https://jules.google.com/task/12507762445723436670) started by @karolak6612*