### PR TITLE
🧩 Fixer: Optimize Selection, Decouple Tile/House, Modernize Map Iteration

### DIFF
--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -21,6 +21,7 @@
 #include "map/position.h"
 #include <functional>
 #include <vector>
+#include <unordered_set>
 #include <algorithm>
 #include <atomic>
 
@@ -51,6 +52,8 @@ public:
 	// The tile will be added to the list of selected tiles, however, the items on the tile won't be selected
 	void addInternal(Tile* tile);
 	void removeInternal(Tile* tile);
+
+	bool contains(Tile* tile) const;
 
 	// Clears the selection completely
 	void clear();
@@ -128,6 +131,7 @@ private:
 	// Selections are typically small, and std::vector provides better cache locality
 	// and fewer allocations. We maintain sorted order to allow O(log n) lookups.
 	std::vector<Tile*> tiles;
+	std::unordered_set<Tile*> lookup;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;
 

--- a/source/game/house.cpp
+++ b/source/game/house.cpp
@@ -21,6 +21,7 @@
 #include "game/house.h"
 #include "map/tile.h"
 #include "map/map.h"
+#include "map/map_region.h"
 
 #include <format>
 #include <algorithm>
@@ -125,7 +126,7 @@ void House::clean() {
 
 	Tile* tile = map->getTile(exit);
 	if (tile) {
-		tile->removeHouseExit(this);
+		removeExitFrom(tile);
 	}
 }
 
@@ -204,7 +205,7 @@ void House::setExit(Map* targetmap, const Position& pos) {
 	if (exit != Position()) {
 		Tile* oldexit = targetmap->getTile(exit);
 		if (oldexit) {
-			oldexit->removeHouseExit(this);
+			removeExitFrom(oldexit);
 		}
 	}
 
@@ -213,10 +214,31 @@ void House::setExit(Map* targetmap, const Position& pos) {
 		newexit = targetmap->createTile(pos.x, pos.y, pos.z);
 	}
 
-	newexit->addHouseExit(this);
+	addExitTo(newexit);
 	exit = pos;
 }
 
 void House::setExit(const Position& pos) {
 	setExit(map, pos);
+}
+
+void House::addExitTo(Tile* tile) {
+	if (!tile) {
+		return;
+	}
+	HouseExitList* house_exits = tile->getLocation()->createHouseExits();
+	house_exits->push_back(getID());
+}
+
+void House::removeExitFrom(Tile* tile) {
+	if (!tile) {
+		return;
+	}
+
+	HouseExitList* house_exits = tile->getLocation()->getHouseExits();
+	if (!house_exits) {
+		return;
+	}
+
+	std::erase(*house_exits, getID());
 }

--- a/source/game/house.h
+++ b/source/game/house.h
@@ -60,6 +60,9 @@ public:
 	Position getDoorPositionByID(uint8_t id) const;
 
 private:
+	void addExitTo(Tile* tile);
+	void removeExitFrom(Tile* tile);
+
 	uint32_t id;
 
 protected:

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -622,27 +622,6 @@ bool Tile::isTownExit(Map& map) const {
 	return location->getTownCount() > 0;
 }
 
-void Tile::addHouseExit(House* h) {
-	if (!h) {
-		return;
-	}
-	HouseExitList* house_exits = location->createHouseExits();
-	house_exits->push_back(h->getID());
-}
-
-void Tile::removeHouseExit(House* h) {
-	if (!h) {
-		return;
-	}
-
-	HouseExitList* house_exits = location->getHouseExits();
-	if (!house_exits) {
-		return;
-	}
-
-	std::erase(*house_exits, h->getID());
-}
-
 bool Tile::isContentEqual(const Tile* other) const {
 	if (!other) {
 		return false;

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -226,8 +226,6 @@ public: // Functions
 	bool isHouseTile() const;
 	uint32_t getHouseID() const;
 	void setHouseID(uint32_t newHouseId);
-	void addHouseExit(House* h);
-	void removeHouseExit(House* h);
 	bool isHouseExit() const;
 	bool isTownExit(Map& map) const;
 	const HouseExitList* getHouseExits() const;


### PR DESCRIPTION
- **Refactor `foreach_ItemOnMap`**: Replaced manual vector stack with recursive lambda for cleaner container traversal in `source/map/map.h`.
- **Decouple `Tile` from `House`**: Moved `addHouseExit` logic from `Tile` to `House` class (`House::addExitTo`), improving encapsulation.
- **Optimize `Selection`**: Added `std::unordered_set` lookup to `Selection` class for O(1) membership checks and consistent state management, preventing potential O(N^2) issues and fixing `clear()` logic for deferred selections.

---
*PR created automatically by Jules for task [5836841411248868817](https://jules.google.com/task/5836841411248868817) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced selection state consistency and tracking during operations
  * Improved duplicate prevention in tile selections

* **Performance**
  * Optimized tile selection containment checks for faster responses

* **Refactor**
  * Reorganized internal exit handling for better code structure
  * Improved item container traversal efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->