### PR TITLE
🔄 Upgrader: Remove unused macro and modernize Sprite base class

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <format>
 #include <iterator>
+#include <cstring>
 
 class wxFileName;
 using FileName = wxFileName;

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -41,13 +41,12 @@ public:
 	Sprite() { }
 	virtual ~Sprite() = default;
 
+	Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
+
 	virtual void DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width = -1, int height = -1) = 0;
 	virtual void unloadDC() = 0;
 	virtual wxSize GetSize() const = 0;
-
-private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
 };
 
 class GameSprite;

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"


### PR DESCRIPTION
- Deleted the unused `EVT_ON_UPDATE_MENUS` macro in `source/ui/gui.h`.
- Modernized the `Sprite` base class in `source/rendering/core/game_sprite.h` by deleting the private copy constructor and assignment operator and instead using `= delete` in the public block.
- Fixed a missing `<cstring>` include in `source/io/filehandle.h` which caused a compilation error on newer compilers.

---
*PR created automatically by Jules for task [16193501238369123984](https://jules.google.com/task/16193501238369123984) started by @karolak6612*