### PR TITLE
[UI] Add missing icons to House Palette and Recent Files

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -12,6 +12,7 @@
 #include "map/map.h"
 #include "game/house.h"
 #include "game/town.h"
+#include "util/image_manager.h"
 
 #include <sstream>
 
@@ -94,8 +95,13 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -15,6 +15,7 @@
 #include "brushes/managers/brush_manager.h"
 #include "brushes/house/house_brush.h"
 #include "brushes/house/house_exit_brush.h"
+#include "util/image_manager.h"
 
 #include <algorithm>
 
@@ -59,8 +60,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);

--- a/source/ui/managers/recent_files_manager.cpp
+++ b/source/ui/managers/recent_files_manager.cpp
@@ -1,7 +1,9 @@
 #include "ui/managers/recent_files_manager.h"
 #include <toml++/toml.h>
 #include <wx/filename.h>
+#include <wx/menu.h>
 #include "app/settings.h"
+#include "util/image_manager.h"
 
 RecentFilesManager::RecentFilesManager() :
 	recentFiles(10) {
@@ -60,6 +62,14 @@ void RecentFilesManager::AddFile(const FileName& file) {
 void RecentFilesManager::UseMenu(wxMenu* menu) {
 	recentFiles.UseMenu(menu);
 	recentFiles.AddFilesToMenu();
+
+	for (size_t i = 0; i < recentFiles.GetCount(); ++i) {
+		int id = recentFiles.GetBaseId() + i;
+		wxMenuItem* item = menu->FindItem(id);
+		if (item) {
+			item->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE, wxSize(16, 16)));
+		}
+	}
 }
 
 std::vector<wxString> RecentFilesManager::GetFiles() const {


### PR DESCRIPTION
This PR adds missing icons to several UI components to improve visual consistency and user experience.

**Changes:**
*   **House Palette:** Added `ICON_PLUS`, `ICON_PEN_TO_SQUARE`, and `ICON_MINUS` to the "Add", "Edit", and "Remove" buttons respectively.
*   **Edit House Dialog:** Added `ICON_CHECK` and `ICON_XMARK` to the "OK" and "Cancel" buttons.
*   **Recent Files:** Added `ICON_FILE` to dynamically generated recent file menu items.

These changes ensure that all buttons in the House Palette workflow have appropriate icons, matching the style of other dialogs in the application. It also adds a visual cue to recent file items.

---
*PR created automatically by Jules for task [10505962026006982418](https://jules.google.com/task/10505962026006982418) started by @karolak6612*