### PR TITLE
[TILE/WXWIDGETS] Fix polymorphic item replacement in ReplacementEngine

### DIFF
--- a/source/ui/replace_tool/replacement_engine.h
+++ b/source/ui/replace_tool/replacement_engine.h
@@ -6,6 +6,8 @@
 #include "map/position.h"
 #include <random>
 #include <vector>
+#include <map>
+#include <memory>
 
 enum class ReplaceScope {
 	Selection,
@@ -27,6 +29,10 @@ public:
 
 private:
 	std::mt19937 rng;
+
+	void ProcessTile(class Tile* tile, const std::map<uint16_t, const ReplacementRule*>& ruleMap);
+	void ProcessContainer(class Container* container, const std::map<uint16_t, const ReplacementRule*>& ruleMap);
+	void ProcessItemRef(std::unique_ptr<class Item>& itemRef, const std::map<uint16_t, const ReplacementRule*>& ruleMap);
 };
 
 #endif


### PR DESCRIPTION
Refactored `ReplacementEngine` to correctly handle item replacements where the C++ class type changes (e.g. Item -> Container). Implemented recursive processing for containers and safe in-place vector modification using `std::unique_ptr`.

---
*PR created automatically by Jules for task [8627517117025904068](https://jules.google.com/task/8627517117025904068) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Viewport and Full Map replacement scopes, complementing the existing Selection scope for item replacement operations.
  * Enhanced container support to properly handle item replacements within nested containers.

* **Improvements**
  * Unified replacement behavior across all scopes, ensuring consistent results regardless of the selected replacement scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->