### PR TITLE
✨ Designer: Upgraded Browse Tile and Find Item to rich Grid layouts

### DIFF
--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -59,7 +59,8 @@ protected:
 
 BrowseTileListBox::BrowseTileListBox(wxWindow* parent, wxWindowID id, Tile* tile) :
 	NanoVGListBox(parent, id, wxLB_SINGLE), edit_tile(tile) {
-	SetMinSize(FromDIP(wxSize(200, 180)));
+	SetMinSize(FromDIP(wxSize(260, 200)));
+	SetGridMode(true, FromDIP(64), FromDIP(64));
 	UpdateItems();
 }
 
@@ -74,10 +75,13 @@ void BrowseTileListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 	if (sprite) {
 		int tex = GetOrCreateSpriteTexture(vg, sprite);
 		if (tex > 0) {
-			int icon_size = 32;
-			NVGpaint imgPaint = nvgImagePattern(vg, rect.x, rect.y, icon_size, icon_size, 0, tex, 1.0f);
+			int icon_size = std::min(32, std::min(rect.width, rect.height));
+			int imgX = rect.x + (rect.width - icon_size) / 2;
+			int imgY = rect.y + (rect.height - icon_size) / 2 - FromDIP(6);
+
+			NVGpaint imgPaint = nvgImagePattern(vg, imgX, imgY, icon_size, icon_size, 0, tex, 1.0f);
 			nvgBeginPath(vg);
-			nvgRect(vg, rect.x, rect.y, icon_size, icon_size);
+			nvgRect(vg, imgX, imgY, icon_size, icon_size);
 			nvgFillPaint(vg, imgPaint);
 			nvgFill(vg);
 		}
@@ -91,16 +95,16 @@ void BrowseTileListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 	}
 
-	std::string label = std::format("{} - {}", item->getID(), item->getName());
+	std::string label = std::format("{}", item->getID());
 
-	nvgFontSize(vg, 12.0f);
+	nvgFontSize(vg, 11.0f);
 	nvgFontFace(vg, "sans");
-	nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-	nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, label.c_str(), nullptr);
+	nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+	nvgText(vg, rect.x + rect.width / 2.0f, rect.y + rect.height - FromDIP(4), label.c_str(), nullptr);
 }
 
 int BrowseTileListBox::OnMeasureItem(size_t n) const {
-	return FromDIP(32);
+	return FromDIP(64);
 }
 
 Item* BrowseTileListBox::GetSelectedItem() {
@@ -173,52 +177,94 @@ void BrowseTileListBox::UpdateItems() {
 //
 
 BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint position /* = wxDefaultPosition */) :
-	wxDialog(parent, wxID_ANY, "Browse Field", position, FROM_DIP(parent, wxSize(600, 400)), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
-	wxSizer* sizer = newd wxBoxSizer(wxVERTICAL);
+	wxDialog(parent, wxID_ANY, "Browse Field", position, FROM_DIP(parent, wxSize(640, 480)), wxCAPTION | wxCLOSE_BOX | wxRESIZE_BORDER) {
+
+	wxSizer* mainSizer = newd wxBoxSizer(wxVERTICAL);
+	wxSizer* topSizer = newd wxBoxSizer(wxHORIZONTAL);
+
+	// Left Side: Grid List
 	item_list = newd BrowseTileListBox(this, wxID_ANY, tile);
-	sizer->Add(item_list, wxSizerFlags(1).Expand());
+	topSizer->Add(item_list, wxSizerFlags(1).Expand().Border(wxALL, 10));
 
-	wxString pos;
-	pos << "x=" << tile->getX() << ",  y=" << tile->getY() << ",  z=" << tile->getZ();
+	// Right Side: Info and Actions
+	wxSizer* rightSizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxSizer* infoSizer = newd wxBoxSizer(wxVERTICAL);
+	// Actions Box
+	wxStaticBoxSizer* actionSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Actions");
 	wxBoxSizer* buttons = newd wxBoxSizer(wxHORIZONTAL);
-	delete_button = newd wxButton(this, wxID_REMOVE, "Delete");
+	delete_button = newd wxButton(actionSizer->GetStaticBox(), wxID_REMOVE, "Delete");
 	delete_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_TRASH_CAN));
 	delete_button->SetToolTip("Delete selected item");
 	delete_button->Enable(false);
-	buttons->Add(delete_button);
-	buttons->AddSpacer(5);
-	select_raw_button = newd wxButton(this, wxID_FIND, "Select RAW");
+	buttons->Add(delete_button, wxSizerFlags(1).Expand().Border(wxRIGHT, 5));
+	select_raw_button = newd wxButton(actionSizer->GetStaticBox(), wxID_FIND, "Select RAW");
 	select_raw_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_SEARCH));
 	select_raw_button->SetToolTip("Select this item in RAW palette");
 	select_raw_button->Enable(false);
