### PR TITLE
Refactor GameSprite decompression logic

### DIFF
--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -100,7 +100,7 @@ public:
 	}
 
 	// Helper for SpritePreloader to decompress data off-thread
-	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, bool use_alpha, int id = 0);
+	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, bool use_alpha, uint32_t id = 0);
 
 	static void ColorizeTemplatePixels(uint8_t* dest, const uint8_t* mask, size_t pixelCount, int lookHead, int lookBody, int lookLegs, int lookFeet, bool destHasAlpha);
 


### PR DESCRIPTION
Extracted decompression logic into `DecompressImpl` helper.
Refactored `GameSprite::Decompress` and `GameSprite::NormalImage::getRGBData` to use the helper.
Fixed type mismatch for `id` parameter in `GameSprite::Decompress`.

---
*PR created automatically by Jules for task [11130657820616401557](https://jules.google.com/task/11130657820616401557) started by @karolak6612*