### PR TITLE
Refactor memory ownership in editor tools and drawers

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -38,15 +38,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	auto c = std::unique_ptr<Change>(newd Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	auto c = std::unique_ptr<Change>(newd Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -127,6 +127,7 @@ private:
 	// We use std::vector here instead of std::set for performance reasons.
 	// Selections are typically small, and std::vector provides better cache locality
 	// and fewer allocations. We maintain sorted order to allow O(log n) lookups.
+	// Non-owning containers (Observer semantics) - Tiles are owned by Map (TileLocation)
 	std::vector<Tile*> tiles;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;

--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -29,7 +29,7 @@ namespace IngamePreview {
 		sprite_batch = std::make_unique<SpriteBatch>();
 		primitive_renderer = std::make_unique<PrimitiveRenderer>();
 		light_buffer = std::make_unique<LightBuffer>();
-		light_drawer = std::make_shared<LightDrawer>();
+		light_drawer = std::make_unique<LightDrawer>();
 		creature_drawer = std::make_unique<CreatureDrawer>();
 		creature_name_drawer = std::make_unique<CreatureNameDrawer>();
 		sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/ingame_preview/ingame_preview_renderer.h
+++ b/source/ingame_preview/ingame_preview_renderer.h
@@ -64,7 +64,7 @@ namespace IngamePreview {
 		std::unique_ptr<SpriteBatch> sprite_batch;
 		std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 		std::unique_ptr<LightBuffer> light_buffer;
-		std::shared_ptr<LightDrawer> light_drawer;
+		std::unique_ptr<LightDrawer> light_drawer;
 
 		// Drawers
 		std::unique_ptr<CreatureDrawer> creature_drawer;

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -57,6 +57,7 @@ enum : uint8_t {
 
 class Tile {
 public: // Members
+	// Raw back-pointer to the owner. Non-owning.
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
 	std::vector<std::unique_ptr<Item>> items;
@@ -257,6 +258,7 @@ bool tilePositionLessThan(const Tile* a, const Tile* b);
 // This sorts them by draw order
 bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 
+// Non-owning containers used to observe or reference tiles owned by Map (TileLocation)
 using TileVector = std::vector<Tile*>;
 using TileSet = std::vector<Tile*>;
 using TileList = std::list<Tile*>;

--- a/source/rendering/core/game_sprite.cpp
+++ b/source/rendering/core/game_sprite.cpp
@@ -376,7 +376,7 @@ GameSprite::Image::Image() :
 }
 
 void GameSprite::Image::visit() const {
-	lastaccess = static_cast<int64_t>(g_gui.gfx.getCachedTime());
+	lastaccess.store(static_cast<int64_t>(g_gui.gfx.getCachedTime()), std::memory_order_relaxed);
 }
 
 void GameSprite::Image::clean(time_t time, int longevity) {
@@ -469,7 +469,7 @@ void GameSprite::NormalImage::clean(time_t time, int longevity) {
 	if (longevity == -1) {
 		longevity = g_settings.getInteger(Config::TEXTURE_LONGEVITY);
 	}
-	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load()) > longevity) {
+	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > longevity) {
 		if (g_gui.gfx.hasAtlasManager()) {
 			g_gui.gfx.getAtlasManager()->removeSprite(id);
 		}
@@ -488,7 +488,7 @@ void GameSprite::NormalImage::clean(time_t time, int longevity) {
 		g_gui.gfx.collector.NotifyTextureUnloaded();
 	}
 
-	if (time - static_cast<time_t>(lastaccess.load()) > 5 && !g_settings.getInteger(Config::USE_MEMCACHED_SPRITES)) { // We keep dumps around for 5 seconds.
+	if (time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > 5 && !g_settings.getInteger(Config::USE_MEMCACHED_SPRITES)) { // We keep dumps around for 5 seconds.
 		dump.reset();
 	}
 }
@@ -763,7 +763,7 @@ void GameSprite::TemplateImage::clean(time_t time, int longevity) {
 	if (longevity == -1) {
 		longevity = g_settings.getInteger(Config::TEXTURE_LONGEVITY);
 	}
-	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load()) > longevity) {
+	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > longevity) {
 		if (g_gui.gfx.hasAtlasManager()) {
 			g_gui.gfx.getAtlasManager()->removeSprite(texture_id);
 		}

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -46,8 +46,8 @@ public:
 	virtual wxSize GetSize() const = 0;
 
 private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
+	Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
 };
 
 class GameSprite;
@@ -120,6 +120,7 @@ protected:
 		virtual ~Image() = default;
 
 		bool isGLLoaded = false;
+		// std::atomic with relaxed memory ordering since it's only used for caching eviction heuristic
 		mutable std::atomic<int64_t> lastaccess;
 		uint32_t generation_id = 0;
 

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -88,7 +88,7 @@ void main() {
 MapDrawer::MapDrawer(MapCanvas* canvas) :
 	canvas(canvas), editor(canvas->editor) {
 
-	light_drawer = std::make_shared<LightDrawer>();
+	light_drawer = std::make_unique<LightDrawer>();
 	tooltip_drawer = std::make_unique<TooltipDrawer>();
 
 	sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -65,7 +65,7 @@ class MapDrawer {
 	Editor& editor;
 	DrawingOptions options;
 	RenderView view;
-	std::shared_ptr<LightDrawer> light_drawer;
+	std::unique_ptr<LightDrawer> light_drawer;
 	LightBuffer light_buffer;
 	std::unique_ptr<TooltipDrawer> tooltip_drawer;
 	std::unique_ptr<GridDrawer> grid_drawer;


### PR DESCRIPTION
1. Refactored `Change::Create` to return `std::unique_ptr<Change>` and updated callers.
2. Migrated `std::shared_ptr<LightDrawer>` to `std::unique_ptr<LightDrawer>` in `MapDrawer` and `IngamePreviewRenderer`.
3. Used `std::memory_order_relaxed` for `GameSprite::Image::lastaccess` for safe atomic access.
4. Added `= delete` to `Sprite` base class copy constructor/assignment to prevent slicing/copying.
5. Added comments clarifying `TileVector`, `TileSet`, `TileList`, and `Selection::tiles` as non-owning observer containers.
6. Added comment clarifying `Tile::location` as non-owning raw back-pointer.

---
*PR created automatically by Jules for task [111957221601017107](https://jules.google.com/task/111957221601017107) started by @karolak6612*