### PR TITLE
Profiler: Optimize tile preloading for complex sprites

### DIFF
--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -104,6 +104,11 @@ public:
 
 	static void ColorizeTemplatePixels(uint8_t* dest, const uint8_t* mask, size_t pixelCount, int lookHead, int lookBody, int lookLegs, int lookFeet, bool destHasAlpha);
 
+	bool isFullyLoaded() const {
+		return loaded_count >= numsprites;
+	}
+	void updateLoadedStatus(bool loaded);
+
 private:
 protected:
 	class Image;
@@ -279,6 +284,7 @@ protected:
 	mutable const AtlasRegion* cached_default_region = nullptr;
 	uint32_t cached_generation_id = 0;
 	uint32_t cached_sprite_id = 0;
+	std::atomic<uint32_t> loaded_count = 0;
 };
 
 #endif

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -347,7 +347,7 @@ void TileRenderer::PreloadItem(const Tile* tile, Item* item, const ItemType& it,
 	}
 
 	GameSprite* spr = it.sprite;
-	if (spr && !spr->isSimpleAndLoaded()) {
+	if (spr && !spr->isFullyLoaded()) {
 		SpritePatterns patterns;
 		if (cached_patterns) {
 			patterns = *cached_patterns;


### PR DESCRIPTION
This change optimizes the rendering pipeline by preventing redundant preloading calls for complex sprites that are already fully loaded.

Previously, `TileRenderer::PreloadItem` only skipped preloading for "simple" sprites (1x1x1 static) that were loaded. Complex sprites (animations, multi-layer) were re-checked every frame even if fully resident.

Changes:
1.  **`GameSprite`**: Added `std::atomic<uint32_t> loaded_count` to track the number of loaded `NormalImage` parts.
2.  **`GameSprite`**: Added `isFullyLoaded()` helper to check if `loaded_count >= numsprites`.
3.  **`GameSprite`**: Added `updateLoadedStatus(bool loaded)` to safely update the counter.
4.  **`NormalImage`**: Updated `EnsureAtlasSprite` and `clean` to call `parent->updateLoadedStatus()` when textures are loaded or unloaded.
5.  **`TileRenderer`**: Switched `PreloadItem` to check `!spr->isFullyLoaded()` instead of `!spr->isSimpleAndLoaded()`.

This ensures that once a complex sprite is fully loaded into the texture atlas, the CPU no longer wastes cycles scheduling preloads for it.

---
*PR created automatically by Jules for task [5440936488209803670](https://jules.google.com/task/5440936488209803670) started by @karolak6612*