### PR TITLE
🎨 Icon: Add icons to dialogs and palettes

### DIFF
--- a/source/palette/house/edit_house_dialog.cpp
+++ b/source/palette/house/edit_house_dialog.cpp
@@ -12,6 +12,7 @@
 #include "map/map.h"
 #include "game/house.h"
 #include "game/town.h"
+#include "util/image_manager.h"
 
 #include <sstream>
 
@@ -21,6 +22,8 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	what_house(house) {
 	ASSERT(map);
 	ASSERT(house);
+
+	SetIcon(IMAGE_MANAGER.GetIcon(ICON_HOUSE));
 
 	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
 	wxSizer* boxsizer = newd wxStaticBoxSizer(wxVERTICAL, this, "House Properties");
@@ -94,8 +97,12 @@ EditHouseDialog::EditHouseDialog(wxWindow* parent, Map* map, House* house) :
 	topsizer->Add(boxsizer, wxSizerFlags(0).Expand().Border(wxRIGHT | wxLEFT, 20));
 
 	wxSizer* buttonsSizer = newd wxBoxSizer(wxHORIZONTAL);
-	buttonsSizer->Add(newd wxButton(this, wxID_OK, "OK"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
-	buttonsSizer->Add(newd wxButton(this, wxID_CANCEL, "Cancel"), wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* okBtn = newd wxButton(this, wxID_OK, "OK");
+	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CHECK, wxSize(16, 16)));
+	buttonsSizer->Add(okBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
+	wxButton* cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
+	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
+	buttonsSizer->Add(cancelBtn, wxSizerFlags(1).Center().Border(wxTOP | wxBOTTOM, 10));
 	topsizer->Add(buttonsSizer, wxSizerFlags(0).Center().Border(wxLEFT | wxRIGHT, 20));
 
 	SetSizerAndFit(topsizer);

--- a/source/palette/house/house_palette.cpp
+++ b/source/palette/house/house_palette.cpp
@@ -59,8 +59,11 @@ HousePalette::HousePalette(wxWindow* parent) :
 	// Action buttons (Add, Edit, Remove)
 	wxBoxSizer* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
 	add_button = newd wxButton(this, ID_ADD_HOUSE, "Add", wxDefaultPosition, wxSize(50, -1));
+	add_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
 	edit_button = newd wxButton(this, ID_EDIT_HOUSE, "Edit", wxDefaultPosition, wxSize(50, -1));
+	edit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
 	remove_button = newd wxButton(this, ID_REMOVE_HOUSE, "Remove", wxDefaultPosition, wxSize(60, -1));
+	remove_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_MINUS, wxSize(16, 16)));
 
 	action_sizer->Add(add_button, 1, wxEXPAND | wxRIGHT, 2);
 	action_sizer->Add(edit_button, 1, wxEXPAND | wxRIGHT, 2);

--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -39,6 +39,7 @@
 ReplaceToolWindow::ReplaceToolWindow(wxWindow* parent, Editor* editor) : wxDialog(parent, wxID_ANY, "Advanced Replace Tool", wxDefaultPosition, wxDefaultSize, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER),
 																		 editor(editor) {
 
+	SetIcon(IMAGE_MANAGER.GetIcon(ICON_WAND_MAGIC));
 	VisualSimilarityService::Get().StartIndexing();
 	SetBackgroundColour(Theme::Get(Theme::Role::Surface));
 

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -234,6 +234,7 @@ private:
 WelcomeDialog::WelcomeDialog(const wxString& titleText, const wxString& versionText, const wxSize& size, const wxBitmap& rmeLogo, const std::vector<wxString>& recentFiles) :
 	wxDialog(nullptr, wxID_ANY, titleText, wxDefaultPosition, size, wxDEFAULT_DIALOG_STYLE | wxRESIZE_BORDER) {
 
+	SetIcon(IMAGE_MANAGER.GetIcon(ICON_MAP));
 	SetBackgroundColour(Theme::Get(Theme::Role::Surface));
 	SetForegroundColour(Theme::Get(Theme::Role::Text));
 


### PR DESCRIPTION
Followed Icon persona instructions to add missing icons to UI surfaces.

---
*PR created automatically by Jules for task [4761501616623837362](https://jules.google.com/task/4761501616623837362) started by @karolak6612*