### PR TITLE
Refactor OpenGL error handling to use while loop

### DIFF
--- a/source/io/filehandle.h
+++ b/source/io/filehandle.h
@@ -30,6 +30,7 @@
 #include <vector>
 #include <format>
 #include <iterator>
+#include <cstring>
 
 class wxFileName;
 using FileName = wxFileName;

--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,17 +117,18 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		bool had_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
-			return false;
+			had_error = true;
 		}
+		if (had_error) return false;
 
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,8 +160,8 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
 	}
 


### PR DESCRIPTION
Fixes `glGetError()` loops in `source/rendering/drawers/minimap_renderer.cpp` and `source/rendering/core/texture_atlas.cpp` to correctly clear queued OpenGL errors. Also fixes compilation error due to missing `<cstring>` include.

---
*PR created automatically by Jules for task [16659851085449590267](https://jules.google.com/task/16659851085449590267) started by @karolak6612*