### PR TITLE
refactor(rendering): switch light drawer from tile to screen coordinates

### DIFF
--- a/data/clients.toml
+++ b/data/clients.toml
@@ -967,7 +967,7 @@ otbMajor = 3
 otbmVersions = [ 3 ]
 sprSignature = '57BBD603'
 spritesFile = 'Tibia.spr'
-transparency = false
+transparency = true
 version = 1098
 
 [[clients]]

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -231,8 +231,8 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	float uv_w = static_cast<float>(buffer_w) / static_cast<float>(buffer_width);
 	float uv_h = static_cast<float>(buffer_h) / static_cast<float>(buffer_height);
 
-	shader->SetVec2("uUVMin", glm::vec2(0.0f, 1.0f));
-	shader->SetVec2("uUVMax", glm::vec2(uv_w, 1.0f - uv_h));
+	shader->SetVec2("uUVMin", glm::vec2(0.0f, uv_h));
+	shader->SetVec2("uUVMax", glm::vec2(uv_w, 0.0f));
 
 	// Blending: Dst * Src
 	{


### PR DESCRIPTION
- Replaced map tile coordinate calculations with screen buffer dimensions (buffer_w, buffer_h) in light_drawer.cpp
- Updated light culling logic to use screen-space coordinates with zoom and scroll offsets
- Modified FBO projection matrix and UV mapping to work with screen coordinate system
- Changed quad transform to render from origin (0,0) scaled by zoom factor

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized light rendering system with improved culling algorithms and viewport-based coordinate processing for enhanced performance and visual quality.

* **Chores**
  * Updated client configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->