### PR TITLE
🎨 Palette: [UX improvement] Add missing tooltips and fix hardcoded DIPs

### DIFF
--- a/source/palette/palette_window.cpp
+++ b/source/palette/palette_window.cpp
@@ -38,7 +38,7 @@
 // Palette window
 
 PaletteWindow::PaletteWindow(wxWindow* parent, const TilesetContainer& tilesets) :
-	wxPanel(parent, wxID_ANY, wxDefaultPosition, wxSize(230, 250)),
+	wxPanel(parent, wxID_ANY, wxDefaultPosition, parent->FromDIP(wxSize(230, 250))),
 	choicebook(nullptr),
 	terrain_palette(nullptr),
 	doodad_palette(nullptr),
@@ -47,19 +47,20 @@ PaletteWindow::PaletteWindow(wxWindow* parent, const TilesetContainer& tilesets)
 	creature_palette(nullptr),
 	waypoint_palette(nullptr),
 	raw_palette(nullptr) {
-	SetMinSize(wxSize(225, 250));
+	SetMinSize(FromDIP(wxSize(225, 250)));
 
 	// Create choicebook
-	choicebook = newd wxChoicebook(this, PALETTE_CHOICEBOOK, wxDefaultPosition, wxSize(230, 250));
+	choicebook = newd wxChoicebook(this, PALETTE_CHOICEBOOK, wxDefaultPosition, FromDIP(wxSize(230, 250)));
+	choicebook->SetToolTip("Select Palette Category");
 
-	wxImageList* imageList = new wxImageList(16, 16);
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_MOUNTAIN, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_TREE, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FLAG, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CUBES, wxSize(16, 16)));
+	wxImageList* imageList = new wxImageList(FromDIP(16), FromDIP(16));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_MOUNTAIN, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_TREE, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CUBE, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FLAG, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_CUBES, FromDIP(wxSize(16, 16))));
 	choicebook->AssignImageList(imageList);
 
 	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGING, &PaletteWindow::OnSwitchingPage, this, PALETTE_CHOICEBOOK);
@@ -90,7 +91,7 @@ PaletteWindow::PaletteWindow(wxWindow* parent, const TilesetContainer& tilesets)
 
 	// Setup sizers
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
-	choicebook->SetMinSize(wxSize(225, 300));
+	choicebook->SetMinSize(FromDIP(wxSize(225, 300)));
 	sizer->Add(choicebook, 1, wxEXPAND);
 	SetSizer(sizer);
 

--- a/source/ui/properties/properties_window.cpp
+++ b/source/ui/properties/properties_window.cpp
@@ -57,10 +57,10 @@ PropertiesWindow::PropertiesWindow(wxWindow* parent, const Map* map, const Tile*
 void PropertiesWindow::createUI() {
 	notebook = newd wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize);
 
-	wxImageList* imageList = new wxImageList(16, 16);
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FILE, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_BOX_OPEN, wxSize(16, 16)));
-	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_LIST, wxSize(16, 16)));
+	wxImageList* imageList = new wxImageList(FromDIP(16), FromDIP(16));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_FILE, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_BOX_OPEN, FromDIP(wxSize(16, 16))));
+	imageList->Add(IMAGE_MANAGER.GetBitmap(ICON_LIST, FromDIP(wxSize(16, 16))));
 	notebook->AssignImageList(imageList);
 
 	notebook->AddPage(createGeneralPanel(notebook), "Simple", true, 0);
@@ -74,11 +74,11 @@ void PropertiesWindow::createUI() {
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
-	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, FromDIP(wxSize(16, 16))));
 	okBtn->SetToolTip("Apply changes and close");
 	optSizer->Add(okBtn, wxSizerFlags(0).Center());
 	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
-	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, FromDIP(wxSize(16, 16))));
 	cancelBtn->SetToolTip("Discard changes and close");
 	optSizer->Add(cancelBtn, wxSizerFlags(0).Center());
 	topSizer->Add(optSizer, wxSizerFlags(0).Center().DoubleBorder());
