### PR TITLE
👻 Phantom: Remove unused event table macros

### DIFF
--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"


### PR DESCRIPTION
Removed unused `EVT_ON_UPDATE_MENUS` and `EVT_ON_UPDATE_CHECK_FINISHED` macros from `source/ui/gui.h` and `source/app/updater.h` respectively, as they violate the guidelines that require usage of `Bind()` for event handling, and are unused.

---
*PR created automatically by Jules for task [1377091595419514530](https://jules.google.com/task/1377091595419514530) started by @karolak6612*