### PR TITLE
⚡ Bolt: Merge light collection into TileRenderer::DrawTile

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -171,10 +171,7 @@ namespace IngamePreview {
 					if (tile) {
 						int draw_x = (x * TILE_SIZE) + base_draw_x;
 						int draw_y = (y * TILE_SIZE) + base_draw_y;
-						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y);
-						if (lighting_enabled) {
-							tile_renderer->AddLight(tile->location, view, options, *light_buffer);
-						}
+						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y, lighting_enabled ? light_buffer.get() : nullptr);
 						// Add names of creatures on this floor
 						if (creature_name_drawer && z == camera_pos.z) {
 							if (tile->creature) {

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -108,11 +108,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 					continue;
 				}
 
-				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y);
-				// draw light, but only if not zoomed too far
-				if (draw_lights) {
-					tile_renderer->AddLight(location, view, options, light_buffer);
-				}
+				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y, draw_lights ? &light_buffer : nullptr);
 			}
 		}
 	};

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -26,8 +26,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
-	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, LightBuffer* light_buffer = nullptr);
 
 private:
 	void PreloadItem(const Tile* tile, Item* item, const ItemType& it, const SpritePatterns* patterns = nullptr);


### PR DESCRIPTION
Merge light collection into TileRenderer::DrawTile to avoid redundant item iteration.

---
*PR created automatically by Jules for task [14328764074417339425](https://jules.google.com/task/14328764074417339425) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized tile rendering and lighting integration to consolidate separate operations into a unified rendering pass, reducing overall rendering complexity and improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->