### PR TITLE
🗝️ Keeper: Refactor strict memory and RAII ownership

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -39,15 +39,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -127,6 +127,7 @@ private:
 	// We use std::vector here instead of std::set for performance reasons.
 	// Selections are typically small, and std::vector provides better cache locality
 	// and fewer allocations. We maintain sorted order to allow O(log n) lookups.
+	// These are observers, lifetime of tiles is tied to the Map.
 	std::vector<Tile*> tiles;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;

--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -29,7 +29,7 @@ namespace IngamePreview {
 		sprite_batch = std::make_unique<SpriteBatch>();
 		primitive_renderer = std::make_unique<PrimitiveRenderer>();
 		light_buffer = std::make_unique<LightBuffer>();
-		light_drawer = std::make_shared<LightDrawer>();
+		light_drawer = std::make_unique<LightDrawer>();
 		creature_drawer = std::make_unique<CreatureDrawer>();
 		creature_name_drawer = std::make_unique<CreatureNameDrawer>();
 		sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/ingame_preview/ingame_preview_renderer.h
+++ b/source/ingame_preview/ingame_preview_renderer.h
@@ -64,7 +64,7 @@ namespace IngamePreview {
 		std::unique_ptr<SpriteBatch> sprite_batch;
 		std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 		std::unique_ptr<LightBuffer> light_buffer;
-		std::shared_ptr<LightDrawer> light_drawer;
+		std::unique_ptr<LightDrawer> light_drawer;
 
 		// Drawers
 		std::unique_ptr<CreatureDrawer> creature_drawer;

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -64,7 +64,7 @@ enum : uint8_t {
 
 class Tile {
 public: // Members
-	TileLocation* location;
+	TileLocation* location; // Observer pointer, owned by MapRegion
 	std::unique_ptr<Item> ground;
 	std::vector<std::unique_ptr<Item>> items;
 	std::unique_ptr<Creature> creature;
@@ -235,6 +235,7 @@ bool tilePositionLessThan(const Tile* a, const Tile* b);
 // This sorts them by draw order
 bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 
+// Observer containers, tiles are owned by TileLocation
 using TileVector = std::vector<Tile*>;
 using TileSet = std::vector<Tile*>;
 using TileList = std::list<Tile*>;

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -45,9 +45,8 @@ public:
 	virtual void unloadDC() = 0;
 	virtual wxSize GetSize() const = 0;
 
-private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
+	Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
 };
 
 class GameSprite;

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -88,7 +88,7 @@ void main() {
 MapDrawer::MapDrawer(MapCanvas* canvas) :
 	canvas(canvas), editor(canvas->editor) {
 
-	light_drawer = std::make_shared<LightDrawer>();
+	light_drawer = std::make_unique<LightDrawer>();
 	tooltip_drawer = std::make_unique<TooltipDrawer>();
 
 	sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -65,7 +65,7 @@ class MapDrawer {
 	Editor& editor;
 	DrawingOptions options;
 	RenderView view;
-	std::shared_ptr<LightDrawer> light_drawer;
+	std::unique_ptr<LightDrawer> light_drawer;
 	LightBuffer light_buffer;
 	std::unique_ptr<TooltipDrawer> tooltip_drawer;
 	std::unique_ptr<GridDrawer> grid_drawer;


### PR DESCRIPTION
Following the instructions from Keeper (the memory guardian), this PR cleans up raw pointer usage and clarifies memory ownership semantics. `Change::Create` now uses `unique_ptr` to ensure explicit lifetime management, avoiding the risk of dangling pointers. Additionally, `shared_ptr<LightDrawer>` has been simplified to `unique_ptr<LightDrawer>`. Added clear observer semantics documentation to map elements, and modernized the `Sprite` class copy constructor.

---
*PR created automatically by Jules for task [4569723062705295831](https://jules.google.com/task/4569723062705295831) started by @karolak6612*