### PR TITLE
👻 Phantom: Migrate UI lists to NanoVGListBox

### DIFF
--- a/source/palette/controls/waypoint_list_box.cpp
+++ b/source/palette/controls/waypoint_list_box.cpp
@@ -1,0 +1,69 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#include "palette/controls/waypoint_list_box.h"
+#include "ui/theme.h"
+#include "util/nvg_utils.h"
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+
+WaypointListBox::WaypointListBox(wxWindow* parent, wxWindowID id) :
+	NanoVGListBox(parent, id, wxLB_SINGLE) {
+
+	Bind(wxEVT_LEFT_DCLICK, [this](wxMouseEvent& event) {
+		if (GetSelection() != -1) {
+			wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+			evt.SetEventObject(this);
+			evt.SetInt(GetSelection());
+			ProcessWindowEvent(evt);
+		}
+	});
+}
+
+WaypointListBox::~WaypointListBox() {
+}
+
+void WaypointListBox::SetWaypoints(const std::vector<std::string>& names) {
+	m_items = names;
+	SetItemCount(m_items.size());
+}
+
+wxString WaypointListBox::GetSelectedWaypoint() const {
+	int selection = GetSelection();
+	if (selection >= 0 && selection < static_cast<int>(m_items.size())) {
+		return wxstr(m_items[selection]);
+	}
+	return "";
+}
+
+void WaypointListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) {
+	if (index >= m_items.size()) {
+		return;
+	}
+
+	const std::string& name = m_items[index];
+
+	int x = rect.GetX();
+	int y = rect.GetY();
+	int w = rect.GetWidth();
+	int h = rect.GetHeight();
+
+	// Text
+	nvgFontSize(vg, 14.0f);
+	nvgFontFace(vg, "sans");
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+
+	if (IsSelected(index)) {
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	} else {
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Text)));
+	}
+
+	nvgText(vg, x + 10, y + h / 2.0f, name.c_str(), nullptr);
+}
+
+int WaypointListBox::OnMeasureItem(size_t index) const {
+	return 24;
+}

--- a/source/palette/controls/waypoint_list_box.h
+++ b/source/palette/controls/waypoint_list_box.h
@@ -1,0 +1,28 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_WAYPOINT_LIST_BOX_H_
+#define RME_WAYPOINT_LIST_BOX_H_
+
+#include "app/main.h"
+#include "util/nanovg_listbox.h"
+#include <vector>
+#include <string>
+
+class WaypointListBox : public NanoVGListBox {
+public:
+	WaypointListBox(wxWindow* parent, wxWindowID id);
+	~WaypointListBox();
+
+	void SetWaypoints(const std::vector<std::string>& names);
+	wxString GetSelectedWaypoint() const;
+
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
+	int OnMeasureItem(size_t index) const override;
+
+protected:
+	std::vector<std::string> m_items;
+};
+
+#endif

--- a/source/palette/palette_waypoints.h
+++ b/source/palette/palette_waypoints.h
@@ -18,10 +18,10 @@
 #ifndef RME_PALETTE_WAYPOINTS_H_
 #define RME_PALETTE_WAYPOINTS_H_
 
-#include <wx/listctrl.h>
-
 #include "game/waypoints.h"
 #include "palette/palette_common.h"
+
+class WaypointListBox;
 
 class WaypointPalettePanel : public PalettePanel {
 public:
@@ -47,11 +47,11 @@ public:
 	// Called when this page is hidden
 	void OnSwitchOut() override;
 
+	void RenameSelected();
+
 public:
 	// wxWidgets event handling
-	void OnClickWaypoint(wxListEvent& event);
-	void OnBeginEditWaypointLabel(wxListEvent& event);
-	void OnEditWaypointLabel(wxListEvent& event);
+	void OnClickWaypoint(wxCommandEvent& event);
 	void OnClickAddWaypoint(wxCommandEvent& event);
 	void OnClickRemoveWaypoint(wxCommandEvent& event);
 
@@ -59,7 +59,7 @@ public:
 
 protected:
 	Map* map;
-	wxListCtrl* waypoint_list;
+	WaypointListBox* waypoint_list;
 	wxButton* add_waypoint_button;
 	wxButton* remove_waypoint_button;
 };