-	buttons->Add(select_raw_button);
-	infoSizer->Add(buttons);
-	infoSizer->AddSpacer(5);
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
-	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
+	buttons->Add(select_raw_button, wxSizerFlags(1).Expand());
+	actionSizer->Add(buttons, wxSizerFlags(0).Expand().Border(wxALL, 5));
+	rightSizer->Add(actionSizer, wxSizerFlags(0).Expand().Border(wxALL, 5));
 
-	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());
+	// Tile Information Box
+	wxString posStr = std::format("x={}, y={}, z={}", tile->getX(), tile->getY(), tile->getZ());
+	wxStaticBoxSizer* infoSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tile Information");
+	wxFlexGridSizer* infoGrid = newd wxFlexGridSizer(2, FromDIP(5), FromDIP(10));
+
+	infoGrid->Add(newd wxStaticText(infoSizer->GetStaticBox(), wxID_ANY, "Position:"), wxSizerFlags().Right());
+	infoGrid->Add(newd wxStaticText(infoSizer->GetStaticBox(), wxID_ANY, posStr), wxSizerFlags().Left());
+
+	infoGrid->Add(newd wxStaticText(infoSizer->GetStaticBox(), wxID_ANY, "Item count:"), wxSizerFlags().Right());
+	infoGrid->Add(item_count_txt = newd wxStaticText(infoSizer->GetStaticBox(), wxID_ANY, i2ws(item_list->GetItemCount())), wxSizerFlags().Left());
+
+	infoSizer->Add(infoGrid, wxSizerFlags(1).Expand().Border(wxALL, 5));
+	rightSizer->Add(infoSizer, wxSizerFlags(0).Expand().Border(wxALL, 5));
+
+	// Tile Flags Box
+	wxStaticBoxSizer* flagsSizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tile Flags");
+	wxFlexGridSizer* flagsGrid = newd wxFlexGridSizer(2, FromDIP(5), FromDIP(10));
+
+	auto addFlag = [&](const wxString& label, bool value, std::string_view icon) {
+		wxBoxSizer* row = newd wxBoxSizer(wxHORIZONTAL);
+		wxStaticBitmap* sbmp = newd wxStaticBitmap(flagsSizer->GetStaticBox(), wxID_ANY, IMAGE_MANAGER.GetBitmapBundle(icon, wxSize(14, 14)));
+		row->Add(sbmp, wxSizerFlags(0).Center().Border(wxRIGHT, 4));
+		row->Add(newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, label), wxSizerFlags(0).Center());
+		flagsGrid->Add(row, wxSizerFlags().Right());
+
+		wxStaticText* valText = newd wxStaticText(flagsSizer->GetStaticBox(), wxID_ANY, value ? "Yes" : "No");
+		if (value) {
+			valText->SetForegroundColour(wxColour(0, 150, 0)); // Green for Yes
+			wxFont f = valText->GetFont();
+			f.SetWeight(wxFONTWEIGHT_BOLD);
+			valText->SetFont(f);
+		}
+		flagsGrid->Add(valText, wxSizerFlags().Left().CenterVertical());
+	};
+
+	addFlag("Protection zone:", tile->isPZ(), ICON_SHIELD_HALVED);
+	addFlag("No PvP:", tile->getMapFlags() & TILESTATE_NOPVP, ICON_HAND_PEACE);
+	addFlag("No logout:", tile->getMapFlags() & TILESTATE_NOLOGOUT, ICON_BAN);
+	addFlag("PvP zone:", tile->getMapFlags() & TILESTATE_PVPZONE, ICON_SKULL);
+	addFlag("House:", tile->isHouseTile(), ICON_HOUSE);
+
+	flagsSizer->Add(flagsGrid, wxSizerFlags(1).Expand().Border(wxALL, 5));
+	rightSizer->Add(flagsSizer, wxSizerFlags(1).Expand().Border(wxALL, 5));
+
+	topSizer->Add(rightSizer, wxSizerFlags(0).Expand().Border(wxALL, 5));
+	mainSizer->Add(topSizer, wxSizerFlags(1).Expand());
 
 	// OK/Cancel buttons
 	wxSizer* btnSizer = newd wxBoxSizer(wxHORIZONTAL);
 	auto okBtn = newd wxButton(this, wxID_OK, "OK");
 	okBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
 	okBtn->SetToolTip("Confirm selection");
