### PR TITLE
Fix critical UB, race conditions, and buffer overflows in NetworkConnection

### DIFF
--- a/source/net/net_connection.cpp
+++ b/source/net/net_connection.cpp
@@ -39,9 +39,12 @@ void NetworkMessage::expand(const size_t length) {
 template <>
 std::string NetworkMessage::read<std::string>() {
 	const uint16_t length = read<uint16_t>();
-	char* strBuffer = reinterpret_cast<char*>(&buffer[position]);
+	if (position + length > buffer.size()) {
+		throw std::runtime_error("Buffer overflow in NetworkMessage::read<string>");
+	}
+	std::string result(reinterpret_cast<const char*>(buffer.data() + position), length);
 	position += length;
-	return std::string(strBuffer, length);
+	return result;
 }
 
 template <>
@@ -59,7 +62,9 @@ void NetworkMessage::write<std::string>(const std::string& value) {
 	write<uint16_t>(length);
 
 	expand(length);
-	memcpy(&buffer[position], &value[0], length);
+	if (length > 0) {
+		std::memcpy(buffer.data() + position, value.data(), length);
+	}
 	position += length;
 }
 


### PR DESCRIPTION
This PR addresses several critical issues identified in `source/net/net_connection.h` and `source/net/net_connection.cpp`:

1.  **Race Condition**: The `stopped` flag in `NetworkConnection` was accessed by multiple threads without synchronization. It is now `std::atomic<bool>`.
2.  **Undefined Behavior (Strict Aliasing)**: `NetworkMessage::read<T>` used `reinterpret_cast` to read arbitrary types from a byte buffer, violating strict aliasing rules. This is replaced with `std::memcpy`.
3.  **Buffer Overflow**: `NetworkMessage::read<T>` and `NetworkMessage::read<std::string>` lacked bounds checking, allowing reads past the end of the buffer if the packet was malformed or truncated. This is fixed by throwing `std::runtime_error` on overflow.
4.  **Unaligned Access**: `reinterpret_cast` could result in unaligned memory access, which is UB on some platforms. `std::memcpy` handles this safely.

These changes improve the stability and security of the network code, preventing potential crashes and exploits from malicious packets.

---
*PR created automatically by Jules for task [3673785314128617576](https://jules.google.com/task/3673785314128617576) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added runtime protection against buffer overflow when reading network messages.
  * Implemented safer memory operations for network message writing with length validation.
  * Enhanced thread-safety in network connection handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->