--- a/source/ui/controls/dat_debug_list_box.cpp
+++ b/source/ui/controls/dat_debug_list_box.cpp
@@ -1,0 +1,86 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#include "ui/controls/dat_debug_list_box.h"
+#include "ui/theme.h"
+#include "ui/gui.h"
+#include "rendering/core/graphics.h"
+#include "rendering/core/sprites.h"
+#include "util/nvg_utils.h"
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+#include <format>
+
+DatDebugListBox::DatDebugListBox(wxWindow* parent, wxWindowID id) :
+	NanoVGListBox(parent, id, wxLB_SINGLE) {
+	int maxID = g_gui.gfx.getItemSpriteMaxID();
+	sprites.reserve(maxID);
+	for (int i = 0; i < maxID; ++i) {
+		Sprite* spr = g_gui.gfx.getSprite(i);
+		if (spr) {
+			sprites.push_back(spr);
+		}
+	}
+	SetItemCount(sprites.size());
+
+	Bind(wxEVT_LEFT_DCLICK, [this](wxMouseEvent& event) {
+		if (GetSelection() != -1) {
+			wxCommandEvent evt(wxEVT_LISTBOX_DCLICK, GetId());
+			evt.SetEventObject(this);
+			evt.SetInt(GetSelection());
+			ProcessWindowEvent(evt);
+		}
+	});
+}
+
+DatDebugListBox::~DatDebugListBox() {
+}
+
+void DatDebugListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) {
+	if (index >= sprites.size()) {
+		return;
+	}
+
+	Sprite* sprite = sprites[index];
+	if (!sprite) {
+		return;
+	}
+
+	int x = rect.GetX();
+	int y = rect.GetY();
+	int w = rect.GetWidth();
+	int h = rect.GetHeight();
+
+	// Draw Sprite
+	int tex = GetOrCreateSpriteTexture(vg, sprite);
+	if (tex > 0) {
+		// Center vertically
+		float iconY = y + (h - 32) / 2.0f;
+
+		NVGpaint imgPaint = nvgImagePattern(vg, x + 4, iconY, 32, 32, 0, tex, 1.0f);
+		nvgBeginPath(vg);
+		nvgRect(vg, x + 4, iconY, 32, 32);
+		nvgFillPaint(vg, imgPaint);
+		nvgFill(vg);
+	}
+
+	// Draw Text
+	nvgFontSize(vg, 14.0f);
+	nvgFontFace(vg, "sans");
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+
+	if (IsSelected(index)) {
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	} else {
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Text)));
+	}
+
+	std::string text = std::format("ID: {}", index);
+	nvgText(vg, x + 40, y + h / 2.0f, text.c_str(), nullptr);
+}
+
+int DatDebugListBox::OnMeasureItem(size_t index) const {
+	return 40;
+}

--- a/source/ui/controls/dat_debug_list_box.h
+++ b/source/ui/controls/dat_debug_list_box.h
@@ -1,0 +1,26 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_DAT_DEBUG_LIST_BOX_H_
+#define RME_DAT_DEBUG_LIST_BOX_H_
+
+#include "app/main.h"
+#include "util/nanovg_listbox.h"
+#include <vector>
+
+class Sprite;
+
+class DatDebugListBox : public NanoVGListBox {
+public:
+	DatDebugListBox(wxWindow* parent, wxWindowID id);
+	~DatDebugListBox();
+
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
+	int OnMeasureItem(size_t index) const override;
+
+protected:
+	std::vector<Sprite*> sprites;
+};
+
+#endif

