### PR TITLE
📊 Profiler: Optimize Tooltip Rendering with Layout Caching

### DIFF
--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -143,16 +143,6 @@ public:
 	void clear();
 
 protected:
-	struct FieldLine {
-		std::string_view label;
-		std::string_view value;
-		uint8_t r, g, b;
-		std::vector<std::string_view> wrappedLines; // For multi-line values
-	};
-	std::vector<FieldLine> scratch_fields;
-	size_t scratch_fields_count = 0;
-	std::string storage; // Scratch buffer for text generation
-
 	std::vector<TooltipData> tooltips;
 	size_t active_count = 0;
 
@@ -166,24 +156,42 @@ protected:
 	void getHeaderColor(TooltipCategory cat, uint8_t& r, uint8_t& g, uint8_t& b) const;
 
 	// Refactored drawing helpers
-	struct LayoutMetrics {
-		float width;
-		float height;
-		float valueStartX;
-		float gridSlotSize;
-		int containerCols;
-		int containerRows;
-		float containerHeight;
-		int totalContainerSlots;
-		int emptyContainerSlots;
-		int numContainerItems;
+	struct CachedTooltip {
+		struct LayoutMetrics {
+			float width;
+			float height;
+			float valueStartX;
+			float gridSlotSize;
+			int containerCols;
+			int containerRows;
+			float containerHeight;
+			int totalContainerSlots;
+			int emptyContainerSlots;
+			int numContainerItems;
+		};
+
+		struct Field {
+			std::string label;
+			std::string value;
+			uint8_t r, g, b;
+			std::vector<std::string> wrappedLines; // For multi-line values
+		};
+
+		std::vector<Field> fields;
+		LayoutMetrics metrics;
+		uint32_t last_frame_seen = 0;
 	};
 
-	void prepareFields(const TooltipData& tooltip);
-	LayoutMetrics calculateLayout(NVGcontext* vg, const TooltipData& tooltip, float maxWidth, float minWidth, float padding, float fontSize);
+	// Layout cache to avoid redundant text measurement
+	std::unordered_map<uint64_t, CachedTooltip> layoutCache;
+	uint32_t current_frame_counter = 0;
+
+	void pruneCache();
+	void prepareFields(const TooltipData& tooltip, CachedTooltip& cached);
+	void calculateLayout(NVGcontext* vg, const TooltipData& tooltip, CachedTooltip& cached, float maxWidth, float minWidth, float padding, float fontSize);
 	void drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip);
-	void drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize);
-	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const LayoutMetrics& layout);
+	void drawFields(NVGcontext* vg, float x, float y, float valueStartX, float lineHeight, float padding, float fontSize, const CachedTooltip& cached);
+	void drawContainerGrid(NVGcontext* vg, float x, float y, const TooltipData& tooltip, const CachedTooltip::LayoutMetrics& metrics);
 };
 
 #endif


### PR DESCRIPTION
Implemented a persistent, hashed layout cache in TooltipDrawer to eliminate redundant text measurements and line breaking for identical tooltips (e.g. repeated chests/walls). Included an eviction strategy to prune stale entries after 120 frames.

---
*PR created automatically by Jules for task [13330514043481053317](https://jules.google.com/task/13330514043481053317) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tooltip rendering system with an internal caching mechanism to improve performance and reduce redundant computations.
  * Public tooltip API remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->