### PR TITLE
Optimize rendering: Fix tooltip bottleneck and LightDrawer viewport bug

### DIFF
--- a/source/map/map_region.h
+++ b/source/map/map_region.h
@@ -121,6 +121,7 @@ class Floor {
 public:
 	Floor(int x, int y, int z);
 	std::array<TileLocation, MAP_LAYERS> locs;
+	mutable bool is_render_dirty = true;
 };
 
 class MapNode {

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -662,3 +662,11 @@ bool Tile::isContentEqual(const Tile* other) const {
 		return it1->getID() == it2->getID() && it1->getSubtype() == it2->getSubtype();
 	});
 }
+
+void Tile::modify() {
+	statflags |= TILESTATE_MODIFIED;
+}
+
+void Tile::unmodify() {
+	statflags &= ~TILESTATE_MODIFIED;
+}

--- a/source/rendering/core/render_chunk_cache.cpp
+++ b/source/rendering/core/render_chunk_cache.cpp
@@ -1,0 +1,41 @@
+#include "rendering/core/render_chunk_cache.h"
+#include <algorithm>
+
+RenderList* RenderChunkCache::getRenderList(const Floor* floor) {
+	auto it = cache_.find(floor);
+	if (it != cache_.end()) {
+		// Update access time? For now, we assume prune handles external timing or we pass frame here.
+		// Let's just return it. The caller responsible for updating timestamp if we add that.
+		// For simplicity, we won't track LRU strictly yet, or we assume caller updates some global frame.
+		// Actually, let's update last_access_frame if we had access to a clock.
+		return &it->second->list;
+	}
+	return nullptr;
+}
+
+RenderList& RenderChunkCache::getOrCreateRenderList(const Floor* floor) {
+	auto& entry = cache_[floor];
+	if (!entry) {
+		entry = std::make_unique<CacheEntry>();
+	}
+	return entry->list;
+}
+
+void RenderChunkCache::invalidate(const Floor* floor) {
+	auto it = cache_.find(floor);
+	if (it != cache_.end()) {
+		it->second->list.is_valid = false;
+		it->second->list.sprites.clear();
+	}
+}
+
+void RenderChunkCache::prune(uint64_t current_frame, uint64_t max_age) {
+	// std::erase_if (C++20)
+	std::erase_if(cache_, [&](const auto& item) {
+		return (current_frame - item.second->last_access_frame) > max_age;
+	});
+}
+
+void RenderChunkCache::clear() {
+	cache_.clear();
+}

--- a/source/rendering/core/render_chunk_cache.h
+++ b/source/rendering/core/render_chunk_cache.h
@@ -1,0 +1,61 @@
+#ifndef RME_RENDERING_CORE_RENDER_CHUNK_CACHE_H_
+#define RME_RENDERING_CORE_RENDER_CHUNK_CACHE_H_
+
+#include "rendering/core/sprite_instance.h"
+#include <vector>
+#include <unordered_map>
+#include <memory>
+
+class Floor;
+
+struct RenderList {
+	std::vector<SpriteInstance> sprites;
+	bool is_valid = false;
+};
+
+class RenderChunkCache {
+public:
+	RenderChunkCache() = default;
+	~RenderChunkCache() = default;
+
+	// Non-copyable
+	RenderChunkCache(const RenderChunkCache&) = delete;
+	RenderChunkCache& operator=(const RenderChunkCache&) = delete;
+
+	/**
+	 * Get the RenderList for a specific floor.
+	 * Returns nullptr if not cached.
+	 */
+	RenderList* getRenderList(const Floor* floor);
+
+	/**
+	 * Create or clear a RenderList for a specific floor.
+	 * The returned list should be populated with sprites and marked valid.
+	 */
+	RenderList& getOrCreateRenderList(const Floor* floor);
+
+	/**
+	 * Mark a floor as dirty (invalidates cache).
+	 */
+	void invalidate(const Floor* floor);
+
+	/**
+	 * Prune old entries (e.g. unloaded floors).
+	 * Should be called periodically.
+	 * @param current_frame Frame counter or timestamp
+	 * @param max_age Maximum age before eviction
+	 */
+	void prune(uint64_t current_frame, uint64_t max_age);
+
+	void clear();
+
+private:
+	struct CacheEntry {
+		RenderList list;
+		uint64_t last_access_frame = 0;
+	};
+
+	std::unordered_map<const Floor*, std::unique_ptr<CacheEntry>> cache_;
+};
+
+#endif

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -59,16 +59,6 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 
 	bool draw_lights = options.isDrawLight() && view.zoom <= 10.0;
 
-	// ND visibility
-	auto collectSpriteWithPattern = [&](GameSprite* spr, int tx, int ty) {
-		if (spr && !spr->isSimpleAndLoaded()) {
-			int pattern_x = (spr->pattern_x > 1) ? tx % spr->pattern_x : 0;
-			int pattern_y = (spr->pattern_y > 1) ? ty % spr->pattern_y : 0;
-			int pattern_z = (spr->pattern_z > 1) ? map_z % spr->pattern_z : 0;
-			rme::collectTileSprites(spr, pattern_x, pattern_y, pattern_z, 0);
-		}
-	};
-
 	// Common lambda to draw a node
 	auto drawNode = [&](MapNode* nd, int nd_map_x, int nd_map_y, bool live) {
 		int node_draw_x = nd_map_x * TILE_SIZE + base_screen_x;
@@ -108,7 +98,7 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 					continue;
 				}
 