--- a/source/ui/controls/recent_file_list_box.cpp
+++ b/source/ui/controls/recent_file_list_box.cpp
@@ -1,0 +1,96 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#include "ui/controls/recent_file_list_box.h"
+#include "ui/theme.h"
+#include "util/image_manager.h"
+#include "util/nvg_utils.h"
+#include <wx/filename.h>
+#include <wx/datetime.h>
+#include <glad/glad.h>
+#include <nanovg.h>
+#include <nanovg_gl.h>
+
+RecentFileListBox::RecentFileListBox(wxWindow* parent, wxWindowID id) :
+	NanoVGListBox(parent, id, wxLB_SINGLE),
+	m_iconImage(0) {
+}
+
+RecentFileListBox::~RecentFileListBox() {
+}
+
+void RecentFileListBox::SetRecentFiles(const std::vector<wxString>& files) {
+	m_items.clear();
+	for (const auto& f : files) {
+		RecentFileItem item;
+		item.path = f;
+
+		wxFileName fn(f);
+		wxDateTime dt;
+		if (fn.GetTimes(nullptr, &dt, nullptr)) {
+			item.date = dt.Format("%Y-%m-%d %H:%M");
+		} else {
+			item.date = "-";
+		}
+		m_items.push_back(item);
+	}
+	SetItemCount(m_items.size());
+}
+
+wxString RecentFileListBox::GetSelectedFile() const {
+	int index = GetSelection();
+	if (index >= 0 && index < static_cast<int>(m_items.size())) {
+		return m_items[index].path;
+	}
+	return "";
+}
+
+void RecentFileListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) {
+	if (index >= m_items.size()) {
+		return;
+	}
+
+	const RecentFileItem& item = m_items[index];
+
+	int x = rect.GetX();
+	int y = rect.GetY();
+	int w = rect.GetWidth();
+	int h = rect.GetHeight();
+
+	// Icon
+	if (m_iconImage == 0) {
+		m_iconImage = IMAGE_MANAGER.GetNanoVGImage(vg, ICON_MAP);
+	}
+
+	if (m_iconImage > 0) {
+		NVGpaint imgPaint = nvgImagePattern(vg, x + 8, y + (h - 16) / 2, 16, 16, 0, m_iconImage, 1.0f);
+		nvgBeginPath(vg);
+		nvgRect(vg, x + 8, y + (h - 16) / 2, 16, 16);
+		nvgFillPaint(vg, imgPaint);
+		nvgFill(vg);
+	}
+
+	// Text setup
+	nvgFontSize(vg, 14.0f);
+	nvgFontFace(vg, "sans");
+	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+
+	if (IsSelected(index)) {
+		nvgFillColor(vg, nvgRGBA(255, 255, 255, 255));
+	} else {
+		nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Text)));
+	}
+
+	// File Name/Path
+	nvgText(vg, x + 32, y + h / 2.0f, item.path.ToUTF8().data(), nullptr);
+
+	// Date (Right aligned)
+	nvgTextAlign(vg, NVG_ALIGN_RIGHT | NVG_ALIGN_MIDDLE);
+	nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::TextSubtle)));
+	nvgText(vg, x + w - 10, y + h / 2.0f, item.date.ToUTF8().data(), nullptr);
+}
+
+int RecentFileListBox::OnMeasureItem(size_t index) const {
+	return 28;
+}

--- a/source/ui/controls/recent_file_list_box.h
+++ b/source/ui/controls/recent_file_list_box.h
@@ -1,0 +1,34 @@
+//////////////////////////////////////////////////////////////////////
+// This file is part of Remere's Map Editor
+//////////////////////////////////////////////////////////////////////
+
+#ifndef RME_RECENT_FILE_LIST_BOX_H_
+#define RME_RECENT_FILE_LIST_BOX_H_
+
+#include "app/main.h"
+#include "util/nanovg_listbox.h"
+#include <vector>
+#include <string>
+
+struct RecentFileItem {
+	wxString path;
+	wxString date;
+};
+
+class RecentFileListBox : public NanoVGListBox {
+public:
+	RecentFileListBox(wxWindow* parent, wxWindowID id);
+	~RecentFileListBox();
+
+	void SetRecentFiles(const std::vector<wxString>& files);
+	wxString GetSelectedFile() const;
+
+	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
+	int OnMeasureItem(size_t index) const override;
+
+protected:
+	std::vector<RecentFileItem> m_items;
+	int m_iconImage;
+};
+
+#endif

--- a/source/ui/dat_debug_view.cpp
+++ b/source/ui/dat_debug_view.cpp
@@ -18,63 +18,10 @@
 #include "app/main.h"
 
 #include "ui/dat_debug_view.h"
+#include "ui/controls/dat_debug_list_box.h"
 
 #include "rendering/core/graphics.h"
 #include "ui/gui.h"
-
-// ============================================================================
-//
-
-class DatDebugViewListBox : public wxVListBox {
-public:
-	DatDebugViewListBox(wxWindow* parent, wxWindowID id);
-	~DatDebugViewListBox();
-
-	void OnDrawItem(wxDC& dc, const wxRect& rect, size_t index) const;
-	wxCoord OnMeasureItem(size_t index) const;
-
-protected:
-	using SpriteMap = std::vector<Sprite*>;
-	SpriteMap sprites;
-};
-
-DatDebugViewListBox::DatDebugViewListBox(wxWindow* parent, wxWindowID id) :
-	wxVListBox(parent, id, wxDefaultPosition, wxDefaultSize, wxLB_SINGLE) {
-	sprites.reserve(g_gui.gfx.getItemSpriteMaxID());
-	for (int id = 0; id < g_gui.gfx.getItemSpriteMaxID(); ++id) {
-		Sprite* spr = g_gui.gfx.getSprite(id);
-		if (spr) {
-			sprites.push_back(spr);
-		}
-	}
-	SetItemCount(sprites.size());
-}
-
-DatDebugViewListBox::~DatDebugViewListBox() {
-	////
-}
-
-void DatDebugViewListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
-	if (n < sprites.size()) {
-		sprites[n]->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
-	}
-
-	if (IsSelected(n)) {
-		if (HasFocus()) {
-			dc.SetTextForeground(wxColor(0xFF, 0xFF, 0xFF));
-		} else {
-			dc.SetTextForeground(wxColor(0x00, 0x00, 0xFF));
-		}
-	} else {
-		dc.SetTextForeground(wxColor(0x00, 0x00, 0x00));
-	}
-
-	dc.DrawText(wxString() << n, rect.GetX() + 40, rect.GetY() + 6);
-}
-
-wxCoord DatDebugViewListBox::OnMeasureItem(size_t n) const {
-	return 32;
-}
 
 // ============================================================================
 //
