### PR TITLE
👻 Phantom: Remove legacy `DECLARE_EVENT_TABLE_ENTRY` macros

### DIFF
--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"


### PR DESCRIPTION
Removes unused legacy event macros from header files, completing another task as Phantom 👻.

---
*PR created automatically by Jules for task [14651738385113070023](https://jules.google.com/task/14651738385113070023) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal event-handling system by removing redundant macro wrappers for event table declarations. This simplification eliminates boilerplate code and unnecessary abstraction layers while preserving all existing functionality and user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->