### PR TITLE
⚡ Throttle: Optimize item label rendering

### DIFF
--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -149,6 +149,14 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const ItemType& i
 
 	data.updateCategory();
 
+	// Optimization: Use lightweight LABEL style for simple properties
+	// If it has no container items, no text, and no description, it's just a label (ActionID, UniqueID, Destination, etc.)
+	if (data.containerItems.empty() && data.text.empty() && data.description.empty()) {
+		data.style = TooltipStyle::LABEL;
+	} else {
+		data.style = TooltipStyle::FULL;
+	}
+
 	return true;
 }
 

--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -84,6 +84,7 @@ void TooltipDrawer::addWaypointTooltip(Position pos, std::string_view name) {
 	TooltipData& data = requestTooltipData();
 	data.pos = pos;
 	data.category = TooltipCategory::WAYPOINT;
+	data.style = TooltipStyle::LABEL;
 	data.waypointName = name;
 	commitTooltip();
 }
@@ -401,6 +402,15 @@ TooltipDrawer::LayoutMetrics TooltipDrawer::calculateLayout(NVGcontext* vg, cons
 
 void TooltipDrawer::drawBackground(NVGcontext* vg, float x, float y, float width, float height, float cornerRadius, const TooltipData& tooltip) {
 
+	if (tooltip.style == TooltipStyle::LABEL) {
+		// Lightweight background for labels
+		nvgBeginPath(vg);
+		nvgRoundedRect(vg, x, y, width, height, 3.0f);
+		nvgFillColor(vg, nvgRGBA(0, 0, 0, 160)); // Transparent black, similar to CreatureNameDrawer
+		nvgFill(vg);
+		return;
+	}
+
 	// Get border color based on category
 	uint8_t borderR, borderG, borderB;
 	getHeaderColor(tooltip.category, borderR, borderG, borderB);
@@ -573,8 +583,8 @@ void TooltipDrawer::draw(NVGcontext* vg, const RenderView& view) {
 
 		// Constants
 		float fontSize = 11.0f;
-		float padding = 10.0f;
-		float minWidth = 120.0f;
+		float padding = (tooltip.style == TooltipStyle::LABEL) ? 4.0f : 10.0f;
+		float minWidth = (tooltip.style == TooltipStyle::LABEL) ? 0.0f : 120.0f;
 		float maxWidth = 220.0f;
 
 		// 1. Prepare Content
@@ -599,6 +609,8 @@ void TooltipDrawer::draw(NVGcontext* vg, const RenderView& view) {
 		drawFields(vg, tooltipX, tooltipY, layout.valueStartX, fontSize * 1.4f, padding, fontSize);
 
 		// 5. Draw Container Grid
-		drawContainerGrid(vg, tooltipX, tooltipY, tooltip, layout);
+		if (tooltip.style == TooltipStyle::FULL) {
+			drawContainerGrid(vg, tooltipX, tooltipY, tooltip, layout);
+		}
 	}
 }

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -47,10 +47,16 @@ enum class TooltipCategory {
 	TEXT // Gold - readable text (signs, books)
 };
 
+enum class TooltipStyle {
+	FULL, // Full card with shadow, border, and container grid
+	LABEL // Lightweight label (text only, simple background)
+};
+
 // Structured tooltip data for card-based rendering
 struct TooltipData {
 	Position pos;
 	TooltipCategory category = TooltipCategory::ITEM;
+	TooltipStyle style = TooltipStyle::FULL;
 
 	// Header info
 	uint16_t itemId = 0;
@@ -105,6 +111,7 @@ struct TooltipData {
 		// Reset scalars
 		pos = Position();
 		category = TooltipCategory::ITEM;
+		style = TooltipStyle::FULL;
 		itemId = 0;
 		// clear strings
 		itemName = {};


### PR DESCRIPTION
This PR optimizes the rendering of item labels and waypoints by introducing a lightweight `LABEL` style for tooltips. 

Previously, every item with an ActionID or UniqueID was rendered as a full "tooltip" with a rounded rect background, multiple shadow passes, and potential container grid logic. This caused significant performance overhead when many such items were visible.

The changes include:
1.  Added `TooltipStyle` enum to `TooltipData`.
2.  Updated `FillItemTooltipData` to automatically use `LABEL` style for items without container contents, text, or descriptions.
3.  Updated `TooltipDrawer::addWaypointTooltip` to use `LABEL` style.
4.  Optimized `TooltipDrawer::draw` and `drawBackground` to skip shadow passes and complex backgrounds for `LABEL` style, using a simple semi-transparent black background instead.
5.  Reduced padding and removed minimum width constraints for labels to make them more compact.

---
*PR created automatically by Jules for task [15160912704687094494](https://jules.google.com/task/15160912704687094494) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved tooltip rendering efficiency by introducing dual rendering styles: lightweight mode for simple tooltips with minimal content, full-featured mode for detailed tooltips with comprehensive information
  * Waypoint tooltips now automatically render using the lightweight style for enhanced performance and visual responsiveness
  * Automatic content-based style selection optimizes rendering overhead and improves overall application efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->