### PR TITLE
[TILE/WXWIDGETS] Fix sizer mismanagement in PropertiesWindow

### DIFF
--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -50,6 +50,7 @@ PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile*
 	Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &PropertiesWindow::OnNotebookPageChanged, this, wxID_ANY);
 
 	Bind(wxEVT_GRID_CELL_CHANGED, &PropertiesWindow::OnGridValueChanged, this);
+	Bind(wxEVT_SIZE, &PropertiesWindow::OnResize, this);
 
 	createUI();
 }
@@ -179,10 +180,10 @@ wxWindow* PropertiesWindow::createContainerPanel(wxWindow* parent) {
 }
 
 wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
-	wxPanel* panel = newd wxPanel(parent, wxID_ANY);
+	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_ADVANCED_TAB);
 	wxSizer* topSizer = newd wxBoxSizer(wxVERTICAL);
 
-	attributesGrid = newd wxGrid(panel, ITEM_PROPERTIES_ADVANCED_TAB, wxDefaultPosition, wxSize(-1, FromDIP(160)));
+	attributesGrid = newd wxGrid(panel, wxID_ANY, wxDefaultPosition, wxSize(-1, FromDIP(160)));
 	topSizer->Add(attributesGrid, wxSizerFlags(1).Expand());
 
 	wxFont time_font(*wxSWISS_FONT);
@@ -234,17 +235,21 @@ void PropertiesWindow::SetGridValue(wxGrid* grid, int rowIndex, std::string labe
 }
 
 void PropertiesWindow::OnResize(wxSizeEvent& evt) {
-	/*
-	if(wxGrid* grid = (wxGrid*)currentPanel->FindWindowByName("AdvancedGrid")) {
-		int tWidth = 0;
-		for(int i = 0; i < 3; ++i)
-			tWidth += grid->GetColumnWidth(i);
-
-		int wWidth = grid->GetParent()->GetSize().GetWidth();
-
-		grid->SetColumnWidth(2, wWidth - 100 - 80);
+	Layout();
+	if (attributesGrid) {
+		int width = attributesGrid->GetClientSize().GetWidth();
+		if (width > 0) {
+			int col0 = attributesGrid->GetColSize(0);
+			int col1 = attributesGrid->GetColSize(1);
+			int remaining = width - col0 - col1;
+			// Reserve space for scrollbar
+			remaining -= wxSystemSettings::GetMetric(wxSYS_VSCROLL_X);
+			if (remaining > 50) {
+				attributesGrid->SetColSize(2, remaining);
+			}
+		}
 	}
-	*/
+	evt.Skip();
 }
 
 void PropertiesWindow::OnNotebookPageChanged(wxNotebookEvent& evt) {


### PR DESCRIPTION
This PR addresses sizer mismanagement in `PropertiesWindow`. The attributes grid in the "Advanced" tab now resizes its last column to fill the available width, improving readability of long attribute values. It also corrects an ID issue where the "Advanced" tab panel was not correctly identified by `OnNotebookPageChanged`.

---
*PR created automatically by Jules for task [6823867009298175988](https://jules.google.com/task/6823867009298175988) started by @karolak6612*