### PR TITLE
🗝️ Keeper: Modernize memory management with std::unique_ptr

### DIFF
--- a/source/app/extension.h
+++ b/source/app/extension.h
@@ -20,6 +20,8 @@
 
 #include "map/tileset.h"
 #include "app/client_version.h"
+#include <memory>
+#include <vector>
 
 class MaterialsExtension {
 public:
@@ -44,5 +46,6 @@ private:
 };
 
 using MaterialsExtensionList = std::vector<MaterialsExtension*>;
+using MaterialsExtensionOwnerList = std::vector<std::unique_ptr<MaterialsExtension>>;
 
 #endif

--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -40,27 +40,19 @@ Materials::~Materials() {
 }
 
 void Materials::clear() {
-	for (TilesetContainer::iterator iter = tilesets.begin(); iter != tilesets.end(); ++iter) {
-		delete iter->second;
-	}
-
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		delete *iter;
-	}
-
 	tilesets.clear();
 	extensions.clear();
 }
 
-const MaterialsExtensionList& Materials::getExtensions() {
+const MaterialsExtensionOwnerList& Materials::getExtensions() {
 	return extensions;
 }
 
 MaterialsExtensionList Materials::getExtensionsByVersion(const ClientVersionID& version_id) {
 	MaterialsExtensionList ret_list;
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		if ((*iter)->isForVersion(version_id)) {
-			ret_list.push_back(*iter);
+	for (const auto& extension : extensions) {
+		if (extension->isForVersion(version_id)) {
+			ret_list.push_back(extension.get());
 		}
 	}
 	return ret_list;
@@ -151,7 +143,7 @@ bool Materials::loadExtensions(FileName directoryName, wxString& error, std::vec
 		std::string extensionAuthorLink = extensionNode.attribute("authorurl").as_string();
 		extensionAuthorLink.erase(std::remove(extensionAuthorLink.begin(), extensionAuthorLink.end(), '\''));
 
-		MaterialsExtension* materialExtension = newd MaterialsExtension(extensionName, extensionAuthor, extensionDescription);
+		auto materialExtension = std::make_unique<MaterialsExtension>(extensionName, extensionAuthor, extensionDescription);
 		materialExtension->url = extensionUrl;
 		materialExtension->author_url = extensionAuthorLink;
 
@@ -183,8 +175,8 @@ bool Materials::loadExtensions(FileName directoryName, wxString& error, std::vec
 			warnings.push_back((filename + ": Extension is not available for any version.").ToStdString());
 		}
 
-		extensions.push_back(materialExtension);
-		if (materialExtension->isForVersion(g_version.GetCurrentVersionID())) {
+		extensions.push_back(std::move(materialExtension));
+		if (extensions.back()->isForVersion(g_version.GetCurrentVersionID())) {
 			unserializeMaterials(filename, extensionNode, error, warnings);
 		}
 	} while (ext_dir.GetNext(&filename));
@@ -244,19 +236,21 @@ void Materials::createOtherTileset() {
 	Tileset* npc_tileset;
 
 	if (tilesets.find("Others") != tilesets.end()) {
-		others = tilesets["Others"];
+		others = tilesets["Others"].get();
 		others->clear();
 	} else {
-		others = newd Tileset(g_brushes, "Others");
-		tilesets["Others"] = others;
+		auto others_ptr = std::make_unique<Tileset>(g_brushes, "Others");
+		others = others_ptr.get();
+		tilesets["Others"] = std::move(others_ptr);
 	}
 
 	if (tilesets.find("NPCs") != tilesets.end()) {
-		npc_tileset = tilesets["NPCs"];
+		npc_tileset = tilesets["NPCs"].get();
 		npc_tileset->clear();
 	} else {
-		npc_tileset = newd Tileset(g_brushes, "NPCs");
-		tilesets["NPCs"] = npc_tileset;
+		auto npc_tileset_ptr = std::make_unique<Tileset>(g_brushes, "NPCs");
+		npc_tileset = npc_tileset_ptr.get();
+		tilesets["NPCs"] = std::move(npc_tileset_ptr);
 	}
 
 	// There should really be an iterator to do this
@@ -317,15 +311,16 @@ bool Materials::unserializeTileset(pugi::xml_node node, std::vector<std::string>
 	Tileset* tileset = nullptr;
 	auto it = tilesets.find(name);
 	if (it != tilesets.end()) {
-		tileset = it->second;
+		tileset = it->second.get();
 	}
 
 	if (!tileset) {
-		tileset = newd Tileset(g_brushes, name);
+		auto tileset_ptr = std::make_unique<Tileset>(g_brushes, name);
+		tileset = tileset_ptr.get();
 		if (it != tilesets.end()) {
-			it->second = tileset;
+			it->second = std::move(tileset_ptr);
 		} else {
-			tilesets.insert(std::make_pair(name, tileset));
+			tilesets.insert(std::make_pair(name, std::move(tileset_ptr)));
 		}
 	}
 
@@ -345,10 +340,11 @@ void Materials::addToTileset(std::string tilesetName, int itemId, TilesetCategor
 	Tileset* tileset;
 	auto _it = tilesets.find(tilesetName);
 	if (_it != tilesets.end()) {
-		tileset = _it->second;
+		tileset = _it->second.get();
 	} else {
-		tileset = newd Tileset(g_brushes, tilesetName);
-		tilesets.insert(std::make_pair(tilesetName, tileset));
+		auto tileset_ptr = std::make_unique<Tileset>(g_brushes, tilesetName);
+		tileset = tileset_ptr.get();
+		tilesets.insert(std::make_pair(tilesetName, std::move(tileset_ptr)));
 	}
 
 	TilesetCategory* category = tileset->getCategory(categoryType);
@@ -385,7 +381,7 @@ bool Materials::isInTileset(Brush* brush, std::string tilesetName) const {
 	if (tilesetiter == tilesets.end()) {
 		return false;
 	}
-	Tileset* tileset = tilesetiter->second;
+	Tileset* tileset = tilesetiter->second.get();
 
 	return tileset->containsBrush(brush);
 }

--- a/source/game/materials.h
+++ b/source/game/materials.h
@@ -27,7 +27,7 @@ public:
 
 	void clear();
 
-	const MaterialsExtensionList& getExtensions();
+	const MaterialsExtensionOwnerList& getExtensions();
 	MaterialsExtensionList getExtensionsByVersion(const ClientVersionID& version_id);
 
 	TilesetContainer tilesets;
@@ -51,7 +51,7 @@ protected:
 	bool unserializeMaterials(const FileName& filename, pugi::xml_node node, wxString& error, std::vector<std::string>& warnings);
 	bool unserializeTileset(pugi::xml_node node, std::vector<std::string>& warnings);
 
-	MaterialsExtensionList extensions;
+	MaterialsExtensionOwnerList extensions;
 
 private:
 	bool modified = false;

--- a/source/map/tileset.cpp
+++ b/source/map/tileset.cpp
@@ -276,7 +276,7 @@ std::vector<Tileset*> GetSortedTilesets(const TilesetContainer& tilesets) {
 	std::vector<Tileset*> sorted;
 	sorted.reserve(tilesets.size());
 	for (const auto& pair : tilesets) {
-		sorted.push_back(pair.second);
+		sorted.push_back(pair.second.get());
 	}
 	std::ranges::sort(sorted, {}, &Tileset::name);
 	return sorted;

--- a/source/map/tileset.h
+++ b/source/map/tileset.h
@@ -73,7 +73,7 @@ protected:
 	Tileset operator=(const Tileset&);
 	friend class TilesetCategory;
 };
-using TilesetContainer = std::unordered_map<std::string, Tileset*>;
+using TilesetContainer = std::unordered_map<std::string, std::unique_ptr<Tileset>>;
 // Returns tilesets sorted alphabetically by name for UI display.
 std::vector<Tileset*> GetSortedTilesets(const TilesetContainer& tilesets);
 #endif

--- a/source/palette/panels/brush_palette_panel.cpp
+++ b/source/palette/panels/brush_palette_panel.cpp
@@ -246,7 +246,7 @@ void BrushPalettePanel::OnClickAddItemToTileset(wxCommandEvent& WXUNUSED(event))
 
 	auto _it = g_materials.tilesets.find(tilesetName);
 	if (_it != g_materials.tilesets.end()) {
-		wxDialog* w = newd AddItemWindow(g_gui.root, palette_type, _it->second);
+		wxDialog* w = newd AddItemWindow(g_gui.root, palette_type, _it->second.get());
 		int ret = w->ShowModal();
 		w->Destroy();
 

--- a/source/ui/extension_window.cpp
+++ b/source/ui/extension_window.cpp
@@ -93,7 +93,7 @@ wxString ExtensionsDialog::HTML() const {
 		markup << "<i>No extensions loaded.</i>";
 	} else {
 		for (const auto& me : g_materials.getExtensions()) {
-			markup << HTMLForExtension(me);
+			markup << HTMLForExtension(me.get());
 			markup << "<hr>";
 		}
 	}

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -65,12 +65,12 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	using namespace MenuBar;
 	checking_programmaticly = false;
 
-	searchHandler = new SearchHandler(frame);
-	viewSettingsHandler = new ViewSettingsHandler(this);
-	mapActionsHandler = new MapActionsHandler(frame);
-	fileMenuHandler = new FileMenuHandler(frame, this);
-	navigationMenuHandler = new NavigationMenuHandler(frame, this);
-	paletteMenuHandler = new PaletteMenuHandler(frame, this);
+	searchHandler = std::make_unique<SearchHandler>(frame);
+	viewSettingsHandler = std::make_unique<ViewSettingsHandler>(this);
+	mapActionsHandler = std::make_unique<MapActionsHandler>(frame);
+	fileMenuHandler = std::make_unique<FileMenuHandler>(frame, this);
+	navigationMenuHandler = std::make_unique<NavigationMenuHandler>(frame, this);
+	paletteMenuHandler = std::make_unique<PaletteMenuHandler>(frame, this);
 
 	MenuBarActionManager::RegisterActions(this, actions);
 
@@ -91,13 +91,7 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 
 MainMenuBar::~MainMenuBar() {
 	// Don't need to delete menubar, it's owned by the frame
-
-	delete searchHandler;
-	delete viewSettingsHandler;
-	delete mapActionsHandler;
-	delete fileMenuHandler;
-	delete navigationMenuHandler;
-	delete paletteMenuHandler;
+	// Handlers are automatically deleted by std::unique_ptr
 }
 
 void MainMenuBar::EnableItem(MenuBar::ActionID id, bool enable) {

--- a/source/ui/main_menubar.h
+++ b/source/ui/main_menubar.h
@@ -315,12 +315,12 @@ protected:
 
 	std::unordered_map<std::string, std::unique_ptr<MenuBar::Action>> actions;
 
-	SearchHandler* searchHandler;
-	ViewSettingsHandler* viewSettingsHandler;
-	MapActionsHandler* mapActionsHandler;
-	FileMenuHandler* fileMenuHandler;
-	NavigationMenuHandler* navigationMenuHandler;
-	PaletteMenuHandler* paletteMenuHandler;
+	std::unique_ptr<SearchHandler> searchHandler;
+	std::unique_ptr<ViewSettingsHandler> viewSettingsHandler;
+	std::unique_ptr<MapActionsHandler> mapActionsHandler;
+	std::unique_ptr<FileMenuHandler> fileMenuHandler;
+	std::unique_ptr<NavigationMenuHandler> navigationMenuHandler;
+	std::unique_ptr<PaletteMenuHandler> paletteMenuHandler;
 };
 
 namespace MenuBar {

--- a/source/ui/managers/gl_context_manager.cpp
+++ b/source/ui/managers/gl_context_manager.cpp
@@ -9,17 +9,17 @@ GLContextManager::GLContextManager() :
 }
 
 GLContextManager::~GLContextManager() {
-	delete OGLContext;
+	// OGLContext is automatically deleted
 }
 
 wxGLContext* GLContextManager::GetGLContext(wxGLCanvas* win) {
 	if (OGLContext == nullptr) {
 #ifdef __WXOSX__
-		OGLContext = new wxGLContext(win, nullptr);
+		OGLContext = std::make_unique<wxGLContext>(win, nullptr);
 #else
 		wxGLContextAttrs ctxAttrs;
 		ctxAttrs.PlatformDefaults().CoreProfile().MajorVersion(4).MinorVersion(5).EndList();
-		OGLContext = newd wxGLContext(win, nullptr, &ctxAttrs);
+		OGLContext = std::make_unique<wxGLContext>(win, nullptr, &ctxAttrs);
 		spdlog::info("GLContextManager: Created new OpenGL 4.5 Core Profile context");
 #endif
 		// Initialize GLAD for the new context
@@ -31,5 +31,5 @@ wxGLContext* GLContextManager::GetGLContext(wxGLCanvas* win) {
 		}
 	}
 
-	return OGLContext;
+	return OGLContext.get();
 }

--- a/source/ui/managers/gl_context_manager.h
+++ b/source/ui/managers/gl_context_manager.h
@@ -3,6 +3,7 @@
 
 #include <wx/wx.h>
 #include <wx/glcanvas.h>
+#include <memory>
 
 class GLContextManager {
 public:
@@ -12,7 +13,7 @@ public:
 	wxGLContext* GetGLContext(wxGLCanvas* win);
 
 private:
-	wxGLContext* OGLContext;
+	std::unique_ptr<wxGLContext> OGLContext;
 };
 
 extern GLContextManager g_gl_context;


### PR DESCRIPTION
This PR modernizes memory management in `GLContextManager`, `MainMenuBar`, and `Materials` classes by replacing raw pointers and manual deletion with `std::unique_ptr`. This improves exception safety, prevents memory leaks, and simplifies the codebase.

Changes:
- `GLContextManager`: `OGLContext` is now a `std::unique_ptr`.
- `MainMenuBar`: Handlers (e.g., `SearchHandler`, `ViewSettingsHandler`) are now `std::unique_ptr`.
- `Materials`: `tilesets` container is now `std::unordered_map<std::string, std::unique_ptr<Tileset>>`. `extensions` list is now `std::vector<std::unique_ptr<MaterialsExtension>>`.
- Updated `source/map/tileset.h` and `.cpp` to support `unique_ptr` in `TilesetContainer`.
- Updated `source/ui/extension_window.cpp` and `source/palette/panels/brush_palette_panel.cpp` to access raw pointers via `.get()`.

---
*PR created automatically by Jules for task [7039032210054384245](https://jules.google.com/task/7039032210054384245) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal memory management across multiple application components to improve stability and resource handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->