### PR TITLE
🐛 Bugger: Fix undefined behavior, memory leaks, and logic bugs

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -39,15 +39,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	auto c = std::unique_ptr<Change>(newd Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	auto c = std::unique_ptr<Change>(newd Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -107,11 +107,11 @@ public:
 	}
 	Tile* getSelectedTile() {
 		ASSERT(size() == 1);
-		return *tiles.begin();
+		return empty() ? nullptr : *tiles.begin();
 	}
 	Tile* getSelectedTile() const {
 		ASSERT(size() == 1);
-		return *tiles.begin();
+		return empty() ? nullptr : *tiles.begin();
 	}
 
 private:

--- a/source/map/map_region.cpp
+++ b/source/map/map_region.cpp
@@ -147,8 +147,8 @@ void MapNode::setVisible(bool underground, bool value) {
 void SpatialHashGrid::getCellCoordsFromKey(uint64_t key, int& cx, int& cy) {
 	uint32_t raw_cy = static_cast<uint32_t>(key >> 32) ^ 0x80000000u;
 	uint32_t raw_cx = static_cast<uint32_t>(key) ^ 0x80000000u;
-	cy = static_cast<int32_t>(raw_cy);
-	cx = static_cast<int32_t>(raw_cx);
+	cy = std::bit_cast<int32_t>(raw_cy);
+	cx = std::bit_cast<int32_t>(raw_cx);
 }
 
 std::vector<SpatialHashGrid::SortedGridCell> SpatialHashGrid::getSortedCells() const {
@@ -216,6 +216,9 @@ std::unique_ptr<Tile> MapNode::setTile(int x, int y, int z, std::unique_ptr<Tile
 		newtile->setLocation(tmp);
 	}
 	std::unique_ptr<Tile> oldtile = std::move(tmp->tile);
+	if (oldtile) {
+		oldtile->setLocation(nullptr);
+	}
 	tmp->tile = std::move(newtile);
 
 	if (tmp->tile && !oldtile) {
@@ -234,6 +237,9 @@ void MapNode::clearTile(int x, int y, int z) {
 	int offset_y = y & 3;
 
 	TileLocation* tmp = &f->locs[offset_x * 4 + offset_y];
+	if (tmp->tile) {
+		tmp->tile->setLocation(nullptr);
+	}
 	tmp->tile = map.allocator(tmp);
 }
 

--- a/source/map/spatial_hash_grid.h
+++ b/source/map/spatial_hash_grid.h
@@ -189,7 +189,7 @@ protected:
 
 	static uint64_t makeKeyFromCell(int cx, int cy) {
 		static_assert(sizeof(int) == 4, "Key packing assumes exactly 32-bit integers");
-		return (static_cast<uint64_t>(static_cast<uint32_t>(cy) ^ 0x80000000u) << 32) | (static_cast<uint32_t>(cx) ^ 0x80000000u);
+		return (static_cast<uint64_t>(std::bit_cast<uint32_t>(cy) ^ 0x80000000u) << 32) | (std::bit_cast<uint32_t>(cx) ^ 0x80000000u);
 	}
 
 	static uint64_t makeKey(int x, int y) {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -252,6 +252,7 @@ inline uint32_t Tile::getHouseID() const {
 }
 
 inline void Tile::setMapFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_PROTECTIONZONE | TILESTATE_DEPRECATED | TILESTATE_NOPVP | TILESTATE_NOLOGOUT | TILESTATE_PVPZONE | TILESTATE_REFRESH)) == 0);
 	mapflags = _flags | mapflags;
 }
 
@@ -264,6 +265,7 @@ inline uint16_t Tile::getMapFlags() const {
 }
 
 inline void Tile::setStatFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_SELECTED | TILESTATE_UNIQUE | TILESTATE_BLOCKING | TILESTATE_OP_BORDER | TILESTATE_HAS_TABLE | TILESTATE_HAS_CARPET | TILESTATE_MODIFIED | TILESTATE_HOOK_SOUTH | TILESTATE_HOOK_EAST | TILESTATE_HAS_LIGHT)) == 0);
 	statflags = _flags | statflags;
 }
 


### PR DESCRIPTION
Fixed multiple bugs identified by the Bugger agent, including:
1. Undefined behavior in `Selection::getSelectedTile()` by adding an `empty()` check before dereferencing `.begin()`.
2. Memory leaks in `Change::Create` by switching to return `std::unique_ptr<Change>`.
3. Signed integer overflow/UB in `SpatialHashGrid` key generation by replacing `static_cast` with `std::bit_cast`.
4. Silent data corruption risk in `Tile` flags by adding strict assertion masks to `setMapFlags` and `setStatFlags`.
5. Dangling pointers in `TileLocation` by explicitly setting `oldtile->setLocation(nullptr)` when tiles are removed from the map grid.

---
*PR created automatically by Jules for task [7611015455415540977](https://jules.google.com/task/7611015455415540977) started by @karolak6612*