### PR TITLE
Fix wxWidgets layout violations and FindItemDialog list update

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -24,8 +24,7 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "House Properties");
-	wxFlexGridSizer* housePropContainer = newd wxFlexGridSizer(2, 10, 10);
-	housePropContainer->AddGrowableCol(1);
+	wxBoxSizer* housePropContainer = newd wxBoxSizer(wxHORIZONTAL);
 
 	wxFlexGridSizer* subsizer = newd wxFlexGridSizer(2, 10, 10);
 	subsizer->AddGrowableCol(1);
@@ -73,23 +72,23 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	rent_field = newd wxTextCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, wxSize(160, 20), 0, wxTextValidator(wxFILTER_NUMERIC, &house_rent));
 	subsizer->Add(rent_field, wxSizerFlags(1).Expand());
 
-	wxFlexGridSizer* subsizerRight = newd wxFlexGridSizer(1, 10, 10);
+	wxBoxSizer* subsizerRight = newd wxBoxSizer(wxVERTICAL);
 	wxFlexGridSizer* houseSizer = newd wxFlexGridSizer(2, 10, 10);
 
 	houseSizer->Add(newd wxStaticText(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "ID:"), wxSizerFlags(0).Center());
 	id_field = newd wxSpinCtrl(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "", wxDefaultPosition, FROM_DIP(this, wxSize(64, 20)), wxSP_ARROW_KEYS, 1, 0xFFFF, house->getID());
 	houseSizer->Add(id_field, wxSizerFlags(1).Expand());
-	subsizerRight->Add(houseSizer, wxSizerFlags(1).Expand());
+	subsizerRight->Add(houseSizer, wxSizerFlags(0).Expand());
 
 	wxSizer* checkbox_sub_sizer = newd wxBoxSizer(wxVERTICAL);
-	checkbox_sub_sizer->AddSpacer(4);
+	checkbox_sub_sizer->AddSpacer(10);
 	guildhall_field = newd wxCheckBox(static_cast<wxStaticBoxSizer*>(boxsizer)->GetStaticBox(), wxID_ANY, "Guildhall");
 	checkbox_sub_sizer->Add(guildhall_field);
-	subsizerRight->Add(checkbox_sub_sizer);
+	subsizerRight->Add(checkbox_sub_sizer, wxSizerFlags(0).Expand());
 	guildhall_field->SetValue(house->guildhall);
 
-	housePropContainer->Add(subsizer, wxSizerFlags(5).Expand());
-	housePropContainer->Add(subsizerRight, wxSizerFlags(5).Expand());
+	housePropContainer->Add(subsizer, wxSizerFlags(1).Expand());
+	housePropContainer->Add(subsizerRight, wxSizerFlags(1).Expand().Border(wxLEFT, 10));
 	boxsizer->Add(housePropContainer, wxSizerFlags(5).Expand().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -407,6 +407,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	}
 
 	if (found_search_results) {
+		items_list->CommitUpdates();
 		items_list->SetSelection(0);
 		ok_button->Enable(true);
 		ok_button->SetToolTip("Confirm selection");

--- a/source/ui/properties/spawn_properties_window.cpp
+++ b/source/ui/properties/spawn_properties_window.cpp
@@ -20,13 +20,12 @@ SpawnPropertiesWindow::SpawnPropertiesWindow(wxWindow* win_parent, const Map* ma
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Spawn Properties");
 
-	wxFlexGridSizer* subsizer = newd wxFlexGridSizer(2, 10, 10);
-	subsizer->AddGrowableCol(1);
+	wxBoxSizer* subsizer = newd wxBoxSizer(wxHORIZONTAL);
 
-	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Spawn size"));
+	subsizer->Add(newd wxStaticText(this, wxID_ANY, "Spawn size"), wxSizerFlags(0).CenterVertical().Border(wxRIGHT, 10));
 	count_field = newd wxSpinCtrl(this, wxID_ANY, i2ws(edit_spawn->getSize()), wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 1, g_settings.getInteger(Config::MAX_SPAWN_RADIUS), edit_spawn->getSize());
 	count_field->SetToolTip("Radius of the spawn area");
-	subsizer->Add(count_field, wxSizerFlags(1).Expand());
+	subsizer->Add(count_field, wxSizerFlags(1).CenterVertical());
 
 	boxsizer->Add(subsizer, wxSizerFlags(1).Expand());
 


### PR DESCRIPTION
This PR addresses wxWidgets layout violations identified by the Phantom agent instructions. Specifically, it replaces redundant usage of `wxFlexGridSizer` with `wxBoxSizer` in `EditHouseDialog` and `SpawnPropertiesWindow` to improve code clarity and standard layout practice. Additionally, it fixes a functional bug in `FindItemDialog` where the `NanoVGListBox`-based virtual list was not updating its item count after population, which would result in an empty list display.


---
*PR created automatically by Jules for task [11489213030933428569](https://jules.google.com/task/11489213030933428569) started by @karolak6612*