### PR TITLE
Refactor GameSprite decompression and BinaryNode loading logic

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -268,6 +268,8 @@ protected:
 	}
 
 	void load();
+	void scanForControlChar(uint8_t*& p, uint8_t* end);
+	void handleControlChar(uint8_t op, uint8_t*& cache, size_t& local_read_index, size_t& cache_length);
 	std::string data;
 	size_t read_offset;
 	NodeFileReadHandle* file;

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <cstdint>
 #include <span>
+#include <array>
 
 #include <deque>
 #include <memory>
@@ -99,10 +100,17 @@ public:
 		return light;
 	}
 
-	// Helper for SpritePreloader to decompress data off-thread
-	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, bool use_alpha, int id = 0);
+	struct OutfitColors {
+		int head;
+		int body;
+		int legs;
+		int feet;
+	};
 
-	static void ColorizeTemplatePixels(uint8_t* dest, const uint8_t* mask, size_t pixelCount, int lookHead, int lookBody, int lookLegs, int lookFeet, bool destHasAlpha);
+	// Helper for SpritePreloader to decompress data off-thread
+	[[nodiscard]] static std::unique_ptr<uint8_t[]> Decompress(std::span<const uint8_t> dump, bool use_alpha, int id = 0, int output_channels = 4, std::array<uint8_t, 4> clear_color = {0, 0, 0, 0});
+
+	static void ColorizeTemplatePixels(uint8_t* dest, const uint8_t* mask, size_t pixelCount, OutfitColors colors, bool destHasAlpha);
 
 private:
 protected:


### PR DESCRIPTION
Addressed three major code smells:
1.  **Duplicate Code**: Centralized sprite decompression in `GameSprite::Decompress`, removing manual implementation in `NormalImage::getRGBData`.
2.  **Long Parameter List**: Introduced `OutfitColors` struct to bundle outfit color parameters.
3.  **Long Method**: Simplified `BinaryNode::load` by extracting inner scanning and control character handling logic.

---
*PR created automatically by Jules for task [17539370196451043577](https://jules.google.com/task/17539370196451043577) started by @karolak6612*