### PR TITLE
Paint 10 micro-UX improvements

### DIFF
--- a/source/app/preferences/general_page.cpp
+++ b/source/app/preferences/general_page.cpp
@@ -15,10 +15,12 @@ GeneralPage::GeneralPage(wxWindow* parent) : PreferencesPage(parent) {
 
 	always_make_backup_chkbox = newd wxCheckBox(this, wxID_ANY, "Always make map backup");
 	always_make_backup_chkbox->SetValue(g_settings.getInteger(Config::ALWAYS_MAKE_BACKUP) == 1);
+	always_make_backup_chkbox->SetToolTip("Automatically create a backup copy when saving the map.");
 	sizer->Add(always_make_backup_chkbox, wxSizerFlags().Border(wxLEFT | wxTOP, 5));
 
 	update_check_on_startup_chkbox = newd wxCheckBox(this, wxID_ANY, "Check for updates on startup");
 	update_check_on_startup_chkbox->SetValue(g_settings.getInteger(Config::USE_UPDATER) == 1);
+	update_check_on_startup_chkbox->SetToolTip("Check for new versions of the editor when starting.");
 	sizer->Add(update_check_on_startup_chkbox, wxSizerFlags().Border(wxLEFT | wxTOP, 5));
 
 	only_one_instance_chkbox = newd wxCheckBox(this, wxID_ANY, "Open all maps in the same instance");

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -59,8 +59,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetToolTip("Add a new house");
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetToolTip("Edit selected house properties");
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetToolTip("Remove selected house");
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);
@@ -72,7 +75,9 @@ HousePalette::HousePalette(wxWindow* parent) :
 	wxStaticBoxSizer* brush_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Brushes");
 
 	house_brush_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_HOUSE_BRUSH, "House tiles");
+	house_brush_button->SetToolTip("Draw house tiles for the selected house");
 	select_exit_button = newd wxToggleButton(brush_sizer->GetStaticBox(), ID_EXIT_BRUSH, "Select Exit");
+	select_exit_button->SetToolTip("Set the exit position for the selected house");
 
 	brush_sizer->Add(house_brush_button, 0, wxEXPAND | wxBOTTOM, 2);
 	brush_sizer->Add(select_exit_button, 0, wxEXPAND);

--- a/source/rendering/ui/map_status_updater.cpp
+++ b/source/rendering/ui/map_status_updater.cpp
@@ -28,6 +28,12 @@
 void MapStatusUpdater::Update(Editor& editor, int map_x, int map_y, int map_z) {
 	wxString ss;
 	ss << "x: " << map_x << " y:" << map_y << " z:" << map_z;
+
+	size_t count = editor.selection.size();
+	if (count > 0) {
+		ss << " | " << count << " selected";
+	}
+
 	g_gui.root->SetStatusText(ss, 2);
 
 	ss = "";

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -42,11 +42,24 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	result_id(0) {
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 
-	search_field = newd KeyForwardingTextCtrl(this, JUMP_DIALOG_TEXT, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
-	search_field->SetHint("Type to search...");
-	search_field->SetToolTip("Type at least 2 characters to search for brushes or items.");
-	search_field->SetFocus();
-	sizer->Add(search_field, 0, wxEXPAND);
+	{
+		wxBoxSizer* row = newd wxBoxSizer(wxHORIZONTAL);
+		search_field = newd KeyForwardingTextCtrl(this, JUMP_DIALOG_TEXT, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+		search_field->SetHint("Type to search...");
+		search_field->SetToolTip("Type at least 2 characters to search for brushes or items.");
+		search_field->SetFocus();
+		row->Add(search_field, 1, wxEXPAND);
+
+		wxButton* clearBtn = newd wxButton(this, wxID_ANY, "", wxDefaultPosition, wxSize(30, -1));
+		clearBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+		clearBtn->SetToolTip("Clear search");
+		clearBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+			search_field->Clear();
+			search_field->SetFocus();
+		});
+		row->Add(clearBtn, 0);
+		sizer->Add(row, 0, wxEXPAND);
+	}
 
 	item_list = newd FindDialogListBox(this, JUMP_DIALOG_LIST);
 	item_list->SetMinSize(FROM_DIP(item_list, wxSize(470, 400)));

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -5,6 +5,7 @@
 #include "app/main.h"
 #include "ui/dialogs/goto_position_dialog.h"
 #include "editor/editor.h"
+#include "util/common.h"
 #include "map/map.h"
 #include "ui/positionctrl.h"
 #include "ui/gui.h"
@@ -24,6 +25,18 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 
 	posctrl = newd PositionCtrl(this, "Destination", map.getWidth() / 2, map.getHeight() / 2, GROUND_LAYER, map.getWidth(), map.getHeight());
 	sizer->Add(posctrl, 0, wxTOP | wxLEFT | wxRIGHT, 20);
+
+	// Paste Button
+	wxButton* pasteBtn = newd wxButton(this, wxID_ANY, "Paste from Clipboard");
+	pasteBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PASTE, wxSize(16, 16)));
+	pasteBtn->SetToolTip("Paste coordinates from clipboard");
+	pasteBtn->Bind(wxEVT_BUTTON, [this, &map](wxCommandEvent&) {
+		Position pos;
+		if (posFromClipboard(pos, map.getWidth(), map.getHeight())) {
+			posctrl->SetPosition(pos);
+		}
+	});
+	sizer->Add(pasteBtn, wxSizerFlags(0).Center().Border(wxTOP, 10));
 
 	// OK/Cancel buttons
 	wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/ui/map/map_properties_window.cpp
