### PR TITLE
[MODERNIZE] Use C++20 features in materials and listbox

### DIFF
--- a/source/game/materials.cpp
+++ b/source/game/materials.cpp
@@ -40,12 +40,12 @@ Materials::~Materials() {
 }
 
 void Materials::clear() {
-	for (TilesetContainer::iterator iter = tilesets.begin(); iter != tilesets.end(); ++iter) {
-		delete iter->second;
+	for (auto& [name, tileset] : tilesets) {
+		delete tileset;
 	}
 
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		delete *iter;
+	for (auto* extension : extensions) {
+		delete extension;
 	}
 
 	tilesets.clear();
@@ -58,9 +58,9 @@ const MaterialsExtensionList& Materials::getExtensions() {
 
 MaterialsExtensionList Materials::getExtensionsByVersion(const ClientVersionID& version_id) {
 	MaterialsExtensionList ret_list;
-	for (MaterialsExtensionList::iterator iter = extensions.begin(); iter != extensions.end(); ++iter) {
-		if ((*iter)->isForVersion(version_id)) {
-			ret_list.push_back(*iter);
+	for (auto* extension : extensions) {
+		if (extension->isForVersion(version_id)) {
+			ret_list.push_back(extension);
 		}
 	}
 	return ret_list;
@@ -243,7 +243,7 @@ void Materials::createOtherTileset() {
 	Tileset* others;
 	Tileset* npc_tileset;
 
-	if (tilesets.find("Others") != tilesets.end()) {
+	if (tilesets.contains("Others")) {
 		others = tilesets["Others"];
 		others->clear();
 	} else {
@@ -251,7 +251,7 @@ void Materials::createOtherTileset() {
 		tilesets["Others"] = others;
 	}
 
-	if (tilesets.find("NPCs") != tilesets.end()) {
+	if (tilesets.contains("NPCs")) {
 		npc_tileset = tilesets["NPCs"];
 		npc_tileset->clear();
 	} else {
@@ -285,9 +285,7 @@ void Materials::createOtherTileset() {
 		}
 	}
 
-	for (CreatureMap::iterator iter = g_creatures.begin(); iter != g_creatures.end(); ++iter) {
-		CreatureType* type = iter->second;
-
+	for (auto& [name, type] : g_creatures) {
 		if (type->brush == nullptr) {
 			auto creature_brush = std::make_unique<CreatureBrush>(type);
 			type->brush = creature_brush.get();
@@ -381,11 +379,8 @@ bool Materials::isInTileset(Brush* brush, std::string tilesetName) const {
 		return false;
 	}
 
-	TilesetContainer::const_iterator tilesetiter = tilesets.find(tilesetName);
-	if (tilesetiter == tilesets.end()) {
-		return false;
+	if (auto it = tilesets.find(tilesetName); it != tilesets.end()) {
+		return it->second->containsBrush(brush);
 	}
-	Tileset* tileset = tilesetiter->second;
-
-	return tileset->containsBrush(brush);
+	return false;
 }

--- a/source/rendering/core/shared_geometry.cpp
+++ b/source/rendering/core/shared_geometry.cpp
@@ -28,7 +28,7 @@ bool SharedGeometry::initialize() {
 
 	std::lock_guard<std::mutex> lock(mutex_);
 
-	if (auto it = contexts_.find(ctx); it != contexts_.end()) {
+	if (contexts_.contains(ctx)) {
 		return true;
 	}
 

--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -66,7 +66,7 @@ void NanoVGListBox::SetSelection(int index) {
 
 int NanoVGListBox::GetSelection() const {
 	if (m_style & wxLB_MULTIPLE) {
-		const auto it = std::find(m_multiSelection.begin(), m_multiSelection.end(), true);
+		const auto it = std::ranges::find(m_multiSelection, true);
 		if (it != m_multiSelection.end()) {
 			return (int)std::distance(m_multiSelection.begin(), it);
 		}
@@ -110,7 +110,7 @@ void NanoVGListBox::Select(int index, bool select) {
 
 int NanoVGListBox::GetSelectedCount() const {
 	if (m_style & wxLB_MULTIPLE) {
-		return std::count(m_multiSelection.begin(), m_multiSelection.end(), true);
+		return std::ranges::count(m_multiSelection, true);
 	}
 	return (m_selection != -1) ? 1 : 0;
 }


### PR DESCRIPTION
[MODERNIZE] Use C++20 features in materials and listbox

BEFORE: Using iterator loops, `find() != end()`, and legacy algorithms.
AFTER: Using range-based for loops, `map::contains`, and `std::ranges` algorithms.
BENEFITS:
1. Improved readability with range-based loops and structured bindings.
2. Clearer intent with `contains` instead of iterator comparison.
3. Modern standard library usage with `std::ranges`.
STANDARD: C++20
CHANGES:
- source/game/materials.cpp: Replaced iterator loops with range-based for loops and `contains`.
- source/util/nanovg_listbox.cpp: Replaced `std::find`/`count` with `std::ranges::find`/`count`.
- source/rendering/core/shared_geometry.cpp: Replaced `find` with `contains`.
TESTED:
Compiles with C++20. Verified manually.

---
*PR created automatically by Jules for task [8248774156101083693](https://jules.google.com/task/8248774156101083693) started by @karolak6612*