### PR TITLE
⚡ Throttle: Optimize ToolOptionsSurface with NanoVG

### DIFF
--- a/source/ui/tool_options_surface.h
+++ b/source/ui/tool_options_surface.h
@@ -6,23 +6,22 @@
 #include <wx/timer.h>
 #include <vector>
 #include "palette/palette_common.h"
+#include "util/nanovg_canvas.h"
 
 class Brush;
 
 // A custom-drawn, high-density surface for tool options.
 // Replaces the old panel-based layout with a unified, paint-optimized control.
-class ToolOptionsSurface : public wxControl {
+class ToolOptionsSurface : public NanoVGCanvas {
 public:
 	ToolOptionsSurface(wxWindow* parent);
 	~ToolOptionsSurface();
 
 	// Mandatory overrides for custom controls
 	wxSize DoGetBestClientSize() const override;
-	void DoSetSizeHints(int minW, int minH, int maxW, int maxH, int incW, int incH) override;
 
 	// Event Handlers
-	void OnPaint(wxPaintEvent& evt);
-	void OnEraseBackground(wxEraseEvent& evt); // No-op
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
 	void OnMouse(wxMouseEvent& evt);
 	void OnLeave(wxMouseEvent& evt);
 	void OnSize(wxSizeEvent& evt);
@@ -92,9 +91,9 @@ private:
 
 	// Internal Helpers
 	void RebuildLayout();
-	void DrawToolIcon(wxDC& dc, const ToolRect& tr);
-	void DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
-	void DrawCheckbox(wxDC& dc, const wxRect& rect, const wxString& label, bool value, bool hover);
+	void DrawToolIcon(NVGcontext* vg, const ToolRect& tr);
+	void DrawSlider(NVGcontext* vg, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
+	void DrawCheckbox(NVGcontext* vg, const wxRect& rect, const wxString& label, bool value, bool hover);
 
 	int CalculateSliderValue(const wxRect& sliderRect, int min, int max) const;
 


### PR DESCRIPTION
This PR optimizes `ToolOptionsSurface` by migrating it from `wxDC` to `NanoVGCanvas`. This change enables GPU-accelerated rendering and avoids creating excessive GDI handles (wxBitmap/wxMemoryDC) which was identified as a performance bottleneck.

Key changes:
- `ToolOptionsSurface` now inherits from `NanoVGCanvas`.
- `OnPaint` is replaced by `OnNanoVGPaint`.
- Drawing logic for tools, sliders, and checkboxes is ported to NanoVG.
- Input handling in `OnMouse` is updated to account for scrolling offset.
- `source/ui/tool_options_surface.cpp` now includes `util/nvg_utils.h`.

---
*PR created automatically by Jules for task [6558476117489287439](https://jules.google.com/task/6558476117489287439) started by @karolak6612*