### PR TITLE
🧩 Fixer: Refactor Tile behavior into TileOperations

### DIFF
--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -5,7 +5,11 @@
 #include "app/main.h"
 #include "map/tile_operations.h"
 #include "map/tile.h"
+#include "map/map.h"
+#include "map/map_region.h"
 #include "game/item.h"
+#include "game/creature.h"
+#include "game/spawn.h"
 #include "brushes/ground/ground_brush.h"
 #include "brushes/wall/wall_brush.h"
 #include "brushes/table/table_brush.h"
@@ -62,6 +66,254 @@ namespace TileOperations {
 
 	void carpetize(Tile* tile, BaseMap* map) {
 		CarpetBrush::doCarpets(map, tile);
+	}
+
+	std::unique_ptr<Tile> deepCopy(const Tile* tile, BaseMap& map) {
+		// Use the destination map's TileLocation at the same position
+		TileLocation* dest_location = map.getTileL(tile->getX(), tile->getY(), tile->getZ());
+		if (!dest_location) {
+			dest_location = map.createTileL(tile->getX(), tile->getY(), tile->getZ());
+		}
+		std::unique_ptr<Tile> copy(map.allocator.allocateTile(dest_location));
+		copy->setMapFlags(tile->getMapFlags());
+		copy->setStatFlags(tile->getStatFlags());
+		copy->setHouseID(tile->getHouseID());
+
+		if (tile->spawn) {
+			copy->spawn = tile->spawn->deepCopy();
+		}
+		if (tile->creature) {
+			copy->creature = tile->creature->deepCopy();
+		}
+		// Spawncount & exits are not transferred on copy!
+		if (tile->ground) {
+			copy->ground = tile->ground->deepCopy();
+		}
+
+		copy->items.reserve(tile->items.size());
+		for (const auto& item : tile->items) {
+			copy->items.push_back(std::unique_ptr<Item>(item->deepCopy()));
+		}
+
+		return copy;
+	}
+
+	void merge(Tile* dest, const Tile* src) {
+		if (src->isPZ()) {
+			dest->setPZ(true);
+		}
+		if (src->getHouseID()) {
+			dest->setHouseID(src->getHouseID());
+		}
+
+		if (src->ground) {
+			dest->ground = src->ground->deepCopy();
+		}
+
+		if (src->creature) {
+			dest->creature = src->creature->deepCopy();
+		}
+
+		if (src->spawn) {
+			dest->spawn = src->spawn->deepCopy();
+		}
+
+		dest->items.reserve(dest->items.size() + src->items.size());
+		for (const auto& item : src->items) {
+			dest->addItem(item->deepCopy());
+		}
+		dest->update();
+	}
+
+	bool isContentEqual(const Tile* a, const Tile* b) {
+		if (!a || !b) {
+			return false;
+		}
+		return a->isContentEqual(b);
+	}
+
+	GroundBrush* getGroundBrush(const Tile* tile) {
+		if (tile->ground) {
+			if (tile->ground->getGroundBrush()) {
+				return tile->ground->getGroundBrush();
+			}
+		}
+		return nullptr;
+	}
+
+	Item* getWall(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isWall();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	bool hasWall(const Tile* tile) {
+		return getWall(tile) != nullptr;
+	}
+
+	void addWallItem(Tile* tile, std::unique_ptr<Item> item) {
+		if (!item) {
+			return;
+		}
+		ASSERT(item->isWall());
+
+		tile->addItem(std::move(item));
+	}
+
+	Item* getCarpet(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isCarpet();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	bool hasCarpet(const Tile* tile) {
+		return getCarpet(tile) != nullptr;
+	}
+
+	Item* getTable(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isTable();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	bool hasTable(const Tile* tile) {
+		return getTable(tile) != nullptr;
+	}
+
+	void addBorderItem(Tile* tile, std::unique_ptr<Item> item) {
+		if (!item) {
+			return;
+		}
+		ASSERT(item->isBorder());
+		tile->items.insert(tile->items.begin(), std::move(item));
+		tile->update();
+	}
+
+	void select(Tile* tile) {
+		if (tile->empty()) {
+			return;
+		}
+		if (tile->ground) {
+			tile->ground->select();
+		}
+		if (tile->spawn) {
+			tile->spawn->select();
+		}
+		if (tile->creature) {
+			tile->creature->select();
+		}
+
+		std::ranges::for_each(tile->items, [](const auto& i) {
+			i->select();
+		});
+
+		tile->setStatFlags(tile->getStatFlags() | TILESTATE_SELECTED);
+	}
+
+	void deselect(Tile* tile) {
+		if (tile->ground) {
+			tile->ground->deselect();
+		}
+		if (tile->spawn) {
+			tile->spawn->deselect();
+		}
+		if (tile->creature) {
+			tile->creature->deselect();
+		}
+
+		std::ranges::for_each(tile->items, [](const auto& i) {
+			i->deselect();
+		});
+
+		tile->unsetStatFlags(TILESTATE_SELECTED);
+	}
+
+	void selectGround(Tile* tile) {
+		bool selected_ = false;
+		if (tile->ground) {
+			tile->ground->select();
+			selected_ = true;
+		}
+
+		for (const auto& i : tile->items | std::views::take_while([](const auto& item) { return item->isBorder(); })) {
+			i->select();
+			selected_ = true;
+		}
+
+		if (selected_) {
+			tile->setStatFlags(tile->getStatFlags() | TILESTATE_SELECTED);
+		}
+	}
+
+	void deselectGround(Tile* tile) {
+		if (tile->ground) {
+			tile->ground->deselect();
+		}
+
+		for (const auto& i : tile->items | std::views::take_while([](const auto& item) { return item->isBorder(); })) {
+			i->deselect();
+		}
+	}
+
+	Item* getTopSelectedItem(Tile* tile) {
+		auto view = std::ranges::reverse_view(tile->items);
+		auto it = std::ranges::find_if(view, [](const std::unique_ptr<Item>& i) {
+			return i->isSelected() && !i->isMetaItem();
+		});
+
+		if (it != view.end()) {
+			return it->get();
+		}
+
+		if (tile->ground && tile->ground->isSelected() && !tile->ground->isMetaItem()) {
+			return tile->ground.get();
+		}
+		return nullptr;
+	}
+
+	std::vector<std::unique_ptr<Item>> popSelectedItems(Tile* tile, bool ignoreTileSelected) {
+		std::vector<std::unique_ptr<Item>> pop_items;
+
+		if (!ignoreTileSelected && !tile->isSelected()) {
+			return pop_items;
+		}
+
+		if (tile->ground && tile->ground->isSelected()) {
+			pop_items.push_back(std::move(tile->ground));
+		}
+
+		auto split_point = std::stable_partition(tile->items.begin(), tile->items.end(), [](const std::unique_ptr<Item>& i) { return !i->isSelected(); });
+		std::move(split_point, tile->items.end(), std::back_inserter(pop_items));
+		tile->items.erase(split_point, tile->items.end());
+
+		tile->unsetStatFlags(TILESTATE_SELECTED);
+		return pop_items;
+	}
+
+	ItemVector getSelectedItems(Tile* tile, bool unzoomed) {
+		ItemVector selected_items;
+
+		if (!tile->isSelected()) {
+			return selected_items;
+		}
+
+		if (tile->ground && tile->ground->isSelected()) {
+			selected_items.push_back(tile->ground.get());
+		}
+
+		// save performance when zoomed out
+		if (!unzoomed) {
+			std::ranges::for_each(tile->items, [&](const auto& item) {
+				if (item->isSelected()) {
+					selected_items.push_back(item.get());
+				}
+			});
+		}
+
+		return selected_items;
 	}
 
 } // namespace TileOperations

--- a/source/map/tile_operations.h
+++ b/source/map/tile_operations.h
@@ -5,9 +5,14 @@
 #ifndef RME_TILE_OPERATIONS_H
 #define RME_TILE_OPERATIONS_H
 
+#include "game/item.h"
+#include <memory>
+#include <vector>
+
 class Tile;
 class BaseMap;
 class WallBrush;
+class GroundBrush;
 
 namespace TileOperations {
 	void borderize(Tile* tile, BaseMap* map);
@@ -21,6 +26,31 @@ namespace TileOperations {
 	void cleanTables(Tile* tile, bool dontdelete = false);
 
 	void carpetize(Tile* tile, BaseMap* map);
+
+	std::unique_ptr<Tile> deepCopy(const Tile* tile, BaseMap& map);
+	void merge(Tile* dest, const Tile* src);
+	bool isContentEqual(const Tile* a, const Tile* b);
+
+	GroundBrush* getGroundBrush(const Tile* tile);
+	Item* getWall(const Tile* tile);
+	bool hasWall(const Tile* tile);
+	void addWallItem(Tile* tile, std::unique_ptr<Item> item);
+
+	Item* getCarpet(const Tile* tile);
+	bool hasCarpet(const Tile* tile);
+	Item* getTable(const Tile* tile);
+	bool hasTable(const Tile* tile);
+
+	void addBorderItem(Tile* tile, std::unique_ptr<Item> item);
+
+	void select(Tile* tile);
+	void deselect(Tile* tile);
+	void selectGround(Tile* tile);
+	void deselectGround(Tile* tile);
+
+	Item* getTopSelectedItem(Tile* tile);
+	std::vector<std::unique_ptr<Item>> popSelectedItems(Tile* tile, bool ignoreTileSelected = false);
+	ItemVector getSelectedItems(Tile* tile, bool unzoomed = false);
 }
 
 #endif


### PR DESCRIPTION
Refactored `Tile` class methods to `TileOperations` namespace for better adherence to DOD and SRP, in line with Fixer agent instructions.

- Moved behavior out of the `Tile` struct to static functions in `TileOperations`.
- Kept `Tile` class closer to a pure data structure.
- Updated 25+ files to call `TileOperations::` methods.

---
*PR created automatically by Jules for task [18303001751417177039](https://jules.google.com/task/18303001751417177039) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced tile management with improved copying and merging capabilities
  * Advanced tile selection and item handling on borders and ground areas
  * Better access to tile properties and content management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->