### PR TITLE
🗝️ Keeper: Fix NanoVG texture cache LRU leak

### DIFF
--- a/source/util/nanovg_canvas.cpp
+++ b/source/util/nanovg_canvas.cpp
@@ -431,6 +431,7 @@ void NanoVGCanvas::ClearImageCache() {
 		nvgDeleteImage(m_nvg.get(), tex);
 	}
 	m_imageCache.clear();
+	m_lruList.clear();
 }
 
 int NanoVGCanvas::GetCachedImage(uint64_t id) const {


### PR DESCRIPTION
This PR fixes a bug in `NanoVGCanvas` where the LRU list (`m_lruList`) was not being cleared when the image cache (`m_imageCache`) was cleared via `ClearImageCache()`. This could lead to the LRU list containing invalid IDs, potentially causing issues when new images are added or the cache is accessed.

**Changes:**
- Added `m_lruList.clear()` to `NanoVGCanvas::ClearImageCache()` in `source/util/nanovg_canvas.cpp`.

---
*PR created automatically by Jules for task [13104109521613190411](https://jules.google.com/task/13104109521613190411) started by @karolak6612*