### PR TITLE
Refactor UI lists to NanoVGListBox

### DIFF
--- a/source/palette/palette_waypoints.h
+++ b/source/palette/palette_waypoints.h
@@ -18,10 +18,11 @@
 #ifndef RME_PALETTE_WAYPOINTS_H_
 #define RME_PALETTE_WAYPOINTS_H_
 
-#include <wx/listctrl.h>
-
 #include "game/waypoints.h"
 #include "palette/palette_common.h"
+
+class WaypointListBox;
+class NanoVGListBox;
 
 class WaypointPalettePanel : public PalettePanel {
 public:
@@ -49,19 +50,19 @@ public:
 
 public:
 	// wxWidgets event handling
-	void OnClickWaypoint(wxListEvent& event);
-	void OnBeginEditWaypointLabel(wxListEvent& event);
-	void OnEditWaypointLabel(wxListEvent& event);
+	void OnClickWaypoint(wxCommandEvent& event);
 	void OnClickAddWaypoint(wxCommandEvent& event);
 	void OnClickRemoveWaypoint(wxCommandEvent& event);
+	void OnClickRenameWaypoint(wxCommandEvent& event);
 
 	void SetMap(Map* map);
 
 protected:
 	Map* map;
-	wxListCtrl* waypoint_list;
+	WaypointListBox* waypoint_list;
 	wxButton* add_waypoint_button;
 	wxButton* remove_waypoint_button;
+	wxButton* rename_waypoint_button;
 };
 
 #endif

--- a/source/ui/dat_debug_view.cpp
+++ b/source/ui/dat_debug_view.cpp
@@ -21,17 +21,20 @@
 
 #include "rendering/core/graphics.h"
 #include "ui/gui.h"
+#include "util/nanovg_listbox.h"
+#include "ui/theme.h"
+#include "util/nvg_utils.h"
 
 // ============================================================================
 //
 
-class DatDebugViewListBox : public wxVListBox {
+class DatDebugViewListBox : public NanoVGListBox {
 public:
 	DatDebugViewListBox(wxWindow* parent, wxWindowID id);
 	~DatDebugViewListBox();
 
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
+	int OnMeasureItem(size_t index) const override;
 
 protected:
 	using SpriteMap = std::vector<Sprite*>;
@@ -39,7 +42,7 @@ protected:
 };
 
 DatDebugViewListBox::DatDebugViewListBox(wxWindow* parent, wxWindowID id) :
-	wxVListBox(parent, id, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE) {
+	NanoVGListBox(parent, id, wxLB_SINGLE) {
 	sprites.reserve(g_gui.gfx.getItemSpriteMaxID());
 	for (int id = 0; id < g_gui.gfx.getItemSpriteMaxID(); ++id) {
 		Sprite* spr = g_gui.gfx.getSprite(id);
@@ -54,25 +57,43 @@ DatDebugViewListBox::~DatDebugViewListBox() {
 	////
 }
 
-void DatDebugViewListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	if (n < sprites.size()) {
-		sprites[n]->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+void DatDebugViewListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n) {
+	if (n >= sprites.size()) {
+		return;
 	}
 
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
+	// Selection background
+	if (IsSelected(static_cast<int>(n))) {
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Accent)));
+		nvgBeginPath(vg);
+		nvgRect(vg, static_cast<float>(rect.x), static_cast<float>(rect.y), static_cast<float>(rect.width), static_cast<float>(rect.height));
+		nvgFill(vg);
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::TextOnAccent)));
 	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Text)));
 	}
 
-	dc.DrawText(wxString() << n, rect.GetX() + 40, rect.GetY() + 6);
+	Sprite* spr = sprites[n];
+	if (spr) {
+		int tex = GetOrCreateSpriteTexture(vg, spr);
+		if (tex > 0) {
+			NVGpaint imgPaint = nvgImagePattern(vg, static_cast<float>(rect.x), static_cast<float>(rect.y), 32.0f, 32.0f, 0.0f, tex, 1.0f);
+			nvgBeginPath(vg);
+			nvgRect(vg, static_cast<float>(rect.x), static_cast<float>(rect.y), 32.0f, 32.0f);
+			nvgFillPaint(vg, imgPaint);
+			nvgFill(vg);
+		}
+	}
+
+	nvgFontSize(vg, 12.0f);
+	nvgFontFace(vg, "sans");
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+
+	std::string label = std::to_string(n);
+	nvgText(vg, static_cast<float>(rect.x + 40), rect.y + rect.height / 2.0f, label.c_str(), nullptr);
 }
 
-wxCoord DatDebugViewListBox::OnMeasureItem(size_t n) const {
+int DatDebugViewListBox::OnMeasureItem(size_t n) const {
 	return 32;
 }
 
@@ -95,6 +116,8 @@ DatDebugView::DatDebugView(wxWindow* parent) :
 	Centre(wxBOTH);
 
 	search_field->Bind(wxEVT_TEXT, &DatDebugView::OnTextChange, this);
+
+	// NanoVGListBox uses wxEVT_LISTBOX
 	item_list->Bind(wxEVT_LISTBOX_DCLICK, &DatDebugView::OnClickList, this);
 }
 

--- a/source/ui/result_window.h
+++ b/source/ui/result_window.h
@@ -15,26 +15,29 @@
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 //////////////////////////////////////////////////////////////////////
 
-#ifndef RME_RESULT_WINDOW_H_
-#define RME_RESULT_WINDOW_H_
+#ifndef RME_UI_RESULT_WINDOW_H_
+#define RME_UI_RESULT_WINDOW_H_
 
-#include "app/main.h"
+#include <wx/panel.h>
+#include "map/position.h"
+#include "util/nanovg_listbox.h"
+
+class SearchResultListBox;
 
 class SearchResultWindow : public wxPanel {
 public:
 	SearchResultWindow(wxWindow* parent);
-	virtual ~SearchResultWindow();
+	~SearchResultWindow();
 
-	void Clear();
 	void AddPosition(wxString description, Position pos);
+	void Clear();
 
-	void OnClickResult(wxCommandEvent&);
-	void OnClickExport(wxCommandEvent&);
-	void OnClickClear(wxCommandEvent&);
+	void OnClickResult(wxCommandEvent& event);
+	void OnClickExport(wxCommandEvent& event);
+	void OnClickClear(wxCommandEvent& event);
 
 protected:
-	wxListBox* result_list;
-
+	SearchResultListBox* result_list;
 };
 
 #endif


### PR DESCRIPTION
This PR migrates the following UI components to use `NanoVGListBox`:
- `WaypointPalettePanel`: Replaced `wxListCtrl`. Added "Rename" button for waypoint renaming.
- `DatDebugView`: Replaced `wxVListBox` (via `DatDebugViewListBox`). Implemented NanoVG sprite rendering.
- `SearchResultWindow`: Replaced `wxListBox` (via `SearchResultListBox`). Implemented NanoVG text rendering.

This aligns with the goal of modernizing the UI and utilizing NanoVG for list rendering.

---
*PR created automatically by Jules for task [398046698110374322](https://jules.google.com/task/398046698110374322) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Rename button and functionality for waypoints with collision detection; creating waypoints now prompts for a name.

* **UI/UX Improvements**
  * Enhanced list rendering across waypoint, debug view, and search results panels with improved visual consistency and theme-aware selection highlighting.
  * Improved waypoint management workflow with better user prompts for add, remove, and rename operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->