### PR TITLE
[ICONS] Add SVG icons to Toolbars, Tabs, and Menus

### DIFF
--- a/source/editor/editor_tabs.cpp
+++ b/source/editor/editor_tabs.cpp
@@ -20,6 +20,8 @@
 #include "editor/editor_tabs.h"
 #include "editor/editor.h"
 #include "live/live_tab.h"
+#include "util/image_manager.h"
+#include "ui/map_tab.h"
 
 EditorTab::EditorTab() {
 	;
@@ -133,7 +135,15 @@ void MapTabbook::OnAllowNotebookDND(wxAuiNotebookEvent& evt) {
 
 void MapTabbook::AddTab(EditorTab* tab, bool select) {
 	tab->GetWindow()->Reparent(notebook);
-	notebook->AddPage(tab->GetWindow(), tab->GetTitle(), select);
+
+	wxBitmap icon = wxNullBitmap;
+	if (dynamic_cast<MapTab*>(tab)) {
+		icon = IMAGE_MANAGER.GetBitmap(ICON_MAP, wxSize(16, 16));
+	} else if (dynamic_cast<LiveLogTab*>(tab)) {
+		icon = IMAGE_MANAGER.GetBitmap(ICON_TERMINAL, wxSize(16, 16));
+	}
+
+	notebook->AddPage(tab->GetWindow(), tab->GetTitle(), select, icon);
 	conv[tab->GetWindow()] = tab;
 }
 

--- a/source/ui/managers/recent_files_manager.cpp
+++ b/source/ui/managers/recent_files_manager.cpp
@@ -2,6 +2,7 @@
 #include <toml++/toml.h>
 #include <wx/filename.h>
 #include "app/settings.h"
+#include "util/image_manager.h"
 
 RecentFilesManager::RecentFilesManager() :
 	recentFiles(10) {
@@ -60,6 +61,12 @@ void RecentFilesManager::AddFile(const FileName& file) {
 void RecentFilesManager::UseMenu(wxMenu* menu) {
 	recentFiles.UseMenu(menu);
 	recentFiles.AddFilesToMenu();
+
+	for (size_t i = 0; i < recentFiles.GetCount(); ++i) {
+		if (wxMenuItem* item = menu->FindItem(recentFiles.GetBaseId() + i)) {
+			item->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CLOCK, wxSize(16, 16)));
+		}
+	}
 }
 
 std::vector<wxString> RecentFilesManager::GetFiles() const {

--- a/source/ui/replace_tool/library_panel.cpp
+++ b/source/ui/replace_tool/library_panel.cpp
@@ -13,6 +13,8 @@
 #include "brushes/table/table_brush.h"
 #include "brushes/carpet/carpet_brush.h"
 #include <wx/splitter.h>
+#include <wx/imaglist.h>
+#include "util/image_manager.h"
 #include <algorithm>
 
 LibraryPanel::LibraryPanel(wxWindow* parent, Listener* listener) :
@@ -43,6 +45,11 @@ void LibraryPanel::InitLayout() {
 
 	m_notebook = new wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP | wxBORDER_NONE);
 
+	wxImageList* imageList = new wxImageList(16, 16);
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CUBES, wxSize(16, 16)));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_PAINTBRUSH, wxSize(16, 16)));
+	m_notebook->AssignImageList(imageList);
+
 	// PAGE 1: Item List
 	wxPanel* itemListPage = new wxPanel(m_notebook);
 	wxBoxSizer* itemListSizer = new wxBoxSizer(wxVERTICAL);
@@ -59,7 +66,7 @@ void LibraryPanel::InitLayout() {
 	itemListSizer->Add(m_allItemsGrid, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, padding);
 
 	itemListPage->SetSizer(itemListSizer);
-	m_notebook->AddPage(itemListPage, "Items");
+	m_notebook->AddPage(itemListPage, "Items", true, 0);
 
 	// PAGE 2: Brush List
 	wxPanel* brushListPage = new wxPanel(m_notebook);
@@ -97,7 +104,7 @@ void LibraryPanel::InitLayout() {
 	brushListSizer->Add(brushSplitter, 1, wxEXPAND | wxALL, padding);
 
 	brushListPage->SetSizer(brushListSizer);
-	m_notebook->AddPage(brushListPage, "Brushes");
+	m_notebook->AddPage(brushListPage, "Brushes", false, 1);
 
 	mainSizer->Add(m_notebook, 1, wxEXPAND);
 	SetSizer(mainSizer);

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -18,21 +18,21 @@ const wxString BrushToolBar::PANE_NAME = "brush_toolbar";
 BrushToolBar::BrushToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_OPTIONAL_BORDER_SMALL, icon_size);
-	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_ERASER_SMALL, icon_size);
-	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PROTECTION_ZONE_SMALL, icon_size);
-	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_PVP_ZONE_SMALL, icon_size);
-	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_NO_LOGOUT_ZONE_SMALL, icon_size);
-	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_PVP_ZONE_SMALL, icon_size);
-	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_SMALL, icon_size);
-	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_LOCKED_SMALL, icon_size);
-	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_MAGIC_SMALL, icon_size);
-	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_QUEST_SMALL, icon_size);
-	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_NORMAL_ALT_SMALL, icon_size);
-	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_DOOR_ARCHWAY_SMALL, icon_size);
+	wxBitmap border_bitmap = IMAGE_MANAGER.GetBitmap(ICON_BORDER_ALL, icon_size);
+	wxBitmap eraser_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ERASER, icon_size);
+	wxBitmap pz_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SHIELD, icon_size);
+	wxBitmap nopvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_USER_SLASH, icon_size);
+	wxBitmap nologout_bitmap = IMAGE_MANAGER.GetBitmap(ICON_LOCK, icon_size);
+	wxBitmap pvp_bitmap = IMAGE_MANAGER.GetBitmap(ICON_FIRE, icon_size);
+	wxBitmap normal_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, icon_size);
+	wxBitmap locked_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, icon_size);
+	wxBitmap magic_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WAND_MAGIC, icon_size);
+	wxBitmap quest_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, icon_size);
+	wxBitmap normal_alt_bitmap = IMAGE_MANAGER.GetBitmap(ICON_DOOR_OPEN, icon_size);
+	wxBitmap archway_bitmap = IMAGE_MANAGER.GetBitmap(ICON_ARCHWAY, icon_size);
 
