### PR TITLE
🧩 Fixer: Extract Tile logic to free functions and optimize tile item storage

### DIFF
--- a/source/brushes/border/optional_border_brush.cpp
+++ b/source/brushes/border/optional_border_brush.cpp
@@ -26,7 +26,7 @@ int OptionalBorderBrush::getLookID() const {
 
 bool OptionalBorderBrush::canDraw(BaseMap* map, const Position& position) const {
 	if (Tile* tile = map->getTile(position)) {
-		if (GroundBrush* bb = tile->getGroundBrush()) {
+		if (GroundBrush* bb = TileOperations::getGroundBrush(tile)) {
 			if (bb->hasOptionalBorder()) {
 				return false;
 			}
@@ -37,7 +37,7 @@ bool OptionalBorderBrush::canDraw(BaseMap* map, const Position& position) const 
 
 	for (const auto& [dx, dy] : offsets) {
 		if (Tile* tile = map->getTile(position.x + dx, position.y + dy, position.z)) {
-			if (GroundBrush* bb = tile->getGroundBrush()) {
+			if (GroundBrush* bb = TileOperations::getGroundBrush(tile)) {
 				if (bb->hasOptionalBorder()) {
 					return true;
 				}

--- a/source/brushes/brush_utility.cpp
+++ b/source/brushes/brush_utility.cpp
@@ -28,7 +28,7 @@ void BrushUtility::GetTilesToDraw(int mouse_map_x, int mouse_map_y, int floor, s
 		Tile* tile = g_gui.GetCurrentMap().getTile(position);
 		GroundBrush* oldBrush = nullptr;
 		if (tile) {
-			oldBrush = tile->getGroundBrush();
+			oldBrush = TileOperations::getGroundBrush(tile);
 		}
 
 		if (oldBrush && oldBrush->getID() == newBrush->getID()) {
@@ -40,7 +40,7 @@ void BrushUtility::GetTilesToDraw(int mouse_map_x, int mouse_map_y, int floor, s
 		}
 
 		if (tile && oldBrush) {
-			GroundBrush* groundBrush = tile->getGroundBrush();
+			GroundBrush* groundBrush = TileOperations::getGroundBrush(tile);
 			if (!groundBrush || groundBrush->getID() != oldBrush->getID()) {
 				return;
 			}
@@ -110,7 +110,7 @@ bool BrushUtility::FloodFill(Map* map, const Position& center, int x, int y, Gro
 	}
 
 	if (tile && brush) {
-		GroundBrush* groundBrush = tile->getGroundBrush();
+		GroundBrush* groundBrush = TileOperations::getGroundBrush(tile);
 		if (!groundBrush || groundBrush->getID() != brush->getID()) {
 			return false;
 		}

--- a/source/brushes/carpet/carpet_brush.cpp
+++ b/source/brushes/carpet/carpet_brush.cpp
@@ -52,7 +52,7 @@ bool CarpetBrush::canDraw(BaseMap* map, const Position& position) const {
 
 void CarpetBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 	undraw(map, tile); // Remove old
-	tile->addItem(Item::Create(getRandomCarpet(CARPET_CENTER)));
+	TileOperations::addItem(tile, Item::Create(getRandomCarpet(CARPET_CENTER)));
 }
 
 void CarpetBrush::undraw(BaseMap* map, Tile* tile) {

--- a/source/brushes/doodad/doodad_brush.cpp
+++ b/source/brushes/doodad/doodad_brush.cpp
@@ -86,7 +86,7 @@ void DoodadBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 
 	Item* randomItem = items.getRandomSingleItem(variation);
 	if (randomItem) {
-		tile->addItem(randomItem->deepCopy());
+		TileOperations::addItem(tile, randomItem->deepCopy());
 	}
 
 	if (settings.clear_mapflags || settings.clear_statflags) {

--- a/source/brushes/door/door_brush.cpp
+++ b/source/brushes/door/door_brush.cpp
@@ -107,7 +107,7 @@ bool DoorBrush::canDraw(BaseMap* map, const Position& position) const {
 		return false;
 	}
 
-	Item* item = tile->getWall();
+	Item* item = TileOperations::getWall(tile);
 	if (!item) {
 		return false;
 	}

--- a/source/brushes/ground/ground_border_calculator.cpp
+++ b/source/brushes/ground/ground_border_calculator.cpp
@@ -17,7 +17,7 @@ void GroundBorderCalculator::calculate(BaseMap* map, Tile* tile) {
 	static const auto extractGroundBrushFromTile = [](BaseMap* map, int x, int y, int z) -> GroundBrush* {
 		Tile* tile = map->getTile(x, y, z);
 		if (tile) {
-			return tile->getGroundBrush();
+			return TileOperations::getGroundBrush(tile);
 		}
 		return nullptr;
 	};

--- a/source/brushes/ground/ground_brush.cpp
+++ b/source/brushes/ground/ground_brush.cpp
@@ -62,7 +62,7 @@ void GroundBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 
 	if (parameter != nullptr) {
 		std::pair<bool, GroundBrush*>& param = *reinterpret_cast<std::pair<bool, GroundBrush*>*>(parameter);
-		GroundBrush* other = tile->getGroundBrush();
+		GroundBrush* other = TileOperations::getGroundBrush(tile);
 		if (param.first) { // Volatile? :)
 			if (other != nullptr) {
 				return;
@@ -83,7 +83,7 @@ void GroundBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 		id = border_items.front().id;
 	}
 
-	tile->addItem(Item::Create(id));
+	TileOperations::addItem(tile, Item::Create(id));
 }
 
 const GroundBrush::BorderBlock* GroundBrush::getBrushTo(GroundBrush* first, GroundBrush* second) {
@@ -142,7 +142,7 @@ const GroundBrush::BorderBlock* GroundBrush::getBrushTo(GroundBrush* first, Grou
 
 inline GroundBrush* extractGroundBrushFromTile(BaseMap* map, uint32_t x, uint32_t y, uint32_t z) {
 	Tile* t = map->getTile(x, y, z);
-	return t ? t->getGroundBrush() : nullptr;
+	return t ? TileOperations::getGroundBrush(t) : nullptr;
 }
 
 void GroundBrush::doBorders(BaseMap* map, Tile* tile) {

--- a/source/brushes/managers/autoborder_preview_manager.cpp
+++ b/source/brushes/managers/autoborder_preview_manager.cpp
@@ -202,7 +202,7 @@ void AutoborderPreviewManager::PruneUnchanged(Editor& editor, const Position& po
 			}
 
 			// Compare tiles
-			bool equal = buf_tile->isContentEqual(src_tile);
+			bool equal = TileOperations::isContentEqual(buf_tile, src_tile);
 
 			if (equal) {
 				// Remove unmodified tile from buffer to prevent ghosting

--- a/source/brushes/managers/doodad_preview_manager.cpp
+++ b/source/brushes/managers/doodad_preview_manager.cpp
@@ -121,7 +121,7 @@ void DoodadPreviewManager::FillBuffer() {
 						}
 
 						for (const auto& item : items) {
-							tile->addItem(item->deepCopy());
+							TileOperations::addItem(tile, item->deepCopy());
 						}
 					}
 					exit = true;
@@ -161,7 +161,7 @@ void DoodadPreviewManager::FillBuffer() {
 				Tile* tile = doodad_buffer_map->createTile(pos.x, pos.y, pos.z);
 
 				for (const auto& item : items) {
-					tile->addItem(item->deepCopy());
+					TileOperations::addItem(tile, item->deepCopy());
 				}
 			}
 		} else if (brush->hasSingleObjects(g_brush_manager.GetBrushVariation())) {

--- a/source/brushes/raw/raw_brush.cpp
+++ b/source/brushes/raw/raw_brush.cpp
@@ -85,5 +85,5 @@ void RAWBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 			return item->getTopOrder() == topOrder;
 		});
 	}
-	tile->addItem(Item::Create(itemtype->id));
+	TileOperations::addItem(tile, Item::Create(itemtype->id));
 }

--- a/source/brushes/table/table_brush.cpp
+++ b/source/brushes/table/table_brush.cpp
@@ -72,7 +72,7 @@ void TableBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 	}
 
 	if (type != 0) {
-		tile->addItem(Item::Create(type));
+		TileOperations::addItem(tile, Item::Create(type));
 	}
 }
 

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -45,7 +45,7 @@ void CopyOperations::copy(Editor& editor, CopyBuffer& buffer, int floor) {
 		for (auto* item : tile_selection) {
 			++item_count;
 			// Copy items to copybuffer
-			copied_tile->addItem(item->deepCopy());
+			TileOperations::addItem(copied_tile.get(), item->deepCopy());
 		}
 
 		if (tile->creature && tile->creature->isSelected()) {
@@ -105,7 +105,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 		for (auto& item : tile_selection) {
 			item_count++;
 			// Add items to copybuffer
-			copied_tile->addItem(std::move(item));
+			TileOperations::addItem(copied_tile.get(), std::move(item));
 		}
 
 		if (newtile->creature && newtile->creature->isSelected()) {

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -26,7 +26,7 @@ void SelectionOperations::doSurroundingBorders(DoodadBrush* doodad_brush, Positi
 					tilestoborder.push_back(Position(new_tile->getPosition().x + x, new_tile->getPosition().y + y, new_tile->getPosition().z));
 				}
 			}
-		} else if (buffer_tile->hasWall()) {
+		} else if (TileOperations::getWall(buffer_tile) != nullptr) {
 			tilestoborder.push_back(Position(new_tile->getPosition().x, new_tile->getPosition().y - 1, new_tile->getPosition().z));
 			tilestoborder.push_back(Position(new_tile->getPosition().x - 1, new_tile->getPosition().y, new_tile->getPosition().z));
 			tilestoborder.push_back(Position(new_tile->getPosition().x + 1, new_tile->getPosition().y, new_tile->getPosition().z));
@@ -66,7 +66,7 @@ void SelectionOperations::randomizeSelection(Editor& editor) {
 	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_RANDOMIZE);
 	for (Tile* tile : editor.selection) {
 		std::unique_ptr<Tile> newTile = TileOperations::deepCopy(tile, editor.map);
-		GroundBrush* groundBrush = newTile->getGroundBrush();
+		GroundBrush* groundBrush = TileOperations::getGroundBrush(newTile.get());
 		if (groundBrush && groundBrush->isReRandomizable()) {
 			groundBrush->draw(&editor.map, newTile.get(), nullptr);
 
@@ -107,7 +107,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 		auto tile_selection = TileOperations::popSelectedItems(new_src_tile.get());
 		for (auto& item : tile_selection) {
 			// Add the copied item to the newd destination tile,
-			tmp_storage_tile->addItem(std::move(item));
+			TileOperations::addItem(tmp_storage_tile.get(), std::move(item));
 		}
 		// Move spawns
 		if (new_src_tile->spawn && new_src_tile->spawn->isSelected()) {

--- a/source/io/otbm/tile_serialization_otbm.cpp
+++ b/source/io/otbm/tile_serialization_otbm.cpp
@@ -81,7 +81,7 @@ void TileSerializationOTBM::readTileArea(IOMapOTBM& iomap, Map& map, BinaryNode*
 				case OTBM_ATTR_ITEM: {
 					auto item = ItemSerializationOTBM::createFromStream(iomap, tileNode);
 					if (item) {
-						tile->addItem(std::move(item));
+						TileOperations::addItem(tile, std::move(item));
 					} else {
 						spdlog::warn("Failed to read item attribute at {},{},{}", pos.x, pos.y, pos.z);
 					}
@@ -107,7 +107,7 @@ void TileSerializationOTBM::readTileArea(IOMapOTBM& iomap, Map& map, BinaryNode*
 					if (!ItemSerializationOTBM::unserializeItemNode(iomap, itemNode, *item)) {
 						spdlog::warn("Failed to unserialize item at {},{},{}", pos.x, pos.y, pos.z);
 					} else {
-						tile->addItem(std::move(item));
+						TileOperations::addItem(tile, std::move(item));
 					}
 				}
 			} else {

--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -332,7 +332,7 @@ std::unique_ptr<Tile> LiveSocket::readTile(BinaryNode* node, Editor& editor, con
 				if (!item) {
 					// warning("Invalid item at tile %d:%d:%d", pos.x, pos.y, pos.z);
 				}
-				tile->addItem(std::move(item));
+				TileOperations::addItem(tile, std::move(item));
 				break;
 			}
 			default:
@@ -357,7 +357,7 @@ std::unique_ptr<Tile> LiveSocket::readTile(BinaryNode* node, Editor& editor, con
 					if (!item->unserializeItemNode_OTBM(mapVersion, itemNode)) {
 						// warning("Couldn't unserialize item attributes at %d:%d:%d", pos.x, pos.y, pos.z);
 					}
-					tile->addItem(std::move(item));
+					TileOperations::addItem(tile, std::move(item));
 				}
 			} else {
 				// warning("Unknown type of tile child node");

--- a/source/map/map_converter.cpp
+++ b/source/map/map_converter.cpp
@@ -96,7 +96,7 @@ namespace {
 					if (item->isGroundTile()) {
 						item->setActionID(aid);
 						item->setUniqueID(uid);
-						tile->addItem(std::move(item));
+						TileOperations::addItem(tile, std::move(item));
 					} else {
 						tile->items.insert(tile->items.begin(), std::move(item));
 						++inserted_items;

--- a/source/map/operations/map_processor.cpp
+++ b/source/map/operations/map_processor.cpp
@@ -48,7 +48,7 @@ void MapProcessor::randomizeMap(Editor& editor, bool showdialog) {
 		Tile* tile = tileLocation.get();
 		ASSERT(tile);
 
-		GroundBrush* groundBrush = tile->getGroundBrush();
+		GroundBrush* groundBrush = TileOperations::getGroundBrush(tile);
 		if (groundBrush) {
 			Item* oldGround = tile->ground.get();
 

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -151,109 +151,6 @@ int Tile::size() const {
 	return sz;
 }
 
-bool Tile::hasProperty(enum ITEMPROPERTY prop) const {
-	if (prop == PROTECTIONZONE && isPZ()) {
-		return true;
-	}
-
-	if (prop == BLOCKSOLID) {
-		// Optimization: Use cached blocking state
-		// Note: isBlocking() returns true for empty tiles (void), but hasProperty checks if *content* has property.
-		return isBlocking() && (ground || !items.empty());
-	}
-
-	if (ground && ground->hasProperty(prop)) {
-		return true;
-	}
-
-	return std::ranges::any_of(items, [prop](const auto& i) {
-		return i->hasProperty(prop);
-	});
-}
-
-int Tile::getIndexOf(Item* item) const {
-	if (!item) {
-		return wxNOT_FOUND;
-	}
-
-	int index = 0;
-	if (ground) {
-		if (ground.get() == item) {
-			return index;
-		}
-		index++;
-	}
-
-	if (!items.empty()) {
-		if (auto it = std::ranges::find_if(items, [item](const std::unique_ptr<Item>& i) { return i.get() == item; }); it != items.end()) {
-			index += std::distance(items.begin(), it);
-			return index;
-		}
-	}
-	return wxNOT_FOUND;
-}
-
-Item* Tile::getTopItem() const {
-	if (!items.empty() && !items.back()->isMetaItem()) {
-		return items.back().get();
-	}
-	if (ground && !ground->isMetaItem()) {
-		return ground.get();
-	}
-	return nullptr;
-}
-
-Item* Tile::getItemAt(int index) const {
-	if (index < 0) {
-		return nullptr;
-	}
-	if (ground) {
-		if (index == 0) {
-			return ground.get();
-		}
-		index--;
-	}
-	if (index >= 0 && index < (int)items.size()) {
-		return items.at(index).get();
-	}
-	return nullptr;
-}
-
-void Tile::addItem(std::unique_ptr<Item> item) {
-	if (!item) {
-		return;
-	}
-	if (item->isGroundTile()) {
-		ground = std::move(item);
-		TileOperations::update(this);
-		return;
-	}
-
-	uint16_t gid = item->getGroundEquivalent();
-	auto it = items.begin();
-
-	if (gid != 0) {
-		ground = Item::Create(gid);
-		TileOperations::update(this);
-		return;
-		// At the very bottom!
-	} else if (item->isAlwaysOnBottom()) {
-		// Find insertion point for always-on-bottom items
-		// They are sorted by TopOrder, and come before normal items.
-		it = std::ranges::find_if(items, [&](const std::unique_ptr<Item>& i) {
-			if (!i->isAlwaysOnBottom()) {
-				return true; // Found a normal item, insert before it
-			}
-			return item->getTopOrder() < i->getTopOrder(); // Found a bottom item with higher order
-		});
-	} else {
-		it = items.end();
-	}
-
-	items.insert(it, std::move(item));
-	TileOperations::update(this);
-}
-
 uint8_t Tile::getMiniMapColor() const {
 	if (minimapColor != INVALID_MINIMAP_COLOR) {
 		return minimapColor;
@@ -305,36 +202,6 @@ bool tilePositionVisualLessThan(const Tile* a, const Tile* b) {
 	return false;
 }
 
-GroundBrush* Tile::getGroundBrush() const {
-	if (ground) {
-		if (ground->getGroundBrush()) {
-			return ground->getGroundBrush();
-		}
-	}
-	return nullptr;
-}
-
-Item* Tile::getWall() const {
-	auto it = std::ranges::find_if(items, [](const std::unique_ptr<Item>& i) {
-		return i->isWall();
-	});
-	return (it != items.end()) ? it->get() : nullptr;
-}
-
-Item* Tile::getCarpet() const {
-	auto it = std::ranges::find_if(items, [](const std::unique_ptr<Item>& i) {
-		return i->isCarpet();
-	});
-	return (it != items.end()) ? it->get() : nullptr;
-}
-
-Item* Tile::getTable() const {
-	auto it = std::ranges::find_if(items, [](const std::unique_ptr<Item>& i) {
-		return i->isTable();
-	});
-	return (it != items.end()) ? it->get() : nullptr;
-}
-
 void Tile::setHouse(House* _house) {
 	house_id = (_house ? _house->getID() : 0);
 }
@@ -345,24 +212,4 @@ void Tile::setHouseID(uint32_t newHouseId) {
 
 bool Tile::isTownExit(Map& map) const {
 	return location->getTownCount() > 0;
-}
-
-bool Tile::isContentEqual(const Tile* other) const {
-	if (!other) {
-		return false;
-	}
-
-	// Compare ground
-	if (ground != nullptr && other->ground != nullptr) {
-		if (ground->getID() != other->ground->getID() || ground->getSubtype() != other->ground->getSubtype()) {
-			return false;
-		}
-	} else if (ground != other->ground) {
-		return false;
-	}
-
-	// Compare items
-	return std::ranges::equal(items, other->items, [](const std::unique_ptr<Item>& it1, const std::unique_ptr<Item>& it2) {
-		return it1->getID() == it2->getID() && it1->getSubtype() == it2->getSubtype();
-	});
 }

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -34,6 +34,7 @@ class Map;
 #include <unordered_set>
 #include <memory>
 #include <vector>
+#include <boost/container/small_vector.hpp>
 
 // TileOperations functions are now in tile_operations.h
 
@@ -66,7 +67,7 @@ class Tile {
 public: // Members
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
-	std::vector<std::unique_ptr<Item>> items;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> items;
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)
@@ -105,8 +106,6 @@ public:
 	int getZ() const;
 
 public: // Functions
-	// Compare the content (ground and items) of two tiles
-	bool isContentEqual(const Tile* other) const;
 
 	// Has tile been modified since the map was loaded/created?
 	bool isModified() const {
@@ -144,13 +143,6 @@ public: // Functions
 		}
 	}
 
-	bool hasProperty(enum ITEMPROPERTY prop) const;
-
-	int getIndexOf(Item* item) const;
-	Item* getTopItem() const; // Returns the topmost item, or nullptr if the tile is empty
-	Item* getItemAt(int index) const;
-	void addItem(std::unique_ptr<Item> item);
-
 	bool isSelected() const {
 		return testFlags(statflags, TILESTATE_SELECTED);
 	}
@@ -168,18 +160,13 @@ public: // Functions
 		return items.size() && items[0]->isBorder();
 	}
 
-	// Get the border brush of this tile
-	GroundBrush* getGroundBrush() const;
-
 	bool hasTable() const {
 		return testFlags(statflags, TILESTATE_HAS_TABLE);
 	}
-	Item* getTable() const;
 
 	bool hasCarpet() const {
 		return testFlags(statflags, TILESTATE_HAS_CARPET);
 	}
-	Item* getCarpet() const;
 
 	bool hasHookSouth() const {
 		return testFlags(statflags, TILESTATE_HOOK_SOUTH);
@@ -203,10 +190,6 @@ public: // Functions
 			statflags &= ~TILESTATE_OP_BORDER;
 		}
 	}
-
-	// Get the (first) wall of this tile
-	Item* getWall() const;
-	bool hasWall() const;
 
 	// Has to do with houses
 	bool isHouseTile() const;
@@ -238,10 +221,6 @@ bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 using TileVector = std::vector<Tile*>;
 using TileSet = std::vector<Tile*>;
 using TileList = std::list<Tile*>;
-
-inline bool Tile::hasWall() const {
-	return getWall() != nullptr;
-}
 
 inline bool Tile::isHouseTile() const {
 	return house_id != 0;

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -159,10 +159,163 @@ namespace TileOperations {
 
 		dest->items.reserve(dest->items.size() + src->items.size());
 		for (auto& item : src->items) {
-			dest->addItem(std::move(item));
+			TileOperations::addItem(dest, std::move(item));
 		}
 		src->items.clear();
 		TileOperations::update(dest);
+	}
+
+	bool hasProperty(const Tile* tile, enum ITEMPROPERTY prop) {
+		if (prop == PROTECTIONZONE && tile->isPZ()) {
+			return true;
+		}
+
+		if (prop == BLOCKSOLID) {
+			// Optimization: Use cached blocking state
+			// Note: isBlocking() returns true for empty tiles (void), but hasProperty checks if *content* has property.
+			return tile->isBlocking() && (tile->ground || !tile->items.empty());
+		}
+
+		if (tile->ground && tile->ground->hasProperty(prop)) {
+			return true;
+		}
+
+		return std::ranges::any_of(tile->items, [prop](const auto& i) {
+			return i->hasProperty(prop);
+		});
+	}
+
+	int getIndexOf(const Tile* tile, Item* item) {
+		if (!item) {
+			return wxNOT_FOUND;
+		}
+
+		int index = 0;
+		if (tile->ground) {
+			if (tile->ground.get() == item) {
+				return index;
+			}
+			index++;
+		}
+
+		if (!tile->items.empty()) {
+			if (auto it = std::ranges::find_if(tile->items, [item](const std::unique_ptr<Item>& i) { return i.get() == item; }); it != tile->items.end()) {
+				index += std::distance(tile->items.begin(), it);
+				return index;
+			}
+		}
+		return wxNOT_FOUND;
+	}
+
+	Item* getTopItem(const Tile* tile) {
+		if (!tile->items.empty() && !tile->items.back()->isMetaItem()) {
+			return tile->items.back().get();
+		}
+		if (tile->ground && !tile->ground->isMetaItem()) {
+			return tile->ground.get();
+		}
+		return nullptr;
+	}
+
+	Item* getItemAt(const Tile* tile, int index) {
+		if (index < 0) {
+			return nullptr;
+		}
+		if (tile->ground) {
+			if (index == 0) {
+				return tile->ground.get();
+			}
+			index--;
+		}
+		if (index >= 0 && index < (int)tile->items.size()) {
+			return tile->items.at(index).get();
+		}
+		return nullptr;
+	}
+
+	void addItem(Tile* tile, std::unique_ptr<Item> item) {
+		if (!item) {
+			return;
+		}
+		if (item->isGroundTile()) {
+			tile->ground = std::move(item);
+			TileOperations::update(tile);
+			return;
+		}
+
+		uint16_t gid = item->getGroundEquivalent();
+		auto it = tile->items.begin();
+
+		if (gid != 0) {
+			tile->ground = Item::Create(gid);
+			TileOperations::update(tile);
+			return;
+			// At the very bottom!
+		} else if (item->isAlwaysOnBottom()) {
+			// Find insertion point for always-on-bottom items
+			// They are sorted by TopOrder, and come before normal items.
+			it = std::ranges::find_if(tile->items, [&](const std::unique_ptr<Item>& i) {
+				if (!i->isAlwaysOnBottom()) {
+					return true; // Found a normal item, insert before it
+				}
+				return item->getTopOrder() < i->getTopOrder(); // Found a bottom item with higher order
+			});
+		} else {
+			it = tile->items.end();
+		}
+
+		tile->items.insert(it, std::move(item));
+		TileOperations::update(tile);
+	}
+
+	GroundBrush* getGroundBrush(const Tile* tile) {
+		if (tile->ground) {
+			if (tile->ground->getGroundBrush()) {
+				return tile->ground->getGroundBrush();
+			}
+		}
+		return nullptr;
+	}
+
+	Item* getWall(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isWall();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	Item* getCarpet(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isCarpet();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	Item* getTable(const Tile* tile) {
+		auto it = std::ranges::find_if(tile->items, [](const std::unique_ptr<Item>& i) {
+			return i->isTable();
+		});
+		return (it != tile->items.end()) ? it->get() : nullptr;
+	}
+
+	bool isContentEqual(const Tile* tile, const Tile* other) {
+		if (!other || !tile) {
+			return false;
+		}
+
+		// Compare ground
+		if (tile->ground != nullptr && other->ground != nullptr) {
+			if (tile->ground->getID() != other->ground->getID() || tile->ground->getSubtype() != other->ground->getSubtype()) {
+				return false;
+			}
+		} else if (tile->ground != other->ground) {
+			return false;
+		}
+
+		// Compare items
+		return std::ranges::equal(tile->items, other->items, [](const std::unique_ptr<Item>& it1, const std::unique_ptr<Item>& it2) {
+			return it1->getID() == it2->getID() && it1->getSubtype() == it2->getSubtype();
+		});
 	}
 
 	Item* transformItem(Item* old_item, uint16_t new_id, Tile* parent) {
@@ -362,7 +515,7 @@ namespace TileOperations {
 			return;
 		}
 		ASSERT(item->isWall());
-		tile->addItem(std::move(item));
+		TileOperations::addItem(tile, std::move(item));
 	}
 
 	void addHouseExit(Tile* tile, House* h) {

--- a/source/map/tile_operations.h
+++ b/source/map/tile_operations.h
@@ -32,6 +32,18 @@ namespace TileOperations {
 	void merge(Tile* dest, Tile* src);
 	Item* transformItem(Item* old_item, uint16_t new_id, Tile* parent = nullptr);
 
+	// Tile queries / accessors
+	bool hasProperty(const Tile* tile, enum ITEMPROPERTY prop);
+	int getIndexOf(const Tile* tile, Item* item);
+	Item* getTopItem(const Tile* tile);
+	Item* getItemAt(const Tile* tile, int index);
+	void addItem(Tile* tile, std::unique_ptr<Item> item);
+	GroundBrush* getGroundBrush(const Tile* tile);
+	Item* getWall(const Tile* tile);
+	Item* getCarpet(const Tile* tile);
+	Item* getTable(const Tile* tile);
+	bool isContentEqual(const Tile* tile, const Tile* other);
+
 	void select(Tile* tile);
 	void deselect(Tile* tile);
 	void selectGround(Tile* tile);

--- a/source/rendering/ui/brush_selector.cpp
+++ b/source/rendering/ui/brush_selector.cpp
@@ -57,7 +57,7 @@ void BrushSelector::SelectGroundBrush(Selection& selection) {
 	if (!tile) {
 		return;
 	}
-	GroundBrush* bb = tile->getGroundBrush();
+	GroundBrush* bb = TileOperations::getGroundBrush(tile);
 
 	if (bb) {
 		g_gui.SelectBrush(bb, TILESET_TERRAIN);
@@ -102,7 +102,7 @@ void BrushSelector::SelectWallBrush(Selection& selection) {
 	if (!tile) {
 		return;
 	}
-	Item* wall = tile->getWall();
+	Item* wall = TileOperations::getWall(tile);
 	WallBrush* wb = wall->getWallBrush();
 
 	if (wb) {
@@ -118,7 +118,7 @@ void BrushSelector::SelectCarpetBrush(Selection& selection) {
 	if (!tile) {
 		return;
 	}
-	Item* wall = tile->getCarpet();
+	Item* wall = TileOperations::getCarpet(tile);
 	CarpetBrush* cb = wall->getCarpetBrush();
 
 	if (cb) {
@@ -134,7 +134,7 @@ void BrushSelector::SelectTableBrush(Selection& selection) {
 	if (!tile) {
 		return;
 	}
-	Item* wall = tile->getTable();
+	Item* wall = TileOperations::getTable(tile);
 	TableBrush* tb = wall->getTableBrush();
 
 	if (tb) {
@@ -199,7 +199,7 @@ void BrushSelector::SelectCollectionBrush(Selection& selection) {
 			}
 		}
 	}
-	GroundBrush* gb = tile->getGroundBrush();
+	GroundBrush* gb = TileOperations::getGroundBrush(tile);
 	if (gb && gb->visibleInPalette() && gb->hasCollection()) {
 		g_gui.SelectBrush(gb, TILESET_COLLECTION);
 		return;
@@ -232,7 +232,7 @@ void BrushSelector::SelectSmartBrush(Editor& editor, Tile* tile) {
 			}
 		}
 		// Fall back to item selection
-		Item* item = tile->getTopItem();
+		Item* item = TileOperations::getTopItem(tile);
 		if (item && item->getRAWBrush()) {
 			g_gui.SelectBrush(item->getRAWBrush(), TILESET_RAW);
 		}

--- a/source/rendering/ui/drawing_controller.cpp
+++ b/source/rendering/ui/drawing_controller.cpp
@@ -137,7 +137,7 @@ void DrawingController::HandleClick(const Position& mouse_map_pos, bool shift_do
 					replace_dragging = true;
 					Tile* draw_tile = editor.map.getTile(mouse_map_pos);
 					if (draw_tile) {
-						editor.replace_brush = draw_tile->getGroundBrush();
+						editor.replace_brush = TileOperations::getGroundBrush(draw_tile);
 					} else {
 						editor.replace_brush = nullptr;
 					}

--- a/source/rendering/ui/selection_controller.cpp
+++ b/source/rendering/ui/selection_controller.cpp
@@ -44,7 +44,7 @@ void SelectionController::HandleClick(const Position& mouse_map_pos, bool shift_
 				}
 			}
 			// Fall back to item selection
-			Item* item = tile->getTopItem();
+			Item* item = TileOperations::getTopItem(tile);
 			if (item && item->getRAWBrush()) {
 				g_gui.SelectBrush(item->getRAWBrush(), TILESET_RAW);
 			}
@@ -93,7 +93,7 @@ void SelectionController::HandleClick(const Position& mouse_map_pos, bool shift_
 						editor.selection.finish(); // Finish selection session
 						editor.selection.updateSelectionCount();
 					} else {
-						Item* item = tile->getTopItem();
+						Item* item = TileOperations::getTopItem(tile);
 						if (item) {
 							editor.selection.start(); // Start selection session
 							if (item->isSelected()) {
@@ -129,7 +129,7 @@ void SelectionController::HandleClick(const Position& mouse_map_pos, bool shift_
 						dragging = true;
 						drag_start_pos = mouse_map_pos;
 					} else {
-						Item* item = tile->getTopItem();
+						Item* item = TileOperations::getTopItem(tile);
 						if (item) {
 							editor.selection.add(tile, item);
 							dragging = true;
@@ -218,7 +218,7 @@ void SelectionController::HandleRelease(const Position& mouse_map_pos, bool shif
 							editor.selection.updateSelectionCount();
 						}
 					} else {
-						Item* item = tile->getTopItem();
+						Item* item = TileOperations::getTopItem(tile);
 						if (item && !item->isSelected()) {
 							editor.selection.start(); // Start a selection session
 							editor.selection.add(tile, item);
@@ -270,7 +270,7 @@ void SelectionController::HandlePropertiesClick(const Position& mouse_map_pos, b
 		} else if (tile->creature && g_settings.getInteger(Config::SHOW_CREATURES)) {
 			editor.selection.add(tile, tile->creature.get());
 		} else {
-			Item* item = tile->getTopItem();
+			Item* item = TileOperations::getTopItem(tile);
 			if (item) {
 				editor.selection.add(tile, item);
 			}

--- a/source/rendering/utilities/tile_describer.cpp
+++ b/source/rendering/utilities/tile_describer.cpp
@@ -16,7 +16,7 @@ wxString TileDescriber::GetDescription(Tile* tile, bool showSpawns, bool showCre
 		} else if (tile->creature && showCreatures) {
 			ss << (tile->creature->isNpc() ? "NPC" : "Monster");
 			ss << " \"" << wxstr(tile->creature->getName()) << "\" spawntime: " << tile->creature->getSpawnTime();
-		} else if (Item* item = tile->getTopItem()) {
+		} else if (Item* item = TileOperations::getTopItem(tile)) {
 			ss << "Item \"" << wxstr(item->getName()) << "\"";
 			ss << " id:" << item->getID();
 			ss << " cid:" << item->getClientID();

--- a/source/ui/dialog_helper.cpp
+++ b/source/ui/dialog_helper.cpp
@@ -46,7 +46,7 @@ void DialogHelper::OpenProperties(Editor& editor, Tile* tile) {
 		}
 
 		if (!item) {
-			item = new_tile->getTopItem();
+			item = TileOperations::getTopItem(new_tile.get());
 		}
 
 		if (item) {

--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -186,11 +186,11 @@ void MapPopupMenu::Update() {
 					Append(MAP_POPUP_MENU_SELECT_DOOR_BRUSH, "Select Doorbrush", "Use this door brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, wxSize(16, 16)));
 				}
 
-				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
+				if (tile->hasGround() && TileOperations::getGroundBrush(tile) && TileOperations::getGroundBrush(tile)->visibleInPalette()) {
 					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current item as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
-				if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
+				if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || TileOperations::getGroundBrush(tile) && TileOperations::getGroundBrush(tile)->hasCollection()) {
 					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
@@ -214,11 +214,11 @@ void MapPopupMenu::Update() {
 				if (hasWall) {
 					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
-				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
+				if (tile->hasGround() && TileOperations::getGroundBrush(tile) && TileOperations::getGroundBrush(tile)->visibleInPalette()) {
 					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current tile as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
-				if (hasCollection || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
+				if (hasCollection || TileOperations::getGroundBrush(tile) && TileOperations::getGroundBrush(tile)->hasCollection()) {
 					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -414,9 +414,9 @@ void ReplaceItemsDialog::OnExecuteButtonClicked(wxCommandEvent& WXUNUSED(event))
 			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_REPLACE_ITEMS);
 			for (const auto& [tile, itemToReplace] : result) {
 				std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(tile, editor->map);
-				int index = tile->getIndexOf(itemToReplace);
+				int index = TileOperations::getIndexOf(tile, itemToReplace);
 				ASSERT(index != wxNOT_FOUND);
-				Item* item = new_tile->getItemAt(index);
+				Item* item = TileOperations::getItemAt(new_tile.get(), index);
 				ASSERT(item && item->getID() == itemToReplace->getID());
 				TileOperations::transformItem(item, info.withId, new_tile.get());
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));

--- a/source/ui/tile_properties/container_property_panel.cpp
+++ b/source/ui/tile_properties/container_property_panel.cpp
@@ -112,9 +112,9 @@ void ContainerPropertyPanel::OnAddItem(wxCommandEvent& WXUNUSED(event)) {
 		uint16_t item_id = dialog.getResultID();
 		if (item_id != 0) {
 			std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-			int index = current_tile->getIndexOf(current_item);
+			int index = TileOperations::getIndexOf(current_tile, current_item);
 			if (index != -1) {
-				Item* new_item_base = new_tile->getItemAt(index);
+				Item* new_item_base = TileOperations::getItemAt(new_tile.get(), index);
 				if (new_item_base && new_item_base->asContainer()) {
 					Container* container = static_cast<Container*>(new_item_base);
 					auto& contents = container->getVector();
@@ -163,12 +163,12 @@ void ContainerPropertyPanel::OnEditItem(wxCommandEvent& WXUNUSED(event)) {
 
 	// Create a deep copy of the tile to edit items inside the container
 	std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-	int container_index = current_tile->getIndexOf(current_item);
+	int container_index = TileOperations::getIndexOf(current_tile, current_item);
 	if (container_index == -1) {
 		return;
 	}
 
-	Item* new_container_base = new_tile->getItemAt(container_index);
+	Item* new_container_base = TileOperations::getItemAt(new_tile.get(), container_index);
 	Container* new_container = new_container_base ? new_container_base->asContainer() : nullptr;
 	if (!new_container) {
 		return;
@@ -220,9 +220,9 @@ void ContainerPropertyPanel::OnRemoveItem(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-	int index = current_tile->getIndexOf(current_item);
+	int index = TileOperations::getIndexOf(current_tile, current_item);
 	if (index != -1) {
-		Item* new_item_base = new_tile->getItemAt(index);
+		Item* new_item_base = TileOperations::getItemAt(new_tile.get(), index);
 		if (new_item_base && new_item_base->asContainer()) {
 			Container* container = static_cast<Container*>(new_item_base);
 			auto& contents = container->getVector();

--- a/source/ui/tile_properties/depot_property_panel.cpp
+++ b/source/ui/tile_properties/depot_property_panel.cpp
@@ -78,9 +78,9 @@ void DepotPropertyPanel::OnDepotIdChange(wxCommandEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item_base = new_tile->getItemAt(index);
+			Item* new_item_base = TileOperations::getItemAt(new_tile.get(), index);
 			if (new_item_base->asDepot()) {
 				Depot* depot = static_cast<Depot*>(new_item_base);
 				int new_depotid = (int)(intptr_t)depot_id_field->GetClientData(depot_id_field->GetSelection());

--- a/source/ui/tile_properties/door_property_panel.cpp
+++ b/source/ui/tile_properties/door_property_panel.cpp
@@ -56,9 +56,9 @@ void DoorPropertyPanel::OnDoorIdChange(wxSpinEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			if (new_item && new_item->asDoor()) {
 				Door* door = static_cast<Door*>(new_item);
 				door->setDoorID(door_id_spin->GetValue());

--- a/source/ui/tile_properties/item_property_panel.cpp
+++ b/source/ui/tile_properties/item_property_panel.cpp
@@ -149,9 +149,9 @@ void ItemPropertyPanel::OnActionIdChange(wxSpinEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			new_item->setActionID(action_id_spin->GetValue());
 
 			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
@@ -169,9 +169,9 @@ void ItemPropertyPanel::OnUniqueIdChange(wxSpinEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			new_item->setUniqueID(unique_id_spin->GetValue());
 
 			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
@@ -189,9 +189,9 @@ void ItemPropertyPanel::OnCountChange(wxSpinEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			new_item->setSubtype(count_spin->GetValue());
 
 			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
@@ -209,9 +209,9 @@ void ItemPropertyPanel::OnSplashTypeChange(wxCommandEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			int new_type = (int)(intptr_t)splash_type_choice->GetClientData(splash_type_choice->GetSelection());
 			new_item->setSubtype(new_type);
 
@@ -235,9 +235,9 @@ void ItemPropertyPanel::OnTextChange(wxEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			new_item->setText(nstr(text_ctrl->GetValue()));
 
 			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);

--- a/source/ui/tile_properties/teleport_property_panel.cpp
+++ b/source/ui/tile_properties/teleport_property_panel.cpp
@@ -70,9 +70,9 @@ void TeleportPropertyPanel::OnDestChange(wxSpinEvent& event) {
 		}
 
 		std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(current_tile, *current_map);
-		int index = current_tile->getIndexOf(current_item);
+		int index = TileOperations::getIndexOf(current_tile, current_item);
 		if (index != -1) {
-			Item* new_item = new_tile->getItemAt(index);
+			Item* new_item = TileOperations::getItemAt(new_tile.get(), index);
 			if (new_item->asTeleport()) {
 				Teleport* teleport = static_cast<Teleport*>(new_item);
 				Position dest(x_spin->GetValue(), y_spin->GetValue(), z_spin->GetValue());


### PR DESCRIPTION
Extract Tile logic to free functions and optimize tile item storage

Moved logic out of the Tile class into TileOperations as free functions to improve SRP.
Changed Tile::items to use boost::container::small_vector to avoid heap allocations for small item collections.
Updated all usages across the codebase to use the new TileOperations methods.

---
*PR created automatically by Jules for task [14703174489405038380](https://jules.google.com/task/14703174489405038380) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized tile operation methods from direct member functions to centralized utility functions in TileOperations. All tile access patterns (ground brush retrieval, item management, content comparison) now route through the TileOperations namespace instead of direct object methods. Adjusted item storage container for improved performance characteristics. Functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->