### PR TITLE
✨ Designer: Implement Grid Mode for Lists & Organize Layouts

### DIFF
--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -70,37 +70,42 @@ BrowseTileListBox::~BrowseTileListBox() {
 void BrowseTileListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n) {
 	Item* item = items[n];
 
+	int icon_size = std::min(rect.width, rect.height) - FromDIP(4);
+	int icon_x = rect.x + (rect.width - icon_size) / 2;
+	int icon_y = rect.y + (rect.height - icon_size) / 2;
+
 	Sprite* sprite = g_gui.gfx.getSprite(item->getClientID());
 	if (sprite) {
 		int tex = GetOrCreateSpriteTexture(vg, sprite);
 		if (tex > 0) {
-			int icon_size = 32;
-			NVGpaint imgPaint = nvgImagePattern(vg, rect.x, rect.y, icon_size, icon_size, 0, tex, 1.0f);
+			NVGpaint imgPaint = nvgImagePattern(vg, icon_x, icon_y, icon_size, icon_size, 0, tex, 1.0f);
 			nvgBeginPath(vg);
-			nvgRect(vg, rect.x, rect.y, icon_size, icon_size);
+			nvgRect(vg, icon_x, icon_y, icon_size, icon_size);
 			nvgFillPaint(vg, imgPaint);
 			nvgFill(vg);
 		}
 	}
 
-	if (IsSelected(n)) {
-		wxColour textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
-		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-	} else {
-		wxColour textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
-		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+	if (!IsGridMode()) {
+		if (IsSelected(n)) {
+			wxColour textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
+			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+		} else {
+			wxColour textColour = wxSystemSettings::GetColour(wxSYS_COLOUR_LISTBOXTEXT);
+			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+		}
+
+		std::string label = std::format("{} - {}", item->getID(), item->getName());
+
+		nvgFontSize(vg, 12.0f);
+		nvgFontFace(vg, "sans");
+		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, label.c_str(), nullptr);
 	}
-
-	std::string label = std::format("{} - {}", item->getID(), item->getName());
-
-	nvgFontSize(vg, 12.0f);
-	nvgFontFace(vg, "sans");
-	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-	nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, label.c_str(), nullptr);
 }
 
 int BrowseTileListBox::OnMeasureItem(size_t n) const {
-	return FromDIP(32);
+	return m_gridMode ? m_itemWidth : FromDIP(32);
 }
 
 Item* BrowseTileListBox::GetSelectedItem() {
@@ -174,51 +179,89 @@ void BrowseTileListBox::UpdateItems() {
 
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
 	wxDialog(parent, wxID_ANY, "Browse Field", position, FROM_DIP(parent, wxSize(600, 400)), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
-	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
-	item_list = newd BrowseTileListBox(this, wxID_ANY, tile);
-	sizer->Add(item_list, wxSizerFlags(1).Expand());
 
-	wxString pos;
-	pos << "x=" << tile->getX() << ",  y=" << tile->getY() << ",  z=" << tile->getZ();
+	wxBoxSizer* main_sizer = newd wxBoxSizer(wxHORIZONTAL);
 
-	wxSizer* infoSizer = newd wxBoxSizer(wxVERTICAL);
-	wxBoxSizer* buttons = newd wxBoxSizer(wxHORIZONTAL);
-	delete_button = newd wxButton(this, wxID_REMOVE, "Delete");
+	// Left Side: List and item buttons
+	wxBoxSizer* left_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	wxStaticBoxSizer* items_box = newd wxStaticBoxSizer(wxVERTICAL, this, "Items on Tile");
+	item_list = newd BrowseTileListBox(items_box->GetStaticBox(), wxID_ANY, tile);
+	item_list->EnableGridMode(FromDIP(48)); // Enable grid layout with thumbnails
+	items_box->Add(item_list, 1, wxEXPAND | wxALL, 2);
+
+	wxBoxSizer* items_buttons = newd wxBoxSizer(wxHORIZONTAL);
+	delete_button = newd wxButton(items_box->GetStaticBox(), wxID_REMOVE, "Delete");
 	delete_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_TRASH_CAN));
 	delete_button->SetToolTip("Delete selected item");
 	delete_button->Enable(false);
-	buttons->Add(delete_button);
-	buttons->AddSpacer(5);
-	select_raw_button = newd wxButton(this, wxID_FIND, "Select RAW");
+	items_buttons->Add(delete_button, 1, wxEXPAND | wxRIGHT, 2);
+
+	select_raw_button = newd wxButton(items_box->GetStaticBox(), wxID_FIND, "Select RAW");
 	select_raw_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SEARCH));
 	select_raw_button->SetToolTip("Select this item in RAW palette");
 	select_raw_button->Enable(false);