-	btnSizer->Add(okBtn, wxSizerFlags(0).Center());
+	btnSizer->Add(okBtn, wxSizerFlags(0).Center().Border(wxRIGHT, 5));
 	auto cancelBtn = newd wxButton(this, wxID_CANCEL, "Cancel");
 	cancelBtn->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
 	cancelBtn->SetToolTip("Cancel");
-	btnSizer->Add(cancelBtn, wxSizerFlags(0).Center());
-	sizer->Add(btnSizer, wxSizerFlags(0).Center().DoubleBorder());
+	btnSizer->Add(cancelBtn, wxSizerFlags(0).Center().Border(wxLEFT, 5));
+	mainSizer->Add(btnSizer, wxSizerFlags(0).Right().Border(wxALL, 10));
 
-	SetSizerAndFit(sizer);
+	SetSizerAndFit(mainSizer);
 
 	// Connect Events
 	item_list->Bind(wxEVT_LISTBOX, &BrowseTileWindow::OnItemSelected, this);

--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -49,7 +49,8 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	sizer->Add(search_field, 0, wxEXPAND);
 
 	item_list = newd FindDialogListBox(this, JUMP_DIALOG_LIST);
-	item_list->SetMinSize(FROM_DIP(item_list, wxSize(470, 400)));
+	item_list->SetGridMode(true, FromDIP(64), FromDIP(64));
+	item_list->SetMinSize(FROM_DIP(item_list, wxSize(512, 400)));
 	item_list->SetToolTip("Double click to select.");
 	sizer->Add(item_list, wxSizerFlags(1).Expand().Border());
 
@@ -361,24 +362,29 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 		nvgFontSize(vg, 12.0f);
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "No matches for your search.", nullptr);
+		nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+		wxRect parentRect = GetClientRect();
+		nvgText(vg, parentRect.width / 2.0f, parentRect.height / 2.0f, "No matches for your search.", nullptr);
 	} else if (cleared) {
 		nvgFontSize(vg, 12.0f);
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
+		nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+		wxRect parentRect = GetClientRect();
+		nvgText(vg, parentRect.width / 2.0f, parentRect.height / 2.0f, "Please enter your search string.", nullptr);
 	} else {
 		ASSERT(n < brushlist.size());
 		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());
 		if (spr) {
 			int tex = GetOrCreateSpriteTexture(vg, spr);
 			if (tex > 0) {
-				int icon_size = rect.height;
-				NVGpaint imgPaint = nvgImagePattern(vg, rect.x, rect.y, icon_size, icon_size, 0, tex, 1.0f);
+				int icon_size = std::min(32, std::min(rect.width, rect.height));
+				int imgX = rect.x + (rect.width - icon_size) / 2;
+				int imgY = rect.y + (rect.height - icon_size) / 2 - FromDIP(6);
+
+				NVGpaint imgPaint = nvgImagePattern(vg, imgX, imgY, icon_size, icon_size, 0, tex, 1.0f);
 				nvgBeginPath(vg);
-				nvgRect(vg, rect.x, rect.y, icon_size, icon_size);
+				nvgRect(vg, imgX, imgY, icon_size, icon_size);
 				nvgFillPaint(vg, imgPaint);
 				nvgFill(vg);
 			}
@@ -392,14 +398,19 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		}
 
