### PR TITLE
Refactor: Modernize wxWidgets usage (High-DPI, Bind, Theming)

### DIFF
--- a/source/ui/dcbutton.cpp
+++ b/source/ui/dcbutton.cpp
@@ -22,6 +22,8 @@
 #include "ui/dcbutton.h"
 #include "game/sprites.h"
 #include "ui/gui.h"
+#include "ui/theme.h"
+#include "util/nvg_utils.h"
 
 #include <glad/glad.h>
 #include <nanovg.h>
@@ -138,6 +140,9 @@ void DCButton::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 		size_y = 68;
 	}
 
+	size_x = FROM_DIP(this, size_x);
+	size_y = FROM_DIP(this, size_y);
+
 	// Background
 	nvgBeginPath(vg);
 	nvgRect(vg, 0, 0, size_x, size_y);
@@ -162,18 +167,21 @@ void DCButton::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 				imgSize = 64; // Not supported in original?
 			}
 
-			NVGpaint imgPaint = nvgImagePattern(vg, 2, 2, imgSize, imgSize, 0, tex, 1.0f);
+			imgSize = FROM_DIP(this, imgSize);
+			float padding = FROM_DIP(this, 2);
+
+			NVGpaint imgPaint = nvgImagePattern(vg, padding, padding, imgSize, imgSize, 0, tex, 1.0f);
 			nvgBeginPath(vg);
-			nvgRect(vg, 2, 2, imgSize, imgSize);
+			nvgRect(vg, padding, padding, imgSize, imgSize);
 			nvgFillPaint(vg, imgPaint);
 			nvgFill(vg);
 
 			if (overlay && type == DC_BTN_TOGGLE && GetValue()) {
 				int overlayTex = GetOrCreateSpriteTexture(vg, overlay);
 				if (overlayTex > 0) {
-					NVGpaint ovPaint = nvgImagePattern(vg, 2, 2, imgSize, imgSize, 0, overlayTex, 1.0f);
+					NVGpaint ovPaint = nvgImagePattern(vg, padding, padding, imgSize, imgSize, 0, overlayTex, 1.0f);
 					nvgBeginPath(vg);
-					nvgRect(vg, 2, 2, imgSize, imgSize);
+					nvgRect(vg, padding, padding, imgSize, imgSize);
 					nvgFillPaint(vg, ovPaint);
 					nvgFill(vg);
 				}
@@ -195,10 +203,10 @@ void DCButton::OnClick(wxMouseEvent& WXUNUSED(evt)) {
 }
 
 void DCButton::DrawSunkenBorder(NVGcontext* vg, float size_x, float size_y) {
-	NVGcolor dark_highlight = nvgRGBA(212, 208, 200, 255);
-	NVGcolor light_shadow = nvgRGBA(128, 128, 128, 255);
-	NVGcolor highlight = nvgRGBA(255, 255, 255, 255);
-	NVGcolor shadow = nvgRGBA(64, 64, 64, 255);
+	NVGcolor dark_highlight = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Border));
+	NVGcolor light_shadow = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Border));
+	NVGcolor highlight = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Border));
+	NVGcolor shadow = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Background));
 
 	nvgStrokeWidth(vg, 1.0f);
 
@@ -232,10 +240,10 @@ void DCButton::DrawSunkenBorder(NVGcontext* vg, float size_x, float size_y) {
 }
 
 void DCButton::DrawRaisedBorder(NVGcontext* vg, float size_x, float size_y) {
-	NVGcolor dark_highlight = nvgRGBA(212, 208, 200, 255);
-	NVGcolor light_shadow = nvgRGBA(128, 128, 128, 255);
-	NVGcolor highlight = nvgRGBA(255, 255, 255, 255);
-	NVGcolor shadow = nvgRGBA(64, 64, 64, 255);
+	NVGcolor dark_highlight = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Border));
+	NVGcolor light_shadow = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Border));
+	NVGcolor highlight = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Surface));
+	NVGcolor shadow = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Background));
 
 	nvgStrokeWidth(vg, 1.0f);
 

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -26,7 +26,7 @@
 #include "util/image_manager.h"
 
 FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onlyPickupables /* = false*/) :
-	wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600), wxDEFAULT_DIALOG_STYLE),
+	wxDialog(parent, wxID_ANY, title, wxDefaultPosition, FromDIP(wxSize(800, 600)), wxDEFAULT_DIALOG_STYLE),
 	input_timer(this),
 	result_brush(nullptr),
 	result_id(0),
