### PR TITLE
Optimize Light Collection by Merging into DrawTile Loop

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -171,10 +171,7 @@ namespace IngamePreview {
 					if (tile) {
 						int draw_x = (x * TILE_SIZE) + base_draw_x;
 						int draw_y = (y * TILE_SIZE) + base_draw_y;
-						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y);
-						if (lighting_enabled) {
-							tile_renderer->AddLight(tile->location, view, options, *light_buffer);
-						}
+						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, lighting_enabled ? light_buffer.get() : nullptr, draw_x, draw_y);
 						// Add names of creatures on this floor
 						if (creature_name_drawer && z == camera_pos.z) {
 							if (tile->creature) {
@@ -219,7 +216,7 @@ namespace IngamePreview {
 			// while the map moves smoothly under it.
 			// So we DO NOT add offset_x/y to draw_x/y again.
 
-			creature_drawer->BlitCreature(*sprite_batch, sprite_drawer.get(), draw_x, draw_y, preview_outfit, preview_direction, CreatureDrawOptions { .animationPhase = animation_phase });
+			creature_drawer->BlitCreature(*sprite_batch, sprite_drawer.get(), draw_x, draw_y, preview_outfit, preview_direction, CreatureDrawOptions { .color = 0xFFFFFFFF, .animationPhase = animation_phase });
 
 			sprite_batch->end(*g_gui.gfx.getAtlasManager());
 		}

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -108,11 +108,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 					continue;
 				}
 
-				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y);
-				// draw light, but only if not zoomed too far
-				if (draw_lights) {
-					tile_renderer->AddLight(location, view, options, light_buffer);
-				}
+				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_lights ? &light_buffer : nullptr, draw_x_base, draw_y);
 			}
 		}
 	};

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -26,8 +26,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
-	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, LightBuffer* light_buffer = nullptr, int in_draw_x = -1, int in_draw_y = -1);
 
 private:
 	void PreloadItem(const Tile* tile, Item* item, const ItemType& it, const SpritePatterns* patterns = nullptr);


### PR DESCRIPTION
This PR optimizes the lighting system by merging the light collection logic directly into the `TileRenderer::DrawTile` loop. Previously, `MapLayerDrawer` would iterate over visible tiles to draw them, and then iterate *again* (via `TileRenderer::AddLight`) to collect light sources. This caused redundant traversal of tile items (pointer chasing).

Changes:
- `TileRenderer::DrawTile` now accepts an optional `LightBuffer*`. If provided, and if the item/ground has a light, it is added to the buffer immediately during the drawing pass.
- `TileRenderer::AddLight` has been removed.
- `MapLayerDrawer` now passes the `LightBuffer` to `DrawTile` if lighting is enabled.
- `IngamePreviewRenderer` was updated to reflect these API changes and also fixes a C++20 designated initializer order warning.

This reduces the complexity of the render loop and eliminates a full pass of item iteration for lighting.

---
*PR created automatically by Jules for task [12126041961034321761](https://jules.google.com/task/12126041961034321761) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined tile rendering by consolidating lighting operations into a single draw call, replacing the previous two-step approach for improved efficiency.
  * Enhanced creature sprite rendering with refined color handling to ensure consistent visual presentation during gameplay.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->