+++ b/source/ui/map/map_properties_window.cpp
@@ -1,5 +1,6 @@
 #include "ui/map/map_properties_window.h"
 
+#include <wx/filedlg.h>
 #include "editor/editor.h"
 #include "map/map.h"
 #include "editor/operations/map_version_changer.h"
@@ -80,32 +81,62 @@ MapPropertiesWindow::MapPropertiesWindow(wxWindow* parent, MapTab* view, Editor&
 	}
 
 	// External files
-	grid_sizer->Add(
-		newd wxStaticText(this, wxID_ANY, "External Housefile")
-	);
+	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "External Housefile"));
+	{
+		wxSizer* row = newd wxBoxSizer(wxHORIZONTAL);
+		house_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getHouseFilename()));
+		house_filename_ctrl->SetToolTip("External house XML file (leave empty for internal)");
+		row->Add(house_filename_ctrl, wxSizerFlags(1).Expand().RightBorder(5));
 
-	grid_sizer->Add(
-		house_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getHouseFilename())), 1, wxEXPAND
-	);
-	house_filename_ctrl->SetToolTip("External house XML file (leave empty for internal)");
+		wxButton* btn = newd wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxSize(30, -1));
+		btn->SetToolTip("Browse for house file...");
+		btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+			wxFileDialog dlg(this, "Select house file", "", "", "XML files (*.xml)|*.xml|All files (*.*)|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+			if (dlg.ShowModal() == wxID_OK) {
+				house_filename_ctrl->SetValue(dlg.GetPath());
+			}
+		});
+		row->Add(btn, wxSizerFlags(0));
+		grid_sizer->Add(row, wxSizerFlags(1).Expand());
+	}
 
-	grid_sizer->Add(
-		newd wxStaticText(this, wxID_ANY, "External Spawnfile")
-	);
+	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "External Spawnfile"));
+	{
+		wxSizer* row = newd wxBoxSizer(wxHORIZONTAL);
+		spawn_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getSpawnFilename()));
+		spawn_filename_ctrl->SetToolTip("External spawn XML file (leave empty for internal)");
+		row->Add(spawn_filename_ctrl, wxSizerFlags(1).Expand().RightBorder(5));
 
-	grid_sizer->Add(
-		spawn_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getSpawnFilename())), 1, wxEXPAND
-	);
-	spawn_filename_ctrl->SetToolTip("External spawn XML file (leave empty for internal)");
+		wxButton* btn = newd wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxSize(30, -1));
+		btn->SetToolTip("Browse for spawn file...");
+		btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+			wxFileDialog dlg(this, "Select spawn file", "", "", "XML files (*.xml)|*.xml|All files (*.*)|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+			if (dlg.ShowModal() == wxID_OK) {
+				spawn_filename_ctrl->SetValue(dlg.GetPath());
+			}
+		});
+		row->Add(btn, wxSizerFlags(0));
+		grid_sizer->Add(row, wxSizerFlags(1).Expand());
+	}
 