@@ -185,7 +185,7 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
 	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
-	items_list->SetMinSize(wxSize(230, 512));
+	items_list->SetMinSize(FromDIP(wxSize(230, 512)));
 	result_box_sizer->Add(items_list, 0, wxALL, 5);
 	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
 

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -165,19 +165,19 @@ void ReplaceToolWindow::InitLayout() {
 	wxBoxSizer* manageBtnsSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	m_addRuleBtn = new wxButton(actionsCard, wxID_ANY, "ADD", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, FromDIP(wxSize(16, 16))));
 	m_addRuleBtn->SetBackgroundColour(wxColour(40, 180, 40)); // Green
 	m_addRuleBtn->SetForegroundColour(*wxWHITE);
 	m_addRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_editRuleBtn = new wxButton(actionsCard, wxID_ANY, "EDIT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
+	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, FromDIP(wxSize(16, 16))));
 	m_editRuleBtn->SetBackgroundColour(wxColour(80, 80, 80)); // Neutral Dark Gray
 	m_editRuleBtn->SetForegroundColour(*wxWHITE);
 	m_editRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_deleteRuleBtn = new wxButton(actionsCard, wxID_ANY, "DEL", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
+	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, FromDIP(wxSize(16, 16))));
 	m_deleteRuleBtn->SetBackgroundColour(wxColour(180, 40, 40)); // Red
 	m_deleteRuleBtn->SetForegroundColour(*wxWHITE);
 	m_deleteRuleBtn->SetFont(Theme::GetFont(9, true));
