### PR TITLE
🔧 WxFixer: Fix 5 wxWidgets violations

### DIFF
--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/ui/dcbutton.cpp
+++ b/source/ui/dcbutton.cpp
@@ -141,7 +141,8 @@ void DCButton::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 	// Background
 	nvgBeginPath(vg);
 	nvgRect(vg, 0, 0, size_x, size_y);
-	nvgFillColor(vg, nvgRGBA(0, 0, 0, 255));
+	wxColour bgCol = wxSystemSettings::GetColour(wxSYS_COLOUR_APPWORKSPACE);
+	nvgFillColor(vg, nvgRGBA(bgCol.Red(), bgCol.Green(), bgCol.Blue(), bgCol.Alpha()));
 	nvgFill(vg);
 
 	if (type == DC_BTN_TOGGLE && GetValue()) {
@@ -195,10 +196,15 @@ void DCButton::OnClick(wxMouseEvent& WXUNUSED(evt)) {
 }
 
 void DCButton::DrawSunkenBorder(NVGcontext* vg, float size_x, float size_y) {
-	NVGcolor dark_highlight = nvgRGBA(212, 208, 200, 255);
-	NVGcolor light_shadow = nvgRGBA(128, 128, 128, 255);
-	NVGcolor highlight = nvgRGBA(255, 255, 255, 255);
-	NVGcolor shadow = nvgRGBA(64, 64, 64, 255);
+	wxColour dhCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+	wxColour lsCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DSHADOW);
+	wxColour hCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DHIGHLIGHT);
+	wxColour sCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW);
+
+	NVGcolor dark_highlight = nvgRGBA(dhCol.Red(), dhCol.Green(), dhCol.Blue(), dhCol.Alpha());
+	NVGcolor light_shadow = nvgRGBA(lsCol.Red(), lsCol.Green(), lsCol.Blue(), lsCol.Alpha());
+	NVGcolor highlight = nvgRGBA(hCol.Red(), hCol.Green(), hCol.Blue(), hCol.Alpha());
+	NVGcolor shadow = nvgRGBA(sCol.Red(), sCol.Green(), sCol.Blue(), sCol.Alpha());
 
 	nvgStrokeWidth(vg, 1.0f);
 
@@ -232,10 +238,15 @@ void DCButton::DrawSunkenBorder(NVGcontext* vg, float size_x, float size_y) {
 }
 
 void DCButton::DrawRaisedBorder(NVGcontext* vg, float size_x, float size_y) {
-	NVGcolor dark_highlight = nvgRGBA(212, 208, 200, 255);
-	NVGcolor light_shadow = nvgRGBA(128, 128, 128, 255);
-	NVGcolor highlight = nvgRGBA(255, 255, 255, 255);
-	NVGcolor shadow = nvgRGBA(64, 64, 64, 255);
+	wxColour dhCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DLIGHT);
+	wxColour lsCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DSHADOW);
+	wxColour hCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DHIGHLIGHT);
+	wxColour sCol = wxSystemSettings::GetColour(wxSYS_COLOUR_3DDKSHADOW);
+
+	NVGcolor dark_highlight = nvgRGBA(dhCol.Red(), dhCol.Green(), dhCol.Blue(), dhCol.Alpha());
+	NVGcolor light_shadow = nvgRGBA(lsCol.Red(), lsCol.Green(), lsCol.Blue(), lsCol.Alpha());
+	NVGcolor highlight = nvgRGBA(hCol.Red(), hCol.Green(), hCol.Blue(), hCol.Alpha());
+	NVGcolor shadow = nvgRGBA(sCol.Red(), sCol.Green(), sCol.Blue(), sCol.Alpha());
 
 	nvgStrokeWidth(vg, 1.0f);
 

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"

--- a/source/ui/menubar_loader.cpp
+++ b/source/ui/menubar_loader.cpp
@@ -125,7 +125,7 @@ wxObject* MenuBarLoader::LoadItem(pugi::xml_node node, wxMenu* parent, std::unor
 			act.kind // Kind of item
 		);
 		if (!act.icon.empty()) {
-			tmp->SetBitmap(IMAGE_MANAGER.GetBitmap(act.icon, wxSize(16, 16)));
+			tmp->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(act.icon));
 		}
 		items[MenuBar::ActionID(act.id)].push_back(tmp);
 		return tmp;

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -270,7 +270,7 @@ WelcomeDialog::~WelcomeDialog() {
 void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, std::string_view artId, const wxColour& valCol) {
 	wxBoxSizer* row = new wxBoxSizer(wxHORIZONTAL);
 
-	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(artId, wxSize(14, 14)));
+	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(artId, FromDIP(wxSize(14, 14))));
 	row->Add(icon, 0, wxCENTER | wxRIGHT, 4);
 
 	wxStaticText* lbl = new wxStaticText(parent, wxID_ANY, label);
@@ -301,8 +301,8 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	// Icon Button - Align Left: 10px total
-	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
+	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(48, 48)));
+	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, FromDIP(wxSize(32, 32)))); // Fallback if logo invalid
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -385,14 +385,14 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 1: Actions (Buttons directly on panel)
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
-	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
-	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 


### PR DESCRIPTION
This PR addresses several wxWidgets violations as requested by the WxFixer autonomous agent schedule.

Fixes include:
- Removing unused event table macros (`gui.h`, `updater.h`) since `Bind()` is the preferred method for modern wxWidgets.
- Wrapping fixed pixel sizes in `FromDIP` to ensure proper layout scaling on High-DPI displays (`welcome_dialog.cpp`).
- Removing hardcoded NanoVG button border colors and replacing them with `wxSystemSettings` equivalents to support dynamic system theming, such as Dark Mode (`dcbutton.cpp`).
- Using `GetBitmapBundle` for menu item icons to leverage native High-DPI icon rendering (`menubar_loader.cpp`).

---
*PR created automatically by Jules for task [3640022620632082497](https://jules.google.com/task/3640022620632082497) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * UI buttons and borders now dynamically adapt to system theme colors instead of using fixed colors, improving visual consistency across different system themes.
  * Menu icons and welcome dialog elements now support DPI-aware scaling for proper display on high-resolution monitors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->