### PR TITLE
🗝️ Keeper: Refactor manual memory management to RAII

### DIFF
--- a/source/app/updater.cpp
+++ b/source/app/updater.cpp
@@ -85,7 +85,7 @@ void UpdateChecker::connect(wxEvtHandler* receiver) {
 		wxGetApp().CallAfter([receiver, data, alive]() {
 			if (*alive && receiver) {
 				wxCommandEvent event(EVT_UPDATE_CHECK_FINISHED);
-				event.SetClientData(newd std::string(data));
+				event.SetString(data);
 				receiver->AddPendingEvent(event);
 			}
 		});

--- a/source/ui/main_frame.cpp
+++ b/source/ui/main_frame.cpp
@@ -103,12 +103,10 @@ void MainFrame::OnIdle(wxIdleEvent& event) {
 
 #ifdef _USE_UPDATER_
 void MainFrame::OnUpdateReceived(wxCommandEvent& event) {
-	void* clientData = event.GetClientData();
-	if (!clientData) {
+	std::string data = event.GetString().ToStdString();
+	if (data.empty()) {
 		return;
 	}
-	std::string data = *static_cast<std::string*>(clientData);
-	delete static_cast<std::string*>(clientData);
 
 	size_t first_colon = data.find(':');
 	size_t second_colon = data.find(':', first_colon + 1);

--- a/source/ui/main_menubar.cpp
+++ b/source/ui/main_menubar.cpp
@@ -65,12 +65,12 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 	using namespace MenuBar;
 	checking_programmaticly = false;
 
-	searchHandler = new SearchHandler(frame);
-	viewSettingsHandler = new ViewSettingsHandler(this);
-	mapActionsHandler = new MapActionsHandler(frame);
-	fileMenuHandler = new FileMenuHandler(frame, this);
-	navigationMenuHandler = new NavigationMenuHandler(frame, this);
-	paletteMenuHandler = new PaletteMenuHandler(frame, this);
+	searchHandler = std::make_unique<SearchHandler>(frame);
+	viewSettingsHandler = std::make_unique<ViewSettingsHandler>(this);
+	mapActionsHandler = std::make_unique<MapActionsHandler>(frame);
+	fileMenuHandler = std::make_unique<FileMenuHandler>(frame, this);
+	navigationMenuHandler = std::make_unique<NavigationMenuHandler>(frame, this);
+	paletteMenuHandler = std::make_unique<PaletteMenuHandler>(frame, this);
 
 	MenuBarActionManager::RegisterActions(this, actions);
 
@@ -91,13 +91,6 @@ MainMenuBar::MainMenuBar(MainFrame* frame) :
 
 MainMenuBar::~MainMenuBar() {
 	// Don't need to delete menubar, it's owned by the frame
-
-	delete searchHandler;
-	delete viewSettingsHandler;
-	delete mapActionsHandler;
-	delete fileMenuHandler;
-	delete navigationMenuHandler;
-	delete paletteMenuHandler;
 }
 
 void MainMenuBar::EnableItem(MenuBar::ActionID id, bool enable) {

--- a/source/ui/main_menubar.h
+++ b/source/ui/main_menubar.h
@@ -315,12 +315,12 @@ protected:
 
 	std::unordered_map<std::string, std::unique_ptr<MenuBar::Action>> actions;
 
-	SearchHandler* searchHandler;
-	ViewSettingsHandler* viewSettingsHandler;
-	MapActionsHandler* mapActionsHandler;
-	FileMenuHandler* fileMenuHandler;
-	NavigationMenuHandler* navigationMenuHandler;
-	PaletteMenuHandler* paletteMenuHandler;
+	std::unique_ptr<SearchHandler> searchHandler;
+	std::unique_ptr<ViewSettingsHandler> viewSettingsHandler;
+	std::unique_ptr<MapActionsHandler> mapActionsHandler;
+	std::unique_ptr<FileMenuHandler> fileMenuHandler;
+	std::unique_ptr<NavigationMenuHandler> navigationMenuHandler;
+	std::unique_ptr<PaletteMenuHandler> paletteMenuHandler;
 };
 
 namespace MenuBar {

--- a/source/ui/map_tab.h
+++ b/source/ui/map_tab.h
@@ -57,12 +57,12 @@ protected:
 	// Session data
 	// Moved to MapSession
 	struct InternalReference {
-		InternalReference(Editor* editor) : session(editor), owner_count(1) { }
+		InternalReference(Editor* editor) : session(editor) { }
+		~InternalReference();
 		MapSession session;
-		int owner_count;
 	};
 	MapTabbook* aui;
-	InternalReference* iref;
+	std::shared_ptr<InternalReference> iref;
 };
 
 inline bool MapTab::HasSameReference(const MapTab* other) const {


### PR DESCRIPTION
Refactored manual memory management in MainMenuBar, MapTab, and Updater/MainFrame to use modern C++ RAII patterns and safer event handling.

*   `MainMenuBar`: Replaced raw pointer handlers with `std::unique_ptr`, removing manual `delete` in destructor.
*   `MapTab`: Replaced manual reference counting with `std::shared_ptr<InternalReference>`, ensuring safe shared ownership of `Editor` sessions. Updated `IsUniqueReference` to use `use_count() == 1` for C++20 compliance.
*   `Updater` & `MainFrame`: Replaced unsafe `void* ClientData` pointer passing for update check results with safe `wxCommandEvent::SetString/GetString` mechanism.

---
*PR created automatically by Jules for task [16573684552375263031](https://jules.google.com/task/16573684552375263031) started by @karolak6612*