### PR TITLE
Fix critical UB: integer overflow, buffer overflow, and race condition

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -23,6 +23,7 @@
 
 #include <sstream>
 #include <algorithm>
+#include <limits>
 #include <ranges>
 #include <unordered_set>
 #include <unordered_map>
@@ -386,14 +387,18 @@ void Map::removeSpawnInternal(Tile* tile) {
 	ASSERT(spawn);
 
 	int z = tile->getZ();
-	int start_x = tile->getX() - spawn->getSize();
-	int start_y = tile->getY() - spawn->getSize();
-	int end_x = tile->getX() + spawn->getSize();
-	int end_y = tile->getY() + spawn->getSize();
+	int64_t start_x = static_cast<int64_t>(tile->getX()) - spawn->getSize();
+	int64_t start_y = static_cast<int64_t>(tile->getY()) - spawn->getSize();
+	int64_t end_x = static_cast<int64_t>(tile->getX()) + spawn->getSize();
+	int64_t end_y = static_cast<int64_t>(tile->getY()) + spawn->getSize();
 
-	for (int y = start_y; y <= end_y; ++y) {
-		for (int x = start_x; x <= end_x; ++x) {
-			TileLocation* ctile_loc = getTileL(x, y, z);
+	for (int64_t y = start_y; y <= end_y; ++y) {
+		for (int64_t x = start_x; x <= end_x; ++x) {
+			if (x < std::numeric_limits<int>::min() || x > std::numeric_limits<int>::max() ||
+				y < std::numeric_limits<int>::min() || y > std::numeric_limits<int>::max()) {
+				continue;
+			}
+			TileLocation* ctile_loc = getTileL(static_cast<int>(x), static_cast<int>(y), z);
 			if (ctile_loc != nullptr && ctile_loc->getSpawnCount() > 0) {
 				ctile_loc->decreaseSpawnCount();
 			}

--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -39,7 +39,11 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
-	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
+	if (position + length > buffer.size()) {
+		spdlog::error("NetworkMessage::read overflow (string)");
+		return std::string();
+	}
+	char* strBuffer = reinterpret_cast<char*>(buffer.data() + position);
 	position += length;
 	return std::string(strBuffer, length);
 }


### PR DESCRIPTION
This PR addresses three critical issues identified during a deep scan:
1.  **Signed Integer Overflow:** In `Map::removeSpawnInternal`, spawn size calculations could overflow `int` if a large size was provided (e.g. from a malicious map file), leading to undefined behavior. This is fixed by using `int64_t` for bounds calculation and loop counters.
2.  **Buffer Overflow & Strict Aliasing:** `NetworkMessage::read<T>` used `reinterpret_cast` which violates strict aliasing and had no bounds checking. `NetworkMessage::read<std::string>` also lacked bounds checking. Both are fixed to use `std::memcpy` (for T) and explicit bounds checks, preventing potential crashes or exploits from malformed network packets.
3.  **Data Race:** `NetworkConnection::stopped` was accessed from both main and worker threads without synchronization. It is now `std::atomic<bool>`.

---
*PR created automatically by Jules for task [6652478899905652096](https://jules.google.com/task/6652478899905652096) started by @karolak6612*