### PR TITLE
🖥️ OpenGL: Centralize quad rendering via SharedGeometry in LightDrawer & MapDrawer

### DIFF
--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -97,8 +97,6 @@ class MapDrawer {
 	bool m_lastAaMode = false;
 
 	std::unique_ptr<GLVertexArray> pp_vao;
-	std::unique_ptr<GLBuffer> pp_vbo;
-	std::unique_ptr<GLBuffer> pp_ebo;
 
 	void InitPostProcess();
 	void DrawPostProcess(const RenderView& view, const DrawingOptions& options);

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -54,7 +54,6 @@ private:
 
 	std::unique_ptr<ShaderProgram> shader;
 	std::unique_ptr<GLVertexArray> vao;
-	std::unique_ptr<GLBuffer> vbo;
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 


### PR DESCRIPTION
This change implements the directives of the `Opengl.md` agent, specifically addressing resource leaks/DRY principles by preventing redundant `glGenBuffers` calls for identical unit quads. `MapDrawer` and `LightDrawer` were updated to leverage `SharedGeometry::Instance()`. Draw calls were updated to reflect the presence of an Element Buffer Object (`glDrawElementsInstanced`). Shader logic was patched to ensure `[0, 1]` positions map to `[-1, 1]` screen space coords.

---
*PR created automatically by Jules for task [5707580853575871874](https://jules.google.com/task/5707580853575871874) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated rendering architecture with improved resource management across light and post-processing systems.
  * Light rendering system now implements a two-pass rendering approach with enhanced geometry handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->