@@ -87,7 +34,7 @@ DatDebugView::DatDebugView(wxWindow* parent) :
 	search_field->SetFocus();
 	sizer->Add(search_field, 0, wxEXPAND, 2);
 
-	item_list = newd DatDebugViewListBox(this, wxID_ANY);
+	item_list = newd DatDebugListBox(this, wxID_ANY);
 	item_list->SetMinSize(wxSize(470, 400));
 	sizer->Add(item_list, 1, wxEXPAND | wxALL, 2);
 

--- a/source/ui/dat_debug_view.h
+++ b/source/ui/dat_debug_view.h
@@ -18,7 +18,7 @@
 #ifndef RME_DAT_DEBUG_VIEW_H_
 #define RME_DAT_DEBUG_VIEW_H_
 
-class DatDebugViewListBox;
+class DatDebugListBox;
 
 class DatDebugView : public wxPanel {
 public:
@@ -29,7 +29,7 @@ public:
 	void OnClickList(wxCommandEvent&);
 
 protected:
-	DatDebugViewListBox* item_list;
+	DatDebugListBox* item_list;
 	wxTextCtrl* search_field;
 
 };

--- a/source/ui/welcome_dialog.h
+++ b/source/ui/welcome_dialog.h
@@ -7,6 +7,8 @@
 #include <string_view>
 #include <memory>
 
+#include "ui/controls/recent_file_list_box.h"
+
 // Forward declarations
 class wxListCtrl;
 class wxImageList;
@@ -21,8 +23,8 @@ public:
 private:
 	// Event Handlers
 	void OnButtonClicked(wxCommandEvent& event);
-	void OnRecentFileActivated(wxListEvent& event);
-	void OnRecentFileSelected(wxListEvent& event);
+	void OnRecentFileActivated(wxCommandEvent& event);
+	void OnRecentFileSelected(wxCommandEvent& event);
 
 	void AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, std::string_view artId, const wxColour& valCol = wxNullColour);
 
@@ -31,7 +33,7 @@ private:
 	wxPanel* CreateFooterPanel(wxWindow* parent, const wxString& versionText);
 
 	std::unique_ptr<wxImageList> m_imageList;
-	wxListCtrl* m_recentList = nullptr;
+	RecentFileListBox* m_recentList = nullptr;
 	wxListCtrl* m_clientList = nullptr;
 };
 


### PR DESCRIPTION
This PR migrates several UI list controls from legacy wxWidgets implementations (`wxListCtrl`, `wxVListBox`) to the modern, GPU-accelerated `NanoVGListBox`.

Changes:
- **DatDebugView**: Replaced `DatDebugViewListBox` (which used `wxVListBox` and `wxDC`) with `DatDebugListBox` (NanoVG).
- **WaypointPalettePanel**: Replaced `wxListCtrl` with `WaypointListBox` (NanoVG). Implemented waypoint renaming using a `wxTextEntryDialog` triggered by F2 or Context Menu, replacing `wxLC_EDIT_LABELS`.
- **WelcomeDialog**: Replaced the "Recent Maps" `wxListCtrl` with `RecentFileListBox` (NanoVG), implementing custom drawing for file icons, paths, and dates. Added keyboard support (Enter key) for opening recent files.

This aligns with the `phantom.md` directive to modernize UI components and eliminate GDI/wxDC usage for list rendering.

---
*PR created automatically by Jules for task [17794631658080728631](https://jules.google.com/task/17794631658080728631) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added waypoint rename functionality via double-click, F2 key, or right-click menu
  * Added improved waypoint list display with custom rendering and visual feedback
  * Added sprite debug list with icons for data viewing
  * Added recent files list in welcome dialog with file icons and timestamps

* **Refactor**
  * Replaced standard list controls with custom-rendered list components for better visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->