### PR TITLE
🗝️ Keeper: Modernize TooltipDrawer with ScopedNvgImage

### DIFF
--- a/source/rendering/ui/tooltip_drawer.cpp
+++ b/source/rendering/ui/tooltip_drawer.cpp
@@ -32,14 +32,7 @@ TooltipDrawer::TooltipDrawer() {
 
 TooltipDrawer::~TooltipDrawer() {
 	clear();
-	if (lastContext) {
-		for (auto& pair : spriteCache) {
-			if (pair.second > 0) {
-				nvgDeleteImage(lastContext, pair.second);
-			}
-		}
-		spriteCache.clear();
-	}
+	spriteCache.clear();
 }
 
 void TooltipDrawer::clear() {
@@ -120,16 +113,6 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 
 	// Detect context change and clear cache
 	if (vg != lastContext) {
-		// If we had a previous context, we'd ideally delete images from it,
-		// but if the context pointer changed, the old one might be invalid.
-		// However, adhering to the request to clear cache with nvgDeleteImage:
-		if (lastContext) {
-			for (auto& pair : spriteCache) {
-				if (pair.second > 0) {
-					nvgDeleteImage(lastContext, pair.second);
-				}
-			}
-		}
 		spriteCache.clear();
 		lastContext = vg;
 	}
@@ -198,11 +181,7 @@ int TooltipDrawer::getSpriteImage(NVGcontext* vg, uint16_t itemId) {
 					// nvgCreateImageRGBA failed
 				} else {
 					// Success
-					// Check if we are overwriting an existing valid image (shouldn't happen given find() above, but safest)
-					if (spriteCache.contains(itemId) && spriteCache[itemId] > 0) {
-						nvgDeleteImage(vg, spriteCache[itemId]);
-					}
-					spriteCache[itemId] = image;
+					spriteCache[itemId] = NvgUtils::ScopedNvgImage(vg, image);
 					return image;
 				}
 			}

--- a/source/rendering/ui/tooltip_drawer.h
+++ b/source/rendering/ui/tooltip_drawer.h
@@ -27,6 +27,7 @@
 #include <string_view>
 #include <sstream>
 #include <unordered_map>
+#include "util/nvg_utils.h"
 
 class Item;
 class Waypoint;
@@ -156,7 +157,7 @@ protected:
 	std::vector<TooltipData> tooltips;
 	size_t active_count = 0;
 
-	std::unordered_map<uint32_t, int> spriteCache; // sprite_id -> nvg image handle
+	std::unordered_map<uint32_t, NvgUtils::ScopedNvgImage> spriteCache; // sprite_id -> nvg image handle
 	NVGcontext* lastContext = nullptr;
 
 	// Helper to get or load sprite image

--- a/source/util/nvg_utils.h
+++ b/source/util/nvg_utils.h
@@ -1,6 +1,7 @@
 #ifndef RME_UTIL_NVG_UTILS_H_
 #define RME_UTIL_NVG_UTILS_H_
 
+#include "app/main.h"
 #include "game/items.h"
 #include "ui/gui.h"
 #include <nanovg.h>
@@ -109,6 +110,59 @@ namespace NvgUtils {
 
 		return nvgCreateImageRGBA(vg, w, h, 0, composite.get());
 	}
+
+	class ScopedNvgImage {
+	public:
+		ScopedNvgImage() :
+			vg(nullptr), image(0) {
+		}
+		ScopedNvgImage(NVGcontext* ctx, int img) :
+			vg(ctx), image(img) {
+		}
+		~ScopedNvgImage() {
+			reset();
+		}
+
+		ScopedNvgImage(ScopedNvgImage&& other) noexcept :
+			vg(other.vg), image(other.image) {
+			other.vg = nullptr;
+			other.image = 0;
+		}
+
+		ScopedNvgImage& operator=(ScopedNvgImage&& other) noexcept {
+			if (this != &other) {
+				reset();
+				vg = other.vg;
+				image = other.image;
+				other.vg = nullptr;
+				other.image = 0;
+			}
+			return *this;
+		}
+
+		// Disable copy
+		ScopedNvgImage(const ScopedNvgImage&) = delete;
+		ScopedNvgImage& operator=(const ScopedNvgImage&) = delete;
+
+		void reset() {
+			if (vg && image > 0) {
+				nvgDeleteImage(vg, image);
+			}
+			vg = nullptr;
+			image = 0;
+		}
+
+		int get() const {
+			return image;
+		}
+		operator int() const {
+			return image;
+		}
+
+	private:
+		NVGcontext* vg;
+		int image;
+	};
 
 } // namespace NvgUtils
 


### PR DESCRIPTION
This PR modernizes the `TooltipDrawer` by introducing and utilizing `NvgUtils::ScopedNvgImage`, a RAII wrapper for NanoVG image handles.

Changes:
1.  **`source/util/nvg_utils.h`**:
    *   Added `class ScopedNvgImage` inside `namespace NvgUtils`. It handles `nvgDeleteImage` in its destructor and supports move semantics.
    *   Added `#include "app/main.h"` to resolve implicit dependencies required by `game/items.h`.

2.  **`source/rendering/ui/tooltip_drawer.h`**:
    *   Changed `spriteCache` type from `std::unordered_map<uint32_t, int>` to `std::unordered_map<uint32_t, NvgUtils::ScopedNvgImage>`.
    *   Included `util/nvg_utils.h`.

3.  **`source/rendering/ui/tooltip_drawer.cpp`**:
    *   Removed manual loops for `nvgDeleteImage` in `~TooltipDrawer()` and `clear()`.
    *   Updated `getSpriteImage` to store `ScopedNvgImage` in the cache.
    *   Verified `std::make_unique` usage.

These changes align with the Keeper agent's goal of enforcing RAII and preventing resource leaks. Use of `ScopedNvgImage` ensures that even if exceptions occur or control flow changes, NanoVG images are properly cleaned up. Verification was done by compiling the modified file using Ninja.

---
*PR created automatically by Jules for task [16675305129586836829](https://jules.google.com/task/16675305129586836829) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal resource management for sprite image caching in tooltip rendering. Enhanced image lifetime management to reduce potential memory-related issues and ensure proper cleanup of cached resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->