### PR TITLE
🔒 Sentinel: Refactor GL buffers to use immutable storage (DSA)

### DIFF
--- a/source/rendering/core/multi_draw_indirect_renderer.cpp
+++ b/source/rendering/core/multi_draw_indirect_renderer.cpp
@@ -49,7 +49,7 @@ bool MultiDrawIndirectRenderer::initialize() {
 	command_buffer_ = std::make_unique<GLBuffer>();
 
 	// Pre-allocate buffer storage
-	glNamedBufferData(command_buffer_->GetID(), MAX_COMMANDS * sizeof(DrawElementsIndirectCommand), nullptr, GL_DYNAMIC_DRAW);
+	glNamedBufferStorage(command_buffer_->GetID(), MAX_COMMANDS * sizeof(DrawElementsIndirectCommand), nullptr, GL_DYNAMIC_STORAGE_BIT);
 
 	initialized_ = true;
 	return true;

--- a/source/rendering/core/pixel_buffer_object.cpp
+++ b/source/rendering/core/pixel_buffer_object.cpp
@@ -48,7 +48,7 @@ bool PixelBufferObject::initialize(size_t size) {
 	for (int i = 0; i < BUFFER_COUNT; ++i) {
 		buffers_[i] = std::make_unique<GLBuffer>();
 		// Allocate generic storage - we map it later
-		glNamedBufferData(buffers_[i]->GetID(), size, nullptr, GL_STREAM_DRAW);
+		glNamedBufferStorage(buffers_[i]->GetID(), size, nullptr, GL_MAP_WRITE_BIT | GL_CLIENT_STORAGE_BIT);
 	}
 
 	current_index_ = 0;

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -153,7 +153,9 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 			if (light_ssbo_capacity_ < 1024) {
 				light_ssbo_capacity_ = 1024;
 			}
-			glNamedBufferData(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_DYNAMIC_DRAW);
+			// Destroy and recreate buffer for Immutable Storage
+			light_ssbo = std::make_unique<GLBuffer>();
+			glNamedBufferStorage(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_DYNAMIC_STORAGE_BIT);
 		}
 		glNamedBufferSubData(light_ssbo->GetID(), 0, needed_size, gpu_lights_.data());
 	}
@@ -385,7 +387,7 @@ void LightDrawer::initRenderResources() {
 	vbo = std::make_unique<GLBuffer>();
 	light_ssbo = std::make_unique<GLBuffer>();
 
-	glNamedBufferData(vbo->GetID(), sizeof(vertices), vertices, GL_STATIC_DRAW);
+	glNamedBufferStorage(vbo->GetID(), sizeof(vertices), vertices, 0);
 
 	glVertexArrayVertexBuffer(vao->GetID(), 0, vbo->GetID(), 0, 2 * sizeof(float));
 


### PR DESCRIPTION
This PR applies a core optimization to our OpenGL buffer creation pipeline by enforcing the use of immutable storage via `glNamedBufferStorage` (OpenGL 4.4+) rather than the mutable `glNamedBufferData` approach. 

Immutable buffers allow graphics drivers to better optimize memory layout and transfer operations, reducing potential stuttering caused by background driver-level reallocations.

### Changes
* **`LightDrawer`**: Migrated `light_ssbo` and `vbo`. Added logic to explicitly destroy and recreate the `light_ssbo` `std::unique_ptr` when a capacity increase is needed, which is a hard requirement for immutable buffers.
* **`MultiDrawIndirectRenderer`**: Migrated `command_buffer_`.
* **`PixelBufferObject`**: Migrated `buffers_` array, ensuring proper flags (`GL_MAP_WRITE_BIT | GL_CLIENT_STORAGE_BIT`) are set for client-mapped memory.

This update directly follows the **Sentinel** mandate to continuously modernize the CPU→GPU data pipeline and strictly enforce RAII resource handling.

---
*PR created automatically by Jules for task [1424793491993764400](https://jules.google.com/task/1424793491993764400) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal buffer allocation mechanisms across rendering components for improved memory management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->