### PR TITLE
📊 Profiler: Fix GPU error queue handling in TextureAtlas and MinimapRenderer

### DIFF
--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,17 +117,20 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		bool has_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
+			has_error = true;
+		}
+		if (has_error) {
 			return false;
 		}
 
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,8 +160,8 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
 	}
 


### PR DESCRIPTION
This fixes the `glGetError()` handling in the OpenGL renderer logic to ensure that the error queue is properly drained using `while ((err = glGetError()) != GL_NO_ERROR)`. Previously, a single `if` statement would only pop one error from the queue, potentially leaving stale errors behind that could misattribute failures to subsequent draw calls. 

This change also preserves the original fail-fast behavior of `TextureAtlas` by collecting a boolean flag and returning *after* the queue has been drained.

---
*PR created automatically by Jules for task [10034477911602145478](https://jules.google.com/task/10034477911602145478) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error reporting in graphics operations to capture and log all errors encountered during texture processing and rendering operations, rather than reporting only the first error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->