### PR TITLE
🔒 Sentinel: Modernize NanoVG Resource Management

### DIFF
--- a/source/rendering/core/render_view.cpp
+++ b/source/rendering/core/render_view.cpp
@@ -115,12 +115,10 @@ void RenderView::SetupGL() {
 	projectionMatrix = glm::ortho(0.0f, width * zoom, height * zoom, 0.0f, -1.0f, 1.0f);
 
 	// Calculate ModelView
-	// glTranslatef(0.375f, 0.375f, 0.0f);
 	viewMatrix = glm::translate(glm::mat4(1.0f), glm::vec3(0.375f, 0.375f, 0.0f));
 }
 
 void RenderView::ReleaseGL() {
-	// No legacy matrix stack to cleanup
 }
 
 void RenderView::Clear() {
@@ -129,7 +127,6 @@ void RenderView::Clear() {
 
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-	// glLoadIdentity(); // Legacy
 	// Blending and State management is now handled by individual renderers
 }
 

--- a/source/rendering/ui/map_display.cpp
+++ b/source/rendering/ui/map_display.cpp
@@ -64,6 +64,7 @@
 #include "rendering/ui/selection_controller.h"
 #include "rendering/ui/drawing_controller.h"
 #include "rendering/ui/map_menu_handler.h"
+#include "util/image_manager.h"
 
 #include "brushes/doodad/doodad_brush.h"
 #include "brushes/house/house_exit_brush.h"
@@ -163,6 +164,10 @@ MapCanvas::~MapCanvas() {
 	}
 
 	drawer.reset();
+
+	if (m_nvg) {
+		IMAGE_MANAGER.RemoveContextResources(m_nvg.get());
+	}
 	m_nvg.reset();
 
 	g_gl_context.UnregisterCanvas(this);

--- a/source/util/image_manager.cpp
+++ b/source/util/image_manager.cpp
@@ -29,9 +29,26 @@ ImageManager::~ImageManager() {
 	ClearCache();
 }
 
+void ImageManager::RemoveContextResources(NVGcontext* vg) {
+	if (!vg) {
+		return;
+	}
+
+	for (auto it = m_nvgImageCache.begin(); it != m_nvgImageCache.end();) {
+		if (it->first.ctx == vg) {
+			nvgDeleteImage(vg, it->second);
+			it = m_nvgImageCache.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
 void ImageManager::ClearCache() {
 	m_bitmapBundleCache.clear();
 	m_tintedBitmapCache.clear();
+	// Note: We cannot safely delete NVG images here because we don't know if the contexts are still valid.
+	// Contexts should clean up their own resources via RemoveContextResources() before destruction.
 	m_nvgImageCache.clear();
 	m_glTextureCache.clear();
 }

--- a/source/util/image_manager.h
+++ b/source/util/image_manager.h
@@ -62,6 +62,7 @@ public:
 	uint32_t GetGLTexture(std::string_view assetPath);
 
 	// Cleanup
+	void RemoveContextResources(NVGcontext* vg);
 	void ClearCache();
 
 private:


### PR DESCRIPTION
This PR addresses a resource leak where NanoVG images cached in `ImageManager` were not being deleted when the associated `NVGcontext` was destroyed. It implements a cleanup mechanism in `ImageManager` and ensures it is called from `MapCanvas`. It also removes some legacy commented-out code.

---
*PR created automatically by Jules for task [14180190929146078076](https://jules.google.com/task/14180190929146078076) started by @karolak6612*