### PR TITLE
⚡ Bolt: [performance improvement] Refactor Tile::items to use small_vector

### DIFF
--- a/source/brushes/carpet/carpet_brush.cpp
+++ b/source/brushes/carpet/carpet_brush.cpp
@@ -56,9 +56,9 @@ void CarpetBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 }
 
 void CarpetBrush::undraw(BaseMap* map, Tile* tile) {
-	std::erase_if(tile->items, [](const auto& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const auto& item) {
 		return item->isCarpet() && item->getCarpetBrush() != nullptr;
-	});
+	}), tile->items.end());
 }
 
 void CarpetBrush::getRelatedItems(std::vector<uint16_t>& items_out) {

--- a/source/brushes/doodad/doodad_brush.cpp
+++ b/source/brushes/doodad/doodad_brush.cpp
@@ -53,7 +53,7 @@ bool DoodadBrush::ownsItem(Item* item) const {
 
 void DoodadBrush::undraw(BaseMap* map, Tile* tile) {
 	// Remove all doodad-related
-	std::erase_if(tile->items, [this](const std::unique_ptr<Item>& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [this](const std::unique_ptr<Item>& item) {
 		if (item->getDoodadBrush() != nullptr) {
 			if (item->isComplex() && g_settings.getInteger(Config::ERASER_LEAVE_UNIQUE)) {
 				return false;
@@ -64,7 +64,7 @@ void DoodadBrush::undraw(BaseMap* map, Tile* tile) {
 			return true;
 		}
 		return false;
-	});
+	}), tile->items.end());
 
 	if (tile->ground && tile->ground->getDoodadBrush() != nullptr) {
 		if (g_settings.getInteger(Config::DOODAD_BRUSH_ERASE_LIKE)) {

--- a/source/brushes/doodad/doodad_brush_types.h
+++ b/source/brushes/doodad/doodad_brush_types.h
@@ -6,6 +6,7 @@
 #define RME_DOODAD_BRUSH_TYPES_H
 
 #include "map/position.h"
+#include <boost/container/small_vector.hpp>
 #include <vector>
 #include <utility>
 #include <cstdint>
@@ -14,7 +15,7 @@ class Item;
 
 #include <memory>
 
-using DoodadItemVector = std::vector<std::unique_ptr<Item>>;
+using DoodadItemVector = boost::container::small_vector<std::unique_ptr<Item>, 4>;
 using CompositeTileList = std::vector<std::pair<Position, DoodadItemVector>>;
 
 struct DoodadBrushSettings {

--- a/source/brushes/eraser/eraser_brush.cpp
+++ b/source/brushes/eraser/eraser_brush.cpp
@@ -46,12 +46,12 @@ bool EraserBrush::canDraw(BaseMap* map, const Position& position) const {
 }
 
 void EraserBrush::undraw(BaseMap* map, Tile* tile) {
-	std::erase_if(tile->items, [](const auto& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const auto& item) {
 		if (item->isComplex() && g_settings.getInteger(Config::ERASER_LEAVE_UNIQUE)) {
 			return false;
 		}
 		return true;
-	});
+	}), tile->items.end());
 
 	if (tile->ground) {
 		if (g_settings.getInteger(Config::ERASER_LEAVE_UNIQUE)) {
@@ -66,10 +66,10 @@ void EraserBrush::undraw(BaseMap* map, Tile* tile) {
 
 void EraserBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 	// Draw is undraw, undraw is super-undraw!
-	std::erase_if(tile->items, [](const auto& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const auto& item) {
 		if ((item->isComplex() || item->isBorder()) && g_settings.getInteger(Config::ERASER_LEAVE_UNIQUE)) {
 			return false;
 		}
 		return true;
-	});
+	}), tile->items.end());
 }

--- a/source/brushes/ground/ground_border_calculator.cpp
+++ b/source/brushes/ground/ground_border_calculator.cpp
@@ -273,9 +273,9 @@ void GroundBorderCalculator::calculate(BaseMap* map, Tile* tile) {
 	}
 
 	// Clean current borders
-	std::erase_if(tile->items, [](const std::unique_ptr<Item>& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const std::unique_ptr<Item>& item) {
 		return item->isBorder();
-	});
+	}), tile->items.end());
 
 	// Sort borders based on z-order
 	std::ranges::sort(borderList, [](const GroundBrush::BorderCluster& a, const GroundBrush::BorderCluster& b) {

--- a/source/brushes/house/house_brush.cpp
+++ b/source/brushes/house/house_brush.cpp
@@ -68,9 +68,9 @@ void HouseBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 	tile->setPZ(true);
 	if (g_settings.getInteger(Config::HOUSE_BRUSH_REMOVE_ITEMS)) {
 		// Remove loose items
-		std::erase_if(tile->items, [](const auto& item) {
+		tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const auto& item) {
 			return item->isNotMoveable() == 0;
-		});
+		}), tile->items.end());
 	}
 	if (g_settings.getInteger(Config::AUTO_ASSIGN_DOORID)) {
 		// Is there a door? If so, find an empty ID and assign it (if the door doesn't already have an id.

--- a/source/brushes/raw/raw_brush.cpp
+++ b/source/brushes/raw/raw_brush.cpp
@@ -69,9 +69,9 @@ void RAWBrush::undraw(BaseMap* map, Tile* tile) {
 	if (tile->ground && tile->ground->getID() == itemtype->id) {
 		tile->ground = nullptr;
 	}
-	std::erase_if(tile->items, [item_id = itemtype->id](const auto& item) {
+	tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [item_id = itemtype->id](const auto& item) {
 		return item->getID() == item_id;
-	});
+	}), tile->items.end());
 }
 
 void RAWBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
