### PR TITLE
Profiler: Fix duplicate tooltip generation for cursor tile

### DIFF
--- a/source/rendering/core/drawing_options.h
+++ b/source/rendering/core/drawing_options.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 #include <wx/wx.h>
 #include <string>
+#include "map/position.h"
 
 struct DrawingOptions {
 	DrawingOptions();
@@ -59,6 +60,8 @@ struct DrawingOptions {
 	bool anti_aliasing;
 
 	std::string screen_shader_name;
+
+	Position cursor_position = Position(-1, -1, -1);
 };
 
 #endif

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -186,8 +186,10 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		waypoint = editor->map.waypoints.getWaypoint(location);
 	}
 
+	bool isCursorTile = (location->getPosition() == options.cursor_position);
+
 	// Waypoint tooltip (one per waypoint)
-	if (options.show_tooltips && waypoint && map_z == view.floor) {
+	if (options.show_tooltips && !isCursorTile && waypoint && map_z == view.floor) {
 		tooltip_drawer->addWaypointTooltip(location->getPosition(), waypoint->name);
 	}
 
@@ -233,7 +235,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (options.show_tooltips && !isCursorTile && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -273,7 +275,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				}
 			}
 
-			bool process_tooltips = options.show_tooltips && map_z == view.floor;
+			bool process_tooltips = options.show_tooltips && !isCursorTile && map_z == view.floor;
 
 			// items on tile
 			for (const auto& item : tile->items) {

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -259,6 +259,7 @@ void MapCanvas::OnPaint(wxPaintEvent& event) {
 			options.Update();
 		}
 
+		options.cursor_position = GetCursorPosition();
 		options.dragging = selection_controller->IsDragging();
 		options.boundbox_selection = selection_controller->IsBoundboxSelection();
 


### PR DESCRIPTION
Modified DrawingOptions to include cursor_position.
Updated MapCanvas::OnPaint to populate cursor_position.
Updated TileRenderer::DrawTile to skip tooltip generation (waypoints, ground, items) for the tile under the mouse cursor.
This change prevents redundant tooltip generation for the hovered tile.

---
*PR created automatically by Jules for task [8763597551363791360](https://jules.google.com/task/8763597551363791360) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Tooltips for waypoints, ground items, and individual tile details no longer appear when hovering the cursor directly over a tile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->