### PR TITLE
📜 Auditor: Fix legacy C++ patterns and memory smells

### DIFF
--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -64,30 +64,6 @@ bool LiveClient::connect(const std::string& address, uint16_t port) {
 		}
 	});
 
-	/*
-	if(!client->WaitOnConnect(5, 0)) {
-		if(log)
-			log->Disconnect();
-		last_err = "Connection timed out.";
-		client->Destroy();
-		client = nullptr;
-		delete connection;
-		return false;
-	}
-
-	if(!client->IsConnected()) {
-		if(log)
-			log->Disconnect();
-		last_err = "Connection refused by peer.";
-		client->Destroy();
-		client = nullptr;
-		delete connection;
-		return false;
-	}
-
-	if(log)
-		log->Message("Connection established!");
-	*/
 	return true;
 }
 

--- a/source/ui/main_frame.cpp
+++ b/source/ui/main_frame.cpp
@@ -103,12 +103,7 @@ void MainFrame::OnIdle(wxIdleEvent& event) {
 
 #ifdef _USE_UPDATER_
 void MainFrame::OnUpdateReceived(wxCommandEvent& event) {
-	void* clientData = event.GetClientData();
-	if (!clientData) {
-		return;
-	}
-	std::string data = *static_cast<std::string*>(clientData);
-	delete static_cast<std::string*>(clientData);
+	std::string data = event.GetString().ToStdString();
 
 	size_t first_colon = data.find(':');
 	size_t second_colon = data.find(':', first_colon + 1);


### PR DESCRIPTION
This PR addresses legacy C++ patterns and potential memory safety issues identified during audit.

Key changes:
1.  **Safety & Modernization in `updater.cpp`:**
    -   Replaced raw pointers `wxURL*` and `wxInputStream*` with `std::unique_ptr`.
    -   Moved `wxURL` ownership into the background thread lambda using `std::move`.
    -   Removed manual `delete` calls, relying on `unique_ptr` destructors for cleanup.
2.  **Event Safety:**
    -   Replaced the unsafe practice of passing `std::string*` via `wxCommandEvent::SetClientData` (which requires manual casting and deletion by the receiver) with `wxCommandEvent::SetString`.
    -   Updated `MainFrame::OnUpdateReceived` to retrieve the string safely using `GetString()`.
3.  **Code Cleanup:**
    -   Removed a large block of commented-out legacy connection logic in `source/live/live_client.cpp`.

This refactoring improves code safety, reduces the risk of memory leaks, and aligns with modern C++ RAII principles.

---
*PR created automatically by Jules for task [17471778897623656735](https://jules.google.com/task/17471778897623656735) started by @karolak6612*