### PR TITLE
🎨 Icon: Add icons to dialogs and main window

### DIFF
--- a/source/app/preferences.cpp
+++ b/source/app/preferences.cpp
@@ -94,9 +94,7 @@ PreferencesWindow::PreferencesWindow(wxWindow* parent, bool clientVersionSelecte
 	Bind(wxEVT_BUTTON, &PreferencesWindow::OnClickApply, this, wxID_APPLY);
 	Bind(wxEVT_COLLAPSIBLEPANE_CHANGED, &PreferencesWindow::OnCollapsiblePane, this);
 
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(32, 32)));
-	SetIcon(icon);
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_GEAR));
 }
 
 PreferencesWindow::~PreferencesWindow() {

--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -22,6 +22,8 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	ASSERT(map);
 	ASSERT(house);
 
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_HOUSE));
+
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "House Properties");
 	wxFlexGridSizer* housePropContainer = newd wxFlexGridSizer(2, 10, 10);

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -174,6 +174,7 @@ void BrowseTileListBox::UpdateItems() {
 
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, "Browse Field", position, FROM_DIP(parent, wxSize(600, 400)), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_SEARCH));
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
 	item_list = newd BrowseTileListBox(this, wxID_ANY, tile);
 	sizer->Add(item_list, wxSizerFlags(1).Expand());

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -78,9 +78,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	// We can't call it here since it calls an abstract function, call in child constructors instead.
 	// RefreshContents();
 
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(32, 32)));
-	SetIcon(icon);
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_SEARCH));
 }
 
 FindDialog::~FindDialog() = default;

--- a/source/ui/dialogs/goto_position_dialog.cpp
+++ b/source/ui/dialogs/goto_position_dialog.cpp
@@ -43,9 +43,7 @@ GotoPositionDialog::GotoPositionDialog(wxWindow* parent, Editor& editor) :
 	okBtn->Bind(wxEVT_BUTTON, &GotoPositionDialog::OnClickOK, this);
 	cancelBtn->Bind(wxEVT_BUTTON, &GotoPositionDialog::OnClickCancel, this);
 
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_LOCATION, wxSize(32, 32)));
-	SetIcon(icon);
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_LOCATION));
 }
 
 void GotoPositionDialog::OnClickCancel(wxCommandEvent&) {

--- a/source/ui/dialogs/outfit_chooser_dialog.cpp
+++ b/source/ui/dialogs/outfit_chooser_dialog.cpp
@@ -245,9 +245,7 @@ OutfitChooserDialog::OutfitChooserDialog(wxWindow* parent, const Outfit& current
 
 	CenterOnParent();
 
-	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_USER_SOLID, wxSize(32, 32)));
-	SetIcon(icon);
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_USER_SOLID));
 }
 
 OutfitChooserDialog::~OutfitChooserDialog() { }

--- a/source/ui/main_frame.cpp
+++ b/source/ui/main_frame.cpp
@@ -35,6 +35,9 @@
 
 MainFrame::MainFrame(const wxString& title, const wxPoint& pos, const wxSize& size) :
 	wxFrame((wxFrame*)nullptr, -1, title, pos, size, wxDEFAULT_FRAME_STYLE) {
+
+	SetIcons(IMAGE_MANAGER.GetIconBundle(IMAGE_EDITOR_ICON));
+
 	// Receive idle events
 	SetExtraStyle(wxWS_EX_PROCESS_IDLE);
 

--- a/source/ui/properties/object_properties_base.cpp
+++ b/source/ui/properties/object_properties_base.cpp
@@ -15,7 +15,7 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 	edit_item(item),
 	edit_creature(nullptr),
 	edit_spawn(nullptr) {
-	////
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_GEAR));
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, const Map* map, const Tile* tile, Creature* creature, wxPoint position /* = wxDefaultPosition */) :
@@ -25,7 +25,7 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 	edit_item(nullptr),
 	edit_creature(creature),
 	edit_spawn(nullptr) {
-	////
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_GEAR));
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, const Map* map, const Tile* tile, Spawn* spawn, wxPoint position /* = wxDefaultPosition */) :
@@ -35,12 +35,12 @@ ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxStrin
 	edit_item(nullptr),
 	edit_creature(nullptr),
 	edit_spawn(spawn) {
-	////
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_GEAR));
 }
 
 ObjectPropertiesWindowBase::ObjectPropertiesWindowBase(wxWindow* parent, wxString title, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, title, position, wxSize(600, 400), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
-	////
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_GEAR));
 }
 
 Item* ObjectPropertiesWindowBase::getItemBeingEdited() {

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -40,6 +40,7 @@ ReplaceToolWindow::ReplaceToolWindow(wxWindow* parent, Editor* editor) : wxDialo
 																		 editor(editor) {
 
 	VisualSimilarityService::Get().StartIndexing();
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_WAND_MAGIC));
 	SetBackgroundColour(Theme::Get(Theme::Role::Surface));
 
 	InitLayout();

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -234,6 +234,8 @@ private:
 WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionText, const wxSize& size, const wxBitmap& rmeLogo, const std::vector<wxString>& recentFiles) :
 	wxDialog(nullptr, wxID_ANY, titleText, wxDefaultPosition, size, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
 
+	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_HANDSHAKE));
+
 	SetBackgroundColour(Theme::Get(Theme::Role::Surface));
 	SetForegroundColour(Theme::Get(Theme::Role::Text));
 


### PR DESCRIPTION
Adds missing icons to various UI windows/dialogs and refactors existing single-bitmap icons to use full `wxIconBundle` via `IMAGE_MANAGER.GetIconBundle(...)`.

Affected dialogs:
- `WelcomeDialog`
- `EditHouseDialog`
- `ReplaceToolWindow`
- `BrowseTileWindow`
- `ObjectPropertiesWindowBase`
- `PreferencesWindow`
- `OutfitChooserDialog`
- `GotoPositionDialog`
- `FindDialog`
- `MainFrame`

---
*PR created automatically by Jules for task [12907713255825211404](https://jules.google.com/task/12907713255825211404) started by @karolak6612*