### PR TITLE
Modernize UI with NanoVG: HUD, Tool Options, and Minimap

### DIFF
--- a/source/rendering/drawers/minimap_drawer.h
+++ b/source/rendering/drawers/minimap_drawer.h
@@ -8,6 +8,7 @@
 #include "rendering/drawers/minimap_renderer.h"
 #include <memory>
 
+struct NVGcontext;
 class Editor;
 class MapCanvas;
 class PrimitiveRenderer;
@@ -18,6 +19,7 @@ public:
 	~MinimapDrawer();
 
 	void Draw(wxDC& dc, const wxSize& size, Editor& editor, MapCanvas* canvas);
+	void DrawOverlay(NVGcontext* vg, const wxSize& size, Editor& editor, MapCanvas* canvas);
 
 	void ScreenToMap(int screen_x, int screen_y, int& map_x, int& map_y);
 

--- a/source/rendering/drawers/overlays/hud_drawer.cpp
+++ b/source/rendering/drawers/overlays/hud_drawer.cpp
@@ -1,0 +1,194 @@
+#include "app/main.h"
+#include "rendering/drawers/overlays/hud_drawer.h"
+#include "editor/editor.h"
+#include "map/map.h"
+#include "map/tile.h"
+#include "brushes/brush.h"
+#include "ui/gui.h"
+#include "ui/theme.h"
+#include "util/nvg_utils.h"
+#include "rendering/ui/map_display.h"
+
+#include <nanovg.h>
+#include <format>
+
+HUDDrawer::HUDDrawer() {
+}
+
+HUDDrawer::~HUDDrawer() {
+}
+
+void HUDDrawer::draw(NVGcontext* vg, const RenderView& view, Editor& editor, const DrawingOptions& options) {
+	DrawCoords(vg, view, editor);
+	DrawBrushInfo(vg, view, editor);
+
+	if (!editor.selection.empty()) {
+		DrawSelectionInfo(vg, view, editor, options);
+	}
+}
+
+void HUDDrawer::DrawCoords(NVGcontext* vg, const RenderView& view, Editor& editor) {
+	// Bottom right corner
+	float w = static_cast<float>(view.screensize_x);
+	float h = static_cast<float>(view.screensize_y);
+	float padding = 10.0f;
+	float pillHeight = 24.0f;
+
+	// Get coords
+	int mx = view.mouse_map_x;
+	int my = view.mouse_map_y;
+	int mz = view.floor;
+
+	std::string text = std::format("X: {}  Y: {}  Z: {}", mx, my, mz);
+
+	nvgFontSize(vg, 13.0f);
+	nvgFontFace(vg, "sans-bold");
+	float textWidth = nvgTextBounds(vg, 0, 0, text.c_str(), nullptr, nullptr);
+	float pillWidth = textWidth + 24.0f;
+
+	float x = w - pillWidth - padding;
+	float y = h - pillHeight - padding;
+
+	// Shadow
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x + 2, y + 2, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(0, 0, 0, 64));
+	nvgFill(vg);
+
+	// Pill background (Glassy)
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x, y, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(30, 30, 30, 200));
+	nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 30));
+	nvgStrokeWidth(vg, 1.0f);
+	nvgFill(vg);
+	nvgStroke(vg);
+
+	// Text
+	nvgFillColor(vg, nvgRGBA(220, 220, 220, 255));
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+	nvgText(vg, x + 12.0f, y + pillHeight / 2.0f, text.c_str(), nullptr);
+}
+
+void HUDDrawer::DrawBrushInfo(NVGcontext* vg, const RenderView& view, Editor& editor) {
+	Brush* brush = g_gui.GetCurrentBrush();
+	if (!brush) return;
+
+	float padding = 10.0f;
+	float pillHeight = 28.0f;
+
+	std::string text = brush->getName().ToStdString();
+
+	nvgFontSize(vg, 14.0f);
+	nvgFontFace(vg, "sans-bold");
+	float textWidth = nvgTextBounds(vg, 0, 0, text.c_str(), nullptr, nullptr);
+
+	// Icon space?
+	float iconSize = 20.0f;
+	float iconPadding = 8.0f;
+	float pillWidth = textWidth + 24.0f + iconSize + iconPadding;
+
+	float x = padding;
+	float y = padding; // Top left
+
+	// Shadow
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x + 2, y + 2, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(0, 0, 0, 64));
+	nvgFill(vg);
+
+	// Pill background
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x, y, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(40, 44, 52, 220)); // Dark blue-ish grey
+
+	// Accent border on left?
+	nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 30));
+	nvgStrokeWidth(vg, 1.0f);
+	nvgFill(vg);
+	nvgStroke(vg);
+
+	// Draw Icon
+	Sprite* spr = brush->getSprite();
+	if (!spr) spr = g_gui.gfx.getSprite(brush->getLookID());
+
+	if (spr) {
+		// We need a way to get GL texture for sprite here.
+		// MapCanvas has helpers but we don't have access to it easily.
+		// However, global `g_gui` or similar might help, or we pass it.
+		// `GetOrCreateSpriteTexture` is in `NanoVGCanvas` or `VirtualBrushGrid`.
+		// We can duplicate the logic or skip icon for now.
+		// Let's try to draw a simple colored circle or skip icon if too complex.
+		// Actually, `MapCanvas` has `GetOrCreateSpriteTexture` but we don't have `MapCanvas`.
+		// But we can use `GetOrCreateSpriteTexture` if we make it available or copy it.
+		// For now, let's just draw the text.
+
+		// Update pill width to remove icon space
+		pillWidth = textWidth + 24.0f;
+
+		// Redraw background with correct width
+		nvgBeginPath(vg);
+		nvgRoundedRect(vg, x, y, pillWidth, pillHeight, pillHeight / 2.0f);
+		nvgFillColor(vg, nvgRGBA(40, 44, 52, 220));
+		nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 30));
+		nvgStrokeWidth(vg, 1.0f);
+		nvgFill(vg);
+		nvgStroke(vg);
+
+		// Text
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, x + 12.0f, y + pillHeight / 2.0f, text.c_str(), nullptr);
+	} else {
+		// Just text
+		pillWidth = textWidth + 24.0f;
+		nvgBeginPath(vg);
+		nvgRoundedRect(vg, x, y, pillWidth, pillHeight, pillHeight / 2.0f);
+		nvgFillColor(vg, nvgRGBA(40, 44, 52, 220));
+		nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 30));
+		nvgStrokeWidth(vg, 1.0f);
+		nvgFill(vg);
+		nvgStroke(vg);
+
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, x + 12.0f, y + pillHeight / 2.0f, text.c_str(), nullptr);
+	}
+}
+
+void HUDDrawer::DrawSelectionInfo(NVGcontext* vg, const RenderView& view, Editor& editor, const DrawingOptions& options) {
+	// Show count
+	size_t count = editor.selection.size();
+	std::string text = std::format("{} items selected", count);
+
+	float padding = 10.0f;
+	float pillHeight = 24.0f;
+
+	nvgFontSize(vg, 13.0f);
+	nvgFontFace(vg, "sans");
+	float textWidth = nvgTextBounds(vg, 0, 0, text.c_str(), nullptr, nullptr);
+	float pillWidth = textWidth + 24.0f;
+
+	float x = view.screensize_x / 2.0f - pillWidth / 2.0f; // Center bottom
+	float y = view.screensize_y - pillHeight - padding;
+
+	// Shadow
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x + 2, y + 2, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(0, 0, 0, 64));
+	nvgFill(vg);
+
+	// Pill
+	nvgBeginPath(vg);
+	nvgRoundedRect(vg, x, y, pillWidth, pillHeight, pillHeight / 2.0f);
+	nvgFillColor(vg, nvgRGBA(52, 152, 219, 220)); // Accent blue
+	nvgStrokeColor(vg, nvgRGBA(255, 255, 255, 50));
+	nvgStrokeWidth(vg, 1.0f);
+	nvgFill(vg);
+	nvgStroke(vg);
+
+	// Text
+	nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+	nvgText(vg, x + 12.0f, y + pillHeight / 2.0f, text.c_str(), nullptr);
+}

