### PR TITLE
⚡ Bolt: Multithreaded Sprite Preloading with Persistent File Handles

### DIFF
--- a/source/io/loaders/spr_loader.cpp
+++ b/source/io/loaders/spr_loader.cpp
@@ -165,13 +165,6 @@ bool SprLoader::LoadDump(GraphicManager* manager, std::unique_ptr<uint8_t[]>& ta
 }
 
 bool SprLoader::LoadDump(const std::string& filename, bool extended, std::unique_ptr<uint8_t[]>& target, uint16_t& size, int sprite_id) {
-	if (sprite_id == 0) {
-		// Empty GameSprite
-		size = 0;
-		target.reset();
-		return true;
-	}
-
 	if (filename.empty()) {
 		return false;
 	}
@@ -179,6 +172,17 @@ bool SprLoader::LoadDump(const std::string& filename, bool extended, std::unique
 	FileReadHandle fh(filename);
 	if (!fh.isOk()) {
 		return false;
+	}
+
+	return LoadDump(fh, extended, target, size, sprite_id);
+}
+
+bool SprLoader::LoadDump(FileReadHandle& fh, bool extended, std::unique_ptr<uint8_t[]>& target, uint16_t& size, int sprite_id) {
+	if (sprite_id == 0) {
+		// Empty GameSprite
+		size = 0;
+		target.reset();
+		return true;
 	}
 
 	uint32_t address_size = extended ? SPRITE_ADDRESS_SIZE_EXTENDED : SPRITE_ADDRESS_SIZE_NORMAL;

--- a/source/io/loaders/spr_loader.h
+++ b/source/io/loaders/spr_loader.h
@@ -16,6 +16,7 @@ public:
 	static bool LoadData(GraphicManager* manager, const wxFileName& datafile, wxString& error, std::vector<std::string>& warnings);
 	static bool LoadDump(GraphicManager* manager, std::unique_ptr<uint8_t[]>& target, uint16_t& size, int sprite_id);
 	static bool LoadDump(const std::string& filename, bool extended, std::unique_ptr<uint8_t[]>& target, uint16_t& size, int sprite_id);
+	static bool LoadDump(FileReadHandle& fh, bool extended, std::unique_ptr<uint8_t[]>& target, uint16_t& size, int sprite_id);
 
 private:
 	static std::vector<uint32_t> ReadSpriteIndexes(FileReadHandle& fh, uint32_t total_pics, wxString& error);

--- a/source/rendering/core/sprite_preloader.h
+++ b/source/rendering/core/sprite_preloader.h
@@ -61,7 +61,7 @@ private:
 	std::mutex queue_mutex;
 	std::condition_variable cv;
 	bool stopping = false;
-	std::jthread worker;
+	std::vector<std::jthread> workers;
 
 	std::queue<Task> task_queue;
 	std::queue<Result> result_queue;


### PR DESCRIPTION
- **Multithreading:** Replaced single `std::jthread` in `SpritePreloader` with a vector of workers scaling to hardware concurrency (clamped 2-8).
- **Persistent I/O:** Implemented thread-local caching of `FileReadHandle` in `workerLoop` to reuse open handles for sequential reads from the same sprite file.
- **Refactoring:** Added `SprLoader::LoadDump` overload accepting `FileReadHandle&` to support handle reuse.
- **Performance:** Reduces I/O latency and accelerates sprite loading on multi-core systems.

---
*PR created automatically by Jules for task [17480134454463536754](https://jules.google.com/task/17480134454463536754) started by @karolak6612*