### PR TITLE
🔧 WxFixer: Fix 3 wxWidgets violations

### DIFF
--- a/build_log.txt
+++ b/build_log.txt
@@ -1,0 +1,99 @@
+[1/5] Checking/Installing Tools (Quiet)...
+[2/5] Setting up Conan Clang profile...
+[3/5] Installing dependencies (Debug)...
+[4/5] Configuring CMake (Ninja + Mold)...
+[5/5] Building with Ninja (j2 to avoid OOM)...
+ninja: Entering directory `/app/build_clang/build/Debug'
+[1/317] Building CXX object CMakeFiles/rme.dir/source/app/client_version.cpp.o
+FAILED: CMakeFiles/rme.dir/source/app/client_version.cpp.o
+ccache /usr/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DNANOVG_GL3 -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -DUNICODE=1 -DWXUSINGDLL -DWXWIN_COMPATIBILITY_3_3 -D_FILE_OFFSET_BITS=64 -D_UNICODE=1 -D__WXGTK__ -I/app/source -I/app/ext/nanovg/src -isystem /usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.2 -isystem /usr/include/wx-3.2 -isystem /home/jules/.conan2/p/b/glad3f6fabaabcc35/p/include -isystem /home/jules/.conan2/p/tomlpf6611d18152aa/p/include -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result -pthread -O0 -g -D__DEBUG__ -std=gnu++20 -pthread -MD -MT CMakeFiles/rme.dir/source/app/client_version.cpp.o -MF CMakeFiles/rme.dir/source/app/client_version.cpp.o.d -o CMakeFiles/rme.dir/source/app/client_version.cpp.o -c /app/source/app/client_version.cpp
+error: "Never use <enqcmdintrin.h> directly; include <immintrin.h> instead."
+error: "Never use <f16cintrin.h> directly; include <immintrin.h> instead."
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: expected unqualified-id
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+error: source file is not valid UTF-8
+fatal error: too many errors emitted, stopping now [-ferror-limit=]
+PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace, preprocessed source, and associated run script.
+Stack dump:
+0.	Program arguments: /usr/bin/clang++ -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_SYSTEM_DYN_LINK -DBOOST_SYSTEM_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DFMT_SHARED -DNANOVG_GL3 -DSPDLOG_COMPILED_LIB -DSPDLOG_FMT_EXTERNAL -DSPDLOG_SHARED_LIB -DUNICODE=1 -DWXUSINGDLL -DWXWIN_COMPATIBILITY_3_3 -D_FILE_OFFSET_BITS=64 -D_UNICODE=1 -D__WXGTK__ -I/app/source -I/app/ext/nanovg/src -isystem /usr/lib/x86_64-linux-gnu/wx/include/gtk3-unicode-3.2 -isystem /usr/include/wx-3.2 -isystem /home/jules/.conan2/p/b/glad3f6fabaabcc35/p/include -isystem /home/jules/.conan2/p/tomlpf6611d18152aa/p/include -Wall -Wextra -Wno-unused-parameter -Wno-unused-variable -Wno-deprecated-declarations -Wno-overloaded-virtual -Wno-strict-aliasing -Wno-sign-compare -Wno-unused-function -Wunused-result -pthread -O0 -g -D__DEBUG__ -std=gnu++20 -pthread -MD -MT CMakeFiles/rme.dir/source/app/client_version.cpp.o -MF CMakeFiles/rme.dir/source/app/client_version.cpp.o.d -o CMakeFiles/rme.dir/source/app/client_version.cpp.o -c /app/source/app/client_version.cpp
+1.	<unknown> parser at unknown location
+Stack dump without symbol names (ensure you have llvm-symbolizer in your PATH or set the environment var `LLVM_SYMBOLIZER_PATH` to point to it):
+0  libLLVM.so.18.1      0x00007feabe4e73bf llvm::sys::PrintStackTrace(llvm::raw_ostream&, int) + 63
+1  libLLVM.so.18.1      0x00007feabe4e54f9 llvm::sys::RunSignalHandlers() + 89
+2  libLLVM.so.18.1      0x00007feabe431227
+3  libc.so.6            0x00007feabd2e5330
+4  libclang-cpp.so.18.1 0x00007feac586dd3d clang::Lexer::SkipWhitespace(clang::Token&, char const*, bool&) + 45
+5  libclang-cpp.so.18.1 0x00007feac58722f7 clang::Lexer::LexTokenInternal(clang::Token&, bool) + 1847
+6  libclang-cpp.so.18.1 0x00007feac58db5ed clang::Preprocessor::Lex(clang::Token&) + 45
+7  libclang-cpp.so.18.1 0x00007feac58e929d
+8  libclang-cpp.so.18.1 0x00007feac59a9af2 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 1026
+9  libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+10 libclang-cpp.so.18.1 0x00007feac59a9b23 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 1075
+11 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+12 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+13 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+14 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+15 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+16 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+17 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+18 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+19 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+20 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+21 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+22 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+23 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+24 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+25 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+26 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+27 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+28 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+29 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+30 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+31 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+32 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+33 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+34 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+35 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+36 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+37 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+38 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+39 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+40 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+41 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+42 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+43 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+44 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+45 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+46 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+47 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+48 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+49 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+50 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+51 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+52 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+53 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+54 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+55 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+56 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+57 libclang-cpp.so.18.1 0x00007feac59a9b23 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 1075
+58 libclang-cpp.so.18.1 0x00007feac59a9b23 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 1075
+59 libclang-cpp.so.18.1 0x00007feac59a9b23 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 1075
+60 libclang-cpp.so.18.1 0x00007feac59a99e5 clang::Parser::SkipUntil(llvm::ArrayRef<clang::tok::TokenKind>, clang::Parser::SkipUntilFlags) + 757
+61 libclang-cpp.so.18.1 0x00007feac58f97a9 clang::Parser::SkipMalformedDecl() + 297
+62 libclang-cpp.so.18.1 0x00007feac58f8912 clang::Parser::ParseDeclGroup(clang::ParsingDeclSpec&, clang::DeclaratorContext, clang::ParsedAttributes&, clang::SourceLocation*, clang::Parser::ForRangeInit*) + 2242
+63 libclang-cpp.so.18.1 0x00007feac59af07f clang::Parser::ParseDeclOrFunctionDefInternal(clang::ParsedAttributes&, clang::ParsedAttributes&, clang::ParsingDeclSpec&, clang::AccessSpecifier) + 1087
+64 libclang-cpp.so.18.1 0x00007feac59a

--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -77,11 +77,11 @@ private:
 
 		// Draw Inner Highlight/Shadow for 3D effect
 		if (!m_pressed) {
-			dc.SetPen(wxPen(wxColour(255, 255, 255))); // Highlight top/left
+			dc.SetPen(wxPen(bg.ChangeLightness(150))); // Highlight top/left
 			dc.DrawLine(1, 1, sz.x - 1, 1);
 			dc.DrawLine(1, 1, 1, sz.y - 1);
 
-			dc.SetPen(wxPen(wxColour(0, 0, 0))); // Shadow bottom/right
+			dc.SetPen(wxPen(bg.ChangeLightness(50))); // Shadow bottom/right
 			dc.DrawLine(1, sz.y - 2, sz.x - 1, sz.y - 2);
 			dc.DrawLine(sz.x - 2, 1, sz.x - 2, sz.y - 2);
 		}
@@ -270,7 +270,7 @@ WelcomeDialog::~WelcomeDialog() {
 void WelcomeDialog::AddInfoField(wxSizer* sizer, wxWindow* parent, const wxString& label, const wxString& value, std::string_view artId, const wxColour& valCol) {
 	wxBoxSizer* row = new wxBoxSizer(wxHORIZONTAL);
 
-	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(artId, wxSize(14, 14)));
+	wxStaticBitmap* icon = new wxStaticBitmap(parent, wxID_ANY, IMAGE_MANAGER.GetBitmap(artId, FromDIP(wxSize(14, 14))));
 	row->Add(icon, 0, wxCENTER | wxRIGHT, 4);
 
 	wxStaticText* lbl = new wxStaticText(parent, wxID_ANY, label);
@@ -301,8 +301,8 @@ wxPanel* WelcomeDialog::CreateHeaderPanel(wxWindow* parent, const wxString& titl
 	wxBoxSizer* headerSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	// Icon Button - Align Left: 10px total
-	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, wxSize(48, 48));
-	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, wxSize(32, 32))); // Fallback if logo invalid
+	ConvexButton* iconBtn = new ConvexButton(headerPanel, wxID_ANY, "", wxDefaultPosition, FromDIP(wxSize(48, 48)));
+	iconBtn->SetBitmap(rmeLogo.IsOk() ? rmeLogo : IMAGE_MANAGER.GetBitmap(ICON_QUESTION_CIRCLE, FromDIP(wxSize(32, 32)))); // Fallback if logo invalid
 	headerSizer->Add(iconBtn, 0, wxALL | wxCENTER, 8);
 
 	wxBoxSizer* titleSizer = new wxBoxSizer(wxVERTICAL);
@@ -385,14 +385,14 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	// Column 1: Actions (Buttons directly on panel)
 	wxBoxSizer* col1 = new wxBoxSizer(wxVERTICAL);
 
-	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, wxSize(130, 50));
-	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, wxSize(24, 24)));
+	ConvexButton* newMapBtn = new ConvexButton(contentPanel, wxID_NEW, "New map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	newMapBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(24, 24))));
 	newMapBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	// Align "New Map" with Icon (8px from left edge of content panel)
 	col1->Add(newMapBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
-	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, wxSize(130, 50));
-	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, wxSize(24, 24)));
+	ConvexButton* browseBtn = new ConvexButton(contentPanel, wxID_OPEN, "Browse Map", wxDefaultPosition, FromDIP(wxSize(130, 50)));
+	browseBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(24, 24))));
 	browseBtn->Bind(wxEVT_BUTTON, &WelcomeDialog::OnButtonClicked, this);
 	col1->Add(browseBtn, 0, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 4);
 
@@ -448,7 +448,7 @@ wxPanel* WelcomeDialog::CreateContentPanel(wxWindow* parent, const std::vector<w
 	AddInfoField(col4->GetSizer(), col4, "Client Version", "Placeholder", ICON_CHECK);
 	AddInfoField(col4->GetSizer(), col4, "Data Directory", "Placeholder", ICON_FOLDER);
 	col4->GetSizer()->Add(new wxStaticLine(col4), 0, wxEXPAND | wxALL, 4);
-	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", ICON_CHECK, wxColour(0, 200, 0));
+	AddInfoField(col4->GetSizer(), col4, "Status", "Placeholder", ICON_CHECK, Theme::Get(Theme::Role::Success));
 	contentSizer->Add(col4, 1, wxEXPAND | wxTOP | wxBOTTOM | wxRIGHT, 5); // Add Column 4
 
 	// Column 5: Available Clients


### PR DESCRIPTION
Fixes a set of wxWidgets violations automatically detected by WxFixer rules including incorrect event handling macro usages, missing `FromDIP()` for UI sizes, and hardcoded colors in custom controls.

---
*PR created automatically by Jules for task [9291855115072143881](https://jules.google.com/task/9291855115072143881) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visual scaling and layout for consistent appearance across different screen resolutions and DPI settings.
  * Enhanced color consistency throughout the interface using theme-based color selection.

* **Chores**
  * Removed deprecated event handling code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->