### PR TITLE
🖥️ OpenGL: Make TextureGarbageCollector thread-safe

### DIFF
--- a/source/rendering/core/texture_garbage_collector.cpp
+++ b/source/rendering/core/texture_garbage_collector.cpp
@@ -33,6 +33,7 @@ TextureGarbageCollector::~TextureGarbageCollector() {
 void TextureGarbageCollector::Clear() {
 	loaded_textures = 0;
 	lastclean = time(nullptr);
+	std::lock_guard<std::mutex> lock(cleanup_mutex);
 	cleanup_list.clear();
 }
 
@@ -48,8 +49,12 @@ void TextureGarbageCollector::NotifyTextureUnloaded() {
 const int MIN_CLEAN_THRESHOLD = 100;
 
 void TextureGarbageCollector::AddSpriteToCleanup(GameSprite* spr) {
+	std::lock_guard<std::mutex> lock(cleanup_mutex);
 	cleanup_list.push_back(spr);
-	// Clean if needed
+}
+
+void TextureGarbageCollector::ProcessCleanupQueue() {
+	std::lock_guard<std::mutex> lock(cleanup_mutex);
 	const size_t clean_threshold = static_cast<size_t>(std::max(MIN_CLEAN_THRESHOLD, g_settings.getInteger(Config::SOFTWARE_CLEAN_THRESHOLD)));
 	if (cleanup_list.size() > clean_threshold) {
 		const auto software_clean_size = std::max(0, g_settings.getInteger(Config::SOFTWARE_CLEAN_SIZE));
@@ -63,6 +68,8 @@ void TextureGarbageCollector::AddSpriteToCleanup(GameSprite* spr) {
 }
 
 void TextureGarbageCollector::GarbageCollect(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time) {
+	ProcessCleanupQueue();
+
 	if (g_settings.getInteger(Config::TEXTURE_MANAGEMENT)) {
 		if (loaded_textures > g_settings.getInteger(Config::TEXTURE_CLEAN_THRESHOLD) && current_time - lastclean > g_settings.getInteger(Config::TEXTURE_CLEAN_PULSE)) {
 

--- a/source/rendering/core/texture_garbage_collector.h
+++ b/source/rendering/core/texture_garbage_collector.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <memory>
 #include <time.h>
+#include <mutex>
 
 class GameSprite;
 class Sprite;
@@ -33,6 +34,7 @@ public:
 
 	void GarbageCollect(std::vector<GameSprite*>& resident_game_sprites, std::vector<void*>& resident_images, time_t current_time);
 	void AddSpriteToCleanup(GameSprite* spr);
+	void ProcessCleanupQueue();
 	void CleanSoftwareSprites(std::vector<std::unique_ptr<Sprite>>& sprite_space);
 	void Clear();
 
@@ -47,6 +49,7 @@ private:
 	int loaded_textures;
 	time_t lastclean;
 	std::deque<GameSprite*> cleanup_list;
+	std::mutex cleanup_mutex;
 };
 
 #endif


### PR DESCRIPTION
Following `.jules/newagents/opengl.md` instructions, this makes `TextureGarbageCollector` thread-safe, addressing the bullet point: "Texture GC. Verify it runs asynchronously, not blocking render." by properly separating queuing from execution with a mutex.

---
*PR created automatically by Jules for task [2501522674504934036](https://jules.google.com/task/2501522674504934036) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced thread-safety in texture cleanup operations to prevent race conditions and ensure reliable memory management during concurrent access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->