-	buttons->Add(select_raw_button);
-	infoSizer->Add(buttons);
-	infoSizer->AddSpacer(5);
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
-	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
+	items_buttons->Add(select_raw_button, 1, wxEXPAND | wxLEFT, 2);
 
-	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());
+	items_box->Add(items_buttons, 0, wxEXPAND | wxALL, 2);
+	left_sizer->Add(items_box, 1, wxEXPAND | wxALL, 5);
+
+	main_sizer->Add(left_sizer, 1, wxEXPAND | wxALL, 5);
+
+	// Right Side: Info and Dialog Buttons
+	wxBoxSizer* right_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	wxStaticBoxSizer* info_box = newd wxStaticBoxSizer(wxVERTICAL, this, "Tile Information");
+	wxFlexGridSizer* info_grid = newd wxFlexGridSizer(2, FromDIP(5), FromDIP(15));
+
+	wxString pos;
+	pos << "x=" << tile->getX() << ", y=" << tile->getY() << ", z=" << tile->getZ();
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "Position:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, pos), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "Item count:"), 0, wxALIGN_CENTER_VERTICAL);
+	item_count_txt = newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, i2ws(item_list->GetItemCount()));
+	info_grid->Add(item_count_txt, 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "Protection zone:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, b2yn(tile->isPZ())), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "No PvP:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "No logout:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "PvP zone:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, "House:"), 0, wxALIGN_CENTER_VERTICAL);
+	info_grid->Add(newd wxStaticText(info_box->GetStaticBox(), wxID_ANY, b2yn(tile->isHouseTile())), 0, wxALIGN_CENTER_VERTICAL);
+
+	info_box->Add(info_grid, 1, wxEXPAND | wxALL, 5);
+	right_sizer->Add(info_box, 0, wxEXPAND | wxALL, 5);
+
+	right_sizer->AddStretchSpacer(1);
 
 	// OK/Cancel buttons
-	wxSizer* btnSizer = newd wxBoxSizer(wxHORIZONTAL);
+	wxStdDialogButtonSizer* btnSizer = newd wxStdDialogButtonSizer();
 	auto okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
 	okBtn->SetToolTip("Confirm selection");
-	btnSizer->Add(okBtn, wxSizerFlags(0).Center());
+	btnSizer->AddButton(okBtn);
 	auto cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
 	cancelBtn->SetToolTip("Cancel");
-	btnSizer->Add(cancelBtn, wxSizerFlags(0).Center());
-	sizer->Add(btnSizer, wxSizerFlags(0).Center().DoubleBorder());
+	btnSizer->AddButton(cancelBtn);
+	btnSizer->Realize();
 
-	SetSizerAndFit(sizer);
+	right_sizer->Add(btnSizer, 0, wxALIGN_RIGHT | wxALL, 5);
+
+	main_sizer->Add(right_sizer, 0, wxEXPAND | wxALL, 5);
+
+	SetSizer(main_sizer);
+	Layout();
 
 	// Connect Events
 	item_list->Bind(wxEVT_LISTBOX, &BrowseTileWindow::OnItemSelected, this);
@@ -239,7 +282,7 @@ void BrowseTileWindow::OnItemSelected(wxCommandEvent& WXUNUSED(event)) {
 
 void BrowseTileWindow::OnClickDelete(wxCommandEvent& WXUNUSED(event)) {
 	item_list->RemoveSelected();
-	item_count_txt->SetLabelText("Item count:  " + i2ws(item_list->GetItemCount()));
+	item_count_txt->SetLabelText(i2ws(item_list->GetItemCount()));
 }
 
 void BrowseTileWindow::OnClickSelectRaw(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -362,23 +362,27 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "No matches for your search.", nullptr);
+		nvgText(vg, rect.x + 10, rect.y + rect.height / 2.0f, "No matches for your search.", nullptr);
 	} else if (cleared) {
 		nvgFontSize(vg, 12.0f);
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
+		nvgText(vg, rect.x + 10, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
 	} else {
 		ASSERT(n < brushlist.size());
 		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());
+
+		int icon_size = std::min(rect.width, rect.height) - FromDIP(4);
+		int icon_x = rect.x + (rect.width - icon_size) / 2;
+		int icon_y = rect.y + (rect.height - icon_size) / 2;
+
 		if (spr) {
 			int tex = GetOrCreateSpriteTexture(vg, spr);
 			if (tex > 0) {
-				int icon_size = rect.height;
-				NVGpaint imgPaint = nvgImagePattern(vg, rect.x, rect.y, icon_size, icon_size, 0, tex, 1.0f);
+				NVGpaint imgPaint = nvgImagePattern(vg, icon_x, icon_y, icon_size, icon_size, 0, tex, 1.0f);
 				nvgBeginPath(vg);
-				nvgRect(vg, rect.x, rect.y, icon_size, icon_size);
+				nvgRect(vg, icon_x, icon_y, icon_size, icon_size);
 				nvgFillPaint(vg, imgPaint);
 				nvgFill(vg);
 			}
@@ -386,20 +390,21 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 
 		if (IsSelected(n)) {
 			textColour = Theme::Get(Theme::Role::TextOnAccent);
-			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		} else {
 			textColour = Theme::Get(Theme::Role::Text);
-			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		}
 
-		nvgFontSize(vg, 12.0f);
-		nvgFontFace(vg, "sans");
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		wxString name = wxstr(brushlist[n]->getName());
-		nvgText(vg, rect.x + rect.height + 8, rect.y + rect.height / 2.0f, name.ToUTF8().data(), nullptr);
+		if (!IsGridMode()) {
+			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+			nvgFontSize(vg, 12.0f);
+			nvgFontFace(vg, "sans");
+			nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+			wxString name = wxstr(brushlist[n]->getName());
+			nvgText(vg, rect.x + rect.height + 8, rect.y + rect.height / 2.0f, name.ToUTF8().data(), nullptr);
+		}
 	}
 }
 
 int FindDialogListBox::OnMeasureItem(size_t n) const {
-	return FromDIP(32);
+	return m_gridMode ? m_itemWidth : FromDIP(32);
 }

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -24,6 +24,7 @@
 #include "brushes/brush.h"
 #include "brushes/raw/raw_brush.h"
 #include "util/image_manager.h"