-	grid_sizer->Add(
-		newd wxStaticText(this, wxID_ANY, "External Waypointfile")
-	);
+	grid_sizer->Add(newd wxStaticText(this, wxID_ANY, "External Waypointfile"));
+	{
+		wxSizer* row = newd wxBoxSizer(wxHORIZONTAL);
+		waypoint_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getWaypointFilename()));
+		waypoint_filename_ctrl->SetToolTip("External waypoint XML file (leave empty for internal)");
+		row->Add(waypoint_filename_ctrl, wxSizerFlags(1).Expand().RightBorder(5));
 
-	grid_sizer->Add(
-		waypoint_filename_ctrl = newd wxTextCtrl(this, wxID_ANY, wxstr(map.getWaypointFilename())), 1, wxEXPAND
-	);
-	waypoint_filename_ctrl->SetToolTip("External waypoint XML file (leave empty for internal)");
+		wxButton* btn = newd wxButton(this, wxID_ANY, "...", wxDefaultPosition, wxSize(30, -1));
+		btn->SetToolTip("Browse for waypoint file...");
+		btn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+			wxFileDialog dlg(this, "Select waypoint file", "", "", "XML files (*.xml)|*.xml|All files (*.*)|*.*", wxFD_OPEN | wxFD_FILE_MUST_EXIST);
+			if (dlg.ShowModal() == wxID_OK) {
+				waypoint_filename_ctrl->SetValue(dlg.GetPath());
+			}
+		});
+		row->Add(btn, wxSizerFlags(0));
+		grid_sizer->Add(row, wxSizerFlags(1).Expand());
+	}
 
 	topsizer->Add(grid_sizer, wxSizerFlags(1).Expand().Border(wxALL, 20));
 

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -308,6 +308,7 @@ void PropertiesWindow::OnClickOK(wxCommandEvent&) {
 
 	saveGeneralPanel();
 	saveAttributesPanel();
+	wxLogStatus("Item properties applied.");
 	EndModal(1);
 }
 

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -232,6 +232,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	items_sizer->SetMinSize(wxSize(-1, FromDIP(40)));
 
 	replace_button = new ReplaceItemsButton(this);
+	replace_button->SetToolTip("Click to select item to replace");
 	items_sizer->Add(replace_button, 0, wxALL, 5);
 
 	wxBitmap bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCATION_ARROW, FromDIP(wxSize(16, 16)));
@@ -239,6 +240,7 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 	items_sizer->Add(arrow_bitmap, 0, wxTOP, 15);
 
 	with_button = new ReplaceItemsButton(this);
+	with_button->SetToolTip("Click to select replacement item");
 	items_sizer->Add(with_button, 0, wxALL, 5);
 
 	items_sizer->Add(0, 0, 1, wxEXPAND, 5);

--- a/source/ui/result_window.cpp
+++ b/source/ui/result_window.cpp
@@ -21,6 +21,7 @@
 #include "ui/gui.h"
 #include "map/position.h"
 #include "util/image_manager.h"
+#include <wx/clipbrd.h>
 
 SearchResultWindow::SearchResultWindow(wxWindow* parent) :
 	wxPanel(parent, wxID_ANY) {
@@ -33,6 +34,23 @@ SearchResultWindow::SearchResultWindow(wxWindow* parent) :
 	exportBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
 	exportBtn->SetToolTip("Export results to text file");
 	buttonsSizer->Add(exportBtn, wxSizerFlags(0).Center());
+
+	wxButton* copyBtn = newd wxButton(this, wxID_COPY, "Copy");
+	copyBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_COPY, wxSize(16, 16)));
+	copyBtn->SetToolTip("Copy results to clipboard");
+	copyBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
+		if (result_list->GetCount() > 0) {
+			wxString text;
+			for (unsigned int i = 0; i < result_list->GetCount(); ++i) {
+				text += result_list->GetString(i) + "\n";
+			}
+			if (wxTheClipboard->Open()) {
+				wxTheClipboard->SetData(new wxTextDataObject(text));
+				wxTheClipboard->Close();
+			}
+		}
+	});
+	buttonsSizer->Add(copyBtn, wxSizerFlags(0).Center());
 
 	wxButton* clearBtn = newd wxButton(this, wxID_CLEAR, "Clear");
 	clearBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -72,20 +72,20 @@ void BrushToolBar::Update() {
 		toolbar->SetToolShortHelp(id, has_map ? name : name + " - No map open");
 	};
 
