### PR TITLE
🖥️ OpenGL: Fix error logging, GC blocking, and light offsets

### DIFF
--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,8 +117,8 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
 			return false;
 		}
@@ -126,8 +126,7 @@ bool TextureAtlas::addLayer() {
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,8 +160,8 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
 	}
 

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -223,12 +223,12 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	// Quad Transform for Screen
 	float draw_dest_x = 0.0f;
 	float draw_dest_y = 0.0f;
-	float draw_dest_w = static_cast<float>(buffer_w) * view.zoom;
-	float draw_dest_h = static_cast<float>(buffer_h) * view.zoom;
+	float draw_dest_w = static_cast<float>(buffer_w);
+	float draw_dest_h = static_cast<float>(buffer_h);
 
 	glm::mat4 model = glm::translate(glm::mat4(1.0f), glm::vec3(draw_dest_x, draw_dest_y, 0.0f));
 	model = glm::scale(model, glm::vec3(draw_dest_w, draw_dest_h, 1.0f));
-	shader->SetMat4("uProjection", view.projectionMatrix * view.viewMatrix * model); // reusing uProjection as MVP
+	shader->SetMat4("uProjection", view.projectionMatrix * model); // reusing uProjection as MVP, FBO is already screen space
 
 	float uv_w = static_cast<float>(buffer_w) / static_cast<float>(buffer_width);
 	float uv_h = static_cast<float>(buffer_h) / static_cast<float>(buffer_height);


### PR DESCRIPTION
Applied the fixes requested by the `Opengl.md` agent profile:
- **Missing multiple OpenGL error logs (`glGetError`)**: Fixed by replacing `if` blocks with `while` loops in `TextureAtlas` and `MinimapRenderer`.
- **`TextureGarbageCollector` Blocking Render**: Changed `TextureGarbageCollector::GarbageCollect` to process a maximum of 500 items per call using static iterators to maintain state across frames, preventing render thread stalls.
- **LightDrawer Coordinate Mapping (Lights Disappear on Large Viewports)**: Fixed the FBO projection matrix to only use `view.projectionMatrix` and not `view.viewMatrix` or `view.zoom`, as the FBO is already rendered in screen space and applying camera transforms again was incorrect.

---
*PR created automatically by Jules for task [3477581583433012996](https://jules.google.com/task/3477581583433012996) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for GPU graphics operations to better capture and report issues.

* **Performance**
  * Optimized texture cleanup with batch-based processing for improved efficiency.

* **Rendering**
  * Updated projection handling for more accurate visual rendering in composite passes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->