### PR TITLE
[UB FIX] Fix strict aliasing, data race, and coordinate overflow in Network/Live logic

### DIFF
--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -322,6 +322,12 @@ void LiveClient::sendReady() {
 }
 
 void LiveClient::queryNode(int32_t ndx, int32_t ndy, bool underground) {
+	if (ndx < 0 || ndx >= 65536 || ndy < 0 || ndy >= 65536) {
+		// Prevent overflow/truncation when packing coordinates into 14 bits (shifted by 2).
+		// 14 bits can hold up to 16383. 16383 * 4 + 3 = 65535.
+		return;
+	}
+
 	uint32_t nd = 0;
 	nd |= (static_cast<uint32_t>(ndx >> 2) << 18);
 	nd |= (static_cast<uint32_t>(ndy >> 2) << 4);

--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -113,6 +113,12 @@ void LiveSocket::receiveNode(NetworkMessage& message, Editor& editor, Action* ac
 }
 
 void LiveSocket::sendNode(uint32_t clientId, MapNode* node, int32_t ndx, int32_t ndy, uint32_t floorMask) {
+	if (ndx < 0 || ndx >= 16384 || ndy < 0 || ndy >= 16384) {
+		// Prevent overflow/truncation when packing coordinates into 14 bits.
+		// 16384 * 4 = 65536, so this supports map coordinates up to 65536.
+		return;
+	}
+
 	bool underground;
 	if (floorMask & 0xFF00) {
 		if (floorMask & 0x00FF) {

--- a/source/net/net_connection.h
+++ b/source/net/net_connection.h
@@ -26,6 +26,8 @@
 #include <thread>
 #include <mutex>
 #include <memory>
+#include <cstring>
+#include <atomic>
 
 struct NetworkMessage {
 	NetworkMessage();
@@ -36,7 +38,8 @@ struct NetworkMessage {
 	//
 	template <typename T>
 	T read() {
-		T& value = *reinterpret_cast<T*>(&buffer[position]);
+		T value;
+		std::memcpy(&value, &buffer[position], sizeof(T));
 		position += sizeof(T);
 		return value;
 	}
@@ -44,7 +47,7 @@ struct NetworkMessage {
 	template <typename T>
 	void write(const T& value) {
 		expand(sizeof(T));
-		memcpy(&buffer[position], &value, sizeof(T));
+		std::memcpy(&buffer[position], &value, sizeof(T));
 		position += sizeof(T);
 	}
 
@@ -81,7 +84,7 @@ public:
 private:
 	std::unique_ptr<boost::asio::io_context> service;
 	std::thread thread;
-	bool stopped;
+	std::atomic<bool> stopped;
 };
 
 #endif


### PR DESCRIPTION
BUG TYPE: Undefined Behavior / Race Condition / Logic Bug
SEVERITY: CRITICAL
ISSUE:
1. Strict Aliasing Violation: NetworkMessage::read used reinterpret_cast<T*> on a byte buffer, violating strict aliasing and potentially causing alignment faults.
2. Data Race: NetworkConnection::stopped was a plain bool accessed from multiple threads (main and IO thread) without synchronization.
3. Coordinate Overflow: LiveSocket/LiveClient packed 32-bit coordinates into 14 bits without checking, leading to silent data corruption for maps > 65536.

FIX:
1. Replaced reinterpret_cast with std::memcpy in NetworkMessage.
2. Changed bool stopped to std::atomic<bool> stopped in NetworkConnection.
3. Added bounds checks in LiveSocket::sendNode and LiveClient::queryNode to prevent packing invalid coordinates.

TESTED: Verified compilation and ran a unit test for NetworkMessage to ensure memcpy works correctly. Verified std::atomic usage.

---
*PR created automatically by Jules for task [18075370392951285905](https://jules.google.com/task/18075370392951285905) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented coordinate validation checks to prevent out-of-range node positions from causing overflow errors during data transmission.

* **Refactor**
  * Enhanced memory handling and concurrency mechanisms to improve system reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->