### PR TITLE
✨ Designer: Reorganize Tile Browse, Find Item dialogs, and Context Menu

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <format>
 #include <iterator>
+#include <cstring>
 
 class wxFileName;
 using FileName = wxFileName;

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -175,36 +175,69 @@ void BrowseTileListBox::UpdateItems() {
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, "Browse Field", position, FROM_DIP(parent, wxSize(600, 400)), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
 	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
-	item_list = newd BrowseTileListBox(this, wxID_ANY, tile);
-	sizer->Add(item_list, wxSizerFlags(1).Expand());
 
-	wxString pos;
-	pos << "x=" << tile->getX() << ",  y=" << tile->getY() << ",  z=" << tile->getZ();
+	wxSizer* splitSizer = newd wxBoxSizer(wxHORIZONTAL);
 
-	wxSizer* infoSizer = newd wxBoxSizer(wxVERTICAL);
+	// Left side: Items List and Actions
+	wxSizer* leftSizer = newd wxBoxSizer(wxVERTICAL);
+
+	wxStaticBoxSizer* listSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Items on Tile");
+	item_list = newd BrowseTileListBox(listSizer->GetStaticBox(), wxID_ANY, tile);
+	listSizer->Add(item_list, wxSizerFlags(1).Expand().Border(wxALL, 2));
+
 	wxBoxSizer* buttons = newd wxBoxSizer(wxHORIZONTAL);
-	delete_button = newd wxButton(this, wxID_REMOVE, "Delete");
+	delete_button = newd wxButton(listSizer->GetStaticBox(), wxID_REMOVE, "Delete");
 	delete_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_TRASH_CAN));
 	delete_button->SetToolTip("Delete selected item");
 	delete_button->Enable(false);
-	buttons->Add(delete_button);
-	buttons->AddSpacer(5);
-	select_raw_button = newd wxButton(this, wxID_FIND, "Select RAW");
+	buttons->Add(delete_button, wxSizerFlags(1).Expand().Border(wxRIGHT, 2));
+
+	select_raw_button = newd wxButton(listSizer->GetStaticBox(), wxID_FIND, "Select RAW");
 	select_raw_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SEARCH));
 	select_raw_button->SetToolTip("Select this item in RAW palette");
 	select_raw_button->Enable(false);
-	buttons->Add(select_raw_button);
-	infoSizer->Add(buttons);
-	infoSizer->AddSpacer(5);
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
-	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
+	buttons->Add(select_raw_button, wxSizerFlags(1).Expand().Border(wxLEFT, 2));
 
-	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());
+	listSizer->Add(buttons, wxSizerFlags(0).Expand().Border(wxALL, 2));
+	leftSizer->Add(listSizer, wxSizerFlags(1).Expand().DoubleBorder());
+
+	splitSizer->Add(leftSizer, wxSizerFlags(2).Expand());
+
+	// Right side: Tile Stats & Properties
+	wxSizer* rightSizer = newd wxBoxSizer(wxVERTICAL);
+
+	wxString pos;
+	pos << "x=" << tile->getX() << ", y=" << tile->getY() << ", z=" << tile->getZ();
+
+	wxStaticBoxSizer* statsSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tile Stats");
+	statsSizer->Add(newd wxStaticText(statsSizer->GetStaticBox(), wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left().Border(wxALL, 4));
+	statsSizer->Add(item_count_txt = newd wxStaticText(statsSizer->GetStaticBox(), wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left().Border(wxALL, 4));
+	rightSizer->Add(statsSizer, wxSizerFlags(0).Expand().DoubleBorder(wxTOP | wxRIGHT | wxBOTTOM));
+
+	wxStaticBoxSizer* flagsSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Flags");
+	wxFlexGridSizer* flagsGrid = newd wxFlexGridSizer(2, 5, 5); // 2 columns, gaps
+
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, "Protection zone:"), wxSizerFlags(0).Right().Align(wxALIGN_CENTER_VERTICAL));
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, b2yn(tile->isPZ())), wxSizerFlags(0).Left().Align(wxALIGN_CENTER_VERTICAL));
+
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, "No PvP:"), wxSizerFlags(0).Right().Align(wxALIGN_CENTER_VERTICAL));
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left().Align(wxALIGN_CENTER_VERTICAL));
+
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, "No logout:"), wxSizerFlags(0).Right().Align(wxALIGN_CENTER_VERTICAL));
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left().Align(wxALIGN_CENTER_VERTICAL));
+
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, "PvP zone:"), wxSizerFlags(0).Right().Align(wxALIGN_CENTER_VERTICAL));
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left().Align(wxALIGN_CENTER_VERTICAL));
+
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, "House:"), wxSizerFlags(0).Right().Align(wxALIGN_CENTER_VERTICAL));
+	flagsGrid->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, b2yn(tile->isHouseTile())), wxSizerFlags(0).Left().Align(wxALIGN_CENTER_VERTICAL));
+
+	flagsSizer->Add(flagsGrid, wxSizerFlags(1).Expand().Border(wxALL, 4));
+	rightSizer->Add(flagsSizer, wxSizerFlags(0).Expand().DoubleBorder(wxRIGHT | wxBOTTOM));
+
+	splitSizer->Add(rightSizer, wxSizerFlags(1).Expand());
+
+	sizer->Add(splitSizer, wxSizerFlags(1).Expand());
 
 	// OK/Cancel buttons
 	wxSizer* btnSizer = newd wxBoxSizer(wxHORIZONTAL);

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -44,11 +44,18 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 									"Find by Properties" };
 
 	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
