### PR TITLE
Modernize UI for High DPI support

### DIFF
--- a/source/ingame_preview/ingame_preview_window.cpp
+++ b/source/ingame_preview/ingame_preview_window.cpp
@@ -54,29 +54,29 @@ namespace IngamePreview {
 		wxBoxSizer* toolbar_sizer = new wxBoxSizer(wxHORIZONTAL);
 
 		// Toggles
-		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, wxSize(28, 24));
-		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+		follow_btn = new wxToggleButton(this, ID_FOLLOW_SELECTION, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, FromDIP(wxSize(16, 16)), wxColour(76, 175, 80)));
 		follow_btn->SetValue(true);
 		follow_btn->SetToolTip("Follow Selection / Camera");
 		toolbar_sizer->Add(follow_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, wxSize(28, 24));
-		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SUNNY, wxSize(16, 16), wxColour(255, 235, 59)));
+		lighting_btn = new wxToggleButton(this, ID_ENABLE_LIGHTING, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		lighting_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SUNNY, FromDIP(wxSize(16, 16)), wxColour(255, 235, 59)));
 		lighting_btn->SetValue(false);
 		lighting_btn->SetToolTip("Toggle Lighting");
 		toolbar_sizer->Add(lighting_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, wxSize(28, 24));
-		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ACCOUNT, wxSize(16, 16), wxColour(96, 125, 139)));
+		outfit_btn = new wxButton(this, ID_CHOOSE_OUTFIT, "", wxDefaultPosition, FromDIP(wxSize(28, 24)));
+		outfit_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ACCOUNT, FromDIP(wxSize(16, 16)), wxColour(96, 125, 139)));
 		outfit_btn->SetToolTip("Change Preview Creature Outfit");
 		toolbar_sizer->Add(outfit_btn, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
 		// Sliders
-		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, wxSize(60, -1));
+		ambient_slider = new wxSlider(this, ID_AMBIENT_SLIDER, 128, 0, 255, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		ambient_slider->SetToolTip("Ambient Light");
 		toolbar_sizer->Add(ambient_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, wxSize(60, -1));
+		intensity_slider = new wxSlider(this, ID_INTENSITY_SLIDER, 100, 0, 200, wxDefaultPosition, FromDIP(wxSize(60, -1)));
 		intensity_slider->SetToolTip("Light Intensity");
 		toolbar_sizer->Add(intensity_slider, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
@@ -87,29 +87,29 @@ namespace IngamePreview {
 
 		// Viewport Controls
 		// Width
-		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_w_down = new wxButton(this, ID_VIEWPORT_W_DOWN, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_w_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
-		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
+		viewport_x_text = new wxTextCtrl(this, wxID_ANY, "15", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
 		toolbar_sizer->Add(viewport_x_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_w_up = new wxButton(this, ID_VIEWPORT_W_UP, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_w_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_w_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
 		toolbar_sizer->Add(new wxStaticText(this, wxID_ANY, "x"), 0, wxALL | wxALIGN_CENTER_VERTICAL, 2);
 
 		// Height
-		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_h_down = new wxButton(this, ID_VIEWPORT_H_DOWN, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_down->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_h_down, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
-		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, wxSize(30, -1), wxTE_READONLY | wxTE_CENTER);
+		viewport_y_text = new wxTextCtrl(this, wxID_ANY, "11", wxDefaultPosition, FromDIP(wxSize(30, -1)), wxTE_READONLY | wxTE_CENTER);
 		toolbar_sizer->Add(viewport_y_text, 0, wxALL | wxALIGN_CENTER_VERTICAL, 1);
 
-		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, wxSize(24, 24));
-		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16), wxColour(0, 150, 136)));
+		viewport_h_up = new wxButton(this, ID_VIEWPORT_H_UP, "", wxDefaultPosition, FromDIP(wxSize(24, 24)));
+		viewport_h_up->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, FromDIP(wxSize(16, 16)), wxColour(0, 150, 136)));
 		toolbar_sizer->Add(viewport_h_up, 0, wxALL | wxALIGN_CENTER_VERTICAL, 0);
 
 		main_sizer->Add(toolbar_sizer, 0, wxEXPAND | wxALL, 2);
@@ -184,9 +184,9 @@ namespace IngamePreview {
 	void IngamePreviewWindow::SetFollowSelection(bool follow) {
 		follow_selection = follow;
 		if (follow_selection) {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(76, 175, 80)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, FromDIP(wxSize(16, 16)), wxColour(76, 175, 80)));
 		} else {
-			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(16, 16), wxColour(158, 158, 158)));
+			follow_btn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, FromDIP(wxSize(16, 16)), wxColour(158, 158, 158)));
 		}
 		follow_btn->SetValue(follow_selection);
 	}

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -165,19 +165,19 @@ void ReplaceToolWindow::InitLayout() {
 	wxBoxSizer* manageBtnsSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	m_addRuleBtn = new wxButton(actionsCard, wxID_ANY, "ADD", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS));
 	m_addRuleBtn->SetBackgroundColour(wxColour(40, 180, 40)); // Green
 	m_addRuleBtn->SetForegroundColour(*wxWHITE);
 	m_addRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_editRuleBtn = new wxButton(actionsCard, wxID_ANY, "EDIT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
+	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PEN_TO_SQUARE));
 	m_editRuleBtn->SetBackgroundColour(wxColour(80, 80, 80)); // Neutral Dark Gray
 	m_editRuleBtn->SetForegroundColour(*wxWHITE);
 	m_editRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_deleteRuleBtn = new wxButton(actionsCard, wxID_ANY, "DEL", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
+	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_TRASH_CAN));
 	m_deleteRuleBtn->SetBackgroundColour(wxColour(180, 40, 40)); // Red
 	m_deleteRuleBtn->SetForegroundColour(*wxWHITE);
 	m_deleteRuleBtn->SetFont(Theme::GetFont(9, true));