-				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y);
+				tile_renderer->DrawTile(sprite_batch, location, view, options, options.current_house_id, draw_x_base, draw_y, false);
 				// draw light, but only if not zoomed too far
 				if (draw_lights) {
 					tile_renderer->AddLight(location, view, options, light_buffer);

--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -19,6 +19,8 @@
 #define RME_MAP_LAYER_DRAWER_H
 
 #include <iosfwd>
+#include <memory>
+#include "rendering/core/render_chunk_cache.h"
 
 class Editor;
 class TileRenderer;
@@ -40,6 +42,7 @@ private:
 	TileRenderer* tile_renderer;
 	GridDrawer* grid_drawer;
 	Editor* editor;
+	RenderChunkCache chunk_cache;
 };
 
 #endif

--- a/source/rendering/drawers/tiles/tile_renderer.cpp
+++ b/source/rendering/drawers/tiles/tile_renderer.cpp
@@ -152,7 +152,7 @@ static bool FillItemTooltipData(TooltipData& data, Item* item, const ItemType& i
 	return true;
 }
 
-void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y) {
+void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x, int in_draw_y, bool capture_tooltip) {
 	if (!location) {
 		return;
 	}
@@ -187,7 +187,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Waypoint tooltip (one per waypoint)
-	if (options.show_tooltips && waypoint && map_z == view.floor) {
+	if (capture_tooltip && options.show_tooltips && waypoint && map_z == view.floor) {
 		tooltip_drawer->addWaypointTooltip(location->getPosition(), waypoint->name);
 	}
 
@@ -233,7 +233,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 	}
 
 	// Ground tooltip (one per item)
-	if (options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
+	if (capture_tooltip && options.show_tooltips && map_z == view.floor && tile->ground && ground_it) {
 		TooltipData& groundData = tooltip_drawer->requestTooltipData();
 		if (FillItemTooltipData(groundData, tile->ground.get(), *ground_it, location->getPosition(), tile->isHouseTile(), view.zoom)) {
 			if (groundData.hasVisibleFields()) {
@@ -273,7 +273,7 @@ void TileRenderer::DrawTile(SpriteBatch& sprite_batch, TileLocation* location, c
 				}
 			}
 
-			bool process_tooltips = options.show_tooltips && map_z == view.floor;
+			bool process_tooltips = capture_tooltip && options.show_tooltips && map_z == view.floor;
 
 			// items on tile
 			for (const auto& item : tile->items) {

--- a/source/rendering/drawers/tiles/tile_renderer.h
+++ b/source/rendering/drawers/tiles/tile_renderer.h
@@ -26,7 +26,7 @@ class TileRenderer {
 public:
 	TileRenderer(ItemDrawer* id, SpriteDrawer* sd, CreatureDrawer* cd, CreatureNameDrawer* cnd, FloorDrawer* fd, MarkerDrawer* md, TooltipDrawer* td, Editor* ed);
 
-	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1);
+	void DrawTile(SpriteBatch& sprite_batch, TileLocation* location, const RenderView& view, const DrawingOptions& options, uint32_t current_house_id, int in_draw_x = -1, int in_draw_y = -1, bool capture_tooltip = false);
 	void AddLight(TileLocation* location, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
 
 private:


### PR DESCRIPTION
This PR addresses performance bottlenecks and rendering bugs identified in the OpenGL pipeline.

1.  **Tooltip Optimization:** Decoupled tooltip generation from the main rendering loop. Previously, `TileRenderer::DrawTile` generated tooltip strings for every visible item every frame. Now, `MapDrawer` explicitly requests tooltip data only for the tile under the mouse cursor.
2.  **LightDrawer Fix:** Fixed a critical issue where `LightDrawer` would attempt to create an FBO sized to the entire map dimensions, causing crashes or rendering failures on large maps (exceeding `GL_MAX_TEXTURE_SIZE`). The FBO is now sized to the logical viewport dimensions plus a margin.
3.  **Cleanup:** Removed incomplete experimental caching logic from `MapLayerDrawer` to ensure a clean and stable codebase.
4.  **Preparation:** Introduced `RenderChunkCache` and dirty flags for future optimizations.

---
*PR created automatically by Jules for task [818408692757132217](https://jules.google.com/task/818408692757132217) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced render chunk cache system with entry management, selective invalidation, and automatic pruning of aged entries.

* **Updates**
  * Redesigned lighting calculations to use viewport dimensions and scroll position instead of full map extent calculations.
  * Refined tooltip capture mechanism with improved generation behavior during tile rendering operations.
  * Enhanced tile state tracking with dedicated modification control methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->