### PR TITLE
Sentinel: Shared Geometry Refactor

### DIFF
--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -97,8 +97,6 @@ class MapDrawer {
 	bool m_lastAaMode = false;
 
 	std::unique_ptr<GLVertexArray> pp_vao;
-	std::unique_ptr<GLBuffer> pp_vbo;
-	std::unique_ptr<GLBuffer> pp_ebo;
 
 	void InitPostProcess();
 	void DrawPostProcess(const RenderView& view, const DrawingOptions& options);

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -54,7 +54,6 @@ private:
 
 	std::unique_ptr<ShaderProgram> shader;
 	std::unique_ptr<GLVertexArray> vao;
-	std::unique_ptr<GLBuffer> vbo;
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 


### PR DESCRIPTION
Refactored MapDrawer and LightDrawer to use SharedGeometry for quad rendering, removing redundant VBOs/EBOs and updating drawing calls to use indexed rendering.

---
*PR created automatically by Jules for task [12451436204748180060](https://jules.google.com/task/12451436204748180060) started by @karolak6612*