@@ -81,9 +81,9 @@ void RAWBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 
 	bool b = parameter ? *reinterpret_cast<bool*>(parameter) : false;
 	if ((g_settings.getInteger(Config::RAW_LIKE_SIMONE) && !b) && itemtype->alwaysOnBottom && itemtype->alwaysOnTopOrder == 2) {
-		std::erase_if(tile->items, [topOrder = itemtype->alwaysOnTopOrder](const auto& item) {
+		tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [topOrder = itemtype->alwaysOnTopOrder](const auto& item) {
 			return item->getTopOrder() == topOrder;
-		});
+		}), tile->items.end());
 	}
 	tile->addItem(Item::Create(itemtype->id));
 }

--- a/source/brushes/table/table_brush.cpp
+++ b/source/brushes/table/table_brush.cpp
@@ -48,9 +48,9 @@ bool TableBrush::canDraw(BaseMap* map, const Position& position) const {
 }
 
 void TableBrush::undraw(BaseMap* map, Tile* t) {
-	std::erase_if(t->items, [this](const auto& item) {
+	t->items.erase(std::remove_if(t->items.begin(), t->items.end(), [this](const auto& item) {
 		return item->isTable() && item->getTableBrush() == this;
-	});
+	}), t->items.end());
 }
 
 void TableBrush::draw(BaseMap* map, Tile* tile, void* parameter) {

--- a/source/brushes/wall/wall_border_calculator.cpp
+++ b/source/brushes/wall/wall_border_calculator.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "brushes/wall/wall_border_calculator.h"
+#include <boost/container/small_vector.hpp>
 #include "brushes/wall/wall_brush.h"
 #include "brushes/wall/wall_brush_items.h"
 #include "map/basemap.h"
@@ -46,7 +47,7 @@ void WallBorderCalculator::doWalls(BaseMap* map, Tile* tile) {
 	for (; it != tile->items.end() && (*it)->isBorder(); ++it)
 		;
 
-	std::vector<std::unique_ptr<Item>> items_to_add;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> items_to_add;
 
 	while (it != tile->items.end()) {
 		Item* wall = it->get();

--- a/source/game/complexitem.h
+++ b/source/game/complexitem.h
@@ -19,6 +19,7 @@
 #define RME_CONTAINER_H_
 
 #include "map/position.h"
+#include <boost/container/small_vector.hpp>
 #include "game/item.h"
 #include "game/outfit.h"
 
@@ -54,10 +55,10 @@ public:
 		return g_items[id].volume;
 	}
 
-	std::vector<std::unique_ptr<Item>>& getVector() {
+	boost::container::small_vector<std::unique_ptr<Item>, 4>& getVector() {
 		return contents;
 	}
-	const std::vector<std::unique_ptr<Item>>& getVector() const {
+	const boost::container::small_vector<std::unique_ptr<Item>, 4>& getVector() const {
 		return contents;
 	}
 	double getWeight() const;
@@ -67,7 +68,7 @@ public:
 	virtual bool serializeItemNode_OTBM(const IOMap& maphandle, NodeFileWriteHandle& f) const;
 
 protected:
-	std::vector<std::unique_ptr<Item>> contents;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> contents;
 };
 
 class Teleport : public Item {

--- a/source/map/map.h
+++ b/source/map/map.h
@@ -272,14 +272,13 @@ inline int64_t RemoveItemOnMap(Map& map, RemoveIfType& condition, bool selectedO
 			}
 		}
 
-		// Use C++20's std::erase_if for a safer and more idiomatic way to remove elements.
-		std::erase_if(tile->items, [&](const auto& item) {
+				tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [&](const auto& item) {
 			if (condition(map, item.get(), removed, done)) {
 				++removed;
 				return true;
 			}
 			return false;
-		});
+		}), tile->items.end());
 	});
 	return removed;
 }