@@ -87,7 +87,7 @@ void PropertiesWindow::createUI() {
 	Centre(wxBOTH);
 
 	wxIcon icon;
-	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(32, 32)));
+	icon.CopyFromBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(32, 32))));
 	SetIcon(icon);
 }
 
@@ -105,7 +105,7 @@ void PropertiesWindow::Update() {
 
 wxWindow* PropertiesWindow::createGeneralPanel(wxWindow* parent) {
 	wxPanel* panel = newd wxPanel(parent, ITEM_PROPERTIES_GENERAL_TAB);
-	wxFlexGridSizer* gridsizer = newd wxFlexGridSizer(2, 10, 10);
+	wxFlexGridSizer* gridsizer = newd wxFlexGridSizer(2, FromDIP(10), FromDIP(10));
 	gridsizer->AddGrowableCol(1);
 
 	createGeneralFields(gridsizer, panel);
@@ -213,12 +213,12 @@ wxWindow* PropertiesWindow::createAttributesPanel(wxWindow* parent) {
 
 	wxSizer* optSizer = newd wxBoxSizer(wxHORIZONTAL);
 	wxButton* addBtn = newd wxButton(panel, ITEM_PROPERTIES_ADD_ATTRIBUTE, "Add Attribute");
-	addBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+	addBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, FromDIP(wxSize(16, 16))));
 	addBtn->SetToolTip("Add a new custom attribute");
 	optSizer->Add(addBtn, wxSizerFlags(0).Center());
 
 	wxButton* removeBtn = newd wxButton(panel, ITEM_PROPERTIES_REMOVE_ATTRIBUTE, "Remove Attribute");
-	removeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
+	removeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, FromDIP(wxSize(16, 16))));
 	removeBtn->SetToolTip("Remove selected custom attribute");
 	optSizer->Add(removeBtn, wxSizerFlags(0).Center());
 

--- a/source/ui/toolbar/brush_toolbar.cpp
+++ b/source/ui/toolbar/brush_toolbar.cpp
@@ -37,7 +37,7 @@ BrushToolBar::BrushToolBar(wxWindow* parent) {
 	toolbar = newd wxAuiToolBar(parent, TOOLBAR_BRUSHES, wxDefaultPosition, wxDefaultSize, wxAUI_TB_DEFAULT_STYLE);
 	toolbar->SetToolBitmapSize(icon_size);
 	toolbar->AddTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, wxEmptyString, border_bitmap, wxNullBitmap, wxITEM_CHECK, "Border (Add borders to ground)", "Add automatic borders to ground tiles", nullptr);
-	toolbar->AddTool(PALETTE_TERRAIN_ERASER, wxEmptyString, eraser_bitmap, wxNullBitmap, wxITEM_CHECK, "Eraser (Clear tile content)", "Clear content from tiles", nullptr);
+	toolbar->AddTool(PALETTE_TERRAIN_ERASER, wxEmptyString, eraser_bitmap, wxNullBitmap, wxITEM_CHECK, "Eraser (Clear tile content) (E)", "Clear content from tiles", nullptr);
 	toolbar->AddSeparator();
 	toolbar->AddTool(PALETTE_TERRAIN_PZ_TOOL, wxEmptyString, pz_bitmap, wxNullBitmap, wxITEM_CHECK, "Protected Zone (Non-combat area)", "Mark area as Protected Zone (Non-combat)", nullptr);
 	toolbar->AddTool(PALETTE_TERRAIN_NOPVP_TOOL, wxEmptyString, nopvp_bitmap, wxNullBitmap, wxITEM_CHECK, "No PvP Zone (Non-PvP area)", "Mark area as No PvP Zone", nullptr);
@@ -73,7 +73,7 @@ void BrushToolBar::Update() {
 	};
 
 	updateTool(PALETTE_TERRAIN_OPTIONAL_BORDER_TOOL, "Border (Add borders to ground)");
-	updateTool(PALETTE_TERRAIN_ERASER, "Eraser (Clear tile content)");
+	updateTool(PALETTE_TERRAIN_ERASER, "Eraser (Clear tile content) (E)");
 	updateTool(PALETTE_TERRAIN_PZ_TOOL, "Protected Zone (Non-combat area)");
 	updateTool(PALETTE_TERRAIN_NOPVP_TOOL, "No PvP Zone (Non-PvP area)");
 	updateTool(PALETTE_TERRAIN_NOLOGOUT_TOOL, "No Logout Zone (Prevents logout)");