-	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
+	options_radio_box = newd wxRadioBox(this, wxID_ANY, "Search Mode", wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
 	options_radio_box->SetSelection(SearchMode::ServerIDs);
 	options_box_sizer->Add(options_radio_box, 0, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
+	wxNotebook* notebook = newd wxNotebook(this, wxID_ANY);
+	options_box_sizer->Add(notebook, 1, wxALL | wxEXPAND, 5);
+
+	// ID & Name Page
+	wxPanel* basic_page = newd wxPanel(notebook, wxID_ANY);
+	wxBoxSizer* basic_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(basic_page, wxID_ANY, "Server ID"), wxVERTICAL);
 	server_id_spin = newd wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
 	server_id_spin->SetToolTip("Search by server ID");
 	server_id_box_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
@@ -57,42 +64,28 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	invalid_item->SetToolTip("Force choose item ID that does not appear on the list.");
 	server_id_box_sizer->Add(invalid_item, 1, wxALL | wxEXPAND, 5);
 
-	options_box_sizer->Add(server_id_box_sizer, 1, wxALL | wxEXPAND, 5);
+	basic_sizer->Add(server_id_box_sizer, 0, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
+	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(basic_page, wxID_ANY, "Client ID"), wxVERTICAL);
 	client_id_spin = newd wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
 	client_id_spin->SetToolTip("Search by client ID");
 	client_id_spin->Enable(false);
 	client_id_box_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
-	options_box_sizer->Add(client_id_box_sizer, 1, wxALL | wxEXPAND, 5);
+	basic_sizer->Add(client_id_box_sizer, 0, wxALL | wxEXPAND, 5);
 
-	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
+	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(basic_page, wxID_ANY, "Name"), wxVERTICAL);
 	name_text_input = newd wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
 	name_text_input->SetToolTip("Search by item name (requires 2+ characters)");
 	name_text_input->Enable(false);
 	name_box_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
-	options_box_sizer->Add(name_box_sizer, 1, wxALL | wxEXPAND, 5);
+	basic_sizer->Add(name_box_sizer, 0, wxALL | wxEXPAND, 5);
 
-	// spacer
-	options_box_sizer->Add(0, 0, 4, wxALL | wxEXPAND, 5);
+	basic_page->SetSizer(basic_sizer);
+	notebook->AddPage(basic_page, "Basic");
 
-	buttons_box_sizer = newd wxStdDialogButtonSizer();
-	ok_button = newd wxButton(this, wxID_OK);
-	ok_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
-	ok_button->SetToolTip("Select an item to confirm");
-	buttons_box_sizer->AddButton(ok_button);
-	cancel_button = newd wxButton(this, wxID_CANCEL);
-	cancel_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
-	cancel_button->SetToolTip("Cancel selection");
-	buttons_box_sizer->AddButton(cancel_button);
-	buttons_box_sizer->Realize();
-	options_box_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
-
-	box_sizer->Add(options_box_sizer, 1, wxALL, 5);
-
-	// --------------- Types ---------------
-
-	wxStaticBoxSizer* type_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Types"), wxVERTICAL);
+	// Types Page
+	wxPanel* types_page = newd wxPanel(notebook, wxID_ANY);
+	wxBoxSizer* types_sizer = newd wxBoxSizer(wxVERTICAL);
 
 	wxString types_choices[] = { "Depot",
 								 "Mailbox",
@@ -106,80 +99,103 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 								 "Podium" };
 
 	int types_choices_count = sizeof(types_choices) / sizeof(wxString);
