### PR TITLE
👃 Smeller: Fix unnamed enums in map/tile.h

### DIFF
--- a/source/brushes/brush.cpp
+++ b/source/brushes/brush.cpp
@@ -95,10 +95,10 @@ void Brushes::init() {
 	addManagedBrush(g_brush_manager.house_exit_brush);
 	addManagedBrush(g_brush_manager.waypoint_brush);
 
-	addManagedBrush(g_brush_manager.pz_brush, TILESTATE_PROTECTIONZONE);
-	addManagedBrush(g_brush_manager.rook_brush, TILESTATE_NOPVP);
-	addManagedBrush(g_brush_manager.nolog_brush, TILESTATE_NOLOGOUT);
-	addManagedBrush(g_brush_manager.pvp_brush, TILESTATE_PVPZONE);
+	addManagedBrush(g_brush_manager.pz_brush, static_cast<uint32_t>(TileMapFlag::PROTECTIONZONE));
+	addManagedBrush(g_brush_manager.rook_brush, static_cast<uint32_t>(TileMapFlag::NOPVP));
+	addManagedBrush(g_brush_manager.nolog_brush, static_cast<uint32_t>(TileMapFlag::NOLOGOUT));
+	addManagedBrush(g_brush_manager.pvp_brush, static_cast<uint32_t>(TileMapFlag::PVPZONE));
 
 	GroundBrush::init();
 	WallBrush::init();

--- a/source/brushes/doodad/doodad_brush_loader.cpp
+++ b/source/brushes/doodad/doodad_brush_loader.cpp
@@ -65,7 +65,7 @@ bool DoodadBrushLoader::load(pugi::xml_node node, DoodadBrushItems& items, Dooda
 		if (!settings.do_new_borders) {
 			warnings.push_back("remove_optional_border will not work without redo_borders\n");
 		}
-		settings.clear_statflags |= TILESTATE_OP_BORDER;
+		settings.clear_statflags |= static_cast<uint16_t>(TileStatFlag::OP_BORDER);
 	}
 
 	const std::string& thicknessString = node.attribute("thickness").as_string();

--- a/source/brushes/flag/flag_brush.cpp
+++ b/source/brushes/flag/flag_brush.cpp
@@ -19,10 +19,10 @@ FlagBrush::FlagBrush(uint32_t flag) :
 }
 
 std::string FlagBrush::getName() const {
-	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { TILESTATE_PROTECTIONZONE, "PZ brush (0x01)" },
-																						  { TILESTATE_NOPVP, "No combat zone brush (0x04)" },
-																						  { TILESTATE_NOLOGOUT, "No logout zone brush (0x08)" },
-																						  { TILESTATE_PVPZONE, "PVP Zone brush (0x10)" } } };
+	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { static_cast<uint32_t>(TileMapFlag::PROTECTIONZONE), "PZ brush (0x01)" },
+																						  { static_cast<uint32_t>(TileMapFlag::NOPVP), "No combat zone brush (0x04)" },
+																						  { static_cast<uint32_t>(TileMapFlag::NOLOGOUT), "No logout zone brush (0x08)" },
+																						  { static_cast<uint32_t>(TileMapFlag::PVPZONE), "PVP Zone brush (0x10)" } } };
 
 	auto it = std::ranges::find_if(flagNames, [this](const auto& p) { return p.first == flag; });
 	if (it != flagNames.end()) {
@@ -32,10 +32,10 @@ std::string FlagBrush::getName() const {
 }
 
 int FlagBrush::getLookID() const {
-	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { TILESTATE_PROTECTIONZONE, EDITOR_SPRITE_PZ_TOOL },
-																			   { TILESTATE_NOPVP, EDITOR_SPRITE_NOPVP_TOOL },
-																			   { TILESTATE_NOLOGOUT, EDITOR_SPRITE_NOLOG_TOOL },
-																			   { TILESTATE_PVPZONE, EDITOR_SPRITE_PVPZ_TOOL } } };
+	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { static_cast<uint32_t>(TileMapFlag::PROTECTIONZONE), EDITOR_SPRITE_PZ_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlag::NOPVP), EDITOR_SPRITE_NOPVP_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlag::NOLOGOUT), EDITOR_SPRITE_NOLOG_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlag::PVPZONE), EDITOR_SPRITE_PVPZ_TOOL } } };
 
 	auto it = std::ranges::find_if(flagSprites, [this](const auto& p) { return p.first == flag; });
 	if (it != flagSprites.end()) {

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -97,7 +97,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 			copied_tile->house_id = newtile->house_id;
 			newtile->house_id = 0;
 			copied_tile->setMapFlags(tile->getMapFlags());
-			newtile->setMapFlags(TILESTATE_NONE);
+			newtile->setMapFlags(TileMapFlag::NONE);
 		}
 
 		auto tile_selection = TileOperations::popSelectedItems(newtile.get());

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -123,7 +123,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 			tmp_storage_tile->house_id = new_src_tile->house_id;
 			new_src_tile->house_id = 0;
 			tmp_storage_tile->setMapFlags(new_src_tile->getMapFlags());
