### PR TITLE
⚡ Bolt: [performance improvement] Tile items memory allocation

### DIFF
--- a/source/map/map_converter.cpp
+++ b/source/map/map_converter.cpp
@@ -175,10 +175,8 @@ void MapConverter::cleanInvalidTiles(Map& map, bool showdialog) {
 			continue;
 		}
 
-		// Use std::erase_if from C++20 for cleanup
-		std::erase_if(tile->items, [](const std::unique_ptr<Item>& item) {
-			return !g_items.typeExists(item->getID());
-		});
+		// Use erase-remove idiom for small_vector
+		tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const std::unique_ptr<Item>& item) { return !g_items.typeExists(item->getID()); }), tile->items.end());
 
 		++tiles_done;
 		if (showdialog && tiles_done % 0x10000 == 0) {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -34,6 +34,7 @@ class Map;
 #include <unordered_set>
 #include <memory>
 #include <vector>
+#include <boost/container/small_vector.hpp>
 
 // TileOperations functions are now in tile_operations.h
 
@@ -66,7 +67,7 @@ class Tile {
 public: // Members
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
-	std::vector<std::unique_ptr<Item>> items;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> items;
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)


### PR DESCRIPTION
⚡ Bolt: [performance improvement] Tile items memory allocation

💡 **What**: Replaced `std::vector<std::unique_ptr<Item>> items` in `Tile` with `boost::container::small_vector<std::unique_ptr<Item>, 4> items`. Also refactored `std::erase_if` usages on `Tile::items` in `map_converter.cpp` to use the erase-remove idiom compatible with `small_vector`.
🎯 **Why**: Tiles iterate frequently in hot render paths, and the vast majority hold very few (0-2) items. Using a standard vector forces frequent small dynamic heap allocations. `small_vector<..., 4>` eliminates these heap allocations by keeping the vector elements inline within the tile class up to 4 items.
📊 **Impact**: Minimizes pointer chasing and cache misses during tile rendering by flattening item pointers directly into the `Tile` struct memory footprint, saving millions of heap allocations during map loading and streaming.

---
*PR created automatically by Jules for task [17951959266637282038](https://jules.google.com/task/17951959266637282038) started by @karolak6612*