--- a/source/ui/toolbar/position_toolbar.cpp
+++ b/source/ui/toolbar/position_toolbar.cpp
@@ -8,7 +8,6 @@
 #include "ui/gui_ids.h"
 #include "editor/editor.h"
 #include "util/image_manager.h"
-#include <wx/artprov.h>
 
 const wxString PositionToolBar::PANE_NAME = "position_toolbar";
 
@@ -20,17 +19,17 @@ PositionToolBar::PositionToolBar(wxWindow* parent) {
 	toolbar->SetToolBitmapSize(icon_size);
 
 	x_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_WIDTH, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
-	x_control->SetToolTip("X Coordinate");
+	x_control->SetToolTip("X Coordinate (Tab to next)");
 
 	y_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_HEIGHT, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
-	y_control->SetToolTip("Y Coordinate");
+	y_control->SetToolTip("Y Coordinate (Tab to next)");
 
 	z_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_LAYER, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, FROM_DIP(parent, wxSize(35, 20)));
-	z_control->SetToolTip("Z Coordinate");
+	z_control->SetToolTip("Z Coordinate (Enter to go)");
 
 	go_button = newd wxButton(toolbar, TOOLBAR_POSITION_GO, wxEmptyString, wxDefaultPosition, parent->FromDIP(wxSize(22, 20)));
 	go_button->SetBitmap(go_bitmap);
-	go_button->SetToolTip("Go To Position");
+	go_button->SetToolTip("Go To Position (Enter)");
 
 	toolbar->AddControl(x_control);
 	toolbar->AddControl(y_control);

--- a/source/ui/toolbar/size_toolbar.cpp
+++ b/source/ui/toolbar/size_toolbar.cpp
@@ -8,7 +8,6 @@
 #include "ui/gui_ids.h"
 #include "editor/editor.h"
 #include "util/image_manager.h"
-#include <wx/artprov.h>
 
 const wxString SizeToolBar::PANE_NAME = "sizes_toolbar";
 
@@ -30,13 +29,13 @@ SizeToolBar::SizeToolBar(wxWindow* parent) {
 	toolbar->AddTool(TOOLBAR_SIZES_RECTANGULAR, wxEmptyString, rectangular_bitmap, wxNullBitmap, wxITEM_CHECK, "Rectangular Brush", wxEmptyString, nullptr);
 	toolbar->AddTool(TOOLBAR_SIZES_CIRCULAR, wxEmptyString, circular_bitmap, wxNullBitmap, wxITEM_CHECK, "Circular Brush", wxEmptyString, nullptr);
 	toolbar->AddSeparator();
-	toolbar->AddTool(TOOLBAR_SIZES_1, wxEmptyString, size1_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 1", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_2, wxEmptyString, size2_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 2", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_3, wxEmptyString, size3_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 3", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_4, wxEmptyString, size4_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 4", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_5, wxEmptyString, size5_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 5", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_6, wxEmptyString, size6_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 6", wxEmptyString, nullptr);
-	toolbar->AddTool(TOOLBAR_SIZES_7, wxEmptyString, size7_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 7", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_1, wxEmptyString, size1_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 1 (1)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_2, wxEmptyString, size2_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 2 (2)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_3, wxEmptyString, size3_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 3 (3)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_4, wxEmptyString, size4_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 4 (4)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_5, wxEmptyString, size5_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 5 (5)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_6, wxEmptyString, size6_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 6 (6)", wxEmptyString, nullptr);
+	toolbar->AddTool(TOOLBAR_SIZES_7, wxEmptyString, size7_bitmap, wxNullBitmap, wxITEM_CHECK, "Size 7 (7)", wxEmptyString, nullptr);
 	toolbar->Realize();
 	toolbar->ToggleTool(TOOLBAR_SIZES_RECTANGULAR, true);
 	toolbar->ToggleTool(TOOLBAR_SIZES_1, true);

--- a/source/ui/toolbar/standard_toolbar.cpp
+++ b/source/ui/toolbar/standard_toolbar.cpp
@@ -10,7 +10,6 @@
 #include "editor/editor.h"
 #include "editor/action_queue.h"
 #include "util/image_manager.h"
-#include <wx/artprov.h>
 
 const wxString StandardToolBar::PANE_NAME = "standard_toolbar";
 

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -325,6 +325,7 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	ConvexButton* prefBtn = new ConvexButton(headerPanel, wxID_PREFERENCES, "Preferences");
 	prefBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(24, 24))));
 	prefBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	prefBtn->SetToolTip("Open Editor Preferences");
 
 	// Align Right: 10px total
 	headerSizer->Add(prefBtn, 0, wxCENTER | wxALL, 8);