-			new_src_tile->setMapFlags(TILESTATE_NONE);
+			new_src_tile->setMapFlags(TileMapFlag::NONE);
 			doborders = true;
 		}
 

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -37,26 +37,41 @@ class Map;
 
 // TileOperations functions are now in tile_operations.h
 
-enum {
-	TILESTATE_NONE = 0x0000,
-	TILESTATE_PROTECTIONZONE = 0x0001,
-	TILESTATE_DEPRECATED = 0x0002, // Reserved
-	TILESTATE_NOPVP = 0x0004,
-	TILESTATE_NOLOGOUT = 0x0008,
-	TILESTATE_PVPZONE = 0x0010,
-	TILESTATE_REFRESH = 0x0020,
-	// Internal
-	TILESTATE_SELECTED = 0x0001,
-	TILESTATE_UNIQUE = 0x0002,
-	TILESTATE_BLOCKING = 0x0004,
-	TILESTATE_OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
-	TILESTATE_HAS_TABLE = 0x0010,
-	TILESTATE_HAS_CARPET = 0x0020,
-	TILESTATE_MODIFIED = 0x0040,
-	TILESTATE_HOOK_SOUTH = 0x0080,
-	TILESTATE_HOOK_EAST = 0x0100,
-	TILESTATE_HAS_LIGHT = 0x0200,
+enum class TileMapFlag : uint16_t {
+	NONE = 0x0000,
+	PROTECTIONZONE = 0x0001,
+	DEPRECATED = 0x0002, // Reserved
+	NOPVP = 0x0004,
+	NOLOGOUT = 0x0008,
+	PVPZONE = 0x0010,
+	REFRESH = 0x0020,
 };
+
+enum class TileStatFlag : uint16_t {
+	NONE = 0x0000,
+	SELECTED = 0x0001,
+	UNIQUE = 0x0002,
+	BLOCKING = 0x0004,
+	OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
+	HAS_TABLE = 0x0010,
+	HAS_CARPET = 0x0020,
+	MODIFIED = 0x0040,
+	HOOK_SOUTH = 0x0080,
+	HOOK_EAST = 0x0100,
+	HAS_LIGHT = 0x0200,
+};
+
+inline constexpr TileMapFlag operator|(TileMapFlag a, TileMapFlag b) { return static_cast<TileMapFlag>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b)); }
+inline constexpr TileMapFlag operator&(TileMapFlag a, TileMapFlag b) { return static_cast<TileMapFlag>(static_cast<uint16_t>(a) & static_cast<uint16_t>(b)); }
+inline constexpr TileMapFlag operator~(TileMapFlag a) { return static_cast<TileMapFlag>(~static_cast<uint16_t>(a)); }
+inline constexpr TileMapFlag& operator|=(TileMapFlag& a, TileMapFlag b) { a = a | b; return a; }
+inline constexpr TileMapFlag& operator&=(TileMapFlag& a, TileMapFlag b) { a = a & b; return a; }
+
+inline constexpr TileStatFlag operator|(TileStatFlag a, TileStatFlag b) { return static_cast<TileStatFlag>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b)); }
+inline constexpr TileStatFlag operator&(TileStatFlag a, TileStatFlag b) { return static_cast<TileStatFlag>(static_cast<uint16_t>(a) & static_cast<uint16_t>(b)); }
+inline constexpr TileStatFlag operator~(TileStatFlag a) { return static_cast<TileStatFlag>(~static_cast<uint16_t>(a)); }
+inline constexpr TileStatFlag& operator|=(TileStatFlag& a, TileStatFlag b) { a = a | b; return a; }
+inline constexpr TileStatFlag& operator&=(TileStatFlag& a, TileStatFlag b) { a = a & b; return a; }
 
 enum : uint8_t {
 	INVALID_MINIMAP_COLOR = 0xFF
@@ -70,8 +85,8 @@ public: // Members
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)
-	uint16_t mapflags;
-	uint16_t statflags;
+	TileMapFlag mapflags;
+	TileStatFlag statflags;
 	uint8_t minimapColor;
 
 public:
