### PR TITLE
🗝️ Keeper: Memory safety modernization and ownership clarifications

### DIFF
--- a/source/app/rme_forward_declarations.h
+++ b/source/app/rme_forward_declarations.h
@@ -52,6 +52,7 @@ class ReplaceToolWindow;
 #include <vector>
 
 using HouseExitList = std::vector<uint32_t>;
+// Observer containers, elements are owned by MapNode
 using TileVector = std::vector<Tile*>;
 using TileSet = std::vector<Tile*>;
 using ItemVector = std::vector<Item*>;

--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -39,15 +39,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	std::unique_ptr<Change> c(new Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	std::unique_ptr<Change> c(new Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -127,6 +127,7 @@ private:
 	// We use std::vector here instead of std::set for performance reasons.
 	// Selections are typically small, and std::vector provides better cache locality
 	// and fewer allocations. We maintain sorted order to allow O(log n) lookups.
+	// These are observer pointers. Tiles are owned by the Map.
 	std::vector<Tile*> tiles;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -64,7 +64,7 @@ enum : uint8_t {
 
 class Tile {
 public: // Members
-	TileLocation* location;
+	TileLocation* location; // Observer pointer, owned by MapNode
 	std::unique_ptr<Item> ground;
 	std::vector<std::unique_ptr<Item>> items;
 	std::unique_ptr<Creature> creature;
@@ -235,6 +235,7 @@ bool tilePositionLessThan(const Tile* a, const Tile* b);
 // This sorts them by draw order
 bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 
+// Observer containers, elements are owned by MapNode
 using TileVector = std::vector<Tile*>;
 using TileSet = std::vector<Tile*>;
 using TileList = std::list<Tile*>;

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -45,9 +45,8 @@ public:
 	virtual void unloadDC() = 0;
 	virtual wxSize GetSize() const = 0;
 
-private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
+	Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
 };
 
 class GameSprite;

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -88,7 +88,7 @@ void main() {
 MapDrawer::MapDrawer(MapCanvas* canvas) :
 	canvas(canvas), editor(canvas->editor) {
 
-	light_drawer = std::make_shared<LightDrawer>();
+	light_drawer = std::make_unique<LightDrawer>();
 	tooltip_drawer = std::make_unique<TooltipDrawer>();
 
 	sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -65,7 +65,7 @@ class MapDrawer {
 	Editor& editor;
 	DrawingOptions options;
 	RenderView view;
-	std::shared_ptr<LightDrawer> light_drawer;
+	std::unique_ptr<LightDrawer> light_drawer;
 	LightBuffer light_buffer;
 	std::unique_ptr<TooltipDrawer> tooltip_drawer;
 	std::unique_ptr<GridDrawer> grid_drawer;


### PR DESCRIPTION
Autonomously executed Keeper's memory safety directives to modernize C++ ownership models, fix leak risks, and improve code clarity.

- **Leak Risk Fixed**: `Change::Create` now correctly returns a `std::unique_ptr<Change>`, and its call sites in `draw_operations.cpp` and `action.cpp` have been updated.
- **Strict Ownership**: Converted `std::shared_ptr<LightDrawer>` to `std::unique_ptr<LightDrawer>` in `MapDrawer`.
- **Modern C++**: Replaced private implicit deletion of copy semantics in `Sprite` with explicit `= delete`.
- **Clear Semantics**: Annotated observer pointers (`TileLocation*`, `TileVector`, `TileList`, `TileSet`, and `Selection::tiles`) with clear comments indicating they do not own the resources they point to.

---
*PR created automatically by Jules for task [4684045375713852965](https://jules.google.com/task/4684045375713852965) started by @karolak6612*