### PR TITLE
⚡ Throttle: Map rendering & selection optimizations

### DIFF
--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -271,7 +271,20 @@ void Selection::addInternal(Tile* tile) {
 		auto it = std::ranges::lower_bound(tiles, tile, tilePositionLessThan);
 		if (it == tiles.end() || *it != tile) {
 			tiles.insert(it, tile);
-			bounds_dirty = true;
+			if (!bounds_dirty) {
+				const Position& pos = tile->getPosition();
+				if (tiles.size() == 1) {
+					cached_min = pos;
+					cached_max = pos;
+				} else {
+					cached_min.x = std::min(cached_min.x, pos.x);
+					cached_min.y = std::min(cached_min.y, pos.y);
+					cached_min.z = std::min(cached_min.z, pos.z);
+					cached_max.x = std::max(cached_max.x, pos.x);
+					cached_max.y = std::max(cached_max.y, pos.y);
+					cached_max.z = std::max(cached_max.z, pos.z);
+				}
+			}
 		}
 	}
 }
@@ -284,7 +297,13 @@ void Selection::removeInternal(Tile* tile) {
 		auto it = std::ranges::lower_bound(tiles, tile, tilePositionLessThan);
 		if (it != tiles.end() && *it == tile) {
 			tiles.erase(it);
-			bounds_dirty = true;
+			if (!bounds_dirty) {
+				const Position& pos = tile->getPosition();
+				if (pos.x == cached_min.x || pos.y == cached_min.y || pos.z == cached_min.z ||
+					pos.x == cached_max.x || pos.y == cached_max.y || pos.z == cached_max.z) {
+					bounds_dirty = true;
+				}
+			}
 		}
 	}
 }

--- a/source/rendering/drawers/map_layer_drawer.cpp
+++ b/source/rendering/drawers/map_layer_drawer.cpp
@@ -40,7 +40,7 @@ MapLayerDrawer::MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_dra
 MapLayerDrawer::~MapLayerDrawer() {
 }
 
-void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer) {
+void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, const std::vector<std::pair<MapNode*, std::pair<int, int>>>* visible_nodes) {
 	int nd_start_x = view.start_x & ~3;
 	int nd_start_y = view.start_y & ~3;
 	int nd_end_x = (view.end_x & ~3) + 4;
@@ -115,15 +115,21 @@ void MapLayerDrawer::Draw(SpriteBatch& sprite_batch, int map_z, bool live_client
 			}
 		}
 	} else {
-		// Use SpatialHashGrid::visitLeaves which handles O(1) viewport query internally
-		// Expand the query range slightly to handle the 4-tile alignment and safety margin
-		int safe_start_x = nd_start_x - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
-		int safe_start_y = nd_start_y - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
-		int safe_end_x = nd_end_x + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
-		int safe_end_y = nd_end_y + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+		if (visible_nodes) {
+			for (const auto& [nd, pos] : *visible_nodes) {
+				drawNode(nd, pos.first, pos.second, false);
+			}
+		} else {
+			// Use SpatialHashGrid::visitLeaves which handles O(1) viewport query internally
+			// Expand the query range slightly to handle the 4-tile alignment and safety margin
+			int safe_start_x = nd_start_x - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+			int safe_start_y = nd_start_y - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+			int safe_end_x = nd_end_x + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+			int safe_end_y = nd_end_y + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
 
-		editor->map.visitLeaves(safe_start_x, safe_start_y, safe_end_x, safe_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
-			drawNode(nd, nd_map_x, nd_map_y, false);
-		});
+			editor->map.visitLeaves(safe_start_x, safe_start_y, safe_end_x, safe_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
+				drawNode(nd, nd_map_x, nd_map_y, false);
+			});
+		}
 	}
 }

--- a/source/rendering/drawers/map_layer_drawer.h
+++ b/source/rendering/drawers/map_layer_drawer.h
@@ -28,13 +28,16 @@ struct DrawingOptions;
 struct LightBuffer;
 class SpriteBatch;
 class PrimitiveRenderer;
