### PR TITLE
[TILE/WXWIDGETS] Optimize TileLocation memory usage and fix MapStatisticsDialog UI

### DIFF
--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -41,9 +41,9 @@ public:
 protected:
 	std::unique_ptr<Tile> tile;
 	Position position;
-	size_t spawn_count;
-	size_t waypoint_count;
-	size_t town_count;
+	uint16_t spawn_count;
+	uint16_t waypoint_count;
+	uint16_t town_count;
 	std::unique_ptr<HouseExitList> house_exits; // Any house exits pointing here
 
 public:
@@ -73,7 +73,7 @@ public:
 		return position.z;
 	}
 
-	size_t getSpawnCount() const {
+	uint16_t getSpawnCount() const {
 		return spawn_count;
 	}
 	void increaseSpawnCount() {
@@ -82,7 +82,7 @@ public:
 	void decreaseSpawnCount() {
 		spawn_count--;
 	}
-	size_t getWaypointCount() const {
+	uint16_t getWaypointCount() const {
 		return waypoint_count;
 	}
 	void increaseWaypointCount() {
@@ -91,7 +91,7 @@ public:
 	void decreaseWaypointCount() {
 		waypoint_count--;
 	}
-	size_t getTownCount() const {
+	uint16_t getTownCount() const {
 		return town_count;
 	}
 	void increaseTownCount() {

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -77,8 +77,6 @@
 #include "brushes/carpet/carpet_brush.h"
 #include "brushes/table/table_brush.h"
 
-bool MapCanvas::processed[] = { 0 };
-
 // Helper to create attributes
 static wxGLAttributes& GetCoreProfileAttributes() {
 	static wxGLAttributes vAttrs = []() {

--- a/source/rendering/ui/map_display.h
+++ b/source/rendering/ui/map_display.h
@@ -109,15 +109,6 @@ public:
 
 	void TakeScreenshot(wxFileName path, wxString format);
 
-	enum {
-		BLOCK_SIZE = 100
-	};
-
-	inline int getFillIndex(int x, int y) const {
-		return x + BLOCK_SIZE * y;
-	}
-
-	static bool processed[BLOCK_SIZE * BLOCK_SIZE];
 	Editor& editor;
 	std::unique_ptr<MapDrawer> drawer;
 	int keyCode;

--- a/source/ui/map_statistics_dialog.cpp
+++ b/source/ui/map_statistics_dialog.cpp
@@ -92,28 +92,29 @@ void MapStatisticsDialog::Show(wxWindow* parent) {
 	topsizer->Add(text_field, wxSizerFlags(5).Expand());
 
 	wxSizer* choicesizer = newd wxBoxSizer(wxHORIZONTAL);
-	wxButton* export_button = newd wxButton(dg, wxID_OK, "Export as XML");
+	wxButton* export_button = newd wxButton(dg, wxID_SAVE, "Export as XML");
 	export_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE_EXPORT, wxSize(16, 16)));
 	choicesizer->Add(export_button, wxSizerFlags(1).Center());
 	export_button->SetToolTip("Not implemented yet");
 	export_button->Enable(false);
-	wxButton* okBtn = newd wxButton(dg, wxID_CANCEL, "OK");
+	wxButton* okBtn = newd wxButton(dg, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
 	okBtn->SetToolTip("Close this window");
 	choicesizer->Add(okBtn, wxSizerFlags(1).Center());
 	topsizer->Add(choicesizer, wxSizerFlags(1).Center());
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHART_BAR, wxSize(32, 32)));
+	dg->SetIcon(icon);
+
 	dg->SetSizerAndFit(topsizer);
 	dg->Centre(wxBOTH);
 
 	int ret = dg->ShowModal();
 
-	if (ret == wxID_OK) {
-	} else if (ret == wxID_CANCEL) {
+	if (ret == wxID_SAVE) {
+	} else if (ret == wxID_OK) {
 	}
-
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHART_BAR, wxSize(32, 32)));
-	dg->SetIcon(icon);
 
 	dg->Destroy();
 }


### PR DESCRIPTION
This PR addresses a high-impact memory optimization for the tile engine and fixes a UI anti-pattern in the statistics dialog.

**Memory Optimization:**
The `TileLocation` struct (used for every tile on the map) was using `size_t` (8 bytes) for `spawn_count`, `waypoint_count`, and `town_count`. These have been changed to `uint16_t` (2 bytes), saving approximately 18 bytes per tile. For a large map (e.g., 30000x30000), this results in significant memory savings (potentially gigabytes).

**UI Fixes:**
- Fixed `MapStatisticsDialog` where the window icon was set *after* the dialog was closed, resulting in no icon being shown.
- Swapped confusing button IDs: The "OK" button now uses `wxID_OK` (standard), and the "Export" button uses `wxID_SAVE`.

**Code Cleanup:**
- Removed unused `processed` static array and `BLOCK_SIZE` constant from `MapCanvas` (`map_display.h/cpp`), which were dead code.


---
*PR created automatically by Jules for task [15969276415530450537](https://jules.google.com/task/15969276415530450537) started by @karolak6612*