--- a/source/rendering/drawers/overlays/hud_drawer.h
+++ b/source/rendering/drawers/overlays/hud_drawer.h
@@ -1,0 +1,24 @@
+#ifndef RME_RENDERING_DRAWERS_OVERLAYS_HUD_DRAWER_H_
+#define RME_RENDERING_DRAWERS_OVERLAYS_HUD_DRAWER_H_
+
+#include <memory>
+#include "rendering/core/render_view.h"
+#include "rendering/core/drawing_options.h"
+
+struct NVGcontext;
+class Editor;
+
+class HUDDrawer {
+public:
+	HUDDrawer();
+	~HUDDrawer();
+
+	void draw(NVGcontext* vg, const RenderView& view, Editor& editor, const DrawingOptions& options);
+
+private:
+	void DrawCoords(NVGcontext* vg, const RenderView& view, Editor& editor);
+	void DrawBrushInfo(NVGcontext* vg, const RenderView& view, Editor& editor);
+	void DrawSelectionInfo(NVGcontext* vg, const RenderView& view, Editor& editor, const DrawingOptions& options);
+};
+
+#endif

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -61,6 +61,7 @@
 #include "rendering/drawers/overlays/marker_drawer.h"
 #include "rendering/drawers/overlays/hook_indicator_drawer.h"
 #include "rendering/drawers/overlays/door_indicator_drawer.h"