-	updateTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, "Border (Add borders to ground)");
-	updateTool(PALETTE_TERRAIN_ERASER, "Eraser (Clear tile content)");
-	updateTool(PALETTE_TERRAIN_PZ_TOOL, "Protected Zone (Non-combat area)");
-	updateTool(PALETTE_TERRAIN_NOPVP_TOOL, "No PvP Zone (Non-PvP area)");
-	updateTool(PALETTE_TERRAIN_NOLOGOUT_TOOL, "No Logout Zone (Prevents logout)");
-	updateTool(PALETTE_TERRAIN_PVPZONE_TOOL, "PvP Zone (Combat area)");
-	updateTool(PALETTE_TERRAIN_NORMAL_DOOR, "Normal Door");
-	updateTool(PALETTE_TERRAIN_LOCKED_DOOR, "Locked Door");
-	updateTool(PALETTE_TERRAIN_MAGIC_DOOR, "Magic Door");
-	updateTool(PALETTE_TERRAIN_QUEST_DOOR, "Quest Door");
+	updateTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, "Border (Add borders to ground) [A]");
+	updateTool(PALETTE_TERRAIN_ERASER, "Eraser (Clear tile content) [E]");
+	updateTool(PALETTE_TERRAIN_PZ_TOOL, "Protected Zone (Non-combat area) [P]");
+	updateTool(PALETTE_TERRAIN_NOPVP_TOOL, "No PvP Zone (Non-PvP area) [Z]");
+	updateTool(PALETTE_TERRAIN_NOLOGOUT_TOOL, "No Logout Zone (Prevents logout) [L]");
+	updateTool(PALETTE_TERRAIN_PVPZONE_TOOL, "PvP Zone (Combat area) [Y]");
+	updateTool(PALETTE_TERRAIN_NORMAL_DOOR, "Normal Door [D]");
+	updateTool(PALETTE_TERRAIN_LOCKED_DOOR, "Locked Door [Shift+D]");
+	updateTool(PALETTE_TERRAIN_MAGIC_DOOR, "Magic Door [Ctrl+D]");
+	updateTool(PALETTE_TERRAIN_QUEST_DOOR, "Quest Door [Alt+D]");
 	updateTool(PALETTE_TERRAIN_NORMAL_ALT_DOOR, "Normal Door (alt)");
 	updateTool(PALETTE_TERRAIN_ARCHWAY_DOOR, "Archway");
-	updateTool(PALETTE_TERRAIN_HATCH_DOOR, "Hatch Window");
-	updateTool(PALETTE_TERRAIN_WINDOW_DOOR, "Window");
+	updateTool(PALETTE_TERRAIN_HATCH_DOOR, "Hatch Window [W]");
+	updateTool(PALETTE_TERRAIN_WINDOW_DOOR, "Window [Shift+W]");
 
 	Brush* brush = g_gui.GetCurrentBrush();
 	if (brush) {


### PR DESCRIPTION
Implemented 10 micro-UX improvements as requested by Palette agent:
1. Added "Browse" buttons for external files (House, Spawn, Waypoint) in Map Properties.
2. Added keyboard shortcut hints to tooltips in Brush Toolbar.
3. Added selection count display to Status Bar.
4. Added missing tooltips to General Preferences page.
5. Added "Paste" button to Go To Position Dialog.
6. Added "Clear" button to Find Dialog.
7. Added success feedback to Item Properties Window.
8. Added "Copy to Clipboard" button to Search Result Window.
9. Added tooltips to item buttons in Replace Items Dialog.
10. Added tooltips to buttons in House Palette.

---
*PR created automatically by Jules for task [5796606735833834978](https://jules.google.com/task/5796606735833834978) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Copy button to search results window
  * Added Clear button to Find dialog
  * Added Paste from Clipboard button to Go To Position dialog
  * Added Browse buttons for external file selection in Map Properties window

* **Improvements**
  * Status bar now displays count of selected items
  * Tool tooltips now include keyboard shortcut hints

* **Documentation**
  * Enhanced tooltips across dialogs and UI elements for better usability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->