-	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_HATCH_SMALL, icon_size);
-	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_WINDOW_NORMAL_SMALL, icon_size);
+	wxBitmap hatch_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MINIMIZE, icon_size);
+	wxBitmap window_bitmap = IMAGE_MANAGER.GetBitmap(ICON_WINDOW_MAXIMIZE, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_BRUSHES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);

--- a/source/ui/toolbar/size_toolbar.cpp
+++ b/source/ui/toolbar/size_toolbar.cpp
@@ -15,15 +15,15 @@ const wxString SizeToolBar::PANE_NAME = "sizes_toolbar";
 SizeToolBar::SizeToolBar(wxWindow* parent) {
 	wxSize icon_size = FROM_DIP(parent, wxSize(16, 16));
 
-	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size);
-	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size);
-	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size);
-	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size);
-	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size);
-	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size);
-	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size);
-	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size);
+	wxBitmap circular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_CIRCLE, icon_size);
+	wxBitmap rectangular_bitmap = IMAGE_MANAGER.GetBitmap(ICON_SQUARE, icon_size);
+	wxBitmap size1_bitmap = IMAGE_MANAGER.GetBitmap(ICON_1, icon_size);
+	wxBitmap size2_bitmap = IMAGE_MANAGER.GetBitmap(ICON_2, icon_size);
+	wxBitmap size3_bitmap = IMAGE_MANAGER.GetBitmap(ICON_3, icon_size);
+	wxBitmap size4_bitmap = IMAGE_MANAGER.GetBitmap(ICON_4, icon_size);
+	wxBitmap size5_bitmap = IMAGE_MANAGER.GetBitmap(ICON_5, icon_size);
+	wxBitmap size6_bitmap = IMAGE_MANAGER.GetBitmap(ICON_6, icon_size);
+	wxBitmap size7_bitmap = IMAGE_MANAGER.GetBitmap(ICON_7, icon_size);
 
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_SIZES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
@@ -69,27 +69,9 @@ void SizeToolBar::UpdateBrushSize(BrushShape shape, int size) {
 	if (shape == BRUSHSHAPE_CIRCLE) {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, true);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, false);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_CIRCULAR_7_SMALL, icon_size));
 	} else {
 		toolbar->ToggleTool(TOOLBAR_SIZES_CIRCULAR, false);
 		toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, true);
-
-		wxSize icon_size = wxSize(16, 16);
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_1, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_1_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_2, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_2_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_3, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_3_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_4, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_4_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_5, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_5_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_6, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_6_SMALL, icon_size));
-		toolbar->SetToolBitmap(TOOLBAR_SIZES_7, IMAGE_MANAGER.GetBitmap(IMAGE_RECTANGULAR_7_SMALL, icon_size));
 	}
 
 	toolbar->ToggleTool(TOOLBAR_SIZES_1, size == 0);


### PR DESCRIPTION
This PR updates the UI to use the unified SVG icon system provided by `ImageManager`.
It replaces legacy PNG bitmaps in toolbars with modern SVG icons, and adds icon support to areas that were previously missing them, such as recent files menu, library panel tabs, and map tabs.

Key changes:
- `BrushToolBar`: Replaced all PNG assets with `ICON_*` equivalents (e.g., `ICON_SHIELD` for PZ, `ICON_DOOR_OPEN` for normal door).
- `SizeToolBar`: Replaced PNG assets with `ICON_SQUARE`, `ICON_CIRCLE`, and `ICON_1` through `ICON_7` for size buttons. Removed legacy bitmap swapping logic as generic number icons are now used.
- `RecentFilesManager`: Added `ICON_CLOCK` to recent file menu items.
- `LibraryPanel`: Added `ICON_CUBES` and `ICON_PAINTBRUSH` to "Items" and "Brushes" tabs respectively.
- `MapTabbook`: Added logic to assign `ICON_MAP` or `ICON_TERMINAL` to tabs based on their type.

---
*PR created automatically by Jules for task [18367569564889233432](https://jules.google.com/task/18367569564889233432) started by @karolak6612*