### PR TITLE
Refactor Brush System, Optimize Selection, and Add Brush Factory

### DIFF
--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -271,6 +271,7 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/autoborder_preview_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/managers/status_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/brush_manager.h
+    ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/brush_factory.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/managers/palette_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/ui/managers/recent_files_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/editor/managers/editor_manager.h
@@ -609,6 +610,7 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/autoborder_preview_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/managers/status_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/brush_manager.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/brushes/managers/brush_factory.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/managers/palette_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/ui/managers/recent_files_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/editor/managers/editor_manager.cpp

--- a/source/brushes/managers/brush_factory.cpp
+++ b/source/brushes/managers/brush_factory.cpp
@@ -1,0 +1,36 @@
+#include "app/main.h"
+#include "brushes/managers/brush_factory.h"
+#include "brushes/brush.h"
+#include "brushes/ground/ground_brush.h"
+#include "brushes/wall/wall_brush.h"
+#include "brushes/carpet/carpet_brush.h"
+#include "brushes/table/table_brush.h"
+#include "brushes/doodad/doodad_brush.h"
+
+BrushFactory& BrushFactory::getInstance() {
+	static BrushFactory instance;
+	return instance;
+}
+
+void BrushFactory::registerBrush(std::string_view typeName, BrushCreator creator) {
+	creators[std::string(typeName)] = std::move(creator);
+}
+
+std::unique_ptr<Brush> BrushFactory::createBrush(std::string_view typeName) const {
+	auto it = creators.find(std::string(typeName));
+	if (it != creators.end()) {
+		return it->second();
+	}
+	return nullptr;
+}
+
+void BrushFactory::registerStandardBrushes() {
+	auto& factory = getInstance();
+	factory.registerBrush("border", [] { return std::make_unique<GroundBrush>(); });
+	factory.registerBrush("ground", [] { return std::make_unique<GroundBrush>(); });
+	factory.registerBrush("wall", [] { return std::make_unique<WallBrush>(); });
+	factory.registerBrush("wall decoration", [] { return std::make_unique<WallDecorationBrush>(); });
+	factory.registerBrush("carpet", [] { return std::make_unique<CarpetBrush>(); });
+	factory.registerBrush("table", [] { return std::make_unique<TableBrush>(); });
+	factory.registerBrush("doodad", [] { return std::make_unique<DoodadBrush>(); });
+}

--- a/source/brushes/managers/brush_factory.h
+++ b/source/brushes/managers/brush_factory.h
@@ -1,0 +1,28 @@
+#ifndef RME_BRUSH_FACTORY_H
+#define RME_BRUSH_FACTORY_H
+
+#include <string>
+#include <unordered_map>
+#include <functional>
+#include <memory>
+#include <string_view>
+
+class Brush;
+
+class BrushFactory {
+public:
+	using BrushCreator = std::function<std::unique_ptr<Brush>()>;
+
+	static BrushFactory& getInstance();
+
+	void registerBrush(std::string_view typeName, BrushCreator creator);
+	std::unique_ptr<Brush> createBrush(std::string_view typeName) const;
+
+	// Helper to auto-register standard brushes
+	static void registerStandardBrushes();
+
+private:
+	std::unordered_map<std::string, BrushCreator> creators;
+};
+
+#endif


### PR DESCRIPTION
This PR refactors core systems to improve maintainability, type safety, and performance.

### Brush System Refactor
- Introduced `BrushContext` struct to replace `void* parameter` in `draw` and `undraw` methods. This eliminates unsafe casts and makes parameter passing explicit (e.g. `alt`, `shift`, `variation`, `size`).
- Updated all brush implementations (`GroundBrush`, `WallBrush`, `DoodadBrush`, etc.) to use `BrushContext`.

### Selection System Optimization
- Replaced manual vector manipulation in `Selection` with a `TileSet` helper class.
- `TileSet` maintains a sorted `std::vector<Tile*>` and uses `std::ranges` algorithms (`lower_bound`, `set_union`, `set_difference`) for efficient addition, removal, and batch updates. This improves performance for large selection operations.

### Brush Factory Implementation
- Created `BrushFactory` singleton to handle brush instantiation.
- Refactored `Brushes::unserializeBrush` to use the factory instead of a hardcoded map, allowing for easier registration of new brush types.
- Registered standard brushes in `Brushes::init`.

---
*PR created automatically by Jules for task [8672007381921873420](https://jules.google.com/task/8672007381921873420) started by @karolak6612*