### PR TITLE
⚡ Bolt: Optimize rendering pipeline with loop fusion and batching

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -4,6 +4,7 @@
 #include "rendering/core/sprite_batch.h"
 #include "rendering/core/primitive_renderer.h"
 #include "rendering/core/light_buffer.h"
+#include "rendering/core/sprite_preloader.h"
 #include "rendering/utilities/light_drawer.h"
 #include "rendering/drawers/entities/creature_drawer.h"
 #include "rendering/drawers/entities/creature_name_drawer.h"
@@ -171,10 +172,7 @@ namespace IngamePreview {
 					if (tile) {
 						int draw_x = (x * TILE_SIZE) + base_draw_x;
 						int draw_y = (y * TILE_SIZE) + base_draw_y;
-						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y);
-						if (lighting_enabled) {
-							tile_renderer->AddLight(tile->location, view, options, *light_buffer);
-						}
+						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y, lighting_enabled ? light_buffer.get() : nullptr);
 						// Add names of creatures on this floor
 						if (creature_name_drawer && z == camera_pos.z) {
 							if (tile->creature) {
@@ -277,6 +275,9 @@ namespace IngamePreview {
 			}
 			TextRenderer::EndFrame(vg);
 		}
+
+		// Flush any pending sprite preloads
+		SpritePreloader::get().flushThreadLocal();
 	}
 
 	int IngamePreviewRenderer::GetTileElevationOffset(const Tile* tile) const {

--- a/source/rendering/core/sprite_preloader.h
+++ b/source/rendering/core/sprite_preloader.h
@@ -24,6 +24,10 @@ public:
 	// This corresponds to the loop logic previously in collectTileSprites.
 	void preload(GameSprite* spr, int pattern_x, int pattern_y, int pattern_z, int frame);
 
+	// Pushes any pending thread-local tasks to the main queue.
+	// Must be called at the end of the frame/draw pass.
+	void flushThreadLocal();
+
 	// Processes finished preload tasks and uploads data to the GPU.
 	// Should be called on the main thread.
 	void update();

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -108,11 +108,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 					continue;
 				}
 
-				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y);
-				// draw light, but only if not zoomed too far
-				if (draw_lights) {
-					tile_renderer->AddLight(location, view, options, light_buffer);
-				}
+				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y, draw_lights ? &light_buffer : nullptr);
 			}
 		}
 	};
@@ -140,4 +136,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 			drawNode(nd, nd_map_x, nd_map_y, false);
 		});
 	}
+
+	// Flush any pending sprite preloads collected during this layer's draw
+	SpritePreloader::get().flushThreadLocal();
 }

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -152,7 +152,7 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const ItemType& i
 	return true;
 }
 
-void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y) {
+void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y, LightBuffer* light_buffer) {
 	if (!location) {
 		return;
 	}
@@ -232,6 +232,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 		}
 	}
 
+	// Light for ground tile
+	if (light_buffer && tile->ground && tile->ground->hasLight()) {
+		light_buffer->AddLight(map_x, map_y, map_z, tile->ground->getLight());
+	}
+
 	// Ground tooltip (one per item)
 	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
@@ -278,6 +283,11 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 			// items on tile
 			for (const auto& item : tile->items) {
 				const ItemType& it = g_items[item->getID()];
+
+				// Light for item
+				if (light_buffer && item->hasLight()) {
+					light_buffer->AddLight(map_x, map_y, map_z, item->getLight());
+				}
 
 				// item tooltip (one per item)
 				if (process_tooltips) {
@@ -358,30 +368,3 @@ void TileRenderer::PreloadItem(const Tile* tile, Item* item, const ItemType& it,
 	}
 }
 
-void TileRenderer::AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {
-	if (!options.isDrawLight() || !location) {
-		return;
-	}
-
-	auto tile = location->get();
-	if (!tile || !tile->hasLight()) {
-		return;
-	}
-
-	const auto& position = location->getPosition();
-
-	if (tile->ground) {
-		if (tile->ground->hasLight()) {
-			light_buffer.AddLight(position.x, position.y, position.z, tile->ground->getLight());
-		}
-	}
-
-	bool hidden = options.hide_items_when_zoomed && view.zoom > 10.f;
-	if (!hidden && !tile->items.empty()) {
-		for (const auto& item : tile->items) {
-			if (item->hasLight()) {
-				light_buffer.AddLight(position.x, position.y, position.z, item->getLight());
-			}
-		}
-	}
-}

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -26,8 +26,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
-	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, LightBuffer* light_buffer = nullptr);
 
 private:
 	void PreloadItem(const Tile* tile, Item* item, const ItemType& it, const SpritePatterns* patterns = nullptr);


### PR DESCRIPTION
This PR introduces targeted performance optimizations for the rendering pipeline.

**Key Changes:**
1.  **Loop Fusion:** The separate `TileRenderer::AddLight` pass has been integrated directly into `TileRenderer::DrawTile`. This removes an entire iteration over tile items per visible tile, improving CPU efficiency and cache locality.
2.  **Sprite Preloading Optimization:** `SpritePreloader` now uses a `thread_local` buffer to batch sprite load requests. Instead of acquiring a mutex for every single sprite, it now batches them in chunks of 64 or flushes them at the end of the frame. This drastically reduces lock contention on the shared task queue.
3.  **Correctness:** Updated both `MapLayerDrawer` and `IngamePreviewRenderer` to support the new `DrawTile` signature and to explicitly flush pending sprite preloads at the end of their respective draw calls, ensuring no visual delays.

**Impact:**
- Reduced CPU overhead during rendering.
- Reduced thread contention in sprite loading.


---
*PR created automatically by Jules for task [10498027731237578833](https://jules.google.com/task/10498027731237578833) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Optimized sprite preloading through batched processing for improved efficiency.
  * Enhanced lighting rendering pipeline for better performance during tile drawing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->