### PR TITLE
Pack cell key by (cy,cx) and optimize iteration

### DIFF
--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -165,8 +165,10 @@ void SpatialHashGrid::updateSortedCells() const {
 }
 
 void SpatialHashGrid::getCellCoordsFromKey(uint64_t key, int& cx, int& cy) {
-	cy = static_cast<int32_t>(key >> 32);
-	cx = static_cast<int32_t>(key);
+	uint32_t raw_cy = static_cast<uint32_t>(key >> 32) ^ 0x80000000u;
+	uint32_t raw_cx = static_cast<uint32_t>(key) ^ 0x80000000u;
+	cy = static_cast<int32_t>(raw_cy);
+	cx = static_cast<int32_t>(raw_cx);
 }
 
 const std::vector<SpatialHashGrid::SortedGridCell>& SpatialHashGrid::getSortedCells() const {


### PR DESCRIPTION
Change the cell key packing to store cy in the high 32 bits and cx in the low 32 bits, and switch all cell comparisons to use the packed key instead of tuple comparisons. Fix getCellCoordsFromKey to match the new packing. Use try_emplace when creating cells to avoid double-map lookups and update last_cell appropriately. Optimize viewport iteration by hoisting per-cell index calculations into a small RowCellInfoHoisted structure stored in a thread_local vector, replace std::views::iota with an explicit loop, and precompute index bases to reduce work and allocations when scanning nodes. These changes improve correctness and runtime performance of spatial grid operations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Faster viewport queries by hoisting row processing and reducing per-cell overhead.
  * More consistent cell ordering and lookups via revised key packing and sorting behavior.
  * Replaced thread-local storage with safer per-invocation allocations to improve stability and memory behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->