### PR TITLE
🔒 Sentinel: Consolidate MapDrawer and LightDrawer unit quads to SharedGeometry

### DIFF
--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -24,6 +24,7 @@
 #include "game/sprites.h"
 
 #include "rendering/map_drawer.h"
+#include "rendering/core/shared_geometry.h"
 #include "brushes/brush.h"
 #include "rendering/drawers/map_layer_drawer.h"
 #include "rendering/ui/map_display.h"
@@ -80,7 +81,7 @@ layout(location = 1) in vec2 aTexCoord; // 0..1
 out vec2 vTexCoord;
 
 void main() {
-    gl_Position = vec4(aPos, 0.0, 1.0);
+    gl_Position = vec4(aPos * 2.0 - 1.0, 0.0, 1.0);
     vTexCoord = aTexCoord;
 }
 )";
@@ -169,32 +170,13 @@ void MapDrawer::InitPostProcess() {
 	}
 
 	// Load Shaders
-	// Load Shaders
 	PostProcessManager::Instance().Initialize(screen_vert);
 
 	// Setup Screen Quad
 	pp_vao = std::make_unique<GLVertexArray>();
-	pp_vbo = std::make_unique<GLBuffer>();
-	pp_ebo = std::make_unique<GLBuffer>();
 
-	float quadVertices[] = {
-		// positions   // texCoords
-		-1.0f, 1.0f, 0.0f, 1.0f,
-		-1.0f, -1.0f, 0.0f, 0.0f,
-		1.0f, -1.0f, 1.0f, 0.0f,
-		1.0f, 1.0f, 1.0f, 1.0f
-	};
-
-	unsigned int quadIndices[] = {
-		0, 1, 2,
-		0, 2, 3
-	};
-
-	glNamedBufferStorage(pp_vbo->GetID(), sizeof(quadVertices), quadVertices, 0);
-	glNamedBufferStorage(pp_ebo->GetID(), sizeof(quadIndices), quadIndices, 0);
-
-	glVertexArrayVertexBuffer(pp_vao->GetID(), 0, pp_vbo->GetID(), 0, 4 * sizeof(float));
-	glVertexArrayElementBuffer(pp_vao->GetID(), pp_ebo->GetID());
+	glVertexArrayVertexBuffer(pp_vao->GetID(), 0, SharedGeometry::Instance().getQuadVBO(), 0, 4 * sizeof(float));
+	glVertexArrayElementBuffer(pp_vao->GetID(), SharedGeometry::Instance().getQuadEBO());
 
 	glEnableVertexArrayAttrib(pp_vao->GetID(), 0);
 	glVertexArrayAttribFormat(pp_vao->GetID(), 0, 2, GL_FLOAT, GL_FALSE, 0);

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -97,8 +97,6 @@ class MapDrawer {
 	bool m_lastAaMode = false;
 
 	std::unique_ptr<GLVertexArray> pp_vao;
-	std::unique_ptr<GLBuffer> pp_vbo;
-	std::unique_ptr<GLBuffer> pp_ebo;
 
 	void InitPostProcess();
 	void DrawPostProcess(const RenderView& view, const DrawingOptions& options);

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -17,6 +17,7 @@
 
 #include "app/main.h"
 #include "rendering/utilities/light_drawer.h"
+#include "rendering/core/shared_geometry.h"
 #include "rendering/utilities/light_calculator.h"
 #include <glm/gtc/matrix_transform.hpp>
 #include <format>
@@ -181,7 +182,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 					spdlog::error("Too many lights for glDrawArraysInstanced");
 					return;
 				}
-				glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(gpu_lights_.size()));
+				glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, static_cast<GLsizei>(gpu_lights_.size()));
 			}
 
 			glBindVertexArray(0);
@@ -242,7 +243,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 		ScopedGLBlend blendState(GL_DST_COLOR, GL_ZERO);
 
 		glBindVertexArray(vao->GetID());
-		glDrawArrays(GL_TRIANGLE_FAN, 0, 4);
+		glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 		glBindVertexArray(0);
 	}
 
@@ -342,20 +343,11 @@ void LightDrawer::initRenderResources() {
 	shader = std::make_unique<ShaderProgram>();
 	shader->Load(vs, fs);
 
-	float vertices[] = {
-		0.0f, 0.0f, // BL
-		1.0f, 0.0f, // BR
-		1.0f, 1.0f, // TR
-		0.0f, 1.0f // TL
-	};
-
 	vao = std::make_unique<GLVertexArray>();
-	vbo = std::make_unique<GLBuffer>();
 	light_ssbo = std::make_unique<GLBuffer>();
 
-	glNamedBufferStorage(vbo->GetID(), sizeof(vertices), vertices, 0);
-
-	glVertexArrayVertexBuffer(vao->GetID(), 0, vbo->GetID(), 0, 2 * sizeof(float));
+	glVertexArrayVertexBuffer(vao->GetID(), 0, SharedGeometry::Instance().getQuadVBO(), 0, 4 * sizeof(float));
+	glVertexArrayElementBuffer(vao->GetID(), SharedGeometry::Instance().getQuadEBO());
 
 	glEnableVertexArrayAttrib(vao->GetID(), 0);
 	glVertexArrayAttribFormat(vao->GetID(), 0, 2, GL_FLOAT, GL_FALSE, 0);

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -54,7 +54,6 @@ private:
 
 	std::unique_ptr<ShaderProgram> shader;
 	std::unique_ptr<GLVertexArray> vao;
-	std::unique_ptr<GLBuffer> vbo;
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 


### PR DESCRIPTION
This patch addresses OpenGL rendering efficiency by consolidating geometry according to Data Oriented Design principles. 

Following the `sentinel` agent's instructions, standalone vertex buffers used for rendering unit/screen quads in `MapDrawer` and `LightDrawer` have been removed. Instead, they now reuse the centralized `SharedGeometry` singleton. This reduces memory bloat, avoids unnecessary runtime `glGenBuffers` allocations, and ensures DRYesque reuse of statically initialized geometry across rendering passes. Draw calls have also been updated to `glDrawElements` to properly utilize the shared element buffer object.

---
*PR created automatically by Jules for task [7019620520099335172](https://jules.google.com/task/7019620520099335172) started by @karolak6612*