### PR TITLE
👻 Phantom: UI Error Reporting and Layout Fixes

### DIFF
--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -217,16 +217,10 @@ ReplaceItemsDialog::ReplaceItemsDialog(wxWindow* parent, bool selectionOnly) :
 
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 
-	wxFlexGridSizer* list_sizer = new wxFlexGridSizer(0, 2, 0, 0);
-	list_sizer->SetFlexibleDirection(wxBOTH);
-	list_sizer->SetNonFlexibleGrowMode(wxFLEX_GROWMODE_SPECIFIED);
-	list_sizer->SetMinSize(wxSize(-1, FromDIP(300)));
-
 	list = new ReplaceItemsListBox(this);
 	list->SetMinSize(FromDIP(wxSize(480, 320)));
 
-	list_sizer->Add(list, 0, wxALL | wxEXPAND, 5);
-	sizer->Add(list_sizer, 1, wxALL | wxEXPAND, 5);
+	sizer->Add(list, 1, wxALL | wxEXPAND, 5);
 
 	wxBoxSizer* items_sizer = new wxBoxSizer(wxHORIZONTAL);
 	items_sizer->SetMinSize(wxSize(-1, FromDIP(40)));

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -20,6 +20,7 @@
 #include <wx/msgdlg.h>
 #include <wx/textdlg.h>
 #include <wx/artprov.h>
+#include <wx/log.h>
 
 // Brush includes
 #include "brushes/brush.h"
@@ -320,7 +321,7 @@ void ReplaceToolWindow::OnRuleDeleted(const std::string& name) {
 void ReplaceToolWindow::OnRuleRenamed(const std::string& oldName, const std::string& newName) {
 	std::vector<std::string> existing = RuleManager::Get().GetAvailableRuleSets();
 	if (std::find(existing.begin(), existing.end(), newName) != existing.end()) {
-		wxMessageBox("A rule set with this name already exists.", "Rename Error", wxOK | wxICON_ERROR);
+		wxLogError("A rule set with this name already exists.");
 		return;
 	}
 
@@ -335,7 +336,7 @@ void ReplaceToolWindow::OnRuleRenamed(const std::string& oldName, const std::str
 			}
 			UpdateSavedRulesList();
 		} else {
-			wxMessageBox("Failed to save the renamed rule set.", "Rename Error", wxOK | wxICON_ERROR);
+			wxLogError("Failed to save the renamed rule set.");
 		}
 	}
 }
@@ -352,7 +353,7 @@ void ReplaceToolWindow::OnRuleChanged() {
 void ReplaceToolWindow::OnExecute(wxCommandEvent&) {
 	std::vector<ReplacementRule> rules = ruleBuilder->GetRules();
 	if (rules.empty()) {
-		wxMessageBox("No rules defined. Add some rules first.", "Replace", wxOK | wxICON_INFORMATION);
+		wxLogError("No rules defined. Add some rules first.");
 		return;
 	}
 
@@ -365,17 +366,18 @@ void ReplaceToolWindow::OnExecute(wxCommandEvent&) {
 	}
 
 	if (scope == ReplaceScope::Selection && editor->selection.empty()) {
-		wxMessageBox("No selection active. Please select an area first or change scope.", "Replace", wxOK | wxICON_WARNING);
+		wxLogError("No selection active. Please select an area first or change scope.");
 		return;
 	}
 
-	int confirm = wxMessageBox(
+	wxMessageDialog dlg(this,
 		"Are you sure you want to execute replacements on the map?",
 		"Confirm Bulk Replacement",
 		wxYES_NO | wxNO_DEFAULT | wxICON_WARNING
 	);
+	dlg.CenterOnParent();
 
-	if (confirm != wxYES) {
+	if (dlg.ShowModal() != wxID_YES) {
 		return;
 	}
 
@@ -492,7 +494,7 @@ void ReplaceToolWindow::OnSaveRule() {
 
 	std::vector<std::string> existing = RuleManager::Get().GetAvailableRuleSets();
 	if (std::find(existing.begin(), existing.end(), name.ToStdString()) != existing.end()) {
-		wxMessageBox("A rule set with this name already exists. Please choose a different name.", "Name Collision", wxOK | wxICON_ERROR);
+		wxLogError("A rule set with this name already exists. Please choose a different name.");
 		return;
 	}
 


### PR DESCRIPTION
This PR addresses UI code quality issues identified by the Phantom agent instructions. It modernizes error reporting in the Replace Tool by using `wxLogError` instead of `wxMessageBox` and cleans up unnecessary sizer nesting in the Replace Items Window. Compilation was verified using Ninja.

---
*PR created automatically by Jules for task [11053521186245469540](https://jules.google.com/task/11053521186245469540) started by @karolak6612*