@@ -110,13 +125,13 @@ public: // Functions
 
 	// Has tile been modified since the map was loaded/created?
 	bool isModified() const {
-		return testFlags(statflags, TILESTATE_MODIFIED);
+		return testFlags(statflags, TileStatFlag::MODIFIED);
 	}
 	void modify() {
-		statflags |= TILESTATE_MODIFIED;
+		statflags |= TileStatFlag::MODIFIED;
 	}
 	void unmodify() {
-		statflags &= ~TILESTATE_MODIFIED;
+		statflags &= ~TileStatFlag::MODIFIED;
 	}
 
 	// Get memory footprint size
@@ -129,18 +144,18 @@ public: // Functions
 
 	// Blocking?
 	bool isBlocking() const {
-		return testFlags(statflags, TILESTATE_BLOCKING);
+		return testFlags(statflags, TileStatFlag::BLOCKING);
 	}
 
 	// PZ
 	bool isPZ() const {
-		return testFlags(mapflags, TILESTATE_PROTECTIONZONE);
+		return testFlags(mapflags, TileMapFlag::PROTECTIONZONE);
 	}
 	void setPZ(bool pz) {
 		if (pz) {
-			mapflags |= TILESTATE_PROTECTIONZONE;
+			mapflags |= TileMapFlag::PROTECTIONZONE;
 		} else {
-			mapflags &= ~TILESTATE_PROTECTIONZONE;
+			mapflags &= ~TileMapFlag::PROTECTIONZONE;
 		}
 	}
 
@@ -152,10 +167,10 @@ public: // Functions
 	void addItem(std::unique_ptr<Item> item);
 
 	bool isSelected() const {
-		return testFlags(statflags, TILESTATE_SELECTED);
+		return testFlags(statflags, TileStatFlag::SELECTED);
 	}
 	bool hasUniqueItem() const {
-		return testFlags(statflags, TILESTATE_UNIQUE);
+		return testFlags(statflags, TileStatFlag::UNIQUE);
 	}
 
 	uint8_t getMiniMapColor() const;
