### PR TITLE
[ICONS] Add icons to Recent Files, DatDebugView, and ReplaceToolWindow

### DIFF
--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -59,6 +59,7 @@
 
 #include "editor/operations/search_operations.h"
 #include "editor/operations/clean_operations.h"
+#include "util/image_manager.h"
 
 MainMenuBar::MainMenuBar(MainFrame* frame) :
 	frame(frame) {
@@ -237,6 +238,11 @@ void MainMenuBar::OnExportTilesets(wxCommandEvent& event) {
 
 void MainMenuBar::OnDebugViewDat(wxCommandEvent& event) {
 	wxDialog dlg(frame, wxID_ANY, "Debug .dat file", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER);
+
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_BUG, wxSize(32, 32)));
+	dlg.SetIcon(icon);
+
 	new DatDebugView(&dlg);
 	dlg.ShowModal();
 }

--- a/source/ui/managers/recent_files_manager.cpp
+++ b/source/ui/managers/recent_files_manager.cpp
@@ -2,6 +2,7 @@
 #include <toml++/toml.h>
 #include <wx/filename.h>
 #include "app/settings.h"
+#include "util/image_manager.h"
 
 RecentFilesManager::RecentFilesManager() :
 	recentFiles(10) {
@@ -60,6 +61,13 @@ void RecentFilesManager::AddFile(const FileName& file) {
 void RecentFilesManager::UseMenu(wxMenu* menu) {
 	recentFiles.UseMenu(menu);
 	recentFiles.AddFilesToMenu();
+
+	for (size_t i = 0; i < recentFiles.GetCount(); ++i) {
+		wxMenuItem* item = menu->FindItem(recentFiles.GetBaseId() + i);
+		if (item) {
+			item->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FILE, wxSize(16, 16)));
+		}
+	}
 }
 
 std::vector<wxString> RecentFilesManager::GetFiles() const {

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -46,6 +46,10 @@ ReplaceToolWindow::ReplaceToolWindow(wxWindow* parent, Editor* editor) : wxDialo
 
 	UpdateSavedRulesList();
 
+	wxIcon icon;
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_WAND_MAGIC, wxSize(32, 32)));
+	SetIcon(icon);
+
 	Bind(wxEVT_CLOSE_WINDOW, &ReplaceToolWindow::OnClose, this);
 
 	// Restore window size (Physical pixels)


### PR DESCRIPTION
Added icons to Recent Files menu items in `RecentFilesManager`, `DatDebugView` dialog in `MainMenuBar`, and `ReplaceToolWindow` dialog. This improves visual consistency and adheres to the icon integration guidelines.

---
*PR created automatically by Jules for task [17586357841548353987](https://jules.google.com/task/17586357841548353987) started by @karolak6612*