### PR TITLE
⚡ Throttle: Replace vector with small_vector for tile items

### DIFF
--- a/source/map/map.h
+++ b/source/map/map.h
@@ -273,13 +273,13 @@ inline int64_t RemoveItemOnMap(Map& map, RemoveIfType& condition, bool selectedO
 		}
 
 		// Use C++20's std::erase_if for a safer and more idiomatic way to remove elements.
-		std::erase_if(tile->items, [&](const auto& item) {
+		tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [&](const auto& item) {
 			if (condition(map, item.get(), removed, done)) {
 				++removed;
 				return true;
 			}
 			return false;
-		});
+		}), tile->items.end());
 	});
 	return removed;
 }

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -34,6 +34,7 @@ class Map;
 #include <unordered_set>
 #include <memory>
 #include <vector>
+#include <boost/container/small_vector.hpp>
 
 // TileOperations functions are now in tile_operations.h
 
@@ -66,7 +67,7 @@ class Tile {
 public: // Members
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
-	std::vector<std::unique_ptr<Item>> items;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> items;
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)


### PR DESCRIPTION
⚡ Throttle: Replace vector with small_vector for tile items

Replaced `std::vector` with `boost::container::small_vector<std::unique_ptr<Item>, 4>` for `Tile::items`. This eliminates heap allocations for common map tiles which typically contain fewer than 4 items, greatly improving cache locality and reducing memory overhead.

Refactored `std::erase_if` in `RemoveItemOnMap` to use the standard erase-remove idiom to maintain compatibility with `boost::container::small_vector`.

---
*PR created automatically by Jules for task [8263793870248216562](https://jules.google.com/task/8263793870248216562) started by @karolak6612*