### PR TITLE
📊 Profiler: Fuse item loops in TileRenderer to reduce CPU overhead

### DIFF
--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -171,10 +171,7 @@ namespace IngamePreview {
 					if (tile) {
 						int draw_x = (x * TILE_SIZE) + base_draw_x;
 						int draw_y = (y * TILE_SIZE) + base_draw_y;
-						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y);
-						if (lighting_enabled) {
-							tile_renderer->AddLight(tile->location, view, options, *light_buffer);
-						}
+						tile_renderer->DrawTile(*sprite_batch, tile->location, view, options, 0, draw_x, draw_y, lighting_enabled ? light_buffer.get() : nullptr);
 						// Add names of creatures on this floor
 						if (creature_name_drawer && z == camera_pos.z) {
 							if (tile->creature) {

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -108,11 +108,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 					continue;
 				}
 
-				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y);
-				// draw light, but only if not zoomed too far
-				if (draw_lights) {
-					tile_renderer->AddLight(location, view, options, light_buffer);
-				}
+				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y, draw_lights ? &light_buffer : nullptr);
 			}
 		}
 	};

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -26,8 +26,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
-	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, LightBuffer* light_buffer = nullptr);
 
 private:
 	void PreloadItem(const Tile* tile, Item* item, const ItemType& it, const SpritePatterns* patterns = nullptr);


### PR DESCRIPTION
This PR optimizes the rendering pipeline by fusing the item iteration loops for drawing and light collection. Previously, `TileRenderer` would iterate over `Tile::items` once to draw them and then `MapLayerDrawer` (or `IngamePreviewRenderer`) would call `TileRenderer::AddLight`, causing a second iteration over the same items to collect light sources. This patch refactors `DrawTile` to accept a `LightBuffer*` and collect lights during the primary drawing loop, eliminating the second pass and reducing CPU overhead, particularly in scenes with many items. The `AddLight` method has been removed as it is no longer needed.

---
*PR created automatically by Jules for task [10020821669321067290](https://jules.google.com/task/10020821669321067290) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated tile lighting system to streamline rendering operations and improve code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->