--- a/source/map/map_converter.cpp
+++ b/source/map/map_converter.cpp
@@ -175,10 +175,9 @@ void MapConverter::cleanInvalidTiles(Map& map, bool showdialog) {
 			continue;
 		}
 
-		// Use std::erase_if from C++20 for cleanup
-		std::erase_if(tile->items, [](const std::unique_ptr<Item>& item) {
+				tile->items.erase(std::remove_if(tile->items.begin(), tile->items.end(), [](const std::unique_ptr<Item>& item) {
 			return !g_items.typeExists(item->getID());
-		});
+		}), tile->items.end());
 
 		++tiles_done;
 		if (showdialog && tiles_done % 0x10000 == 0) {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -19,6 +19,7 @@
 #define RME_TILE_H
 
 #include "map/position.h"
+#include <boost/container/small_vector.hpp>
 #include "game/item.h"
 
 namespace TileOperations {
@@ -66,7 +67,7 @@ class Tile {
 public: // Members
 	TileLocation* location;
 	std::unique_ptr<Item> ground;
-	std::vector<std::unique_ptr<Item>> items;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> items;
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////////////////////
 
 #include "app/main.h"
+#include <boost/container/small_vector.hpp>
 #include "map/tile_operations.h"
 #include "map/tile.h"
 #include "map/basemap.h"
@@ -290,8 +291,8 @@ namespace TileOperations {
 		TileOperations::update(tile);
 	}
 
-	std::vector<std::unique_ptr<Item>> popSelectedItems(Tile* tile, bool ignoreTileSelected) {
-		std::vector<std::unique_ptr<Item>> pop_items;
+	boost::container::small_vector<std::unique_ptr<Item>, 4> popSelectedItems(Tile* tile, bool ignoreTileSelected) {
+		boost::container::small_vector<std::unique_ptr<Item>, 4> pop_items;
 
 		if (!ignoreTileSelected && !tile->isSelected()) {
 			return pop_items;

--- a/source/map/tile_operations.h
+++ b/source/map/tile_operations.h
@@ -6,6 +6,7 @@
 #define RME_TILE_OPERATIONS_H
 
 #include "game/item.h"
+#include <boost/container/small_vector.hpp>
 #include <memory>
 #include <vector>
 
@@ -37,7 +38,7 @@ namespace TileOperations {
 	void selectGround(Tile* tile);
 	void deselectGround(Tile* tile);
 
-	std::vector<std::unique_ptr<Item>> popSelectedItems(Tile* tile, bool ignoreTileSelected = false);
+	boost::container::small_vector<std::unique_ptr<Item>, 4> popSelectedItems(Tile* tile, bool ignoreTileSelected = false);
 	ItemVector getSelectedItems(Tile* tile, bool unzoomed = false);
 	Item* getTopSelectedItem(Tile* tile);
 


### PR DESCRIPTION
💡 **What**: Refactored `Tile::items` and related vectors in `ComplexItem` and brush tools to use `boost::container::small_vector<std::unique_ptr<Item>, 4>`.
🎯 **Why**: To prevent pointer chasing on the heap for small collections of items (like a few items on a tile), directly addressing Data Oriented Design guidelines by flattening memory layout and avoiding repeated dynamic allocations. Replaced `std::erase_if` with the erase-remove idiom since `small_vector` does not provide the same free-function specialization.
📊 **Impact**: Reduces heap allocations during tile manipulation and map rendering, improving cache locality for hot path map operations.

---
*PR created automatically by Jules for task [8713743889370248718](https://jules.google.com/task/8713743889370248718) started by @karolak6612*