@@ -189,7 +189,7 @@ void ReplaceToolWindow::InitLayout() {
 	actionsSizer->Add(manageBtnsSizer, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	m_addVisibleBtn = new wxButton(actionsCard, wxID_ANY, "ADD VISIBLE FROM VIEWPORT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, wxSize(16, 16)));
+	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, FromDIP(wxSize(16, 16))));
 	m_addVisibleBtn->SetBackgroundColour(wxColour(45, 120, 180)); // Sky Blue
 	m_addVisibleBtn->SetForegroundColour(*wxWHITE);
 	m_addVisibleBtn->SetFont(Theme::GetFont(9, true));
@@ -220,7 +220,7 @@ void ReplaceToolWindow::InitLayout() {
 
 	// Execute Button
 	m_executeBtn = new wxButton(actionsCard, wxID_ANY, "EXECUTE REPLACE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, wxSize(16, 16)));
+	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, FromDIP(wxSize(16, 16))));
 	m_executeBtn->SetDefault();
 	m_executeBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Blue
 	m_executeBtn->SetForegroundColour(*wxWHITE);
@@ -229,7 +229,7 @@ void ReplaceToolWindow::InitLayout() {
 
 	// Close Button
 	wxButton* closeBtn = new wxButton(actionsCard, wxID_ANY, "CLOSE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, FromDIP(wxSize(16, 16))));
 	closeBtn->SetBackgroundColour(wxColour(120, 120, 120)); // Gray
 	closeBtn->SetForegroundColour(*wxWHITE);
 	closeBtn->SetFont(Theme::GetFont(10, true));

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -248,8 +248,8 @@ void ToolOptionsSurface::DrawToolIcon(wxDC& dc, const ToolRect& tr) {
 		if (s) {
 			// Center the sprite in the rect
 			// Assuming 32x32 icon size for now, which matches SPRITE_SIZE_32x32 (32x32)
-			int x_off = r.x + (r.width - 32) / 2;
-			int y_off = r.y + (r.height - 32) / 2;
+			int x_off = r.x + (r.width - FromDIP(32)) / 2;
+			int y_off = r.y + (r.height - FromDIP(32)) / 2;
 			s->DrawTo(&dc, SPRITE_SIZE_32x32, x_off, y_off);
 		} else {
 			// Fallback text/color if no sprite
@@ -326,8 +326,8 @@ void ToolOptionsSurface::DrawCheckbox(wxDC& dc, const wxRect& rect, const wxStri
 	// Checkmark (simple)
 	if (value) {
 		dc.SetPen(*wxWHITE_PEN);
-		dc.DrawLine(box.GetLeft() + 3, box.GetTop() + 7, box.GetLeft() + 6, box.GetTop() + 10);
-		dc.DrawLine(box.GetLeft() + 6, box.GetTop() + 10, box.GetRight() - 3, box.GetTop() + 4);
+		dc.DrawLine(box.GetLeft() + FromDIP(3), box.GetTop() + FromDIP(7), box.GetLeft() + FromDIP(6), box.GetTop() + FromDIP(10));
+		dc.DrawLine(box.GetLeft() + FromDIP(6), box.GetTop() + FromDIP(10), box.GetRight() - FromDIP(3), box.GetTop() + FromDIP(4));
 	}
 
 	// Label

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -29,7 +29,7 @@ public:
 		Bind(wxEVT_MOUSE_CAPTURE_LOST, &ConvexButton::OnMouseCaptureLost, this);
 	}
 
-	void SetBitmap(const wxBitmap& bitmap) {
+	void SetBitmap(const wxBitmapBundle& bitmap) {
 		m_icon = bitmap;
 		InvalidateBestSize();
 		Refresh();
@@ -41,14 +41,14 @@ public:
 		wxSize text = dc.GetTextExtent(GetLabel());
 		int width = text.x + FromDIP(30);
 		if (m_icon.IsOk()) {
-			width += m_icon.GetWidth() + FromDIP(8);
+			width += m_icon.GetBitmap(wxDefaultSize).GetWidth() + FromDIP(8);
 		}
-		int height = std::max(text.y, m_icon.IsOk() ? m_icon.GetHeight() : 0) + FromDIP(16);
+		int height = std::max(text.y, m_icon.IsOk() ? m_icon.GetBitmap(wxDefaultSize).GetHeight() : 0) + FromDIP(16);
 		return wxSize(std::max(width, FromDIP(100)), std::max(height, FromDIP(30)));
 	}
 
 private:
-	wxBitmap m_icon;
+	wxBitmapBundle m_icon;
 	bool m_hover = false;
 	bool m_pressed = false;
 
@@ -93,7 +93,7 @@ private:
 
 		int x = (sz.x - textSize.x) / 2;
 		if (m_icon.IsOk()) {
-			x -= (m_icon.GetWidth() + FromDIP(8)) / 2;
+			x -= (m_icon.GetBitmap(wxDefaultSize).GetWidth() + FromDIP(8)) / 2;
 		}
 
 		int y = (sz.y - textSize.y) / 2;
@@ -103,12 +103,12 @@ private:
 		} // Shift content when pressed
 
 		if (m_icon.IsOk()) {
-			int iy = (sz.y - m_icon.GetHeight()) / 2;
+			int iy = (sz.y - m_icon.GetBitmap(wxDefaultSize).GetHeight()) / 2;
 			if (m_pressed) {
 				iy += 1;
 			}
-			dc.DrawBitmap(m_icon, x, iy, true);
-			x += m_icon.GetWidth() + FromDIP(8);
+			dc.DrawBitmap(m_icon.GetBitmap(wxDefaultSize), x, iy, true);
+			x += m_icon.GetBitmap(wxDefaultSize).GetWidth() + FromDIP(8);
 		}
 
 		dc.DrawText(GetLabel(), x, y);
@@ -302,7 +302,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 
 	// Icon Button - Align Left: 10px total
 	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
+	iconBtn->SetBitmap(wxBitmapBundle::FromBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32)))); // Fallback if logo invalid
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -323,7 +323,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	headerSizer->Add(titleSizer, 1, wxALL | wxEXPAND, 10);
 
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
-	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
+	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_GEAR));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Right: 10px total
@@ -338,14 +338,14 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	wxBoxSizer* footerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
-	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
+	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_POWER_OFF));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
 
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
-	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
+	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_NEW));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
@@ -357,7 +357,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	footerSizer->AddStretchSpacer();
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
-	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
+	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN));
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -386,13 +386,13 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
 	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_NEW));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 


### PR DESCRIPTION
This change modernizes the codebase by refactoring legacy wxWidgets patterns. It removes deprecated event table macros in favor of dynamic `Bind`, updates custom controls and dialogs to be High-DPI aware using `FromDIP` and `wxBitmapBundle`, and enforces consistent theming by replacing hardcoded colors with theme lookups.

---
*PR created automatically by Jules for task [2789454897972383411](https://jules.google.com/task/2789454897972383411) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved high-DPI display support with proper UI element scaling for dialogs, buttons, and icons.
  * Enhanced visual consistency by applying theme-based colors to UI borders and components instead of fixed colors.

* **Style**
  * Refined button and icon rendering with DPI-aware padding and positioning adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->