@@ -172,35 +187,35 @@ public: // Functions
 	GroundBrush* getGroundBrush() const;
 
 	bool hasTable() const {
-		return testFlags(statflags, TILESTATE_HAS_TABLE);
+		return testFlags(statflags, TileStatFlag::HAS_TABLE);
 	}
 	Item* getTable() const;
 
 	bool hasCarpet() const {
-		return testFlags(statflags, TILESTATE_HAS_CARPET);
+		return testFlags(statflags, TileStatFlag::HAS_CARPET);
 	}
 	Item* getCarpet() const;
 
 	bool hasHookSouth() const {
-		return testFlags(statflags, TILESTATE_HOOK_SOUTH);
+		return testFlags(statflags, TileStatFlag::HOOK_SOUTH);
 	}
 
 	bool hasHookEast() const {
-		return testFlags(statflags, TILESTATE_HOOK_EAST);
+		return testFlags(statflags, TileStatFlag::HOOK_EAST);
 	}
 
 	bool hasLight() const {
-		return testFlags(statflags, TILESTATE_HAS_LIGHT);
+		return testFlags(statflags, TileStatFlag::HAS_LIGHT);
 	}
 
 	bool hasOptionalBorder() const {
-		return testFlags(statflags, TILESTATE_OP_BORDER);
+		return testFlags(statflags, TileStatFlag::OP_BORDER);
 	}
 	void setOptionalBorder(bool b) {
 		if (b) {
-			statflags |= TILESTATE_OP_BORDER;
+			statflags |= TileStatFlag::OP_BORDER;
 		} else {
-			statflags &= ~TILESTATE_OP_BORDER;
+			statflags &= ~TileStatFlag::OP_BORDER;
 		}
 	}
 
@@ -221,14 +236,14 @@ public: // Functions
 	void setHouse(House* house);
 
 	// Mapflags (PZ, PVPZONE etc.)
-	void setMapFlags(uint16_t _flags);
-	void unsetMapFlags(uint16_t _flags);
-	uint16_t getMapFlags() const;
+	void setMapFlags(TileMapFlag _flags);
+	void unsetMapFlags(TileMapFlag _flags);
+	TileMapFlag getMapFlags() const;
 
 	// Statflags (You really ought not to touch this)
-	void setStatFlags(uint16_t _flags);
-	void unsetStatFlags(uint16_t _flags);
-	uint16_t getStatFlags() const;
+	void setStatFlags(TileStatFlag _flags);
+	void unsetStatFlags(TileStatFlag _flags);
+	TileStatFlag getStatFlags() const;
 };
 
 bool tilePositionLessThan(const Tile* a, const Tile* b);
@@ -251,27 +266,27 @@ inline uint32_t Tile::getHouseID() const {
 	return house_id;
 }
 