+class MapNode;
+#include <vector>
+#include <utility>
 
 class MapLayerDrawer {
 public:
 	MapLayerDrawer(TileRenderer* tile_renderer, GridDrawer* grid_drawer, Editor* editor);
 	~MapLayerDrawer();
 
-	void Draw(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer);
+	void Draw(SpriteBatch& sprite_batch, int map_z, bool live_client, const RenderView& view, const DrawingOptions& options, LightBuffer& light_buffer, const std::vector<std::pair<MapNode*, std::pair<int, int>>>* visible_nodes = nullptr);
 
 private:
 	TileRenderer* tile_renderer;

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -378,6 +378,36 @@ void MapDrawer::DrawMap() {
 
 	bool only_colors = options.show_as_minimap || options.show_only_colors;
 
+	// Pre-calculate visible leaf nodes based on the initial view to avoid O(N) queries per z-layer
+	// The viewport expands by 1 for each Z-level drawn downwards.
+	// We calculate the maximum possible extent for the worst case z-level.
+	int max_z_diff = view.start_z - view.end_z;
+	if (max_z_diff < 0) {
+		max_z_diff = 0;
+	}
+	int max_start_x = view.start_x - max_z_diff;
+	int max_start_y = view.start_y - max_z_diff;
+	int max_end_x = view.end_x + max_z_diff;
+	int max_end_y = view.end_y + max_z_diff;
+
+	int nd_start_x = max_start_x & ~3;
+	int nd_start_y = max_start_y & ~3;
+	int nd_end_x = (max_end_x & ~3) + 4;
+	int nd_end_y = (max_end_y & ~3) + 4;
+
+	int safe_start_x = nd_start_x - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+	int safe_start_y = nd_start_y - PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+	int safe_end_x = nd_end_x + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+	int safe_end_y = nd_end_y + PAINTERS_ALGORITHM_SAFETY_MARGIN_PIXELS / TILE_SIZE;
+
+	std::vector<std::pair<MapNode*, std::pair<int, int>>> visible_nodes;
+	if (!live_client) {
+		// Use SpatialHashGrid::visitLeaves which handles O(1) viewport query internally
+		editor.map.visitLeaves(safe_start_x, safe_start_y, safe_end_x, safe_end_y, [&](MapNode* nd, int nd_map_x, int nd_map_y) {
+			visible_nodes.push_back({nd, {nd_map_x, nd_map_y}});
+		});
+	}
+
 	// Enable texture mode
 
 	for (int map_z = view.start_z; map_z >= view.superend_z; map_z--) {
@@ -386,7 +416,7 @@ void MapDrawer::DrawMap() {
 		}
 
 		if (map_z >= view.end_z) {
-			DrawMapLayer(map_z, live_client);
+			DrawMapLayer(map_z, live_client, live_client ? nullptr : &visible_nodes);
 		}
 
 		preview_drawer->draw(*sprite_batch, canvas, view, map_z, options, editor, item_drawer.get(), sprite_drawer.get(), creature_drawer.get(), options.current_house_id);
@@ -424,8 +454,8 @@ void MapDrawer::DrawCreatureNames(NVGcontext* vg) {
 	creature_name_drawer->draw(vg, view);
 }
 
-void MapDrawer::DrawMapLayer(int map_z, bool live_client) {
-	map_layer_drawer->Draw(*sprite_batch, map_z, live_client, view, options, light_buffer);
+void MapDrawer::DrawMapLayer(int map_z, bool live_client, const std::vector<std::pair<MapNode*, std::pair<int, int>>>* visible_nodes) {
+	map_layer_drawer->Draw(*sprite_batch, map_z, live_client, view, options, light_buffer, visible_nodes);
 }
 
 void MapDrawer::DrawLight() {

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -152,7 +152,7 @@ public:
 	}
 
 private:
-	void DrawMapLayer(int map_z, bool live_client);
+	void DrawMapLayer(int map_z, bool live_client, const std::vector<std::pair<class MapNode*, std::pair<int, int>>>* visible_nodes = nullptr);
 	bool renderers_initialized = false;
 };
 


### PR DESCRIPTION
Implemented two key optimizations:
1. `Selection::addInternal` and `removeInternal` now incrementally update `cached_min`/`cached_max`, preventing full `O(N)` bounds recalculation queries across large selections.
2. Hoisted the spatial hash grid query (`visitLeaves`) out of the z-layer rendering loop in `MapDrawer::DrawMap`, computing perspective bounds once and caching the `MapNode`s.

---
*PR created automatically by Jules for task [5410560095301033392](https://jules.google.com/task/5410560095301033392) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Optimized bounds calculation to reduce unnecessary invalidations and improve responsiveness.
  * Enhanced viewport visibility computation with precomputed data, enabling more efficient rendering operations and faster screen updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->