### PR TITLE
🏗️ Architect: Flatten MapDrawer pointer tangles

### DIFF
--- a/source/rendering/drawers/overlays/brush_overlay_drawer.cpp
+++ b/source/rendering/drawers/overlays/brush_overlay_drawer.cpp
@@ -371,7 +371,7 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 								if (brush->is<WaypointBrush>()) {
 									uint8_t r, g, b;
 									get_color(brush, editor, Position(view.mouse_map_x + x, view.mouse_map_y + y, view.floor), r, g, b);
-									drawer->brush_cursor_drawer->draw(sprite_batch, primitive_renderer, cx, cy, brush, r, g, b);
+										drawer->brush_cursor_drawer.draw(sprite_batch, primitive_renderer, cx, cy, brush, r, g, b);
 								} else {
 									glm::vec4 c = brushColor;
 									if (brush->is<HouseExitBrush>() || brush->is<OptionalBorderBrush>()) {
@@ -392,7 +392,7 @@ void BrushOverlayDrawer::draw(SpriteBatch& sprite_batch, PrimitiveRenderer& prim
 								if (brush->is<WaypointBrush>()) {
 									uint8_t r, g, b;
 									get_color(brush, editor, Position(view.mouse_map_x + x, view.mouse_map_y + y, view.floor), r, g, b);
-									drawer->brush_cursor_drawer->draw(sprite_batch, primitive_renderer, cx, cy, brush, r, g, b);
+										drawer->brush_cursor_drawer.draw(sprite_batch, primitive_renderer, cx, cy, brush, r, g, b);
 								} else {
 									glm::vec4 c = brushColor;
 									if (brush->is<HouseExitBrush>() || brush->is<OptionalBorderBrush>()) {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -38,27 +38,28 @@ class DoorIndicatorDrawer;
 #include "rendering/core/gl_resources.h"
 #include "rendering/core/shader_program.h"
 
-class GridDrawer;
+#include "rendering/ui/tooltip_drawer.h"
+#include "rendering/drawers/overlays/grid_drawer.h"
+#include "rendering/drawers/cursors/live_cursor_drawer.h"
+#include "rendering/drawers/overlays/selection_drawer.h"
+#include "rendering/drawers/cursors/brush_cursor_drawer.h"
+#include "rendering/drawers/overlays/brush_overlay_drawer.h"
+#include "rendering/drawers/cursors/drag_shadow_drawer.h"
+#include "rendering/drawers/tiles/floor_drawer.h"
+#include "rendering/drawers/entities/sprite_drawer.h"
+#include "rendering/drawers/map_layer_drawer.h"
+#include "rendering/drawers/entities/creature_drawer.h"
+#include "rendering/drawers/entities/item_drawer.h"
+#include "rendering/drawers/overlays/marker_drawer.h"
+#include "rendering/drawers/overlays/preview_drawer.h"
+#include "rendering/drawers/tiles/shade_drawer.h"
+#include "rendering/drawers/tiles/tile_renderer.h"
+#include "rendering/drawers/entities/creature_name_drawer.h"
+#include "rendering/drawers/overlays/hook_indicator_drawer.h"
+#include "rendering/drawers/overlays/door_indicator_drawer.h"
 
 class MapCanvas;
 class LightDrawer;
-class LiveCursorDrawer;
-class SelectionDrawer;
-class BrushCursorDrawer;
-class BrushOverlayDrawer;
-class DragShadowDrawer;
-class FloorDrawer;
-class SpriteDrawer;
-class ItemDrawer;
-class MapLayerDrawer;
-class CreatureDrawer;
-class MarkerDrawer;
-class PreviewDrawer;
-class ShadeDrawer;
-class TileRenderer;
-class CreatureNameDrawer;
-class HookIndicatorDrawer;
-class DoorIndicatorDrawer;
 
 class MapDrawer {
 	MapCanvas* canvas;
@@ -67,27 +68,27 @@ class MapDrawer {
 	RenderView view;
 	std::shared_ptr<LightDrawer> light_drawer;
 	LightBuffer light_buffer;
-	std::unique_ptr<TooltipDrawer> tooltip_drawer;
-	std::unique_ptr<GridDrawer> grid_drawer;
-	std::unique_ptr<LiveCursorDrawer> live_cursor_drawer;
-	std::unique_ptr<SelectionDrawer> selection_drawer;
-	std::unique_ptr<BrushCursorDrawer> brush_cursor_drawer;
-	std::unique_ptr<BrushOverlayDrawer> brush_overlay_drawer;
-	std::unique_ptr<DragShadowDrawer> drag_shadow_drawer;
-	std::unique_ptr<FloorDrawer> floor_drawer;
-	std::unique_ptr<SpriteDrawer> sprite_drawer;
-	std::unique_ptr<MapLayerDrawer> map_layer_drawer;
-	std::unique_ptr<CreatureDrawer> creature_drawer;
-	std::unique_ptr<ItemDrawer> item_drawer;
-	std::unique_ptr<MarkerDrawer> marker_drawer;
-	std::unique_ptr<PreviewDrawer> preview_drawer;
-	std::unique_ptr<ShadeDrawer> shade_drawer;
-	std::unique_ptr<TileRenderer> tile_renderer;
-	std::unique_ptr<CreatureNameDrawer> creature_name_drawer;
-	std::unique_ptr<HookIndicatorDrawer> hook_indicator_drawer;
-	std::unique_ptr<DoorIndicatorDrawer> door_indicator_drawer;
-	std::unique_ptr<SpriteBatch> sprite_batch;
-	std::unique_ptr<PrimitiveRenderer> primitive_renderer;
+	TooltipDrawer tooltip_drawer;
+	GridDrawer grid_drawer;
+	LiveCursorDrawer live_cursor_drawer;
+	SelectionDrawer selection_drawer;
+	BrushCursorDrawer brush_cursor_drawer;
+	BrushOverlayDrawer brush_overlay_drawer;
+	DragShadowDrawer drag_shadow_drawer;
+	FloorDrawer floor_drawer;
+	SpriteDrawer sprite_drawer;
+	CreatureDrawer creature_drawer;
+	ItemDrawer item_drawer;
+	MarkerDrawer marker_drawer;
+	PreviewDrawer preview_drawer;
+	ShadeDrawer shade_drawer;
+	CreatureNameDrawer creature_name_drawer;
+	HookIndicatorDrawer hook_indicator_drawer;
+	DoorIndicatorDrawer door_indicator_drawer;
+	SpriteBatch sprite_batch;
+	PrimitiveRenderer primitive_renderer;
+	TileRenderer tile_renderer;
+	MapLayerDrawer map_layer_drawer;
 
 	// Post-processing
 	std::unique_ptr<GLFramebuffer> scale_fbo;
@@ -139,16 +140,16 @@ public:
 	}
 
 	SpriteBatch* getSpriteBatch() {
-		return sprite_batch.get();
+		return &sprite_batch;
 	}
 	PrimitiveRenderer* getPrimitiveRenderer() {
-		return primitive_renderer.get();
+		return &primitive_renderer;
 	}
 	TileRenderer* getTileRenderer() {
-		return tile_renderer.get();
+		return &tile_renderer;
 	}
 	DoorIndicatorDrawer* getDoorIndicatorDrawer() {
-		return door_indicator_drawer.get();
+		return &door_indicator_drawer;
 	}
 
 private:


### PR DESCRIPTION
In alignment with the "Architect" Data-Oriented Design guidelines, this PR refactors `MapDrawer` to store its 19+ sub-drawer components as direct value instances rather than `std::unique_ptr`s. This removes unnecessary heap allocations and ensures memory is laid out contiguously within `MapDrawer`, minimizing pointer chasing and cache misses on every frame rendering pass.

Tested with Conan Ninja build successfully on Linux.

---
*PR created automatically by Jules for task [8166636205567136447](https://jules.google.com/task/8166636205567136447) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal rendering code restructured for improved maintainability and memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->