-	types_radio_box = newd wxRadioBox(type_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
+	types_radio_box = newd wxRadioBox(types_page, wxID_ANY, "Select Type", wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
 	types_radio_box->SetSelection(0);
 	types_radio_box->Enable(false);
-	type_box_sizer->Add(types_radio_box, 0, wxALL | wxEXPAND, 5);
+	types_sizer->Add(types_radio_box, 1, wxALL | wxEXPAND, 5);
 
-	box_sizer->Add(type_box_sizer, 1, wxALL | wxEXPAND, 5);
+	types_page->SetSizer(types_sizer);
+	notebook->AddPage(types_page, "Types");
 
-	// --------------- Properties ---------------
+	// Properties Page
+	wxPanel* properties_page = newd wxPanel(notebook, wxID_ANY);
+	wxBoxSizer* prop_page_sizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
+	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(properties_page, wxID_ANY, "Properties"), wxVERTICAL);
+	wxFlexGridSizer* prop_grid = newd wxFlexGridSizer(3, 5, 5); // 3 cols, 5px gap
 
-	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
+	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable");
 	unpassable->SetToolTip("Item blocks movement");
-	properties_box_sizer->Add(unpassable, 0, wxALL, 5);
+	prop_grid->Add(unpassable, 0, wxALL, 5);
 
-	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
+	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable");
 	unmovable->SetToolTip("Item cannot be moved");
-	properties_box_sizer->Add(unmovable, 0, wxALL, 5);
+	prop_grid->Add(unmovable, 0, wxALL, 5);
 
-	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
+	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles");
 	block_missiles->SetToolTip("Item blocks projectiles");
-	properties_box_sizer->Add(block_missiles, 0, wxALL, 5);
+	prop_grid->Add(block_missiles, 0, wxALL, 5);
 
-	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
+	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Path");
 	block_pathfinder->SetToolTip("Item blocks pathfinding");
-	properties_box_sizer->Add(block_pathfinder, 0, wxALL, 5);
+	prop_grid->Add(block_pathfinder, 0, wxALL, 5);
 
-	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
+	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable");
 	readable->SetToolTip("Item has text");
-	properties_box_sizer->Add(readable, 0, wxALL, 5);
+	prop_grid->Add(readable, 0, wxALL, 5);
 
-	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
+	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable");
 	writeable->SetToolTip("Item can be written on");
-	properties_box_sizer->Add(writeable, 0, wxALL, 5);
+	prop_grid->Add(writeable, 0, wxALL, 5);
 
-	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
+	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable");
 	pickupable->SetToolTip("Item can be picked up");
 	pickupable->SetValue(only_pickupables);
 	pickupable->Enable(!only_pickupables);
-	properties_box_sizer->Add(pickupable, 0, wxALL, 5);
+	prop_grid->Add(pickupable, 0, wxALL, 5);
 
-	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
+	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable");
 	stackable->SetToolTip("Item is stackable");
-	properties_box_sizer->Add(stackable, 0, wxALL, 5);
+	prop_grid->Add(stackable, 0, wxALL, 5);
 
-	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
+	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable");
 	rotatable->SetToolTip("Item can be rotated");
-	properties_box_sizer->Add(rotatable, 0, wxALL, 5);
+	prop_grid->Add(rotatable, 0, wxALL, 5);
 
-	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
+	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable");
 	hangable->SetToolTip("Item can be hung on walls");
-	properties_box_sizer->Add(hangable, 0, wxALL, 5);
+	prop_grid->Add(hangable, 0, wxALL, 5);
 
-	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
+	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East");
 	hook_east->SetToolTip("Item hooks to the east");
-	properties_box_sizer->Add(hook_east, 0, wxALL, 5);
+	prop_grid->Add(hook_east, 0, wxALL, 5);
 
-	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
+	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South");
 	hook_south->SetToolTip("Item hooks to the south");
-	properties_box_sizer->Add(hook_south, 0, wxALL, 5);
+	prop_grid->Add(hook_south, 0, wxALL, 5);
 
-	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
+	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation");
 	has_elevation->SetToolTip("Item has height (elevation)");
-	properties_box_sizer->Add(has_elevation, 0, wxALL, 5);
+	prop_grid->Add(has_elevation, 0, wxALL, 5);
 
-	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
+	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look");
 	ignore_look->SetToolTip("Item is ignored when looking");
-	properties_box_sizer->Add(ignore_look, 0, wxALL, 5);
+	prop_grid->Add(ignore_look, 0, wxALL, 5);
 
-	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
+	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change");
 	floor_change->SetToolTip("Item causes floor change");
-	properties_box_sizer->Add(floor_change, 0, wxALL, 5);
+	prop_grid->Add(floor_change, 0, wxALL, 5);
 
-	box_sizer->Add(properties_box_sizer, 1, wxALL | wxEXPAND, 5);
+	properties_box_sizer->Add(prop_grid, 1, wxALL | wxEXPAND, 0);
+	prop_page_sizer->Add(properties_box_sizer, 1, wxALL | wxEXPAND, 5);
+
+	properties_page->SetSizer(prop_page_sizer);
+	notebook->AddPage(properties_page, "Properties");
+
+	// Add buttons to bottom of options sizer
+	buttons_box_sizer = newd wxStdDialogButtonSizer();
+	ok_button = newd wxButton(this, wxID_OK);
+	ok_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
+	ok_button->SetToolTip("Select an item to confirm");
+	buttons_box_sizer->AddButton(ok_button);
+	cancel_button = newd wxButton(this, wxID_CANCEL);
+	cancel_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
+	cancel_button->SetToolTip("Cancel selection");
+	buttons_box_sizer->AddButton(cancel_button);
+	buttons_box_sizer->Realize();
+	options_box_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
+
+	box_sizer->Add(options_box_sizer, 1, wxALL | wxEXPAND, 5);
 
 	// --------------- Items list ---------------
 

--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -152,79 +152,87 @@ void MapPopupMenu::Update() {
 					}
 				}
 