-		nvgFontSize(vg, 12.0f);
-		nvgFontFace(vg, "sans");
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
 		wxString name = wxstr(brushlist[n]->getName());
-		nvgText(vg, rect.x + rect.height + 8, rect.y + rect.height / 2.0f, name.ToUTF8().data(), nullptr);
+		// Ellipsize long names
+		if (name.length() > 10) {
+			name = name.Mid(0, 8) + "...";
+		}
+
+		nvgFontSize(vg, 11.0f);
+		nvgFontFace(vg, "sans");
+		nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_BOTTOM);
+		nvgText(vg, rect.x + rect.width / 2.0f, rect.y + rect.height - FromDIP(4), name.ToUTF8().data(), nullptr);
 	}
 }
 
 int FindDialogListBox::OnMeasureItem(size_t n) const {
-	return FromDIP(32);
+	return FromDIP(64);
 }

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -116,78 +116,81 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	// --------------- Properties ---------------
 
 	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
+	wxWrapSizer* properties_wrap_sizer = newd wxWrapSizer(wxHORIZONTAL);
 
-	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
+	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable");
 	unpassable->SetToolTip("Item blocks movement");
-	properties_box_sizer->Add(unpassable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(unpassable, 0, wxALL, 5);
 
-	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
+	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable");
 	unmovable->SetToolTip("Item cannot be moved");
-	properties_box_sizer->Add(unmovable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(unmovable, 0, wxALL, 5);
 
-	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
+	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles");
 	block_missiles->SetToolTip("Item blocks projectiles");
-	properties_box_sizer->Add(block_missiles, 0, wxALL, 5);
+	properties_wrap_sizer->Add(block_missiles, 0, wxALL, 5);
 
-	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
+	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder");
 	block_pathfinder->SetToolTip("Item blocks pathfinding");
-	properties_box_sizer->Add(block_pathfinder, 0, wxALL, 5);
+	properties_wrap_sizer->Add(block_pathfinder, 0, wxALL, 5);
 
-	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
+	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable");
 	readable->SetToolTip("Item has text");
-	properties_box_sizer->Add(readable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(readable, 0, wxALL, 5);
 
-	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
+	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable");
 	writeable->SetToolTip("Item can be written on");
-	properties_box_sizer->Add(writeable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(writeable, 0, wxALL, 5);
 
-	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
+	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable");
 	pickupable->SetToolTip("Item can be picked up");
 	pickupable->SetValue(only_pickupables);
 	pickupable->Enable(!only_pickupables);
-	properties_box_sizer->Add(pickupable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(pickupable, 0, wxALL, 5);
 
-	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
+	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable");
 	stackable->SetToolTip("Item is stackable");
-	properties_box_sizer->Add(stackable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(stackable, 0, wxALL, 5);
 
-	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
+	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable");
 	rotatable->SetToolTip("Item can be rotated");
-	properties_box_sizer->Add(rotatable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(rotatable, 0, wxALL, 5);
 
-	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
+	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable");
 	hangable->SetToolTip("Item can be hung on walls");
-	properties_box_sizer->Add(hangable, 0, wxALL, 5);
+	properties_wrap_sizer->Add(hangable, 0, wxALL, 5);
 
-	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
+	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East");
 	hook_east->SetToolTip("Item hooks to the east");
-	properties_box_sizer->Add(hook_east, 0, wxALL, 5);
+	properties_wrap_sizer->Add(hook_east, 0, wxALL, 5);
 
-	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
+	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South");
 	hook_south->SetToolTip("Item hooks to the south");
-	properties_box_sizer->Add(hook_south, 0, wxALL, 5);
+	properties_wrap_sizer->Add(hook_south, 0, wxALL, 5);
 
-	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
+	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation");
 	has_elevation->SetToolTip("Item has height (elevation)");
-	properties_box_sizer->Add(has_elevation, 0, wxALL, 5);
+	properties_wrap_sizer->Add(has_elevation, 0, wxALL, 5);
 
-	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
+	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look");
 	ignore_look->SetToolTip("Item is ignored when looking");
-	properties_box_sizer->Add(ignore_look, 0, wxALL, 5);
+	properties_wrap_sizer->Add(ignore_look, 0, wxALL, 5);
 
-	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
+	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change");
 	floor_change->SetToolTip("Item causes floor change");
-	properties_box_sizer->Add(floor_change, 0, wxALL, 5);
+	properties_wrap_sizer->Add(floor_change, 0, wxALL, 5);
 
+	properties_box_sizer->Add(properties_wrap_sizer, 1, wxEXPAND);
 	box_sizer->Add(properties_box_sizer, 1, wxALL | wxEXPAND, 5);
 
 	// --------------- Items list ---------------
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
 	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
+	items_list->SetGridMode(true, FromDIP(64), FromDIP(64));
 	items_list->SetMinSize(wxSize(230, 512));
-	result_box_sizer->Add(items_list, 0, wxALL, 5);
-	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
+	result_box_sizer->Add(items_list, 1, wxALL | wxEXPAND, 5);
+	box_sizer->Add(result_box_sizer, 2, wxALL | wxEXPAND, 5);
 
 	this->SetSizer(box_sizer);
 	this->Layout();

--- a/source/util/nanovg_listbox.cpp
+++ b/source/util/nanovg_listbox.cpp
@@ -24,6 +24,14 @@ NanoVGListBox::NanoVGListBox(wxWindow* parent, wxWindowID id, long style) :
 NanoVGListBox::~NanoVGListBox() {
 }
 
+void NanoVGListBox::SetGridMode(bool grid_mode, int item_width, int item_height) {
+	m_gridMode = grid_mode;
+	m_gridItemWidth = item_width;
+	m_gridItemHeight = item_height;
+	UpdateScrollbar();
+	Refresh();
+}
+
 void NanoVGListBox::SetItemCount(size_t count) {
 	if (m_count != count) {
 		m_count = count;
@@ -142,12 +150,22 @@ void NanoVGListBox::EnsureVisible(int line) {
 		return;
 	}
 
-	int itemHeight = std::max(1, OnMeasureItem(0)); // Assuming uniform height for simple scrolling logic
+	int itemTop, itemBottom;
+	int clientWidth = GetClientSize().x;
+
+	if (m_gridMode && clientWidth > 0 && m_gridItemWidth > 0) {
+		int cols = std::max(1, clientWidth / m_gridItemWidth);
+		int row = line / cols;
+		itemTop = row * m_gridItemHeight;
+		itemBottom = itemTop + m_gridItemHeight;
+	} else {
+		int itemHeight = std::max(1, OnMeasureItem(0));
+		itemTop = line * itemHeight;
+		itemBottom = itemTop + itemHeight;
+	}
+
 	int scrollPos = GetScrollPosition();
 	int clientHeight = GetClientSize().y;
-
-	int itemTop = line * itemHeight;
-	int itemBottom = itemTop + itemHeight;
 
 	if (itemTop < scrollPos) {
 		SetScrollPosition(itemTop);
@@ -164,16 +182,17 @@ void NanoVGListBox::UpdateScrollbar() {
 		return;
 	}
 
-	// Assuming uniform height for simplicity and performance, or measuring all if needed.
-	// For high performance lists, uniform height is preferred.
-	// If OnMeasureItem varies, we need a smarter system (like caching positions).
-	// Let's assume OnMeasureItem(0) is representative or we check m_itemHeightCache.
+	int totalHeight = 0;
+	int clientWidth = GetClientSize().x;
 
-	int itemHeight = std::max(1, OnMeasureItem(0));
-	int totalHeight = static_cast<int>(m_count) * itemHeight;
-
-	int clientHeight = GetClientSize().y;
-	int pageSize = clientHeight;
+	if (m_gridMode && clientWidth > 0 && m_gridItemWidth > 0) {
+		int cols = std::max(1, clientWidth / m_gridItemWidth);
+		int rows = (static_cast<int>(m_count) + cols - 1) / cols;
+		totalHeight = rows * m_gridItemHeight;
+	} else {
+		int itemHeight = std::max(1, OnMeasureItem(0));
+		totalHeight = static_cast<int>(m_count) * itemHeight;
+	}
 
 	NanoVGCanvas::UpdateScrollbar(totalHeight);
 }
@@ -194,42 +213,76 @@ void NanoVGListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 	}
 
 	int scrollPos = GetScrollPosition();
-	int itemHeight = std::max(1, OnMeasureItem(0)); // Simplified assumption
 
-	int startRow = scrollPos / itemHeight;
-	int endRow = (scrollPos + height + itemHeight - 1) / itemHeight;
+	if (m_gridMode) {
+		int cols = std::max(1, width / m_gridItemWidth);
+		int startRow = scrollPos / m_gridItemHeight;
+		int endRow = (scrollPos + height + m_gridItemHeight - 1) / m_gridItemHeight;
 
-	startRow = std::max(0, startRow);
-	endRow = std::min(static_cast<int>(m_count), endRow);
+		startRow = std::max(0, startRow);
 
-	// Translate by scroll position is handled by caller (NanoVGCanvas::OnPaint)?
-	// NanoVGCanvas calls OnNanoVGPaint(m_nvg, width, height) after nvgTranslate(m_nvg, 0, -m_scrollPos).
-	// So (0,0) is top of content.
+		int startIndex = startRow * cols;
+		int endIndex = std::min(static_cast<int>(m_count), endRow * cols);
 
-	for (int i = startRow; i < endRow; ++i) {
-		wxRect rect(0, i * itemHeight, width, itemHeight);
+		for (int i = startIndex; i < endIndex; ++i) {
+			int row = i / cols;
+			int col = i % cols;
+			wxRect rect(col * m_gridItemWidth, row * m_gridItemHeight, m_gridItemWidth, m_gridItemHeight);
 
-		// Draw background for selection/hover
-		bool selected = IsSelected(i);
-		bool hover = (i == m_hoverIndex);
-		bool focused = (i == m_focusIndex);
+			bool selected = IsSelected(i);
+			bool hover = (i == m_hoverIndex);
+			bool focused = (i == m_focusIndex);
 
-		if (selected || hover || focused) {
-			nvgBeginPath(vg);
-			nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
-			wxColour c;
-			if (selected) {
-				c = Theme::Get(Theme::Role::Accent);
-			} else if (focused) {
-				c = Theme::Get(Theme::Role::Selected);
-			} else {
-				c = Theme::Get(Theme::Role::CardBaseHover);
+			if (selected || hover || focused) {
+				nvgBeginPath(vg);
+				nvgRoundedRect(vg, rect.x + 2, rect.y + 2, rect.width - 4, rect.height - 4, 4.0f);
+				wxColour c;
+				if (selected) {
+					c = Theme::Get(Theme::Role::Accent);
+				} else if (focused) {
+					c = Theme::Get(Theme::Role::Selected);
+				} else {
+					c = Theme::Get(Theme::Role::CardBaseHover);
+				}
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), c.Alpha()));
+				nvgFill(vg);
 			}
-			nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), c.Alpha()));
-			nvgFill(vg);
-		}
 
-		OnDrawItem(vg, rect, i);
+			OnDrawItem(vg, rect, i);
+		}
+	} else {
+		int itemHeight = std::max(1, OnMeasureItem(0));
+
+		int startRow = scrollPos / itemHeight;
+		int endRow = (scrollPos + height + itemHeight - 1) / itemHeight;
+
+		startRow = std::max(0, startRow);
+		endRow = std::min(static_cast<int>(m_count), endRow);
+
+		for (int i = startRow; i < endRow; ++i) {
+			wxRect rect(0, i * itemHeight, width, itemHeight);
+
+			bool selected = IsSelected(i);
+			bool hover = (i == m_hoverIndex);
+			bool focused = (i == m_focusIndex);
+
+			if (selected || hover || focused) {
+				nvgBeginPath(vg);
+				nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
+				wxColour c;
+				if (selected) {
+					c = Theme::Get(Theme::Role::Accent);
+				} else if (focused) {
+					c = Theme::Get(Theme::Role::Selected);
+				} else {
+					c = Theme::Get(Theme::Role::CardBaseHover);
+				}
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), c.Alpha()));
+				nvgFill(vg);
+			}
+
+			OnDrawItem(vg, rect, i);
+		}
 	}
 }
 