-inline void Tile::setMapFlags(uint16_t _flags) {
-	mapflags = _flags | mapflags;
+inline void Tile::setMapFlags(TileMapFlag _flags) {
+	mapflags |= _flags;
 }
 
-inline void Tile::unsetMapFlags(uint16_t _flags) {
+inline void Tile::unsetMapFlags(TileMapFlag _flags) {
 	mapflags &= ~_flags;
 }
 
-inline uint16_t Tile::getMapFlags() const {
+inline TileMapFlag Tile::getMapFlags() const {
 	return mapflags;
 }
 
-inline void Tile::setStatFlags(uint16_t _flags) {
-	statflags = _flags | statflags;
+inline void Tile::setStatFlags(TileStatFlag _flags) {
+	statflags |= _flags;
 }
 
-inline void Tile::unsetStatFlags(uint16_t _flags) {
+inline void Tile::unsetStatFlags(TileStatFlag _flags) {
 	statflags &= ~_flags;
 }
 
-inline uint16_t Tile::getStatFlags() const {
+inline TileStatFlag Tile::getStatFlags() const {
 	return statflags;
 }
 

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -32,12 +32,12 @@ namespace TileOperations {
 			items.erase(first_to_remove, items.end());
 		}
 
-		void UpdateItemFlags(const Item* i, uint16_t& statflags, uint8_t& minimapColor) {
+		void UpdateItemFlags(const Item* i, TileStatFlag& statflags, uint8_t& minimapColor) {
 			if (i->isSelected()) {
-				statflags |= TILESTATE_SELECTED;
+				statflags |= TileStatFlag::SELECTED;
 			}
 			if (i->getUniqueID() != 0) {
-				statflags |= TILESTATE_UNIQUE;
+				statflags |= TileStatFlag::UNIQUE;
 			}
 			if (i->getMiniMapColor() != 0) {
 				minimapColor = i->getMiniMapColor();
@@ -45,25 +45,25 @@ namespace TileOperations {
 
 			const ItemType& it_type = g_items[i->getID()];
 			if (it_type.unpassable) {
-				statflags |= TILESTATE_BLOCKING;
+				statflags |= TileStatFlag::BLOCKING;
 			}
 			if (it_type.isOptionalBorder) {
-				statflags |= TILESTATE_OP_BORDER;
+				statflags |= TileStatFlag::OP_BORDER;
 			}
 			if (it_type.isTable) {
-				statflags |= TILESTATE_HAS_TABLE;
+				statflags |= TileStatFlag::HAS_TABLE;
 			}
 			if (it_type.isCarpet) {
-				statflags |= TILESTATE_HAS_CARPET;
+				statflags |= TileStatFlag::HAS_CARPET;
 			}
 			if (it_type.hookSouth) {
-				statflags |= TILESTATE_HOOK_SOUTH;
+				statflags |= TileStatFlag::HOOK_SOUTH;
 			}
 			if (it_type.hookEast) {
-				statflags |= TILESTATE_HOOK_EAST;
+				statflags |= TileStatFlag::HOOK_EAST;
 			}
 			if (i->hasLight()) {
-				statflags |= TILESTATE_HAS_LIGHT;
+				statflags |= TileStatFlag::HAS_LIGHT;
 			}
 		}
 
@@ -240,7 +240,7 @@ namespace TileOperations {
 			i->select();
 		});
 
-		tile->statflags |= TILESTATE_SELECTED;
+		tile->statflags |= TileStatFlag::SELECTED;
 	}
 
 	void deselect(Tile* tile) {
@@ -258,7 +258,7 @@ namespace TileOperations {
 			i->deselect();
 		});
 
-		tile->statflags &= ~TILESTATE_SELECTED;
+		tile->statflags &= ~TileStatFlag::SELECTED;
 	}
 
 	void selectGround(Tile* tile) {
@@ -274,7 +274,7 @@ namespace TileOperations {
 		}
 
 		if (selected_) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::SELECTED;
 		}
 	}
 
@@ -387,35 +387,35 @@ namespace TileOperations {
 	}
 
 	void update(Tile* tile) {
-		tile->statflags &= TILESTATE_MODIFIED;
+		tile->statflags &= TileStatFlag::MODIFIED;
 
 		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::SELECTED;
 		}
 		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::SELECTED;
 		}
 
 		tile->minimapColor = 0; // Reset to "no color" (valid)
 
 		if (tile->ground) {
 			if (tile->ground->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
+				tile->statflags |= TileStatFlag::SELECTED;
 			}
 			if (tile->ground->isBlocking()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlag::BLOCKING;
 			}
 			if (tile->ground->getUniqueID() != 0) {
-				tile->statflags |= TILESTATE_UNIQUE;
+				tile->statflags |= TileStatFlag::UNIQUE;
 			}
 			if (tile->ground->getMiniMapColor() != 0) {
 				tile->minimapColor = tile->ground->getMiniMapColor();
 			}
 			if (tile->ground->hasLight()) {
-				tile->statflags |= TILESTATE_HAS_LIGHT;
+				tile->statflags |= TileStatFlag::HAS_LIGHT;
 			}
 		} else {
-			tile->mapflags = TILESTATE_NONE;
+			tile->mapflags = TileMapFlag::NONE;
 			tile->house_id = 0;
 		}
 
@@ -423,9 +423,9 @@ namespace TileOperations {
 			UpdateItemFlags(i.get(), tile->statflags, tile->minimapColor);
 		});
 
-		if ((tile->statflags & TILESTATE_BLOCKING) == 0) {
+		if ((tile->statflags & TileStatFlag::BLOCKING) == TileStatFlag::NONE) {
 			if (tile->ground == nullptr && tile->items.empty()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlag::BLOCKING;
 			}
 		}
 	}

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -80,14 +80,14 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							r /= 2;
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_PVPZONE) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlag::PVPZONE) != TileMapFlag::NONE) {
 							r = r / 3 * 2;
 							b = r / 3 * 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlag::NOLOGOUT) != TileMapFlag::NONE) {
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOPVP) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlag::NOPVP) != TileMapFlag::NONE) {
 							g /= 2;
 						}
 						if (tile->ground) {

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -65,16 +65,16 @@ void TileColorCalculator::Calculate(const Tile* tile, const DrawingOptions& opti
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_PVPZONE) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlag::PVPZONE) != TileMapFlag::NONE) {
 		g = r >> 2;
 		b = (b * 171) >> 8;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlag::NOLOGOUT) != TileMapFlag::NONE) {
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOPVP) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlag::NOPVP) != TileMapFlag::NONE) {
 		g >>= 1;
 	}
 }

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -199,9 +199,9 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
 	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn((tile->getMapFlags() & TileMapFlag::NOPVP) != TileMapFlag::NONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn((tile->getMapFlags() & TileMapFlag::NOLOGOUT) != TileMapFlag::NONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn((tile->getMapFlags() & TileMapFlag::PVPZONE) != TileMapFlag::NONE)), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
 
 	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());