+#include <wx/choice.h>
 
 FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onlyPickupables /* = false*/) :
 	wxDialog(parent, wxID_ANY, title, wxDefaultPosition, wxSize(800, 600), wxDEFAULT_DIALOG_STYLE),
@@ -35,47 +36,96 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxBoxSizer* box_sizer = newd wxBoxSizer(wxHORIZONTAL);
 
-	wxBoxSizer* options_box_sizer = newd wxBoxSizer(wxVERTICAL);
+	wxBoxSizer* left_sizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxString radio_boxChoices[] = { "Find by Server ID",
-									"Find by Client ID",
-									"Find by Name",
-									"Find by Types",
-									"Find by Properties" };
+	notebook = newd wxNotebook(this, wxID_ANY, wxDefaultPosition, wxDefaultSize, wxNB_TOP);
 
-	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
-	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
-	options_radio_box->SetSelection(SearchMode::ServerIDs);
-	options_box_sizer->Add(options_radio_box, 0, wxALL | wxEXPAND, 5);
-
-	wxStaticBoxSizer* server_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Server ID"), wxVERTICAL);
-	server_id_spin = newd wxSpinCtrl(server_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
+	// Server ID Page
+	wxPanel* server_id_panel = newd wxPanel(notebook);
+	wxBoxSizer* server_id_sizer = newd wxBoxSizer(wxVERTICAL);
+	server_id_spin = newd wxSpinCtrl(server_id_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_items.getMaxID(), 100);
 	server_id_spin->SetToolTip("Search by server ID");
-	server_id_box_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
-
-	invalid_item = newd wxCheckBox(server_id_box_sizer->GetStaticBox(), wxID_ANY, "Force select", wxDefaultPosition, wxDefaultSize, 0);
+	server_id_sizer->Add(server_id_spin, 0, wxALL | wxEXPAND, 5);
+	invalid_item = newd wxCheckBox(server_id_panel, wxID_ANY, "Force select");
 	invalid_item->SetToolTip("Force choose item ID that does not appear on the list.");
-	server_id_box_sizer->Add(invalid_item, 1, wxALL | wxEXPAND, 5);
+	server_id_sizer->Add(invalid_item, 0, wxALL | wxEXPAND, 5);
+	server_id_panel->SetSizer(server_id_sizer);
+	notebook->AddPage(server_id_panel, "Server ID", true);
 
-	options_box_sizer->Add(server_id_box_sizer, 1, wxALL | wxEXPAND, 5);
-
-	wxStaticBoxSizer* client_id_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Client ID"), wxVERTICAL);
-	client_id_spin = newd wxSpinCtrl(client_id_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
+	// Client ID Page
+	wxPanel* client_id_panel = newd wxPanel(notebook);
+	wxBoxSizer* client_id_sizer = newd wxBoxSizer(wxVERTICAL);
+	client_id_spin = newd wxSpinCtrl(client_id_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, wxSP_ARROW_KEYS, 100, g_gui.gfx.getItemSpriteMaxID(), 100);
 	client_id_spin->SetToolTip("Search by client ID");
-	client_id_spin->Enable(false);
-	client_id_box_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
-	options_box_sizer->Add(client_id_box_sizer, 1, wxALL | wxEXPAND, 5);
+	client_id_sizer->Add(client_id_spin, 0, wxALL | wxEXPAND, 5);
+	client_id_panel->SetSizer(client_id_sizer);
+	notebook->AddPage(client_id_panel, "Client ID");
 
-	wxStaticBoxSizer* name_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Name"), wxVERTICAL);
-	name_text_input = newd wxTextCtrl(name_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
+	// Name Page
+	wxPanel* name_panel = newd wxPanel(notebook);
+	wxBoxSizer* name_sizer = newd wxBoxSizer(wxVERTICAL);
+	name_text_input = newd wxTextCtrl(name_panel, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, 0);
 	name_text_input->SetToolTip("Search by item name (requires 2+ characters)");
-	name_text_input->Enable(false);
-	name_box_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
-	options_box_sizer->Add(name_box_sizer, 1, wxALL | wxEXPAND, 5);
+	name_sizer->Add(name_text_input, 0, wxALL | wxEXPAND, 5);
+	name_panel->SetSizer(name_sizer);
+	notebook->AddPage(name_panel, "Name");
 
-	// spacer
-	options_box_sizer->Add(0, 0, 4, wxALL | wxEXPAND, 5);
+	// Types Page
+	wxPanel* types_panel = newd wxPanel(notebook);
+	wxBoxSizer* types_sizer = newd wxBoxSizer(wxVERTICAL);
+	wxString types_choices[] = { "Depot", "Mailbox", "Trash Holder", "Container", "Door", "Magic Field", "Teleport", "Bed", "Key", "Podium" };
+	int types_choices_count = sizeof(types_choices) / sizeof(wxString);
+	types_choice = newd wxChoice(types_panel, wxID_ANY, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices);
+	types_choice->SetSelection(0);
+	types_sizer->Add(types_choice, 0, wxALL | wxEXPAND, 5);
+	types_panel->SetSizer(types_sizer);
+	notebook->AddPage(types_panel, "Types");
 
+	// Properties Page
+	wxPanel* props_panel = newd wxPanel(notebook);
+	wxFlexGridSizer* props_sizer = newd wxFlexGridSizer(0, 3, FromDIP(5), FromDIP(5));
+
+	unpassable = newd wxCheckBox(props_panel, wxID_ANY, "Unpassable");
+	unmovable = newd wxCheckBox(props_panel, wxID_ANY, "Unmovable");
+	block_missiles = newd wxCheckBox(props_panel, wxID_ANY, "Block Missiles");
+	block_pathfinder = newd wxCheckBox(props_panel, wxID_ANY, "Block Pathfinder");
+	readable = newd wxCheckBox(props_panel, wxID_ANY, "Readable");
+	writeable = newd wxCheckBox(props_panel, wxID_ANY, "Writeable");
+	pickupable = newd wxCheckBox(props_panel, wxID_ANY, "Pickupable");
+	stackable = newd wxCheckBox(props_panel, wxID_ANY, "Stackable");
+	rotatable = newd wxCheckBox(props_panel, wxID_ANY, "Rotatable");
+	hangable = newd wxCheckBox(props_panel, wxID_ANY, "Hangable");
+	hook_east = newd wxCheckBox(props_panel, wxID_ANY, "Hook East");
+	hook_south = newd wxCheckBox(props_panel, wxID_ANY, "Hook South");
+	has_elevation = newd wxCheckBox(props_panel, wxID_ANY, "Has Elevation");
+	ignore_look = newd wxCheckBox(props_panel, wxID_ANY, "Ignore Look");
+	floor_change = newd wxCheckBox(props_panel, wxID_ANY, "Floor Change");
+
+	pickupable->SetValue(only_pickupables);
+	if (only_pickupables) pickupable->Enable(false);
+
+	props_sizer->Add(unpassable);
+	props_sizer->Add(unmovable);
+	props_sizer->Add(block_missiles);
+	props_sizer->Add(block_pathfinder);
+	props_sizer->Add(readable);
+	props_sizer->Add(writeable);
+	props_sizer->Add(pickupable);
+	props_sizer->Add(stackable);
+	props_sizer->Add(rotatable);
+	props_sizer->Add(hangable);
+	props_sizer->Add(hook_east);
+	props_sizer->Add(hook_south);
+	props_sizer->Add(has_elevation);
+	props_sizer->Add(ignore_look);
+	props_sizer->Add(floor_change);
+
+	props_panel->SetSizer(props_sizer);
+	notebook->AddPage(props_panel, "Properties");
+
+	left_sizer->Add(notebook, 1, wxEXPAND | wxALL, 5);
+
+	// Buttons
 	buttons_box_sizer = newd wxStdDialogButtonSizer();
 	ok_button = newd wxButton(this, wxID_OK);
 	ok_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
@@ -86,108 +136,18 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	cancel_button->SetToolTip("Cancel selection");
 	buttons_box_sizer->AddButton(cancel_button);
 	buttons_box_sizer->Realize();
-	options_box_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
+	left_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
 
-	box_sizer->Add(options_box_sizer, 1, wxALL, 5);
-
-	// --------------- Types ---------------
-
-	wxStaticBoxSizer* type_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Types"), wxVERTICAL);
-
-	wxString types_choices[] = { "Depot",
-								 "Mailbox",
-								 "Trash Holder",
-								 "Container",
-								 "Door",
-								 "Magic Field",
-								 "Teleport",
-								 "Bed",
-								 "Key",
-								 "Podium" };
-
-	int types_choices_count = sizeof(types_choices) / sizeof(wxString);
-	types_radio_box = newd wxRadioBox(type_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
-	types_radio_box->SetSelection(0);
-	types_radio_box->Enable(false);
-	type_box_sizer->Add(types_radio_box, 0, wxALL | wxEXPAND, 5);
-
-	box_sizer->Add(type_box_sizer, 1, wxALL | wxEXPAND, 5);
-
-	// --------------- Properties ---------------
-
-	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
-
-	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
-	unpassable->SetToolTip("Item blocks movement");
-	properties_box_sizer->Add(unpassable, 0, wxALL, 5);
-
-	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
-	unmovable->SetToolTip("Item cannot be moved");
-	properties_box_sizer->Add(unmovable, 0, wxALL, 5);
-
-	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
-	block_missiles->SetToolTip("Item blocks projectiles");
-	properties_box_sizer->Add(block_missiles, 0, wxALL, 5);
-
-	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
-	block_pathfinder->SetToolTip("Item blocks pathfinding");
-	properties_box_sizer->Add(block_pathfinder, 0, wxALL, 5);
-
-	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
-	readable->SetToolTip("Item has text");
-	properties_box_sizer->Add(readable, 0, wxALL, 5);
-
-	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
-	writeable->SetToolTip("Item can be written on");
-	properties_box_sizer->Add(writeable, 0, wxALL, 5);
-
-	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
-	pickupable->SetToolTip("Item can be picked up");
-	pickupable->SetValue(only_pickupables);
-	pickupable->Enable(!only_pickupables);
-	properties_box_sizer->Add(pickupable, 0, wxALL, 5);
-
-	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
-	stackable->SetToolTip("Item is stackable");
-	properties_box_sizer->Add(stackable, 0, wxALL, 5);
-
-	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
-	rotatable->SetToolTip("Item can be rotated");
-	properties_box_sizer->Add(rotatable, 0, wxALL, 5);
-
-	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
-	hangable->SetToolTip("Item can be hung on walls");
-	properties_box_sizer->Add(hangable, 0, wxALL, 5);
-
-	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
-	hook_east->SetToolTip("Item hooks to the east");
-	properties_box_sizer->Add(hook_east, 0, wxALL, 5);
-
-	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
-	hook_south->SetToolTip("Item hooks to the south");
-	properties_box_sizer->Add(hook_south, 0, wxALL, 5);
-
-	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
-	has_elevation->SetToolTip("Item has height (elevation)");
-	properties_box_sizer->Add(has_elevation, 0, wxALL, 5);
-
-	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
-	ignore_look->SetToolTip("Item is ignored when looking");
-	properties_box_sizer->Add(ignore_look, 0, wxALL, 5);
-
-	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
-	floor_change->SetToolTip("Item causes floor change");
-	properties_box_sizer->Add(floor_change, 0, wxALL, 5);
-
-	box_sizer->Add(properties_box_sizer, 1, wxALL | wxEXPAND, 5);
+	box_sizer->Add(left_sizer, 0, wxEXPAND | wxALL, 5);
 
 	// --------------- Items list ---------------
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
 	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
-	items_list->SetMinSize(wxSize(230, 512));
-	result_box_sizer->Add(items_list, 0, wxALL, 5);
-	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
+	items_list->SetMinSize(FromDIP(wxSize(300, 512)));
+	items_list->EnableGridMode(FromDIP(40)); // Enable grid mode with 40px item width
+	result_box_sizer->Add(items_list, 1, wxEXPAND | wxALL, 5);
+	box_sizer->Add(result_box_sizer, 1, wxEXPAND | wxALL, 5);
 
 	this->SetSizer(box_sizer);
 	this->Layout();
@@ -198,14 +158,14 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	SetIcons(IMAGE_MANAGER.GetIconBundle(ICON_SEARCH));
 
 	// Connect Events
-	options_radio_box->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, &FindItemDialog::OnOptionChange, this);
+	notebook->Bind(wxEVT_NOTEBOOK_PAGE_CHANGED, &FindItemDialog::OnTabChange, this);
 	server_id_spin->Bind(wxEVT_COMMAND_SPINCTRL_UPDATED, &FindItemDialog::OnServerIdChange, this);
 	server_id_spin->Bind(wxEVT_COMMAND_TEXT_UPDATED, &FindItemDialog::OnServerIdChange, this);
 	client_id_spin->Bind(wxEVT_COMMAND_SPINCTRL_UPDATED, &FindItemDialog::OnClientIdChange, this);
 	client_id_spin->Bind(wxEVT_COMMAND_TEXT_UPDATED, &FindItemDialog::OnClientIdChange, this);
 	name_text_input->Bind(wxEVT_COMMAND_TEXT_UPDATED, &FindItemDialog::OnText, this);
 
-	types_radio_box->Bind(wxEVT_COMMAND_RADIOBOX_SELECTED, &FindItemDialog::OnTypeChange, this);
+	types_choice->Bind(wxEVT_CHOICE, &FindItemDialog::OnTypeChange, this);
 
 	unpassable->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
 	unmovable->Bind(wxEVT_COMMAND_CHECKBOX_CLICKED, &FindItemDialog::OnPropertyChange, this);
@@ -234,20 +194,14 @@ FindItemDialog::~FindItemDialog() {
 }
 
 FindItemDialog::SearchMode FindItemDialog::getSearchMode() const {
-	return (SearchMode)options_radio_box->GetSelection();
+	return (SearchMode)notebook->GetSelection();
 }
 
 void FindItemDialog::setSearchMode(FindItemDialog::SearchMode mode) {
-	if ((SearchMode)options_radio_box->GetSelection() != mode) {
-		options_radio_box->SetSelection(mode);
+	if ((SearchMode)notebook->GetSelection() != mode) {
+		notebook->SetSelection(mode);
 	}
 
-	server_id_spin->Enable(mode == SearchMode::ServerIDs);
-	invalid_item->Enable(mode == SearchMode::ServerIDs);
-	client_id_spin->Enable(mode == SearchMode::ClientIDs);
-	name_text_input->Enable(mode == SearchMode::Names);
-	types_radio_box->Enable(mode == SearchMode::Types);
-	EnableProperties(mode == SearchMode::Properties);
 	RefreshContentsInternal();
 
 	if (mode == SearchMode::ServerIDs) {
@@ -284,7 +238,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	ok_button->Enable(false);
 	ok_button->SetToolTip("Select an item to continue");
 
-	SearchMode selection = (SearchMode)options_radio_box->GetSelection();
+	SearchMode selection = (SearchMode)notebook->GetSelection();
 	bool found_search_results = false;
 
 	if (selection == SearchMode::ServerIDs) {
@@ -371,7 +325,7 @@ void FindItemDialog::RefreshContentsInternal() {
 				continue;
 			}
 
-			SearchItemType selection = (SearchItemType)types_radio_box->GetSelection();
+			SearchItemType selection = (SearchItemType)types_choice->GetSelection();
 			if ((selection == SearchItemType::Depot && !item.isDepot()) || (selection == SearchItemType::Mailbox && !item.isMailbox()) || (selection == SearchItemType::TrashHolder && !item.isTrashHolder()) || (selection == SearchItemType::Container && !item.isContainer()) || (selection == SearchItemType::Door && !item.isDoor()) || (selection == SearchItemType::MagicField && !item.isMagicField()) || (selection == SearchItemType::Teleport && !item.isTeleport()) || (selection == SearchItemType::Bed && !item.isBed()) || (selection == SearchItemType::Key && !item.isKey()) || (selection == SearchItemType::Podium && !item.isPodium())) {
 				continue;
 			}
@@ -415,8 +369,8 @@ void FindItemDialog::RefreshContentsInternal() {
 	items_list->Refresh();
 }
 
-void FindItemDialog::OnOptionChange(wxCommandEvent& WXUNUSED(event)) {
-	setSearchMode((SearchMode)options_radio_box->GetSelection());
+void FindItemDialog::OnTabChange(wxBookCtrlEvent& WXUNUSED(event)) {
+	setSearchMode((SearchMode)notebook->GetSelection());
 }
 
 void FindItemDialog::OnServerIdChange(wxCommandEvent& WXUNUSED(event)) {
@@ -444,7 +398,7 @@ void FindItemDialog::OnInputTimer(wxTimerEvent& WXUNUSED(event)) {
 }
 
 void FindItemDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
-	if (invalid_item->GetValue() && (SearchMode)options_radio_box->GetSelection() == SearchMode::ServerIDs && result_id != 0) {
+	if (invalid_item->GetValue() && (SearchMode)notebook->GetSelection() == SearchMode::ServerIDs && result_id != 0) {
 		EndModal(wxID_OK);
 		return;
 	}

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -26,6 +26,7 @@
 #include <wx/checkbox.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
+#include <wx/notebook.h>
 
 class FindDialogListBox;
 
@@ -69,7 +70,7 @@ private:
 	void EnableProperties(bool enable);
 	void RefreshContentsInternal();
 
-	void OnOptionChange(wxCommandEvent& event);
+	void OnTabChange(wxBookCtrlEvent& event);
 	void OnServerIdChange(wxCommandEvent& event);
 	void OnClientIdChange(wxCommandEvent& event);
 	void OnText(wxCommandEvent& event);
@@ -79,9 +80,9 @@ private:
 	void OnClickOK(wxCommandEvent& event);
 	void OnClickCancel(wxCommandEvent& event);
 
-	wxRadioBox* options_radio_box;
+	wxNotebook* notebook;
 
-	wxRadioBox* types_radio_box;
+	wxChoice* types_choice;
 
 	wxSpinCtrl* server_id_spin;
 	wxSpinCtrl* client_id_spin;

--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -24,6 +24,19 @@ NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
 NanoVGListBox::~NanoVGListBox() {
 }
 
+void NanoVGListBox::EnableGridMode(int itemWidth) {
+	m_gridMode = true;
+	m_itemWidth = std::max(1, itemWidth);
+	UpdateScrollbar();
+	Refresh();
+}
+
+int NanoVGListBox::GetColumns() const {
+	if (!m_gridMode || m_itemWidth <= 0) return 1;
+	int cols = GetClientSize().x / m_itemWidth;
+	return std::max(1, cols);
+}
+
 void NanoVGListBox::SetItemCount(size_t count) {
 	if (m_count != count) {
 		m_count = count;
@@ -137,8 +150,8 @@ void NanoVGListBox::ScrollToLine(int line) {
 	EnsureVisible(line);
 }
 
-void NanoVGListBox::EnsureVisible(int line) {
-	if (line < 0 || line >= static_cast<int>(m_count)) {
+void NanoVGListBox::EnsureVisible(int index) {
+	if (index < 0 || index >= static_cast<int>(m_count)) {
 		return;
 	}
 
@@ -146,7 +159,8 @@ void NanoVGListBox::EnsureVisible(int line) {
 	int scrollPos = GetScrollPosition();
 	int clientHeight = GetClientSize().y;
 
-	int itemTop = line * itemHeight;
+	int row = m_gridMode ? (index / GetColumns()) : index;
+	int itemTop = row * itemHeight;
 	int itemBottom = itemTop + itemHeight;
 
 	if (itemTop < scrollPos) {
@@ -170,10 +184,9 @@ void NanoVGListBox::UpdateScrollbar() {
 	// Let's assume OnMeasureItem(0) is representative or we check m_itemHeightCache.
 
 	int itemHeight = std::max(1, OnMeasureItem(0));
-	int totalHeight = static_cast<int>(m_count) * itemHeight;
 
-	int clientHeight = GetClientSize().y;
-	int pageSize = clientHeight;
+	int totalRows = m_gridMode ? ((static_cast<int>(m_count) + GetColumns() - 1) / GetColumns()) : static_cast<int>(m_count);
+	int totalHeight = totalRows * itemHeight;
 
 	NanoVGCanvas::UpdateScrollbar(totalHeight);
 }
@@ -195,19 +208,28 @@ void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 
 	int scrollPos = GetScrollPosition();
 	int itemHeight = std::max(1, OnMeasureItem(0)); // Simplified assumption
+	int cols = GetColumns();
 
 	int startRow = scrollPos / itemHeight;
 	int endRow = (scrollPos + height + itemHeight - 1) / itemHeight;
 
-	startRow = std::max(0, startRow);
-	endRow = std::min(static_cast<int>(m_count), endRow);
+	int startIndex = startRow * cols;
+	int endIndex = (endRow + 1) * cols;
+
+	startIndex = std::max(0, startIndex);
+	endIndex = std::min(static_cast<int>(m_count), endIndex);
 
 	// Translate by scroll position is handled by caller (NanoVGCanvas::OnPaint)?
 	// NanoVGCanvas calls OnNanoVGPaint(m_nvg, width, height) after nvgTranslate(m_nvg, 0, -m_scrollPos).
 	// So (0,0) is top of content.
 
-	for (int i = startRow; i < endRow; ++i) {
-		wxRect rect(0, i * itemHeight, width, itemHeight);
+	for (int i = startIndex; i < endIndex; ++i) {
+		int row = m_gridMode ? (i / cols) : i;
+		int col = m_gridMode ? (i % cols) : 0;
+		int rectWidth = m_gridMode ? m_itemWidth : width;
+		int rectX = col * rectWidth;
+
+		wxRect rect(rectX, row * itemHeight, rectWidth, itemHeight);
 
 		// Draw background for selection/hover
 		bool selected = IsSelected(i);
@@ -238,7 +260,15 @@ int NanoVGListBox::HitTest(int x, int y) const {
 		return -1;
 	}
 	int itemHeight = std::max(1, OnMeasureItem(0));
-	int index = y / itemHeight;
+	int cols = GetColumns();
+
+	int row = y / itemHeight;
+	int col = m_gridMode ? (x / std::max(1, m_itemWidth)) : 0;
+
+	if (col >= cols) return -1;
+
+	int index = row * cols + col;
+
 	if (index >= 0 && index < static_cast<int>(m_count)) {
 		return index;
 	}
@@ -247,7 +277,11 @@ int NanoVGListBox::HitTest(int x, int y) const {
 
 wxRect NanoVGListBox::GetItemRect(int index) const {
 	int itemHeight = std::max(1, OnMeasureItem(0));
-	return wxRect(0, index * itemHeight, GetClientSize().x, itemHeight);
+	int cols = GetColumns();
+	int row = m_gridMode ? (index / cols) : index;
+	int col = m_gridMode ? (index % cols) : 0;
+	int rectWidth = m_gridMode ? m_itemWidth : GetClientSize().x;
+	return wxRect(col * rectWidth, row * itemHeight, rectWidth, itemHeight);
 }
 
 void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
@@ -308,12 +342,30 @@ void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
 	}
 	int next = current;
 
+	int cols = GetColumns();
+
 	switch (event.GetKeyCode()) {
+		case WXK_LEFT:
+			if (m_gridMode) {
+				next = std::max(0, current - 1);
+			} else {
+				event.Skip();
+				return;
+			}
+			break;
+		case WXK_RIGHT:
+			if (m_gridMode) {
+				next = std::min(static_cast<int>(m_count) - 1, current + 1);
+			} else {
+				event.Skip();
+				return;
+			}
+			break;
 		case WXK_UP:
-			next = std::max(0, current - 1);
+			next = std::max(0, current - cols);
 			break;
 		case WXK_DOWN:
-			next = std::min(static_cast<int>(m_count) - 1, current + 1);
+			next = std::min(static_cast<int>(m_count) - 1, current + cols);
 			break;
 		case WXK_HOME:
 			next = 0;
@@ -323,14 +375,14 @@ void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
 			break;
 		case WXK_PAGEUP: {
 			int itemHeight = OnMeasureItem(0);
-			int pageSize = GetClientSize().y / itemHeight;
-			next = std::max(0, current - pageSize);
+			int pageSizeRows = GetClientSize().y / itemHeight;
+			next = std::max(0, current - (pageSizeRows * cols));
 			break;
 		}
 		case WXK_PAGEDOWN: {
 			int itemHeight = OnMeasureItem(0);
-			int pageSize = GetClientSize().y / itemHeight;
-			next = std::min(static_cast<int>(m_count) - 1, current + pageSize);
+			int pageSizeRows = GetClientSize().y / itemHeight;
+			next = std::min(static_cast<int>(m_count) - 1, current + (pageSizeRows * cols));
 			break;
 		}
 		default:

--- a/source/util/nanovg_listbox.h
+++ b/source/util/nanovg_listbox.h
@@ -22,6 +22,10 @@ public:
 		return m_count;
 	}
 
+	// Layout Mode
+	void EnableGridMode(int itemWidth);
+	bool IsGridMode() const { return m_gridMode; }
+
 	// Selection
 	virtual void SetSelection(int index);
 	int GetSelection() const;
@@ -64,6 +68,11 @@ protected:
 
 	int m_hoverIndex;
 	int m_focusIndex;
+
+	bool m_gridMode = false;
+	int m_itemWidth = 0;
+
+	int GetColumns() const;
 };
 
 #endif


### PR DESCRIPTION
This PR executes the "Designer" agent instructions by drastically improving the UX/UI of the Find Item and Browse Tile dialogs.

Key improvements:
- **NanoVGListBox Grid Support:** The core virtual listbox now natively supports drawing items in a dynamic grid layout, which is essential for presenting hundreds/thousands of visual sprite thumbnails without scrolling endlessly through a 1-column list.
- **Find Item Dialog Redesign:** Removed the confusing radio-button-controlled sections. Implemented a `wxNotebook` to categorize searches (Server ID, Client ID, Name, Types, Properties). 15 unstructured checkboxes are now neatly organized in a `wxFlexGridSizer`.
- **Browse Tile Window Redesign:** Separated the layout into "Items on Tile" (left) and "Tile Information" (right). Items are now shown as clear square thumbnails using the new grid mode. Tile metadata (coords, PZ flags, logout flags) are properly aligned in a grid rather than a disjointed list of labels.

---
*PR created automatically by Jules for task [2931753604774861210](https://jules.google.com/task/2931753604774861210) started by @karolak6612*