### PR TITLE
🖥️ OpenGL: Fix glGetError loops and avoid GL_SYNC_FLUSH_COMMANDS_BIT stalls

### DIFF
--- a/source/rendering/core/pixel_buffer_object.cpp
+++ b/source/rendering/core/pixel_buffer_object.cpp
@@ -76,7 +76,8 @@ void* PixelBufferObject::mapWrite() {
 	// Wait for GPU to finish reading from this PBO (if it was used previously)
 	if (fences_[current_index_]) {
 		// Reduce timeout to 16ms to avoid long stalls
-		GLenum result = fences_[current_index_].clientWait(GL_SYNC_FLUSH_COMMANDS_BIT, 16000000);
+		// Avoid GL_SYNC_FLUSH_COMMANDS_BIT to prevent command queue flush stall
+		GLenum result = fences_[current_index_].clientWait(0, 16000000);
 		if (result == GL_TIMEOUT_EXPIRED || result == GL_WAIT_FAILED) {
 			spdlog::warn("PixelBufferObject: Fence wait hit timeout (16ms), falling back to synchronous upload");
 			// Don't return nullptr, just proceed with mapping which might stall or handle as needed

--- a/source/rendering/core/ring_buffer.cpp
+++ b/source/rendering/core/ring_buffer.cpp
@@ -119,8 +119,11 @@ void* RingBuffer::waitAndMap(size_t count) {
 	// Wait for fence on current section if it exists
 	if (fences_[current_section_]) {
 		static constexpr uint64_t WAIT_TIMEOUT_NS = 5000000000ULL; // 5 second timeout (increased from 1s for large viewports)
+		// Avoid GL_SYNC_FLUSH_COMMANDS_BIT in hot paths if possible, but for large fences
+		// we might need it. Let's try passing 0 instead to avoid flushing command queue
+		// which can block the render thread, relying on implicit sync.
 		GLenum result = fences_[current_section_].clientWait(
-			GL_SYNC_FLUSH_COMMANDS_BIT, WAIT_TIMEOUT_NS
+			0, WAIT_TIMEOUT_NS
 		);
 
 		if (result == GL_TIMEOUT_EXPIRED || result == GL_WAIT_FAILED) {

--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,17 +117,18 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		bool had_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
-			return false;
+			had_error = true;
 		}
+		if (had_error) return false;
 
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,8 +160,8 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
 	}
 


### PR DESCRIPTION
- Updated source/rendering/drawers/minimap_renderer.cpp and source/rendering/core/texture_atlas.cpp to use while loops to properly drain the glGetError() queue.
- Updated source/rendering/core/ring_buffer.cpp and source/rendering/core/pixel_buffer_object.cpp to call clientWait without GL_SYNC_FLUSH_COMMANDS_BIT to avoid stalls on the command queue during hot paths.

---
*PR created automatically by Jules for task [7672218382240177855](https://jules.google.com/task/7672218382240177855) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Optimized GPU synchronization mechanisms in the rendering pipeline.

* **Bug Fixes**
  * Improved error detection and diagnostic logging for graphics operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->