--- a/source/ui/tile_properties/map_flags_panel.cpp
+++ b/source/ui/tile_properties/map_flags_panel.cpp
@@ -44,9 +44,9 @@ void MapFlagsPanel::SetTile(Tile* tile, Map* map) {
 
 	if (tile) {
 		chk_pz->SetValue(tile->isPZ());
-		chk_nopvp->SetValue(tile->getMapFlags() & TILESTATE_NOPVP);
-		chk_nologout->SetValue(tile->getMapFlags() & TILESTATE_NOLOGOUT);
-		chk_pvpzone->SetValue(tile->getMapFlags() & TILESTATE_PVPZONE);
+		chk_nopvp->SetValue((tile->getMapFlags() & TileMapFlag::NOPVP) != TileMapFlag::NONE);
+		chk_nologout->SetValue((tile->getMapFlags() & TileMapFlag::NOLOGOUT) != TileMapFlag::NONE);
+		chk_pvpzone->SetValue((tile->getMapFlags() & TileMapFlag::PVPZONE) != TileMapFlag::NONE);
 
 		chk_pz->Enable(true);
 		chk_nopvp->Enable(true);
@@ -79,21 +79,21 @@ void MapFlagsPanel::OnToggleFlag(wxCommandEvent& event) {
 	new_tile->setPZ(chk_pz->GetValue());
 
 	if (chk_nopvp->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOPVP);
+		new_tile->setMapFlags(TileMapFlag::NOPVP);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOPVP);
+		new_tile->unsetMapFlags(TileMapFlag::NOPVP);
 	}
 
 	if (chk_nologout->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->setMapFlags(TileMapFlag::NOLOGOUT);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->unsetMapFlags(TileMapFlag::NOLOGOUT);
 	}
 
 	if (chk_pvpzone->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_PVPZONE);
+		new_tile->setMapFlags(TileMapFlag::PVPZONE);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_PVPZONE);
+		new_tile->unsetMapFlags(TileMapFlag::PVPZONE);
 	}
 
 	Tile* old_ptr = new_tile.get();


### PR DESCRIPTION
Smeller: Converted unnamed `TILESTATE_` enums in `source/map/tile.h` to strongly typed C++ `enum class` `TileMapFlag` and `TileStatFlag` to improve safety and data oriented design. Updated all usages across map operations, brushes, drawing code, and UI elements.

---
*PR created automatically by Jules for task [14030497743533603525](https://jules.google.com/task/14030497743533603525) started by @karolak6612*