### PR TITLE
🔄 Upgrader: Replace C-style casts with static_cast

### DIFF
--- a/source/editor/operations/clean_operations.h
+++ b/source/editor/operations/clean_operations.h
@@ -64,9 +64,9 @@ namespace EditorOperations {
 
 			Position pos = tile->getPosition();
 			int sx = std::max(pos.x - UNREACHABLE_SEARCH_RADIUS_X, 0);
-			int ex = std::min(pos.x + UNREACHABLE_SEARCH_RADIUS_X, (int)std::numeric_limits<uint16_t>::max());
+			int ex = std::min(pos.x + UNREACHABLE_SEARCH_RADIUS_X, static_cast<int>(std::numeric_limits<uint16_t>::max()));
 			int sy = std::max(pos.y - UNREACHABLE_SEARCH_RADIUS_Y, 0);
-			int ey = std::min(pos.y + UNREACHABLE_SEARCH_RADIUS_Y, (int)std::numeric_limits<uint16_t>::max());
+			int ey = std::min(pos.y + UNREACHABLE_SEARCH_RADIUS_Y, static_cast<int>(std::numeric_limits<uint16_t>::max()));
 			int sz, ez;
 
 			if (pos.z <= GROUND_LAYER) {

--- a/source/game/item.cpp
+++ b/source/game/item.cpp
@@ -272,7 +272,7 @@ SpriteLight Item::getLight() const {
 double Item::getWeight() const {
 	ItemType& it = g_items[id];
 	if (it.stackable) {
-		return it.weight * std::max(1, (int)subtype);
+		return it.weight * std::max(1, static_cast<int>(subtype));
 	}
 
 	return it.weight;

--- a/source/rendering/drawers/entities/creature_name_drawer.cpp
+++ b/source/rendering/drawers/entities/creature_name_drawer.cpp
@@ -53,8 +53,8 @@ void CreatureNameDrawer::draw(NVGcontext* vg, const RenderView& view) {
 		int unscaled_x, unscaled_y;
 		view.getScreenPosition(label.pos.x, label.pos.y, label.pos.z, unscaled_x, unscaled_y);
 
-		float screen_x = (float)unscaled_x / zoom;
-		float screen_y = (float)unscaled_y / zoom;
+		float screen_x = static_cast<float>(unscaled_x) / zoom;
+		float screen_y = static_cast<float>(unscaled_y) / zoom;
 
 		// Center on tile, position slightly above the creature head
 		// Standard creature is 32x32, but might be tall.

--- a/source/rendering/drawers/minimap_drawer.cpp
+++ b/source/rendering/drawers/minimap_drawer.cpp
@@ -55,7 +55,7 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 
 	// Prepare view
 	glViewport(0, 0, window_width, window_height);
-	glm::mat4 projection = glm::ortho(0.0f, (float)window_width, (float)window_height, 0.0f, -1.0f, 1.0f);
+	glm::mat4 projection = glm::ortho(0.0f, static_cast<float>(window_width), static_cast<float>(window_height), 0.0f, -1.0f, 1.0f);
 
 	// Clear background
 	glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
@@ -112,7 +112,7 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 		renderer->updateRegion(editor.map, floor, start_x, start_y, map_draw_w, map_draw_h);
 
 		// Render
-		renderer->render(projection, 0, 0, window_width, window_height, (float)start_x, (float)start_y, (float)map_draw_w, (float)map_draw_h);
+		renderer->render(projection, 0, 0, window_width, window_height, static_cast<float>(start_x), static_cast<float>(start_y), static_cast<float>(map_draw_w), static_cast<float>(map_draw_h));
 
 		// Draw View Box (Overlay)
 		if (g_settings.getInteger(Config::MINIMAP_VIEW_BOX)) {
@@ -130,10 +130,10 @@ void MinimapDrawer::Draw(wxDC& pdc, const wxSize& size, Editor& editor, MapCanva
 			int view_h = screensize_y / tile_size + 1;
 
 			// Convert to local minimap coords
-			float x = (float)(view_start_x - start_x);
-			float y = (float)(view_start_y - start_y);
-			float w = (float)view_w;
-			float h = (float)view_h;
+			float x = static_cast<float>(view_start_x - start_x);
+			float y = static_cast<float>(view_start_y - start_y);
+			float w = static_cast<float>(view_w);
+			float h = static_cast<float>(view_h);
 
 			// Draw white rectangle using PrimitiveRenderer
 			primitive_renderer->setProjectionMatrix(projection);
@@ -158,4 +158,3 @@ void MinimapDrawer::ScreenToMap(int screen_x, int screen_y, int& map_x, int& map
 	map_x = last_start_x + screen_x;
 	map_y = last_start_y + screen_y;
 }
-

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -292,8 +292,8 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 	}
 
 	// Constants
-	float scale_x = (float)w / map_w;
-	float scale_y = (float)h / map_h;
+	float scale_x = static_cast<float>(w) / map_w;
+	float scale_y = static_cast<float>(h) / map_h;
 
 	// Determine visible tiles
 	// Clamp to integer grid

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -68,7 +68,7 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							b = b / 3 * 2;
 						}
 						if (tile->isHouseTile() && options.show_houses) {
-							if ((int)tile->getHouseID() == current_house_id) {
+							if (static_cast<int>(tile->getHouseID()) == current_house_id) {
 								r /= 2;
 							} else {
 								r /= 2;
@@ -137,7 +137,7 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 			if (g_gui.gfx.ensureAtlasManager()) {
 				// Draw a semi-transparent white box over the tile
 				glm::vec4 highlightColor(1.0f, 1.0f, 1.0f, 0.25f); // 25% white
-				sprite_batch.drawRect((float)draw_x, (float)draw_y, (float)TILE_SIZE, (float)TILE_SIZE, highlightColor, *g_gui.gfx.getAtlasManager());
+				sprite_batch.drawRect(static_cast<float>(draw_x), static_cast<float>(draw_y), static_cast<float>(TILE_SIZE), static_cast<float>(TILE_SIZE), highlightColor, *g_gui.gfx.getAtlasManager());
 			}
 		}
 	}

--- a/source/ui/replace_tool/rule_builder_panel.cpp
+++ b/source/ui/replace_tool/rule_builder_panel.cpp
@@ -50,16 +50,16 @@ bool RuleBuilderPanel::ItemDropTarget::OnDropText(wxCoord x, wxCoord y, const wx
 	RuleBuilderPanel::HitResult hit = m_panel->HitTest(x, y);
 
 	if (hit.type == RuleBuilderPanel::HitResult::Source) {
-		if (hit.ruleIndex >= 0 && hit.ruleIndex < (int)m_panel->m_rules.size()) {
+		if (hit.ruleIndex >= 0 && hit.ruleIndex < static_cast<int>(m_panel->m_rules.size())) {
 			m_panel->m_rules[hit.ruleIndex].fromId = itemId;
 			m_panel->m_listener->OnRuleChanged();
 			m_panel->Refresh();
 			return true;
 		}
 	} else if (hit.type == RuleBuilderPanel::HitResult::Target || hit.type == RuleBuilderPanel::HitResult::DeleteTarget) {
-		if (hit.ruleIndex >= 0 && hit.ruleIndex < (int)m_panel->m_rules.size()) {
+		if (hit.ruleIndex >= 0 && hit.ruleIndex < static_cast<int>(m_panel->m_rules.size())) {
 			// Replace existing target
-			if (hit.targetIndex >= 0 && hit.targetIndex < m_panel->m_rules[hit.ruleIndex].targets.size()) {
+			if (hit.targetIndex >= 0 && hit.targetIndex < static_cast<int>(m_panel->m_rules[hit.ruleIndex].targets.size())) {
 				m_panel->m_rules[hit.ruleIndex].targets[hit.targetIndex].id = itemId;
 				m_panel->m_listener->OnRuleChanged();
 				m_panel->Refresh();
@@ -67,7 +67,7 @@ bool RuleBuilderPanel::ItemDropTarget::OnDropText(wxCoord x, wxCoord y, const wx
 			}
 		}
 	} else if (hit.type == RuleBuilderPanel::HitResult::AddTarget) { // Drag to [+] slot
-		if (hit.ruleIndex >= 0 && hit.ruleIndex < (int)m_panel->m_rules.size()) {
+		if (hit.ruleIndex >= 0 && hit.ruleIndex < static_cast<int>(m_panel->m_rules.size())) {
 			// TRASH LOGIC: Reject if has trash
 			bool hasTrash = std::ranges::any_of(m_panel->m_rules[hit.ruleIndex].targets, [](const auto& t) {
 				return t.id == TRASH_ITEM_ID;
@@ -156,7 +156,7 @@ std::vector<ReplacementRule> RuleBuilderPanel::GetRules() const {
 // ----------------------------------------------------------------------------
 
 int RuleBuilderPanel::GetRuleHeight(int index, int width) const {
-	if (index < 0 || index >= (int)m_rules.size()) {
+	if (index < 0 || index >= static_cast<int>(m_rules.size())) {
 		return FromDIP(ITEM_H);
 	}
 
@@ -166,7 +166,7 @@ int RuleBuilderPanel::GetRuleHeight(int index, int width) const {
 		availableWidth = CARD_W;
 	}
 
-	int columns = std::max(1, (int)(availableWidth / (CARD_W + ITEM_SPACING)));
+	int columns = std::max(1, static_cast<int>(availableWidth / (CARD_W + ITEM_SPACING)));
 	int targetCount = m_rules[index].targets.size();
 
 	bool hasTrash = std::ranges::any_of(m_rules[index].targets, [](const auto& t) {
@@ -182,8 +182,8 @@ int RuleBuilderPanel::GetRuleHeight(int index, int width) const {
 }
 
 int RuleBuilderPanel::GetRuleY(int index, int width) const {
-	if (index < 0 || index >= (int)m_ruleYCache.size()) {
-		if (index == (int)m_ruleYCache.size()) {
+	if (index < 0 || index >= static_cast<int>(m_ruleYCache.size())) {
+		if (index == static_cast<int>(m_ruleYCache.size())) {
 			return m_totalHeight;
 		}
 		return 0;
@@ -202,7 +202,7 @@ void RuleBuilderPanel::LayoutRules() {
 
 	for (size_t i = 0; i < m_rules.size(); ++i) {
 		m_ruleYCache.push_back(currentY);
-		currentY += GetRuleHeight((int)i, width);
+		currentY += GetRuleHeight(static_cast<int>(i), width);
 	}
 	m_totalHeight = currentY;
 
@@ -211,7 +211,7 @@ void RuleBuilderPanel::LayoutRules() {
 }
 
 void RuleBuilderPanel::DistributeProbabilities(int ruleIndex) {
-	if (ruleIndex < 0 || ruleIndex >= m_rules.size()) {
+	if (ruleIndex < 0 || ruleIndex >= static_cast<int>(m_rules.size())) {
 		return;
 	}
 	auto& targets = m_rules[ruleIndex].targets;
@@ -229,8 +229,8 @@ void RuleBuilderPanel::DistributeProbabilities(int ruleIndex) {
 
 	for (auto& target : targets) {
 		accumulated += step;
-		int currentTotal = (int)std::round(accumulated);
-		int prevTotal = (int)std::round(accumulated - step);
+		int currentTotal = static_cast<int>(std::round(accumulated));
+		int prevTotal = static_cast<int>(std::round(accumulated - step));
 		target.probability = currentTotal - prevTotal;
 	}
 }
@@ -332,8 +332,8 @@ RuleBuilderPanel::HitResult RuleBuilderPanel::HitTest(int x, int y) const {
 
 	// Check Rules
 	for (size_t i = 0; i < m_rules.size(); ++i) {
-		int ruleH = GetRuleHeight(i, width);
-		int ruleY = GetRuleY(i, width);
+		int ruleH = GetRuleHeight(static_cast<int>(i), width);
+		int ruleY = GetRuleY(static_cast<int>(i), width);
 		wxRect card(CARD_MARGIN_X, ruleY, width - CARD_MARGIN_X * 2, ruleH);
 
 		if (card.Contains(x, absY)) {
@@ -342,7 +342,7 @@ RuleBuilderPanel::HitResult RuleBuilderPanel::HitTest(int x, int y) const {
 
 			// Delete Rule Button (Top Right)
 			if (localX > card.width - 24 && localY < 24) {
-				return { HitResult::DeleteRule, (int)i, -1 };
+				return { HitResult::DeleteRule, static_cast<int>(i), -1 };
 			}
 
 			// Source Item (Left, always in first row logically)
@@ -350,13 +350,13 @@ RuleBuilderPanel::HitResult RuleBuilderPanel::HitTest(int x, int y) const {
 			float sourceY = CARD_PADDING; // Vertical top in card
 
 			if (localX >= startX && localX <= startX + CARD_W && localY >= sourceY && localY <= sourceY + ITEM_HEIGHT) {
-				return { HitResult::Source, (int)i, -1 };
+				return { HitResult::Source, static_cast<int>(i), -1 };
 			}
 
 			// Targets (Wrapping)
 			float targetStartX = startX + CARD_W + 10 + ARROW_WIDTH;
 			float availableWidth = card.width - targetStartX - CARD_PADDING;
-			int columns = std::max(1, (int)(availableWidth / (CARD_W + ITEM_SPACING)));
+			int columns = std::max(1, static_cast<int>(availableWidth / (CARD_W + ITEM_SPACING)));
 
 			for (size_t t = 0; t < m_rules[i].targets.size(); ++t) {
 				int row = t / columns;
@@ -365,7 +365,7 @@ RuleBuilderPanel::HitResult RuleBuilderPanel::HitTest(int x, int y) const {
 				float ty = RuleCardRenderer::CARD_PADDING + row * (ITEM_HEIGHT + RuleCardRenderer::ITEM_SPACING);
 
 				if (localX >= tx && localX <= tx + RuleCardRenderer::CARD_W && localY >= ty && localY <= ty + ITEM_HEIGHT) {
-					return { HitResult::DeleteTarget, (int)i, (int)t };
+					return { HitResult::DeleteTarget, static_cast<int>(i), static_cast<int>(t) };
 				}
 			}
 
@@ -382,11 +382,11 @@ RuleBuilderPanel::HitResult RuleBuilderPanel::HitTest(int x, int y) const {
 				float ty = RuleCardRenderer::CARD_PADDING + row * (ITEM_HEIGHT + RuleCardRenderer::ITEM_SPACING);
 
 				if (localX >= tx && localX <= tx + RuleCardRenderer::CARD_W && localY >= ty && localY <= ty + ITEM_HEIGHT) {
-					return { HitResult::AddTarget, (int)i, -1 };
+					return { HitResult::AddTarget, static_cast<int>(i), -1 };
 				}
 			}
 
-			return { HitResult::None, (int)i, -1 };
+			return { HitResult::None, static_cast<int>(i), -1 };
 		}
 	}
 
@@ -429,12 +429,12 @@ void RuleBuilderPanel::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 
 	// 2. Draw Content (Implicitly scrolled by base class)
 	for (size_t i = 0; i < m_rules.size(); ++i) {
-		int ruleY = GetRuleY(i, width);
-		bool hoverDel = (m_dragHover.type == HitResult::DeleteRule && m_dragHover.ruleIndex == (int)i);
-		int dragType = (m_dragHover.ruleIndex == (int)i) ? (int)m_dragHover.type : 0;
-		int dragIdx = (m_dragHover.ruleIndex == (int)i) ? m_dragHover.targetIndex : -1;
+		int ruleY = GetRuleY(static_cast<int>(i), width);
+		bool hoverDel = (m_dragHover.type == HitResult::DeleteRule && m_dragHover.ruleIndex == static_cast<int>(i));
+		int dragType = (m_dragHover.ruleIndex == static_cast<int>(i)) ? static_cast<int>(m_dragHover.type) : 0;
+		int dragIdx = (m_dragHover.ruleIndex == static_cast<int>(i)) ? m_dragHover.targetIndex : -1;
 
-		RuleCardRenderer::DrawRuleCard(this, vg, (int)i, ruleY, width, hoverDel, dragIdx, dragType, m_isExternalDrag);
+		RuleCardRenderer::DrawRuleCard(this, vg, static_cast<int>(i), ruleY, width, hoverDel, dragIdx, dragType, m_isExternalDrag);
 	}
 
 	int newRuleY = GetRuleY(m_rules.size(), width) + RuleCardRenderer::CARD_MARGIN_Y;

--- a/source/ui/replace_tool/rule_card_renderer.cpp
+++ b/source/ui/replace_tool/rule_card_renderer.cpp
@@ -87,7 +87,7 @@ void RuleCardRenderer::DrawSaveButton(NVGcontext* vg, float width, bool isHovere
 
 void RuleCardRenderer::DrawRuleCard(RuleBuilderPanel* panel, NVGcontext* vg, int ruleIndex, int y, int width, bool hoverDelete, int dragHoverTargetIdx, int dragHoverType, bool isExternalDrag) {
 	const auto& rules = panel->GetRules();
-	if (ruleIndex < 0 || ruleIndex >= rules.size()) {
+	if (ruleIndex < 0 || ruleIndex >= static_cast<int>(rules.size())) {
 		return;
 	}
 	const auto& rule = rules[ruleIndex];
@@ -99,7 +99,7 @@ void RuleCardRenderer::DrawRuleCard(RuleBuilderPanel* panel, NVGcontext* vg, int
 	if (availableWidth < CARD_W) {
 		availableWidth = CARD_W;
 	}
-	int columns = std::max(1, (int)(availableWidth / (CARD_W + ITEM_SPACING)));
+	int columns = std::max(1, static_cast<int>(availableWidth / (CARD_W + ITEM_SPACING)));
 
 	int targetCount = rule.targets.size();
 	bool hasTrash = false;
@@ -145,7 +145,7 @@ void RuleCardRenderer::DrawRuleCard(RuleBuilderPanel* panel, NVGcontext* vg, int
 		float ty = y + CARD_PADDING + row * (ITEM_H + ITEM_SPACING);
 
 		// HitResult::Target is 2, DeleteTarget is 8
-		bool isThisHovered = (dragHoverTargetIdx == (int)j && (dragHoverType == 2 || dragHoverType == 8));
+		bool isThisHovered = (dragHoverTargetIdx == static_cast<int>(j) && (dragHoverType == 2 || dragHoverType == 8));
 		bool isTargetTrash = (target.id == TRASH_ITEM_ID);
 
 		DrawRuleItemCard(panel, vg, tx, ty, CARD_W, ITEM_H, target.id, isThisHovered, isTargetTrash, isThisHovered, target.probability);

--- a/source/ui/replace_tool/rule_list_control.cpp
+++ b/source/ui/replace_tool/rule_list_control.cpp
@@ -59,7 +59,7 @@ void RuleListControl::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 	wxSize clientSize = GetClientSize();
 
 	int startIdx = scrollPos / m_itemHeight;
-	int endIdx = std::min((int)m_ruleSetNames.size() - 1, (scrollPos + clientSize.y) / m_itemHeight + 1);
+	int endIdx = std::min(static_cast<int>(m_ruleSetNames.size()) - 1, (scrollPos + clientSize.y) / m_itemHeight + 1);
 
 	static const float padding = 4.0f;
 	static const float radius = 4.0f;
@@ -126,7 +126,7 @@ void RuleListControl::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 }
 
 wxRect RuleListControl::GetItemRect(int index) const {
-	if (index < 0 || index >= (int)m_ruleSetNames.size()) {
+	if (index < 0 || index >= static_cast<int>(m_ruleSetNames.size())) {
 		return wxRect();
 	}
 	wxSize clientSize = GetClientSize();
@@ -144,7 +144,7 @@ void RuleListControl::OnMouse(wxMouseEvent& event) {
 		int y = event.GetY() + scrollPos;
 		int idx = y / m_itemHeight;
 
-		if (idx >= 0 && idx < (int)m_ruleSetNames.size()) {
+		if (idx >= 0 && idx < static_cast<int>(m_ruleSetNames.size())) {
 			m_hoveredIndex = idx;
 		} else {
 			m_hoveredIndex = -1;
@@ -215,7 +215,7 @@ void RuleListControl::OnContextMenu(wxContextMenuEvent& event) {
 	menu.Append(wxID_DELETE, "Delete")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
 
 	menu.Bind(wxEVT_MENU, [this, menuIdx](wxCommandEvent& e) {
-		if (menuIdx < 0 || menuIdx >= (int)m_ruleSetNames.size()) {
+		if (menuIdx < 0 || menuIdx >= static_cast<int>(m_ruleSetNames.size())) {
 			return;
 		}
 

--- a/source/ui/replace_tool/visual_similarity_service.cpp
+++ b/source/ui/replace_tool/visual_similarity_service.cpp
@@ -58,10 +58,10 @@ static uint64_t CalculateAHashRGBA(std::span<const uint8_t> rgba, int w, int h) 
 			double block_sum = 0;
 			int pixel_count = 0;
 
-			int start_x = (int)(x * block_w);
-			int start_y = (int)(y * block_h);
-			int end_x = (int)((x + 1) * block_w);
-			int end_y = (int)((y + 1) * block_h);
+			int start_x = static_cast<int>(x * block_w);
+			int start_y = static_cast<int>(y * block_h);
+			int end_x = static_cast<int>((x + 1) * block_w);
+			int end_y = static_cast<int>((y + 1) * block_h);
 
 			for (int py = start_y; py < end_y && py < h; ++py) {
 				for (int px = start_x; px < end_x && px < w; ++px) {
@@ -72,13 +72,13 @@ static uint64_t CalculateAHashRGBA(std::span<const uint8_t> rgba, int w, int h) 
 				}
 			}
 
-			uint8_t avg = (uint8_t)((pixel_count > 0) ? (block_sum / pixel_count) : 0);
+			uint8_t avg = static_cast<uint8_t>((pixel_count > 0) ? (block_sum / pixel_count) : 0);
 			gray_8x8[y * 8 + x] = avg;
 			total_brightness += avg;
 		}
 	}
 
-	uint8_t global_avg = (uint8_t)(total_brightness / 64.0);
+	uint8_t global_avg = static_cast<uint8_t>(total_brightness / 64.0);
 	uint64_t hash = 0;
 	for (int i = 0; i < 64; ++i) {
 		if (gray_8x8[i] >= global_avg) {
@@ -111,9 +111,9 @@ static std::vector<float> CalculateHistogramRGBA(std::span<const uint8_t> rgba, 
 
 	for (size_t i = 0; i < count; ++i) {
 		if (rgba[i * 4 + 3] > threshold) {
-			int r_bin = std::min((int)(rgba[i * 4 + 0] * BINS / 256), BINS - 1);
-			int g_bin = std::min((int)(rgba[i * 4 + 1] * BINS / 256), BINS - 1);
-			int b_bin = std::min((int)(rgba[i * 4 + 2] * BINS / 256), BINS - 1);
+			int r_bin = std::min(static_cast<int>(rgba[i * 4 + 0] * BINS / 256), BINS - 1);
+			int g_bin = std::min(static_cast<int>(rgba[i * 4 + 1] * BINS / 256), BINS - 1);
+			int b_bin = std::min(static_cast<int>(rgba[i * 4 + 2] * BINS / 256), BINS - 1);
 
 			int bin_idx = r_bin * BINS * BINS + g_bin * BINS + b_bin;
 			hist[bin_idx]++;


### PR DESCRIPTION
This PR modernizes the codebase by replacing potentially unsafe C-style casts with `static_cast`. This aligns with the "Upgrader" agent's directive to use modern C++ features and improves code safety by making conversions explicit and searchable. No logic changes were made; only syntax updates.

---
*PR created automatically by Jules for task [8792764285720415796](https://jules.google.com/task/8792764285720415796) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Enhanced code type-safety across rendering, UI, and game systems through modernized casting practices. This internal improvement strengthens code quality and maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->