+				wxMenu* brushMenu = new wxMenu();
+
 				if (topCreature) {
-					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
 				}
 
 				if (topSpawn) {
-					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
-
-				if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
-					Append(MAP_POPUP_MENU_MOVE_TO_TILESET, "Move To Tileset", "Move this item to any tileset")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHARE_FROM_SQUARE, wxSize(16, 16)));
-				}
+				brushMenu->Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 
 				if (hasWall) {
-					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
 
 				if (hasCarpet) {
-					Append(MAP_POPUP_MENU_SELECT_CARPET_BRUSH, "Select Carpetbrush", "Uses the current item as a carpetbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_RUG, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_CARPET_BRUSH, "Select Carpetbrush", "Uses the current item as a carpetbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_RUG, wxSize(16, 16)));
 				}
 
 				if (hasTable) {
-					Append(MAP_POPUP_MENU_SELECT_TABLE_BRUSH, "Select Tablebrush", "Uses the current item as a tablebrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TABLE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_TABLE_BRUSH, "Select Tablebrush", "Uses the current item as a tablebrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TABLE, wxSize(16, 16)));
 				}
 
 				if (topSelectedItem && topSelectedItem->getDoodadBrush() && topSelectedItem->getDoodadBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_DOODAD_BRUSH, "Select Doodadbrush", "Use this doodad brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TREE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_DOODAD_BRUSH, "Select Doodadbrush", "Use this doodad brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TREE, wxSize(16, 16)));
 				}
 
 				if (topSelectedItem && topSelectedItem->isBrushDoor() && topSelectedItem->getDoorBrush()) {
-					Append(MAP_POPUP_MENU_SELECT_DOOR_BRUSH, "Select Doorbrush", "Use this door brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_DOOR_BRUSH, "Select Doorbrush", "Use this door brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, wxSize(16, 16)));
 				}
 
 				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current item as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current item as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
-					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (tile->isHouseTile()) {
-					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
+				}
+
+				AppendSubMenu(brushMenu, "Select Brush...")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PAINTBRUSH, wxSize(16, 16)));
+
+				if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
+					Append(MAP_POPUP_MENU_MOVE_TO_TILESET, "Move To Tileset", "Move this item to any tileset")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHARE_FROM_SQUARE, wxSize(16, 16)));
 				}
 
 				AppendSeparator();
 				Append(MAP_POPUP_MENU_PROPERTIES, "&Properties", "Properties for the current object")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(16, 16)));
 			} else {
 
+				wxMenu* brushMenu = new wxMenu();
+
 				if (topCreature) {
-					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
 				}
 
 				if (topSpawn) {
-					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
+				brushMenu->Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 				if (hasWall) {
-					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
 				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current tile as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current tile as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (hasCollection || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
-					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (tile->isHouseTile()) {
-					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
+					brushMenu->Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
 				}
+
+				AppendSubMenu(brushMenu, "Select Brush...")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PAINTBRUSH, wxSize(16, 16)));
 
 				if (tile->hasGround() || topCreature || topSpawn) {
 					AppendSeparator();


### PR DESCRIPTION
Autonomously applied UX/UI improvements according to `designer.md`. 
1. Reorganized `BrowseTileWindow` into an inspector layout.
2. Grouped `FindItemDialog` properties into grids and tabs.
3. Cleaned up the `MapPopupMenu` context menu by adding a brush submenu.
4. Fixed a compilation error due to missing `<cstring>` include in `filehandle.h`.

---
*PR created automatically by Jules for task [7813540957066482607](https://jules.google.com/task/7813540957066482607) started by @karolak6612*