### PR TITLE
📊 Profiler: Optimize Selection bounds calc and fix GL error handling

### DIFF
--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -57,7 +57,7 @@ void Selection::recalculateBounds() const {
 		minPos = Position(0, 0, 0);
 		maxPos = Position(0, 0, 0);
 	} else {
-		std::ranges::for_each(tiles, [&](Tile* tile) {
+		for (Tile* tile : tiles) {
 			const Position& pos = tile->getPosition();
 			minPos.x = std::min(minPos.x, pos.x);
 			minPos.y = std::min(minPos.y, pos.y);
@@ -66,7 +66,7 @@ void Selection::recalculateBounds() const {
 			maxPos.x = std::max(maxPos.x, pos.x);
 			maxPos.y = std::max(maxPos.y, pos.y);
 			maxPos.z = std::max(maxPos.z, pos.z);
-		});
+		}
 	}
 
 	cached_min = minPos;

--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,17 +117,20 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		bool had_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
+			had_error = true;
+		}
+		if (had_error) {
 			return false;
 		}
 
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,8 +160,8 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
 	}
 


### PR DESCRIPTION
Implemented optimizations per `.jules/newagents/profiler.md` guidelines. Optimized a CPU hot path in `Selection::recalculateBounds` by avoiding lambda overhead, and fixed potential OpenGL synchronization issues by ensuring all queued GL errors are popped and processed correctly using `while ((err = glGetError()) != GL_NO_ERROR)`.

---
*PR created automatically by Jules for task [1418007615237709130](https://jules.google.com/task/1418007615237709130) started by @karolak6612*