### PR TITLE
🐛 Bugger: Fix multiple insidious UB and race condition bugs

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -39,15 +39,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -50,6 +50,11 @@ void Selection::recalculateBounds() const {
 		return;
 	}
 
+	std::lock_guard<std::mutex> lock(bounds_mutex);
+	if (!bounds_dirty) {
+		return;
+	}
+
 	Position minPos(0x10000, 0x10000, 0x10);
 	Position maxPos(0, 0, 0);
 
@@ -76,11 +81,13 @@ void Selection::recalculateBounds() const {
 
 Position Selection::minPosition() const {
 	recalculateBounds();
+	std::lock_guard<std::mutex> lock(bounds_mutex);
 	return cached_min;
 }
 
 Position Selection::maxPosition() const {
 	recalculateBounds();
+	std::lock_guard<std::mutex> lock(bounds_mutex);
 	return cached_max;
 }
 

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <algorithm>
 #include <atomic>
+#include <mutex>
 
 class Action;
 class Editor;
@@ -107,10 +108,12 @@ public:
 	}
 	Tile* getSelectedTile() {
 		ASSERT(size() == 1);
+		if (tiles.empty()) return nullptr;
 		return *tiles.begin();
 	}
 	Tile* getSelectedTile() const {
 		ASSERT(size() == 1);
+		if (tiles.empty()) return nullptr;
 		return *tiles.begin();
 	}
 
@@ -132,6 +135,7 @@ private:
 	std::vector<Tile*> pending_removes;
 
 	mutable std::atomic<bool> bounds_dirty;
+	mutable std::mutex bounds_mutex;
 	mutable Position cached_min;
 	mutable Position cached_max;
 

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -64,6 +64,7 @@ enum : uint8_t {
 
 class Tile {
 public: // Members
+	// Observer pointer, owned by MapNode/Floor
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
 	std::vector<std::unique_ptr<Item>> items;
@@ -252,10 +253,12 @@ inline uint32_t Tile::getHouseID() const {
 }
 
 inline void Tile::setMapFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_NONE | TILESTATE_PROTECTIONZONE | TILESTATE_DEPRECATED | TILESTATE_NOPVP | TILESTATE_NOLOGOUT | TILESTATE_PVPZONE | TILESTATE_REFRESH)) == 0);
 	mapflags = _flags | mapflags;
 }
 
 inline void Tile::unsetMapFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_NONE | TILESTATE_PROTECTIONZONE | TILESTATE_DEPRECATED | TILESTATE_NOPVP | TILESTATE_NOLOGOUT | TILESTATE_PVPZONE | TILESTATE_REFRESH)) == 0);
 	mapflags &= ~_flags;
 }
 
@@ -264,10 +267,12 @@ inline uint16_t Tile::getMapFlags() const {
 }
 
 inline void Tile::setStatFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_SELECTED | TILESTATE_UNIQUE | TILESTATE_BLOCKING | TILESTATE_OP_BORDER | TILESTATE_HAS_TABLE | TILESTATE_HAS_CARPET | TILESTATE_MODIFIED | TILESTATE_HOOK_SOUTH | TILESTATE_HOOK_EAST | TILESTATE_HAS_LIGHT)) == 0);
 	statflags = _flags | statflags;
 }
 
 inline void Tile::unsetStatFlags(uint16_t _flags) {
+	ASSERT((_flags & ~(TILESTATE_SELECTED | TILESTATE_UNIQUE | TILESTATE_BLOCKING | TILESTATE_OP_BORDER | TILESTATE_HAS_TABLE | TILESTATE_HAS_CARPET | TILESTATE_MODIFIED | TILESTATE_HOOK_SOUTH | TILESTATE_HOOK_EAST | TILESTATE_HAS_LIGHT)) == 0);
 	statflags &= ~_flags;
 }
 


### PR DESCRIPTION
Fixed several insidious bugs, race conditions, and undefined behavior problems found by deep codebase scanning.

Specific fixes include:
- Modifying `Change::Create` to return a `std::unique_ptr` rather than a raw pointer, avoiding leaks when caller wraps it late.
- Guarding `cached_min` and `cached_max` updates in `Selection` with `bounds_mutex` since multiple threads (e.g., `SelectionThread` and main thread querying bounds) could overlap on `recalculateBounds()`.
- Explicitly documented `Tile::location` as an observer pointer.
- Added a `.empty()` check in `Selection::getSelectedTile()` to ensure it doesn't dereference an empty iterator even if asserts are stripped in release builds.
- Put assert masks inside `Tile::setMapFlags` and `Tile::setStatFlags` to prevent silent value collisions between the two sets of constants.

---
*PR created automatically by Jules for task [2903962711113921957](https://jules.google.com/task/2903962711113921957) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved memory management in the editor's action system for better resource handling.
  * Enhanced thread safety in selection bounds calculation to prevent data race conditions.
  * Added input validation in tile flag operations for data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->