### PR TITLE
⚡ Throttle: Optimize Map Loading & Tooltips

### DIFF
--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -324,15 +324,7 @@ MapNode* SpatialHashGrid::getLeafForce(int x, int y) {
 	auto& cell = cells[key];
 	if (!cell) {
 		cell = std::make_unique<GridCell>();
-		if (!sorted_cells_dirty) {
-			int cx, cy;
-			getCellCoordsFromKey(key, cx, cy);
-			SortedGridCell new_cell { key, cx, cy, cell.get() };
-			auto it = std::lower_bound(sorted_cells_cache.begin(), sorted_cells_cache.end(), new_cell, [](const auto& a, const auto& b) {
-				return std::tie(a.cy, a.cx) < std::tie(b.cy, b.cx);
-			});
-			sorted_cells_cache.insert(it, new_cell);
-		}
+		sorted_cells_dirty = true;
 	}
 
 	last_key = key;

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -27,6 +27,7 @@ public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
 	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
+	void ProcessTooltip(TileLocation* location, const RenderView& view, const DrawingOptions& options);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -358,6 +358,18 @@ void MapDrawer::Draw() {
 	primitive_renderer->flush();
 
 	// Tooltips are now drawn in MapCanvas::OnPaint (UI Pass)
+	UpdateHoveredTooltip();
+}
+
+void MapDrawer::UpdateHoveredTooltip() {
+	if (!options.show_tooltips) {
+		return;
+	}
+	Position cursor = canvas->GetCursorPosition();
+
+	if (TileLocation* loc = editor.map.getTileL(cursor)) {
+		tile_renderer->ProcessTooltip(loc, view, options);
+	}
 }
 
 void MapDrawer::DrawBackground() {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -118,6 +118,7 @@ public:
 	void Release();
 
 	void Draw();
+	void UpdateHoveredTooltip();
 	void DrawBackground();
 	void DrawMap();
 	void DrawLiveCursors();


### PR DESCRIPTION
This PR addresses significant performance issues in map rendering and loading.
1.  **Tooltip Optimization**: Previously, `TileRenderer::DrawTile` checked for tooltips for every visible tile, causing unnecessary overhead. Logic has been moved to `ProcessTooltip` and is now called only for the tile under the cursor.
2.  **Map Loading Optimization**: `SpatialHashGrid` was performing an O(N) insertion into a sorted vector for every new cell, leading to O(N^2) complexity during map loading. This has been changed to mark the cache as dirty, deferring the sort until needed.

---
*PR created automatically by Jules for task [8749999690693954315](https://jules.google.com/task/8749999690693954315) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized spatial grid cache invalidation for improved performance.
  * Reorganized tooltip processing system for better code maintainability and efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->