### PR TITLE
[MODERNIZE] Use static_cast in rendering drawers

### DIFF
--- a/source/rendering/drawers/minimap_drawer.cpp
+++ b/source/rendering/drawers/minimap_drawer.cpp
@@ -55,7 +55,7 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 
 	// Prepare view
 	glViewport(0, 0, window_width, window_height);
-	glm::mat4 projection = glm::ortho(0.0f, (float)window_width, (float)window_height, 0.0f, -1.0f, 1.0f);
+	glm::mat4 projection = glm::ortho(0.0f, static_cast<float>(window_width), static_cast<float>(window_height), 0.0f, -1.0f, 1.0f);
 
 	// Clear background
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -112,7 +112,7 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 		renderer->updateRegion(editor.map, floor, start_x, start_y, map_draw_w, map_draw_h);
 
 		// Render
-		renderer->render(projection, 0, 0, window_width, window_height, (float)start_x, (float)start_y, (float)map_draw_w, (float)map_draw_h);
+		renderer->render(projection, 0, 0, window_width, window_height, static_cast<float>(start_x), static_cast<float>(start_y), static_cast<float>(map_draw_w), static_cast<float>(map_draw_h));
 
 		// Draw View Box (Overlay)
 		if (g_settings.getInteger(Config::MINIMAP_VIEW_BOX)) {
@@ -130,10 +130,10 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 			int view_h = screensize_y / tile_size + 1;
 
 			// Convert to local minimap coords
-			float x = (float)(view_start_x - start_x);
-			float y = (float)(view_start_y - start_y);
-			float w = (float)view_w;
-			float h = (float)view_h;
+			float x = static_cast<float>(view_start_x - start_x);
+			float y = static_cast<float>(view_start_y - start_y);
+			float w = static_cast<float>(view_w);
+			float h = static_cast<float>(view_h);
 
 			// Draw white rectangle using PrimitiveRenderer
 			primitive_renderer->setProjectionMatrix(projection);

--- a/source/rendering/drawers/overlays/grid_drawer.cpp
+++ b/source/rendering/drawers/overlays/grid_drawer.cpp
@@ -40,8 +40,8 @@ void GridDrawer::DrawIngameBox(SpriteBatch& sprite_batch, const RenderView& view
 		return;
 	}
 
-	int center_x = view.start_x + int(view.screensize_x * view.zoom / 64);
-	int center_y = view.start_y + int(view.screensize_y * view.zoom / 64);
+	int center_x = view.start_x + static_cast<int>(view.screensize_x * view.zoom / 64);
+	int center_y = view.start_y + static_cast<int>(view.screensize_y * view.zoom / 64);
 
 	int offset_y = 2;
 	int box_start_map_x = center_x;
@@ -105,7 +105,7 @@ void GridDrawer::DrawNodeLoadingPlaceholder(SpriteBatch& sprite_batch, int nd_ma
 	glm::vec4 color(1.0f, 0.0f, 1.0f, 0.5f); // 255, 0, 255, 128
 
 	if (g_gui.gfx.ensureAtlasManager()) {
-		sprite_batch.drawRect((float)cx, (float)cy, (float)TILE_SIZE * 4, (float)TILE_SIZE * 4, color, *g_gui.gfx.getAtlasManager());
+		sprite_batch.drawRect(static_cast<float>(cx), static_cast<float>(cy), static_cast<float>(TILE_SIZE) * 4, static_cast<float>(TILE_SIZE) * 4, color, *g_gui.gfx.getAtlasManager());
 	}
 }
 
@@ -114,7 +114,7 @@ void GridDrawer::drawRect(SpriteBatch& sprite_batch, int x, int y, int w, int h,
 	glm::vec4 c(color.Red() / 255.0f, color.Green() / 255.0f, color.Blue() / 255.0f, color.Alpha() / 255.0f);
 
 	if (g_gui.gfx.ensureAtlasManager()) {
-		sprite_batch.drawRectLines((float)x, (float)y, (float)w, (float)h, c, *g_gui.gfx.getAtlasManager());
+		sprite_batch.drawRectLines(static_cast<float>(x), static_cast<float>(y), static_cast<float>(w), static_cast<float>(h), c, *g_gui.gfx.getAtlasManager());
 	}
 }
 
@@ -122,7 +122,7 @@ void GridDrawer::drawFilledRect(SpriteBatch& sprite_batch, int x, int y, int w, 
 	glm::vec4 c(color.Red() / 255.0f, color.Green() / 255.0f, color.Blue() / 255.0f, color.Alpha() / 255.0f);
 
 	if (g_gui.gfx.ensureAtlasManager()) {
-		sprite_batch.drawRect((float)x, (float)y, (float)w, (float)h, c, *g_gui.gfx.getAtlasManager());
+		sprite_batch.drawRect(static_cast<float>(x), static_cast<float>(y), static_cast<float>(w), static_cast<float>(h), c, *g_gui.gfx.getAtlasManager());
 	}
 }
 

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -68,7 +68,7 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							b = b / 3 * 2;
 						}
 						if (tile->isHouseTile() && options.show_houses) {
-							if ((int)tile->getHouseID() == current_house_id) {
+							if (static_cast<int>(tile->getHouseID()) == current_house_id) {
 								r /= 2;
 							} else {
 								r /= 2;
@@ -137,7 +137,7 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 			if (g_gui.gfx.ensureAtlasManager()) {
 				// Draw a semi-transparent white box over the tile
 				glm::vec4 highlightColor(1.0f, 1.0f, 1.0f, 0.25f); // 25% white
-				sprite_batch.drawRect((float)draw_x, (float)draw_y, (float)TILE_SIZE, (float)TILE_SIZE, highlightColor, *g_gui.gfx.getAtlasManager());
+				sprite_batch.drawRect(static_cast<float>(draw_x), static_cast<float>(draw_y), static_cast<float>(TILE_SIZE), static_cast<float>(TILE_SIZE), highlightColor, *g_gui.gfx.getAtlasManager());
 			}
 		}
 	}


### PR DESCRIPTION
Modernized C++ casts in rendering drawers by replacing C-style and functional casts with `static_cast`.

---
*PR created automatically by Jules for task [3075057317221045695](https://jules.google.com/task/3075057317221045695) started by @karolak6612*