@@ -340,6 +341,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	ConvexButton* exitBtn = new ConvexButton(footerPanel, wxID_EXIT, "Exit");
 	exitBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(24, 24))));
 	exitBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	exitBtn->SetToolTip("Exit Application");
 
 	// Align Left: 10px total
 	footerSizer->Add(exitBtn, 0, wxALL, 8);
@@ -347,6 +349,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 	ConvexButton* newBtn = new ConvexButton(footerPanel, wxID_NEW, "New Map");
 	newBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	newBtn->SetToolTip("Create a New Map (Ctrl+N)");
 	footerSizer->Add(newBtn, 0, wxALL, 8);
 
 	footerSizer->AddStretchSpacer();
@@ -358,6 +361,7 @@ wxPanel* WelcomeDialog::CreateFooterPanel(wxWindow* parent, const wxString& vers
 
 	ConvexButton* loadBtn = new ConvexButton(footerPanel, wxID_ANY, "Load Map");
 	loadBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
+	loadBtn->SetToolTip("Load an Existing Map (Ctrl+O)");
 	loadBtn->Bind(wxEVT_BUTTON, [this](wxCommandEvent&) {
 		long item = -1;
 		item = m_recentList->GetNextItem(item, wxLIST_NEXT_ALL, wxLIST_STATE_SELECTED);
@@ -385,15 +389,17 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 1: Actions (Buttons directly on panel)
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
-	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	newMapBtn->SetToolTip("Create a New Map (Ctrl+N)");
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
-	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
+	browseBtn->SetToolTip("Browse for a Map File (Ctrl+O)");
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
 	// Add Column 1 to Sizer FIRST (Explicit LEFTmost placement)


### PR DESCRIPTION
* **`source/ui/welcome_dialog.cpp`**: Added tooltips to the new map, browse map, open preferences, and exit buttons. Updated image and control dimensions to be DPI aware with `FromDIP()`.
* **`source/ui/properties/properties_window.cpp`**: Converted `wxFlexGridSizer` gaps and image list hardcoded dimensions to use `FromDIP()`.
* **`source/palette/palette_window.cpp`**: Converted hardcoded wxPanel and wxChoicebook boundaries, as well as an image list to use DPI scaling. Added an explicit `choicebook` tooltip ("Select Palette Category"). Changed `FromDIP` inside the constructor's initialization list to reference `parent->FromDIP(...)` to avoid a vtable lookup crash.
* **`source/ui/toolbar/size_toolbar.cpp`**: Updated short help text for size buttons to explicitly document the available `(1)` through `(7)` keyboard shortcut shortcuts. Removed dead include `#include <wx/artprov.h>`.
* **`source/ui/toolbar/position_toolbar.cpp`**: Added informative tooltip hints `(Tab to next)` and `(Enter to go)` on X/Y/Z controls and Go button to improve keyboard accessibility discoverability. Removed unused `#include <wx/artprov.h>`.
* **`source/ui/toolbar/standard_toolbar.cpp`**: Removed unused `#include <wx/artprov.h>`.
* **`source/ui/toolbar/brush_toolbar.cpp`**: Added the `(E)` keyboard shortcut hint to the Eraser short help tooltip.

---
*PR created automatically by Jules for task [9943497702138946081](https://jules.google.com/task/9943497702138946081) started by @karolak6612*