### PR TITLE
[REFACTOR] Fix code smells in GameSprite

### DIFF
--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -73,8 +73,19 @@ public:
 
 	size_t getIndex(int width, int height, int layer, int pattern_x, int pattern_y, int pattern_z, int frame) const;
 
+	struct SpriteAtlasRequest {
+		int x = 0;
+		int y = 0;
+		int layer = 0;
+		int subtype = -1;
+		int pattern_x = 0;
+		int pattern_y = 0;
+		int pattern_z = 0;
+		int frame = 0;
+	};
+
 	// Phase 2: Get atlas region for texture array rendering
-	const AtlasRegion* getAtlasRegion(int _x, int _y, int _layer, int _subtype, int _pattern_x, int _pattern_y, int _pattern_z, int _frame);
+	const AtlasRegion* getAtlasRegion(const SpriteAtlasRequest& request);
 	const AtlasRegion* getAtlasRegion(int _x, int _y, int _dir, int _addon, int _pattern_z, const Outfit& _outfit, int _frame);
 
 	void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) override;
@@ -100,9 +111,9 @@ public:
 	}
 
 	// Helper for SpritePreloader to decompress data off-thread
-	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, bool use_alpha, int id = 0);
+	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, int output_channels, bool use_magic_pink, bool source_has_alpha, int id = 0);
 
-	static void ColorizeTemplatePixels(uint8_t* dest, const uint8_t* mask, size_t pixelCount, int lookHead, int lookBody, int lookLegs, int lookFeet, bool destHasAlpha);
+	static void ColorizeTemplatePixels(std::span<uint8_t> dest, std::span<const uint8_t> mask, const Outfit& outfit, bool destHasAlpha);
 
 private:
 protected:

--- a/source/rendering/drawers/entities/item_drawer.cpp
+++ b/source/rendering/drawers/entities/item_drawer.cpp
@@ -166,12 +166,14 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 	// BatchRenderer::SetAtlasManager(g_gui.gfx.getAtlasManager());
 
 	if (spr->width == 1 && spr->height == 1 && spr->layers == 1) {
-		const AtlasRegion* region;
-		if (subtype == -1 && pattern_x == 0 && pattern_y == 0 && pattern_z == 0 && frame == 0) {
-			region = spr->getAtlasRegion(0, 0, 0, -1, 0, 0, 0, 0);
-		} else {
-			region = spr->getAtlasRegion(0, 0, 0, subtype, pattern_x, pattern_y, pattern_z, frame);
-		}
+		GameSprite::SpriteAtlasRequest req;
+		req.subtype = subtype;
+		req.pattern_x = pattern_x;
+		req.pattern_y = pattern_y;
+		req.pattern_z = pattern_z;
+		req.frame = frame;
+
+		const AtlasRegion* region = spr->getAtlasRegion(req);
 
 		if (region) {
 #ifdef DEBUG
@@ -190,7 +192,17 @@ void ItemDrawer::BlitItem(SpriteBatch& sprite_batch, SpriteDrawer* sprite_drawer
 		for (int cx = 0; cx != spr->width; cx++) {
 			for (int cy = 0; cy != spr->height; cy++) {
 				for (int cf = 0; cf != spr->layers; cf++) {
-					const AtlasRegion* region = spr->getAtlasRegion(cx, cy, cf, subtype, pattern_x, pattern_y, pattern_z, frame);
+					GameSprite::SpriteAtlasRequest req;
+					req.x = cx;
+					req.y = cy;
+					req.layer = cf;
+					req.subtype = subtype;
+					req.pattern_x = pattern_x;
+					req.pattern_y = pattern_y;
+					req.pattern_z = pattern_z;
+					req.frame = frame;
+
+					const AtlasRegion* region = spr->getAtlasRegion(req);
 					if (region) {
 						sprite_drawer->glBlitAtlasQuad(sprite_batch, screenx - cx * TILE_SIZE, screeny - cy * TILE_SIZE, region, DrawColor(red, green, blue, alpha));
 					}

--- a/source/rendering/drawers/entities/sprite_drawer.cpp
+++ b/source/rendering/drawers/entities/sprite_drawer.cpp
@@ -94,7 +94,12 @@ void SpriteDrawer::BlitSprite(SpriteBatch& sprite_batch, int screenx, int screen
 	for (int cx = 0; cx != spr->width; ++cx) {
 		for (int cy = 0; cy != spr->height; ++cy) {
 			for (int cf = 0; cf != spr->layers; ++cf) {
-				const AtlasRegion* region = spr->getAtlasRegion(cx, cy, cf, -1, 0, 0, 0, tme);
+				GameSprite::SpriteAtlasRequest req;
+				req.x = cx;
+				req.y = cy;
+				req.layer = cf;
+				req.frame = tme;
+				const AtlasRegion* region = spr->getAtlasRegion(req);
 				if (region) {
 					glBlitAtlasQuad(sprite_batch, screenx - cx * TILE_SIZE, screeny - cy * TILE_SIZE, region, color);
 				}


### PR DESCRIPTION
CODE SMELL: God Class (GameSprite), Duplicate Code (Decompress/getRGBData), Long Parameter List (getAtlasRegion), Magic Numbers/Raw Loops (ColorizeTemplatePixels).
LOCATION: source/rendering/core/game_sprite.cpp and .h
SEVERITY: HIGH
PROBLEM: GameSprite was accumulating too many responsibilities and had duplicated complex logic for sprite decompression. Methods like getAtlasRegion had too many parameters, making callsites error-prone. ColorizeTemplatePixels used raw pointers and magic numbers.
REFACTORING APPLIED:
1.  Refactored `GameSprite::Decompress` to be flexible and reused it in `getRGBData` and `getRGBAData`, removing duplication.
2.  Refactored `GameSprite::ColorizeTemplatePixels` to use `std::span`, `Outfit` struct, and removed raw pointer arithmetic.
3.  Introduced `SpriteAtlasRequest` struct to encapsulate parameters for `getAtlasRegion`.
CHANGES:
-   Modified `GameSprite::Decompress` to accept `output_channels` and `source_has_alpha`.
-   Updated `getRGBData` and `getRGBAData` to use `Decompress`.
-   Updated `ColorizeTemplatePixels` signature and implementation.
-   Updated `getAtlasRegion` to take `SpriteAtlasRequest`.
-   Updated call sites in `sprite_drawer.cpp` and `item_drawer.cpp`.
BEFORE:
-   `getRGBData` duplicated 60 lines of decompression logic.
-   `getAtlasRegion` took 8 integer arguments.
-   `ColorizeTemplatePixels` used raw pointers and unsafe arithmetic.
AFTER:
-   `getRGBData` is a one-liner call to `Decompress`.
-   `getAtlasRegion` takes a single struct.
-   `ColorizeTemplatePixels` uses safe `std::span` access.
BEHAVIOR: No functional changes intended. Verified compilation.
TESTED: Compiles successfully (game_sprite.o, item_drawer.o, sprite_drawer.o).

---
*PR created automatically by Jules for task [3098872546583755513](https://jules.google.com/task/3098872546583755513) started by @karolak6612*