### PR TITLE
Throttle: Optimize Map::getSpawnList and Refactor UI Lists to NanoVG

### DIFF
--- a/source/map/map.cpp
+++ b/source/map/map.cpp
@@ -434,7 +434,8 @@ SpawnList Map::getSpawnList(Tile* where) {
 			};
 
 			// Safety bound: limit search radius to prevent infinite expansion with stale spawn counts
-			const int max_radius = std::max(getWidth(), getHeight());
+			// Spawns are capped at size 100 in Spawn::setSize
+			const int max_radius = 100;
 			while (found < tile_loc->getSpawnCount()) {
 				// Horizontal sides
 				for (int x = start_x; x <= end_x; ++x) {

--- a/source/ui/result_window.h
+++ b/source/ui/result_window.h
@@ -20,6 +20,8 @@
 
 #include "app/main.h"
 
+class SearchResultListBox;
+
 class SearchResultWindow : public wxPanel {
 public:
 	SearchResultWindow(wxWindow* parent);
@@ -33,7 +35,7 @@ public:
 	void OnClickClear(wxCommandEvent&);
 
 protected:
-	wxListBox* result_list;
+	SearchResultListBox* result_list;
 
 };
 

--- a/source/util/nanovg_list_box.cpp
+++ b/source/util/nanovg_list_box.cpp
@@ -1,0 +1,169 @@
+#include "app/main.h"
+#include "util/nanovg_list_box.h"
+#include <wx/dcclient.h>
+
+NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id) :
+	NanoVGCanvas(parent, id, wxVSCROLL | wxWANTS_CHARS) {
+	Bind(wxEVT_LEFT_DOWN, &NanoVGListBox::OnMouseDown, this);
+	Bind(wxEVT_LEFT_DCLICK, &NanoVGListBox::OnMouseDouble, this);
+	Bind(wxEVT_KEY_DOWN, &NanoVGListBox::OnKeyDown, this);
+}
+
+NanoVGListBox::~NanoVGListBox() {
+}
+
+void NanoVGListBox::SetItemCount(size_t count) {
+	m_itemCount = count;
+	SetScrollStep(GetItemHeight());
+	UpdateScrollbar(static_cast<int>(m_itemCount * GetItemHeight()));
+	Refresh();
+}
+
+void NanoVGListBox::SetSelection(int index) {
+	if (index >= (int)m_itemCount) {
+		index = wxNOT_FOUND;
+	}
+	if (m_selection != index) {
+		m_selection = index;
+		Refresh();
+	}
+}
+
+void NanoVGListBox::SendSelectionEvent() {
+	wxCommandEvent event(wxEVT_LISTBOX, GetId());
+	event.SetEventObject(this);
+	event.SetInt(m_selection);
+	GetEventHandler()->ProcessEvent(event);
+}
+
+void NanoVGListBox::RefreshList() {
+	UpdateScrollbar(static_cast<int>(m_itemCount * GetItemHeight()));
+	Refresh();
+}
+
+void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	int itemHeight = GetItemHeight();
+	if (itemHeight <= 0) {
+		return;
+	}
+
+	// Calculate visible range
+	int scrollPos = GetScrollPosition();
+	// Calculate start index based on scroll position
+	int startItem = scrollPos / itemHeight;
+	// Calculate how many items fit in the visible height + 1 for partial
+	int count = (height + itemHeight - 1) / itemHeight + 1;
+
+	// Draw background
+	nvgBeginPath(vg);
+	// We fill the visible area (or whole canvas, since we are translated)
+	// Actually, clearing the background is usually done by caller or by clearing the window.
+	// But let's fill with default color.
+	nvgRect(vg, 0, scrollPos, width, height);
+	nvgFillColor(vg, nvgRGBf(m_bgRed, m_bgGreen, m_bgBlue));
+	nvgFill(vg);
+
+	for (int i = 0; i < count; ++i) {
+		int index = startItem + i;
+		if (index >= (int)m_itemCount) {
+			break;
+		}
+
+		int y = index * itemHeight;
+		wxRect rect(0, y, width, itemHeight);
+
+		bool selected = (index == m_selection);
+		if (selected) {
+			nvgBeginPath(vg);
+			nvgRect(vg, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+			nvgFillColor(vg, nvgRGBA(0, 120, 215, 255)); // Selection blue
+			nvgFill(vg);
+		}
+
+		OnDrawItem(vg, index, rect, selected);
+	}
+}
+
+wxSize NanoVGListBox::DoGetBestClientSize() const {
+	return wxSize(200, 300); // Default size
+}
+
+void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
+	SetFocus();
+	int y = event.GetY() + GetScrollPosition();
+	int itemHeight = GetItemHeight();
+	if (itemHeight > 0) {
+		int index = y / itemHeight;
+
+		if (index >= 0 && index < (int)m_itemCount) {
+			if (m_selection != index) {
+				SetSelection(index);
+				SendSelectionEvent();
+			}
+		}
+	}
+}
+
+void NanoVGListBox::OnMouseDouble(wxMouseEvent& event) {
+	SetFocus();
+	int y = event.GetY() + GetScrollPosition();
+	int itemHeight = GetItemHeight();
+	if (itemHeight > 0) {
+		int index = y / itemHeight;
+
+		if (index >= 0 && index < (int)m_itemCount) {
+			if (m_selection != index) {
+				SetSelection(index);
+				SendSelectionEvent();
+			}
+
+			wxCommandEvent doubleClickEvent(wxEVT_LISTBOX_DCLICK, GetId());
+			doubleClickEvent.SetEventObject(this);
+			doubleClickEvent.SetInt(m_selection);
+			GetEventHandler()->ProcessEvent(doubleClickEvent);
+		}
+	}
+}
+
+void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
+	int key = event.GetKeyCode();
+	int itemHeight = GetItemHeight();
+
+	if (itemHeight <= 0) {
+		event.Skip();
+		return;
+	}
+
+	if (key == WXK_DOWN) {
+		if (m_selection < (int)m_itemCount - 1) {
+			SetSelection(m_selection + 1);
+			SendSelectionEvent();
+			// Ensure visible
+			int y = m_selection * itemHeight;
+			int clientH = GetClientSize().GetHeight();
+			int scrollPos = GetScrollPosition();
+
+			if (y + itemHeight > scrollPos + clientH) {
+				SetScrollPosition(y + itemHeight - clientH);
+			} else if (y < scrollPos) {
+				SetScrollPosition(y);
+			}
+		}
+	} else if (key == WXK_UP) {
+		if (m_selection > 0) {
+			SetSelection(m_selection - 1);
+			SendSelectionEvent();
+			// Ensure visible
+			int y = m_selection * itemHeight;
+			int scrollPos = GetScrollPosition();
+
+			if (y < scrollPos) {
+				SetScrollPosition(y);
+			} else if (y + itemHeight > scrollPos + GetClientSize().GetHeight()) {
+				SetScrollPosition(y + itemHeight - GetClientSize().GetHeight());
+			}
+		}
+	} else {
+		event.Skip();
+	}
+}

