### PR TITLE
⚡ Throttle: Optimize Map Culling & Allocations

### DIFF
--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -28,6 +28,14 @@ struct DrawingOptions;
 struct LightBuffer;
 class SpriteBatch;
 class PrimitiveRenderer;
+class MapNode;
+#include <vector>
+
+struct VisibleNode {
+	MapNode* node;
+	int x;
+	int y;
+};
 
 class MapLayerDrawer {
 public:
@@ -35,6 +43,8 @@ public:
 	~MapLayerDrawer();
 
 	void Draw(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void DrawNodes(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, const std::vector<VisibleNode>& nodes);
+	void DrawSingleNode(MapNode* nd, int nd_map_x, int nd_map_y, int map_z, bool live, SpriteBatch& sprite_batch, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, int base_screen_x, int base_screen_y, bool draw_lights);
 
 private:
 	TileRenderer* tile_renderer;

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -59,6 +59,7 @@ class TileRenderer;
 class CreatureNameDrawer;
 class HookIndicatorDrawer;
 class DoorIndicatorDrawer;
+struct VisibleNode;
 
 class MapDrawer {
 	MapCanvas* canvas;
@@ -100,9 +101,12 @@ class MapDrawer {
 	std::unique_ptr<GLBuffer> pp_vbo;
 	std::unique_ptr<GLBuffer> pp_ebo;
 
+	std::vector<VisibleNode> visible_nodes_cache;
+
 	void InitPostProcess();
 	void DrawPostProcess(const RenderView& view, const DrawingOptions& options);
 	void UpdateFBO(const RenderView& view, const DrawingOptions& options);
+	void UpdateVisibleNodes();
 
 protected:
 	friend class BrushOverlayDrawer;


### PR DESCRIPTION
This change optimizes the main map rendering loop by reducing redundant spatial hash grid queries and memory allocations.

**Key Changes:**
1.  **`SpatialHashGrid` Optimization:** Added a persistent `row_cells_cache` vector to the class. This prevents allocating a new `std::vector<RowCellInfo>` every time `visitLeavesByViewport` is called, which happens thousands of times during panning/zooming.
2.  **Hoisted Visibility Query:** Previously, `MapDrawer::DrawMap` called `map_layer_drawer->Draw` for every map layer (ground + 0-7 + underground). `MapLayerDrawer::Draw` would then query the `SpatialHashGrid` for visible nodes *each time*. Since the visible X/Y viewport doesn't change between layers, this was redundant work.
    *   Added `MapDrawer::UpdateVisibleNodes` which queries the grid *once* per frame and stores the result in `visible_nodes_cache`.
    *   Updated `MapDrawer::DrawMap` to pass this cached list to `MapLayerDrawer` for each layer.
3.  **Refactored `MapLayerDrawer`:**
    *   Extracted the core node rendering logic into `DrawSingleNode`.
    *   Added `DrawNodes` to iterate over the cached `VisibleNode` list.
    *   Maintained the existing `Draw` method for `live_client` (which has dynamic node loading requirements), but refactored it to use `DrawSingleNode` to avoid code duplication.

**Performance Impact:**
- Reduces spatial hash grid traversal complexity from O(Layers * ViewportNodes) to O(ViewportNodes).
- Reduces memory churn in the render loop.
- Should improve framerate stability, especially on maps with many layers or large viewports.

---
*PR created automatically by Jules for task [5690087447950351267](https://jules.google.com/task/5690087447950351267) started by @karolak6612*