@@ -237,17 +290,41 @@ int NanoVGListBox::HitTest(int x, int y) const {
 	if (m_count == 0) {
 		return -1;
 	}
-	int itemHeight = std::max(1, OnMeasureItem(0));
-	int index = y / itemHeight;
-	if (index >= 0 && index < static_cast<int>(m_count)) {
-		return index;
+
+	if (m_gridMode) {
+		int clientWidth = GetClientSize().x;
+		int cols = std::max(1, clientWidth / m_gridItemWidth);
+
+		int col = x / m_gridItemWidth;
+		if (col >= cols) return -1; // Clicked in empty space on the right
+
+		int row = y / m_gridItemHeight;
+		int index = row * cols + col;
+
+		if (index >= 0 && index < static_cast<int>(m_count)) {
+			return index;
+		}
+	} else {
+		int itemHeight = std::max(1, OnMeasureItem(0));
+		int index = y / itemHeight;
+		if (index >= 0 && index < static_cast<int>(m_count)) {
+			return index;
+		}
 	}
 	return -1;
 }
 
 wxRect NanoVGListBox::GetItemRect(int index) const {
-	int itemHeight = std::max(1, OnMeasureItem(0));
-	return wxRect(0, index * itemHeight, GetClientSize().x, itemHeight);
+	if (m_gridMode) {
+		int clientWidth = GetClientSize().x;
+		int cols = std::max(1, clientWidth / m_gridItemWidth);
+		int row = index / cols;
+		int col = index % cols;
+		return wxRect(col * m_gridItemWidth, row * m_gridItemHeight, m_gridItemWidth, m_gridItemHeight);
+	} else {
+		int itemHeight = std::max(1, OnMeasureItem(0));
+		return wxRect(0, index * itemHeight, GetClientSize().x, itemHeight);
+	}
 }
 
 void NanoVGListBox::OnMouseDown(wxMouseEvent& event) {
@@ -310,10 +387,30 @@ void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
 
 	switch (event.GetKeyCode()) {
 		case WXK_UP:
-			next = std::max(0, current - 1);
+			if (m_gridMode) {
+				int cols = std::max(1, GetClientSize().x / m_gridItemWidth);
+				next = std::max(0, current - cols);
+			} else {
+				next = std::max(0, current - 1);
+			}
 			break;
 		case WXK_DOWN:
-			next = std::min(static_cast<int>(m_count) - 1, current + 1);
+			if (m_gridMode) {
+				int cols = std::max(1, GetClientSize().x / m_gridItemWidth);
+				next = std::min(static_cast<int>(m_count) - 1, current + cols);
+			} else {
+				next = std::min(static_cast<int>(m_count) - 1, current + 1);
+			}
+			break;
+		case WXK_LEFT:
+			if (m_gridMode) {
+				next = std::max(0, current - 1);
+			}
+			break;
+		case WXK_RIGHT:
+			if (m_gridMode) {
+				next = std::min(static_cast<int>(m_count) - 1, current + 1);
+			}
 			break;
 		case WXK_HOME:
 			next = 0;
@@ -322,15 +419,27 @@ void NanoVGListBox::OnKeyDown(wxKeyEvent& event) {
 			next = static_cast<int>(m_count) - 1;
 			break;
 		case WXK_PAGEUP: {
-			int itemHeight = OnMeasureItem(0);
-			int pageSize = GetClientSize().y / itemHeight;
-			next = std::max(0, current - pageSize);
+			if (m_gridMode) {
+				int cols = std::max(1, GetClientSize().x / m_gridItemWidth);
+				int rows = GetClientSize().y / m_gridItemHeight;
+				next = std::max(0, current - (cols * rows));
+			} else {
+				int itemHeight = OnMeasureItem(0);
+				int pageSize = GetClientSize().y / itemHeight;
+				next = std::max(0, current - pageSize);
+			}
 			break;
 		}
 		case WXK_PAGEDOWN: {
-			int itemHeight = OnMeasureItem(0);
-			int pageSize = GetClientSize().y / itemHeight;
-			next = std::min(static_cast<int>(m_count) - 1, current + pageSize);
+			if (m_gridMode) {
+				int cols = std::max(1, GetClientSize().x / m_gridItemWidth);
+				int rows = GetClientSize().y / m_gridItemHeight;
+				next = std::min(static_cast<int>(m_count) - 1, current + (cols * rows));
+			} else {
+				int itemHeight = OnMeasureItem(0);
+				int pageSize = GetClientSize().y / itemHeight;
+				next = std::min(static_cast<int>(m_count) - 1, current + pageSize);
+			}
 			break;
 		}
 		default:

--- a/source/util/nanovg_listbox.h
+++ b/source/util/nanovg_listbox.h
@@ -22,6 +22,10 @@ public:
 		return m_count;
 	}
 
+	// Grid Mode
+	void SetGridMode(bool grid_mode, int item_width = 64, int item_height = 64);
+	bool IsGridMode() const { return m_gridMode; }
+
 	// Selection
 	virtual void SetSelection(int index);
 	int GetSelection() const;
@@ -64,6 +68,10 @@ protected:
 
 	int m_hoverIndex;
 	int m_focusIndex;
+
+	bool m_gridMode = false;
+	int m_gridItemWidth = 64;
+	int m_gridItemHeight = 64;
 };
 
 #endif


### PR DESCRIPTION
Implemented major UX upgrades across the editor's primary entity selection windows, transitioning dense text lists into responsive visual grids.

1. **`NanoVGListBox` Grid Mode:** Added a robust `SetGridMode` feature capable of organizing and navigating arbitrary lists into uniform rows and columns without sacrificing the extreme performance of raw NanoVG commands.
2. **`Browse Tile Window`:** Reworked from the ground up. The list view was converted to a spacious thumbnail grid. The previously chaotic mass of tile flags was logically clustered into a structured `wxFlexGridSizer` inside an accented `wxStaticBoxSizer`, utilizing semantic icons (like a Shield for PZ, Skull for PVP) to increase scanability.
3. **`Find Item Window`:** Relieved the UI cramp by packing the 15+ vertical property checkboxes into a responsive `wxWrapSizer`. Transformed the items result container into a 2D thumbnail grid, massively improving browseability when filtering hundreds of items.
4. **`Find Dialog`:** Upgraded the quick search panel to natively render as an image grid, keeping results visual and text safely ellipsized.

---
*PR created automatically by Jules for task [15562398601574041457](https://jules.google.com/task/15562398601574041457) started by @karolak6612*