--- a/source/util/nanovg_list_box.h
+++ b/source/util/nanovg_list_box.h
@@ -1,0 +1,53 @@
+#ifndef RME_UTIL_NANOVG_LIST_BOX_H_
+#define RME_UTIL_NANOVG_LIST_BOX_H_
+
+#include "util/nanovg_canvas.h"
+
+class NanoVGListBox : public NanoVGCanvas {
+public:
+	NanoVGListBox(wxWindow* parent, wxWindowID id = wxID_ANY);
+	virtual ~NanoVGListBox();
+
+	// Data management
+	void SetItemCount(size_t count);
+	size_t GetItemCount() const {
+		return m_itemCount;
+	}
+
+	// Selection
+	void SetSelection(int index);
+	int GetSelection() const {
+		return m_selection;
+	}
+	bool IsSelected(int index) const {
+		return m_selection == index;
+	}
+
+	// Rendering
+	void RefreshList();
+
+protected:
+	// To be implemented by subclasses
+	virtual void OnDrawItem(NVGcontext* vg, int index, const wxRect& rect, bool selected) = 0;
+	virtual int GetItemHeight() const {
+		return 24;
+	}
+
+	// NanoVGCanvas overrides
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
+
+	// Event handlers
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMouseDouble(wxMouseEvent& event);
+	void OnKeyDown(wxKeyEvent& event);
+
+protected:
+	void SendSelectionEvent();
+
+private:
+	size_t m_itemCount = 0;
+	int m_selection = wxNOT_FOUND;
+};
+
+#endif


### PR DESCRIPTION
This PR addresses performance issues identified in `throttle.md`.

1.  **Map Optimization**: `Map::getSpawnList` previously used a dynamic search radius `max(width, height)`, which could lead to severe performance degradation (O(N^2)) on large maps if spawn counts were incorrect (e.g., due to corruption). This is now capped at 100 tiles, consistent with the maximum spawn size.
2.  **UI Modernization**: `DatDebugView` and `SearchResultWindow` relied on native GDI-based list controls (`wxVListBox`, `wxListBox`). These have been refactored to use a new `NanoVGListBox` class, which leverages NanoVG for hardware-accelerated rendering. This reduces GDI handle usage and allows for more consistent and flexible UI rendering (e.g., direct sprite rendering in the debug view).


---
*PR created automatically by Jules for task [10953200998879799835](https://jules.google.com/task/10953200998879799835) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Modernized search results display rendering system
  * Enhanced debug view component with updated visual infrastructure
  * Adjusted spawn search radius parameters

<!-- end of auto-generated comment: release notes by coderabbit.ai -->