### PR TITLE
Fix critical UB, race condition, and logic bugs

### DIFF
--- a/source/io/otbm/tile_serialization_otbm.cpp
+++ b/source/io/otbm/tile_serialization_otbm.cpp
@@ -161,6 +161,15 @@ void TileSerializationOTBM::writeTileData(const IOMapOTBM& iomap, const Map& map
 
 					const Position& pos = save_tile->getPosition();
 
+					if (pos.x < 0 || pos.y < 0) {
+						static bool warned = false;
+						if (!warned) {
+							spdlog::warn("Skipping tile at negative coordinates ({}, {}, {}). OTBM format does not support negative coordinates.", pos.x, pos.y, pos.z);
+							warned = true;
+						}
+						continue;
+					}
+
 					// Decide if new node should be created
 					if (pos.x < local_x || pos.x >= local_x + 256 || pos.y < local_y || pos.y >= local_y + 256 || pos.z != local_z) {
 						if (!first) {

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,7 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <atomic>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -81,7 +82,7 @@ public:
 private:
 	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
-	bool stopped;
+	std::atomic<bool> stopped;
 };
 
 #endif

--- a/source/rendering/ui/selection_controller.cpp
+++ b/source/rendering/ui/selection_controller.cpp
@@ -413,7 +413,8 @@ void SelectionController::ExecuteBoundboxSelection(const Position& start_pos, co
 			if (i == threadcount - 1) {
 				chunksize = remainder;
 			}
-			threads.push_back(std::make_unique<SelectionThread>(editor, Position(s_x + cleared, s_y, s_z), Position(s_x + cleared + chunksize, e_y, e_z)));
+			int end_offset = (i == threadcount - 1) ? chunksize : chunksize - 1;
+			threads.push_back(std::make_unique<SelectionThread>(editor, Position(s_x + cleared, s_y, s_z), Position(s_x + cleared + end_offset, e_y, e_z)));
 			cleared += chunksize;
 			remainder -= chunksize;
 		}


### PR DESCRIPTION
Fixed three critical issues identified during deep scan:
1. Race Condition in NetworkConnection: Changed 'stopped' flag to std::atomic<bool> to prevent data race between main thread and worker thread.
2. Logic Bug in SelectionController: Fixed off-by-one error in thread splitting logic that caused overlapping processing ranges and duplicate work.
3. Data Corruption in OTBM Serialization: Added check to prevent saving tiles with negative coordinates to OTBM format (which only supports unsigned), preventing silent file corruption.

---
*PR created automatically by Jules for task [17633815365073929434](https://jules.google.com/task/17633815365073929434) started by @karolak6612*