+#include "rendering/drawers/overlays/hud_drawer.h"
 #include "rendering/drawers/overlays/preview_drawer.h"
 #include "rendering/drawers/tiles/shade_drawer.h"
 #include "rendering/drawers/tiles/tile_color_calculator.h"
@@ -116,6 +117,7 @@ MapDrawer::MapDrawer(MapCanvas* canvas) :
 	primitive_renderer = std::make_unique<PrimitiveRenderer>();
 	hook_indicator_drawer = std::make_unique<HookIndicatorDrawer>();
 	door_indicator_drawer = std::make_unique<DoorIndicatorDrawer>();
+	hud_drawer = std::make_unique<HUDDrawer>();
 
 	item_drawer->SetHookIndicatorDrawer(hook_indicator_drawer.get());
 	item_drawer->SetDoorIndicatorDrawer(door_indicator_drawer.get());
@@ -413,6 +415,10 @@ void MapDrawer::DrawDoorIndicators(NVGcontext* vg) {
 
 void MapDrawer::DrawCreatureNames(NVGcontext* vg) {
 	creature_name_drawer->draw(vg, view);
+}
+
+void MapDrawer::DrawHUD(NVGcontext* vg) {
+	hud_drawer->draw(vg, view, editor, options);
 }
 
 void MapDrawer::DrawMapLayer(int map_z, bool live_client) {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -59,6 +59,7 @@ class TileRenderer;
 class CreatureNameDrawer;
 class HookIndicatorDrawer;
 class DoorIndicatorDrawer;
+class HUDDrawer;
 
 class MapDrawer {
 	MapCanvas* canvas;
@@ -86,6 +87,7 @@ class MapDrawer {
 	std::unique_ptr<CreatureNameDrawer> creature_name_drawer;
 	std::unique_ptr<HookIndicatorDrawer> hook_indicator_drawer;
 	std::unique_ptr<DoorIndicatorDrawer> door_indicator_drawer;
+	std::unique_ptr<HUDDrawer> hud_drawer;
 	std::unique_ptr<SpriteBatch> sprite_batch;
 	std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 
@@ -129,6 +131,7 @@ public:
 	void DrawDoorIndicators(NVGcontext* vg);
 	void ClearFrameOverlays();
 	void DrawCreatureNames(NVGcontext* vg);
+	void DrawHUD(NVGcontext* vg);
 
 	void DrawLight();
 

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -222,6 +222,7 @@ void MapCanvas::DrawOverlays(NVGcontext* vg, const DrawingOptions& options) {
 	if (options.highlight_locked_doors) {
 		drawer->DrawDoorIndicators(vg);
 	}
+	drawer->DrawHUD(vg);
 
 	TextRenderer::EndFrame(vg);
 

--- a/source/rendering/ui/minimap_window.h
+++ b/source/rendering/ui/minimap_window.h
@@ -22,8 +22,11 @@
 #include <memory>
 
 #include "rendering/core/graphics.h"
+#include "util/nanovg_canvas.h"
 
 class MinimapDrawer;
+struct NVGcontext;
+
 class MinimapWindow : public wxGLCanvas {
 public:
 	MinimapWindow(wxWindow* parent);
@@ -40,9 +43,12 @@ public:
 	void OnKey(wxKeyEvent& event);
 
 protected:
+	void EnsureNanoVG();
 	std::unique_ptr<MinimapDrawer> drawer;
 	wxTimer update_timer;
 	wxGLContext* context;
+
+	std::unique_ptr<NVGcontext, NVGDeleter> m_nvg;
 };
 
 #endif

--- a/source/ui/tool_options_surface.h
+++ b/source/ui/tool_options_surface.h
@@ -6,12 +6,13 @@
 #include <wx/timer.h>
 #include <vector>
 #include "palette/palette_common.h"
+#include "util/nanovg_canvas.h"
 
 class Brush;
 
 // A custom-drawn, high-density surface for tool options.
 // Replaces the old panel-based layout with a unified, paint-optimized control.
-class ToolOptionsSurface : public wxControl {
+class ToolOptionsSurface : public NanoVGCanvas {
 public:
 	ToolOptionsSurface(wxWindow* parent);
 	~ToolOptionsSurface();
@@ -21,7 +22,6 @@ public:
 	void DoSetSizeHints(int minW, int minH, int maxW, int maxH, int incW, int incH) override;
 
 	// Event Handlers
-	void OnPaint(wxPaintEvent& evt);
 	void OnEraseBackground(wxEraseEvent& evt); // No-op
 	void OnMouse(wxMouseEvent& evt);
 	void OnLeave(wxMouseEvent& evt);
@@ -91,10 +91,11 @@ private:
 	bool lock_doors = false;
 
 	// Internal Helpers
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
 	void RebuildLayout();
-	void DrawToolIcon(wxDC& dc, const ToolRect& tr);
-	void DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
-	void DrawCheckbox(wxDC& dc, const wxRect& rect, const wxString& label, bool value, bool hover);
+	void DrawToolIcon(NVGcontext* vg, const ToolRect& tr);
+	void DrawSlider(NVGcontext* vg, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
+	void DrawCheckbox(NVGcontext* vg, const wxRect& rect, const wxString& label, bool value, bool hover);
 
 	int CalculateSliderValue(const wxRect& sliderRect, int min, int max) const;
 


### PR DESCRIPTION
This PR implements key UX improvements requested by the "Designer" agent:
1.  **Semantic World HUD**: A new heads-up display on the map canvas showing real-time coordinates, active brush name, and selection size. This eliminates the need to constantly check the status bar.
2.  **Tool Options Modernization**: The tool options panel is rewritten using NanoVG, providing a sleeker look with hover animations, modern sliders, and vector-based tool icons.
3.  **Minimap Glassmorphism**: The minimap viewport indicator is updated to a semi-transparent, rounded "glass" box, improving visual polish.

Technical details:
- `HUDDrawer` class added to `source/rendering/drawers/overlays/`.
- `ToolOptionsSurface` now inherits from `NanoVGCanvas` and implements `OnNanoVGPaint`.
- `MinimapDrawer` adds `DrawOverlay` method.
- `MinimapWindow` manages a NanoVG context for overlay rendering.


---
*PR created automatically by Jules for task [5569615969976453254](https://jules.google.com/task/5569615969976453254) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added in-game HUD overlay displaying real-time coordinates, active brush information, and selection item count with dynamic sizing and enhanced visual styling.
  * Improved minimap view box rendering with enhanced overlay support for better visual feedback.

* **UI Improvements**
  * Migrated tool options surface to modern vector-based rendering for sharper, more consistent visual appearance across the interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->