@@ -189,7 +189,7 @@ void ReplaceToolWindow::InitLayout() {
 	actionsSizer->Add(manageBtnsSizer, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	m_addVisibleBtn = new wxButton(actionsCard, wxID_ANY, "ADD VISIBLE FROM VIEWPORT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, wxSize(16, 16)));
+	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLUS_SQUARE));
 	m_addVisibleBtn->SetBackgroundColour(wxColour(45, 120, 180)); // Sky Blue
 	m_addVisibleBtn->SetForegroundColour(*wxWHITE);
 	m_addVisibleBtn->SetFont(Theme::GetFont(9, true));
@@ -220,7 +220,7 @@ void ReplaceToolWindow::InitLayout() {
 
 	// Execute Button
 	m_executeBtn = new wxButton(actionsCard, wxID_ANY, "EXECUTE REPLACE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, wxSize(16, 16)));
+	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_PLAY));
 	m_executeBtn->SetDefault();
 	m_executeBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Blue
 	m_executeBtn->SetForegroundColour(*wxWHITE);
@@ -229,7 +229,7 @@ void ReplaceToolWindow::InitLayout() {
 
 	// Close Button
 	wxButton* closeBtn = new wxButton(actionsCard, wxID_ANY, "CLOSE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
 	closeBtn->SetBackgroundColour(wxColour(120, 120, 120)); // Gray
 	closeBtn->SetForegroundColour(*wxWHITE);
 	closeBtn->SetFont(Theme::GetFont(10, true));

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -29,8 +29,8 @@ public:
 		Bind(wxEVT_MOUSE_CAPTURE_LOST, &ConvexButton::OnMouseCaptureLost, this);
 	}
 
-	void SetBitmap(const wxBitmap& bitmap) {
-		m_icon = bitmap;
+	void SetBitmapBundle(const wxBitmapBundle& bundle) {
+		m_icon = bundle;
 		InvalidateBestSize();
 		Refresh();
 	}
@@ -41,14 +41,14 @@ public:
 		wxSize text = dc.GetTextExtent(GetLabel());
 		int width = text.x + FromDIP(30);
 		if (m_icon.IsOk()) {
-			width += m_icon.GetWidth() + FromDIP(8);
+			width += FromDIP(m_icon.GetDefaultSize().GetWidth()) + FromDIP(8);
 		}
-		int height = std::max(text.y, m_icon.IsOk() ? m_icon.GetHeight() : 0) + FromDIP(16);
+		int height = std::max(text.y, m_icon.IsOk() ? FromDIP(m_icon.GetDefaultSize().GetHeight()) : 0) + FromDIP(16);
 		return wxSize(std::max(width, FromDIP(100)), std::max(height, FromDIP(30)));
 	}
 
 private:
-	wxBitmap m_icon;
+	wxBitmapBundle m_icon;
 	bool m_hover = false;
 	bool m_pressed = false;
 
@@ -91,9 +91,14 @@ private:
 		dc.SetTextForeground(Theme::Get(Theme::Role::Text));
 		wxSize textSize = dc.GetTextExtent(GetLabel());
 
-		int x = (sz.x - textSize.x) / 2;
+		wxBitmap bmp;
 		if (m_icon.IsOk()) {
-			x -= (m_icon.GetWidth() + FromDIP(8)) / 2;
+			bmp = m_icon.GetBitmap(FromDIP(m_icon.GetDefaultSize()));
+		}
+
+		int x = (sz.x - textSize.x) / 2;
+		if (bmp.IsOk()) {
+			x -= (bmp.GetWidth() + FromDIP(8)) / 2;
 		}
 
 		int y = (sz.y - textSize.y) / 2;
@@ -102,13 +107,13 @@ private:
 			y += 1;
 		} // Shift content when pressed
 
-		if (m_icon.IsOk()) {
-			int iy = (sz.y - m_icon.GetHeight()) / 2;
+		if (bmp.IsOk()) {
+			int iy = (sz.y - bmp.GetHeight()) / 2;
 			if (m_pressed) {
 				iy += 1;
 			}
-			dc.DrawBitmap(m_icon, x, iy, true);
-			x += m_icon.GetWidth() + FromDIP(8);
+			dc.DrawBitmap(bmp, x, iy, true);
+			x += bmp.GetWidth() + FromDIP(8);
 		}
 
 		dc.DrawText(GetLabel(), x, y);
@@ -301,8 +306,12 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	// Icon Button - Align Left: 10px total
-	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
+	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(48, 48)));
+	if (rmeLogo.IsOk()) {
+		iconBtn->SetBitmapBundle(wxBitmapBundle::FromBitmap(rmeLogo));
+	} else {
+		iconBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_QUESTION_CIRCLE));
+	}
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -323,7 +332,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	headerSizer->Add(titleSizer, 1, wxALL | wxEXPAND, 10);
 
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
-	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
+	prefBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_GEAR));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Right: 10px total
@@ -338,14 +347,14 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	wxBoxSizer* footerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
-	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
+	exitBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_POWER_OFF));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
 
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
-	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
+	newBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_NEW));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
@@ -357,7 +366,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	footerSizer->AddStretchSpacer();
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
-	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
+	loadBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN));
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -385,14 +394,14 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 1: Actions (Buttons directly on panel)
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
-	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	newMapBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_NEW));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
-	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	browseBtn->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 


### PR DESCRIPTION
This PR modernizes key UI components (`WelcomeDialog`, `IngamePreviewWindow`, `ReplaceToolWindow`) to support High DPI displays by replacing hardcoded pixel values with `FromDIP` and utilizing `wxBitmapBundle` for scalable icons. It ensures that the UI scales correctly on 4K/Retina monitors and follows modern wxWidgets practices. The `ConvexButton` helper class was also updated to natively support bitmap bundles.

---
*PR created automatically by Jules for task [9176172808242309471](https://jules.google.com/task/9176172808242309471) started by @karolak6612*