### PR TITLE
🔄 Upgrader: Modernize enums to scoped enum class

### DIFF
--- a/source/brushes/brush.cpp
+++ b/source/brushes/brush.cpp
@@ -95,10 +95,10 @@ void Brushes::init() {
 	addManagedBrush(g_brush_manager.house_exit_brush);
 	addManagedBrush(g_brush_manager.waypoint_brush);
 
-	addManagedBrush(g_brush_manager.pz_brush, TILESTATE_PROTECTIONZONE);
-	addManagedBrush(g_brush_manager.rook_brush, TILESTATE_NOPVP);
-	addManagedBrush(g_brush_manager.nolog_brush, TILESTATE_NOLOGOUT);
-	addManagedBrush(g_brush_manager.pvp_brush, TILESTATE_PVPZONE);
+	addManagedBrush(g_brush_manager.pz_brush, static_cast<uint16_t>(TileState::PROTECTIONZONE));
+	addManagedBrush(g_brush_manager.rook_brush, static_cast<uint16_t>(TileState::NOPVP));
+	addManagedBrush(g_brush_manager.nolog_brush, static_cast<uint16_t>(TileState::NOLOGOUT));
+	addManagedBrush(g_brush_manager.pvp_brush, static_cast<uint16_t>(TileState::PVPZONE));
 
 	GroundBrush::init();
 	WallBrush::init();

--- a/source/brushes/doodad/doodad_brush_loader.cpp
+++ b/source/brushes/doodad/doodad_brush_loader.cpp
@@ -65,7 +65,7 @@ bool DoodadBrushLoader::load(pugi::xml_node node, DoodadBrushItems& items, Dooda
 		if (!settings.do_new_borders) {
 			warnings.push_back("remove_optional_border will not work without redo_borders\n");
 		}
-		settings.clear_statflags |= TILESTATE_OP_BORDER;
+		settings.clear_statflags |= static_cast<uint16_t>(TileState::OP_BORDER);
 	}
 
 	const std::string& thicknessString = node.attribute("thickness").as_string();

--- a/source/brushes/flag/flag_brush.cpp
+++ b/source/brushes/flag/flag_brush.cpp
@@ -19,10 +19,10 @@ FlagBrush::FlagBrush(uint32_t flag) :
 }
 
 std::string FlagBrush::getName() const {
-	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { TILESTATE_PROTECTIONZONE, "PZ brush (0x01)" },
-																						  { TILESTATE_NOPVP, "No combat zone brush (0x04)" },
-																						  { TILESTATE_NOLOGOUT, "No logout zone brush (0x08)" },
-																						  { TILESTATE_PVPZONE, "PVP Zone brush (0x10)" } } };
+	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { static_cast<uint32_t>(TileState::PROTECTIONZONE), "PZ brush (0x01)" },
+																						  { static_cast<uint32_t>(TileState::NOPVP), "No combat zone brush (0x04)" },
+																						  { static_cast<uint32_t>(TileState::NOLOGOUT), "No logout zone brush (0x08)" },
+																						  { static_cast<uint32_t>(TileState::PVPZONE), "PVP Zone brush (0x10)" } } };
 
 	auto it = std::ranges::find_if(flagNames, [this](const auto& p) { return p.first == flag; });
 	if (it != flagNames.end()) {
@@ -32,10 +32,10 @@ std::string FlagBrush::getName() const {
 }
 
 int FlagBrush::getLookID() const {
-	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { TILESTATE_PROTECTIONZONE, EDITOR_SPRITE_PZ_TOOL },
-																			   { TILESTATE_NOPVP, EDITOR_SPRITE_NOPVP_TOOL },
-																			   { TILESTATE_NOLOGOUT, EDITOR_SPRITE_NOLOG_TOOL },
-																			   { TILESTATE_PVPZONE, EDITOR_SPRITE_PVPZ_TOOL } } };
+	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { static_cast<uint32_t>(TileState::PROTECTIONZONE), EDITOR_SPRITE_PZ_TOOL },
+																			   { static_cast<uint32_t>(TileState::NOPVP), EDITOR_SPRITE_NOPVP_TOOL },
+																			   { static_cast<uint32_t>(TileState::NOLOGOUT), EDITOR_SPRITE_NOLOG_TOOL },
+																			   { static_cast<uint32_t>(TileState::PVPZONE), EDITOR_SPRITE_PVPZ_TOOL } } };
 
 	auto it = std::ranges::find_if(flagSprites, [this](const auto& p) { return p.first == flag; });
 	if (it != flagSprites.end()) {

--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -30,25 +30,25 @@
 #include <ctime>
 
 Change::Change() :
-	type(CHANGE_NONE), data(std::monostate {}) {
+	type(ChangeType::CHANGE_NONE), data(std::monostate {}) {
 	////
 }
 
 Change::Change(std::unique_ptr<Tile> t) :
-	type(CHANGE_TILE), data(std::move(t)) {
+	type(ChangeType::CHANGE_TILE), data(std::move(t)) {
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
 Change* Change::Create(House* house, const Position& where) {
 	Change* c = newd Change();
-	c->type = CHANGE_MOVE_HOUSE_EXIT;
+	c->type = ChangeType::CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
 Change* Change::Create(Waypoint* wp, const Position& where) {
 	Change* c = newd Change();
-	c->type = CHANGE_MOVE_WAYPOINT;
+	c->type = ChangeType::CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;
 }
@@ -58,7 +58,7 @@ Change::~Change() {
 }
 
 void Change::clear() {
-	type = CHANGE_NONE;
+	type = ChangeType::CHANGE_NONE;
 	data = std::monostate {};
 }
 
@@ -120,7 +120,7 @@ void Action::commit(DirtyList* dirty_list) {
 	while (it != changes.end()) {
 		Change* c = it->get();
 		switch (c->type) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				auto& uptr = std::get<std::unique_ptr<Tile>>(c->data);
 				ASSERT(uptr);
 				Tile* newtile = uptr.get();
@@ -202,14 +202,14 @@ void Action::commit(DirtyList* dirty_list) {
 				newtile->modify();
 
 				// Update client dirty list
-				if (editor.live_manager.IsClient() && dirty_list && type != ACTION_REMOTE) {
+				if (editor.live_manager.IsClient() && dirty_list && type != ActionIdentifier::ACTION_REMOTE) {
 					// Local action, assemble changes
 					dirty_list->AddChange(c);
 				}
 				break;
 			}
 
-			case CHANGE_MOVE_HOUSE_EXIT: {
+			case ChangeType::CHANGE_MOVE_HOUSE_EXIT: {
 				auto& p = std::get<HouseExitChangeData>(c->data);
 				House* whathouse = editor.map.houses.getHouse(p.houseId);
 
@@ -221,7 +221,7 @@ void Action::commit(DirtyList* dirty_list) {
 				break;
 			}
 
-			case CHANGE_MOVE_WAYPOINT: {
+			case ChangeType::CHANGE_MOVE_WAYPOINT: {
 				auto& p = std::get<WaypointChangeData>(c->data);
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 
@@ -267,7 +267,7 @@ void Action::undo(DirtyList* dirty_list) {
 	while (it != changes.rend()) {
 		Change* c = it->get();
 		switch (c->type) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				auto& uptr = std::get<std::unique_ptr<Tile>>(c->data);
 				std::unique_ptr<Tile> old_uptr = std::move(uptr);
 				ASSERT(old_uptr);
@@ -331,14 +331,14 @@ void Action::undo(DirtyList* dirty_list) {
 				uptr = std::move(newtile_uptr);
 
 				// Update client dirty list
-				if (editor.live_manager.IsClient() && dirty_list && type != ACTION_REMOTE) {
+				if (editor.live_manager.IsClient() && dirty_list && type != ActionIdentifier::ACTION_REMOTE) {
 					// Local action, assemble changes
 					dirty_list->AddChange(c);
 				}
 				break;
 			}
 
-			case CHANGE_MOVE_HOUSE_EXIT: {
+			case ChangeType::CHANGE_MOVE_HOUSE_EXIT: {
 				auto& p = std::get<HouseExitChangeData>(c->data);
 				House* whathouse = editor.map.houses.getHouse(p.houseId);
 				if (whathouse) {
@@ -349,7 +349,7 @@ void Action::undo(DirtyList* dirty_list) {
 				break;
 			}
 
-			case CHANGE_MOVE_WAYPOINT: {
+			case ChangeType::CHANGE_MOVE_WAYPOINT: {
 				auto& p = std::get<WaypointChangeData>(c->data);
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -38,7 +38,7 @@ class Action;
 class BatchAction;
 class ActionQueue;
 
-enum ChangeType {
+enum class ChangeType : uint8_t {
 	CHANGE_NONE,
 	CHANGE_TILE,
 	CHANGE_MOVE_HOUSE_EXIT,
@@ -87,7 +87,7 @@ using ChangeList = std::vector<std::unique_ptr<Change>>;
 
 class DirtyList;
 
-enum ActionIdentifier {
+enum class ActionIdentifier : uint8_t {
 	ACTION_MOVE,
 	ACTION_REMOTE,
 	ACTION_SELECT,

--- a/source/editor/action_queue.cpp
+++ b/source/editor/action_queue.cpp
@@ -70,7 +70,7 @@ void ActionQueue::addBatch(std::unique_ptr<BatchAction> batch, int stacking_dela
 		editor.notifyStateChange();
 	}
 
-	if (batch->getType() == ACTION_REMOTE) {
+	if (batch->getType() == ActionIdentifier::ACTION_REMOTE) {
 		return;
 	}
 

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -82,7 +82,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 	int item_count = 0;
 	buffer.copyPos = Position(0xFFFF, 0xFFFF, floor);
 
-	std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_CUT_TILES);
+	std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_CUT_TILES);
 	std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 	PositionList tilestoborder;
@@ -97,7 +97,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 			copied_tile->house_id = newtile->house_id;
 			newtile->house_id = 0;
 			copied_tile->setMapFlags(tile->getMapFlags());
-			newtile->setMapFlags(TILESTATE_NONE);
+			newtile->setMapFlags(static_cast<uint16_t>(TileState::NONE));
 		}
 
 		auto tile_selection = TileOperations::popSelectedItems(newtile.get());
@@ -172,7 +172,7 @@ void CopyOperations::paste(Editor& editor, CopyBuffer& buffer, const Position& t
 		return;
 	}
 
-	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ACTION_PASTE_TILES);
+	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ActionIdentifier::ACTION_PASTE_TILES);
 	std::unique_ptr<Action> action = editor.actionQueue->createAction(batchAction.get());
 	for (TileLocation& location : *buffer.tiles) {
 		Tile* buffer_tile = location.get();

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -28,7 +28,7 @@
 namespace {
 
 	void drawDoodad(Editor& editor, DoodadBrush* brush, Position offset, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		BaseMap* buffer_map = g_doodad_preview.GetBufferMap();
 
@@ -126,7 +126,7 @@ namespace {
 
 	template <typename T>
 	void drawGroundOrEraserImpl(Editor& editor, T* brush, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		std::pair<bool, GroundBrush*> param_obj;
@@ -210,7 +210,7 @@ namespace {
 	}
 
 	void drawWall(Editor& editor, WallBrush* brush, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		if (alt && dodraw) {
@@ -307,7 +307,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 			return;
 		}
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
 		batch->addAndCommitAction(std::move(action));
@@ -323,13 +323,13 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 			return;
 		}
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		// This will only occur with a size 0, when clicking on a tile (not drawing)
 		Tile* tile = editor.map.getTile(offset);
@@ -350,7 +350,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<SpawnBrush>() || brush->is<CreatureBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		Tile* tile = editor.map.getTile(offset);
@@ -388,7 +388,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, boo
 	}
 #endif
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DRAW);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DRAW);
 
 	if (brush->is<OptionalBorderBrush>()) {
 		// We actually need to do borders, but on the same tiles we draw to
@@ -451,7 +451,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 	} else if (brush->is<EraserBrush>()) {
 		drawGroundOrEraser(editor, brush->as<EraserBrush>(), tilestodraw, tilestoborder, alt, dodraw);
 	} else if (brush->is<TableBrush>() || brush->is<CarpetBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		for (const auto& drawPos : tilestodraw) {
@@ -499,7 +499,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 	} else if (brush->is<WallBrush>()) {
 		drawWall(editor, brush->as<WallBrush>(), tilestodraw, tilestoborder, alt, dodraw);
 	} else if (brush->is<DoorBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		DoorBrush* door_brush = brush->as<DoorBrush>();
 
@@ -546,7 +546,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 
 		editor.addBatch(std::move(batch), 2);
 	} else {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DRAW);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DRAW);
 		for (const auto& drawPos : tilestodraw) {
 			auto* location = editor.map.createTileL(drawPos);
 			auto* tile = location->get();

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -48,7 +48,7 @@ void SelectionOperations::borderizeSelection(Editor& editor) {
 		g_gui.SetStatusText("No items selected. Can't borderize.");
 	}
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_BORDERIZE);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_BORDERIZE);
 	for (Tile* tile : editor.selection) {
 		std::unique_ptr<Tile> newTile = TileOperations::deepCopy(tile, editor.map);
 		TileOperations::borderize(newTile.get(), &editor.map);
@@ -63,7 +63,7 @@ void SelectionOperations::randomizeSelection(Editor& editor) {
 		g_gui.SetStatusText("No items selected. Can't randomize.");
 	}
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_RANDOMIZE);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_RANDOMIZE);
 	for (Tile* tile : editor.selection) {
 		std::unique_ptr<Tile> newTile = TileOperations::deepCopy(tile, editor.map);
 		GroundBrush* groundBrush = newTile->getGroundBrush();
@@ -85,7 +85,7 @@ void SelectionOperations::randomizeSelection(Editor& editor) {
 }
 
 void SelectionOperations::moveSelection(Editor& editor, Position offset) {
-	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ACTION_MOVE); // Our saved action batch, for undo!
+	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ActionIdentifier::ACTION_MOVE); // Our saved action batch, for undo!
 	std::unique_ptr<Action> action;
 
 	// Remove tiles from the map
@@ -123,7 +123,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 			tmp_storage_tile->house_id = new_src_tile->house_id;
 			new_src_tile->house_id = 0;
 			tmp_storage_tile->setMapFlags(new_src_tile->getMapFlags());
-			new_src_tile->setMapFlags(TILESTATE_NONE);
+			new_src_tile->setMapFlags(static_cast<uint16_t>(TileState::NONE));
 			doborders = true;
 		}
 
@@ -341,7 +341,7 @@ void SelectionOperations::destroySelection(Editor& editor) {
 		int item_count = 0;
 		PositionList tilestoborder;
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DELETE_TILES);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DELETE_TILES);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		for (Tile* tile : editor.selection) {

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -351,9 +351,9 @@ void Selection::start(SessionFlags flags) {
 		if (flags & SUBTHREAD) {
 			;
 		} else {
-			session = std::move(editor.actionQueue->createBatch(ACTION_SELECT));
+			session = std::move(editor.actionQueue->createBatch(ActionIdentifier::ACTION_SELECT));
 		}
-		subsession = editor.actionQueue->createAction(ACTION_SELECT);
+		subsession = editor.actionQueue->createAction(ActionIdentifier::ACTION_SELECT);
 	} else {
 		deferred = true;
 		pending_adds.clear();
@@ -373,7 +373,7 @@ void Selection::commit() {
 		tmp->addAndCommitAction(std::move(subsession));
 
 		// Create a newd action for subsequent selects
-		subsession = editor.actionQueue->createAction(ACTION_SELECT);
+		subsession = editor.actionQueue->createAction(ActionIdentifier::ACTION_SELECT);
 		session = std::move(tmp);
 	}
 }

--- a/source/live/live_action.cpp
+++ b/source/live/live_action.cpp
@@ -58,7 +58,7 @@ void NetworkedBatchAction::addAndCommitAction(std::unique_ptr<Action> action) {
 	}
 
 	// Add it!
-	action->commit(type != (ActionIdentifier)ACTION_SELECT ? &dirty_list : nullptr);
+	action->commit(type != (ActionIdentifier)ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 	batch.push_back(std::move(action));
 	timestamp = time(nullptr);
 
@@ -73,7 +73,7 @@ void NetworkedBatchAction::commit() {
 	for (const auto& action_ptr : batch) {
 		NetworkedAction* action = static_cast<NetworkedAction*>(action_ptr.get());
 		if (!action->isCommited()) {
-			action->commit(type != ACTION_SELECT ? &dirty_list : nullptr);
+			action->commit(type != ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 			if (action->owner != 0) {
 				dirty_list.owner = action->owner;
 			}
@@ -88,7 +88,7 @@ void NetworkedBatchAction::undo() {
 	DirtyList dirty_list;
 
 	for (auto& action_ptr : std::ranges::reverse_view(batch)) {
-		action_ptr->undo(type != ACTION_SELECT ? &dirty_list : nullptr);
+		action_ptr->undo(type != ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 	}
 	// Broadcast changes!
 	queue.broadcast(dirty_list);

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -288,7 +288,7 @@ void LiveClient::sendChanges(DirtyList& dirtyList) {
 	mapWriter.reset();
 	for (const auto& change : changeList) {
 		switch (change->getType()) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				const Position& position = change->getTile()->getPosition();
 				sendTile(mapWriter, editor->map.getTile(position), &position);
 				break;
@@ -432,7 +432,7 @@ void LiveClient::parseNode(NetworkMessage& message) {
 	int32_t ndy = (ind >> 4) & 0x3FFF;
 	bool underground = ind & 1;
 
-	std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_REMOTE);
+	std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_REMOTE);
 	receiveNode(message, *editor, action.get(), ndx, ndy, underground);
 	editor->actionQueue->addAction(std::move(action));
 

--- a/source/live/live_peer.cpp
+++ b/source/live/live_peer.cpp
@@ -272,7 +272,7 @@ void LivePeer::parseReceiveChanges(NetworkMessage& message) {
 
 	// We need ownership of the action, but createAction returns unique_ptr.
 	// We'll move it into a temporary unique_ptr, get the raw pointer for metadata, then move to queue.
-	std::unique_ptr<Action> rawAction = editor.actionQueue->createAction(ACTION_REMOTE);
+	std::unique_ptr<Action> rawAction = editor.actionQueue->createAction(ActionIdentifier::ACTION_REMOTE);
 	NetworkedAction* action = static_cast<NetworkedAction*>(rawAction.get());
 	action->owner = clientId;
 

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -37,26 +37,48 @@ class Map;
 
 // TileOperations functions are now in tile_operations.h
 
-enum {
-	TILESTATE_NONE = 0x0000,
-	TILESTATE_PROTECTIONZONE = 0x0001,
-	TILESTATE_DEPRECATED = 0x0002, // Reserved
-	TILESTATE_NOPVP = 0x0004,
-	TILESTATE_NOLOGOUT = 0x0008,
-	TILESTATE_PVPZONE = 0x0010,
-	TILESTATE_REFRESH = 0x0020,
+enum class TileState : uint16_t {
+	NONE = 0x0000,
+	PROTECTIONZONE = 0x0001,
+	DEPRECATED = 0x0002, // Reserved
+	NOPVP = 0x0004,
+	NOLOGOUT = 0x0008,
+	PVPZONE = 0x0010,
+	REFRESH = 0x0020,
 	// Internal
-	TILESTATE_SELECTED = 0x0001,
-	TILESTATE_UNIQUE = 0x0002,
-	TILESTATE_BLOCKING = 0x0004,
-	TILESTATE_OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
-	TILESTATE_HAS_TABLE = 0x0010,
-	TILESTATE_HAS_CARPET = 0x0020,
-	TILESTATE_MODIFIED = 0x0040,
-	TILESTATE_HOOK_SOUTH = 0x0080,
-	TILESTATE_HOOK_EAST = 0x0100,
-	TILESTATE_HAS_LIGHT = 0x0200,
+	SELECTED = 0x0001,
+	UNIQUE = 0x0002,
+	BLOCKING = 0x0004,
+	OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
+	HAS_TABLE = 0x0010,
+	HAS_CARPET = 0x0020,
+	MODIFIED = 0x0040,
+	HOOK_SOUTH = 0x0080,
+	HOOK_EAST = 0x0100,
+	HAS_LIGHT = 0x0200,
 };
+
+constexpr TileState operator|(TileState a, TileState b) {
+	return static_cast<TileState>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b));
+}
+
+constexpr TileState operator&(TileState a, TileState b) {
+	return static_cast<TileState>(static_cast<uint16_t>(a) & static_cast<uint16_t>(b));
+}
+
+constexpr TileState operator~(TileState a) {
+	return static_cast<TileState>(~static_cast<uint16_t>(a));
+}
+
+constexpr TileState& operator|=(TileState& a, TileState b) {
+	a = a | b;
+	return a;
+}
+
+constexpr TileState& operator&=(TileState& a, TileState b) {
+	a = a & b;
+	return a;
+}
 
 enum : uint8_t {
 	INVALID_MINIMAP_COLOR = 0xFF
@@ -110,13 +132,13 @@ public: // Functions
 
 	// Has tile been modified since the map was loaded/created?
 	bool isModified() const {
-		return testFlags(statflags, TILESTATE_MODIFIED);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::MODIFIED));
 	}
 	void modify() {
-		statflags |= TILESTATE_MODIFIED;
+		statflags |= static_cast<uint16_t>(TileState::MODIFIED);
 	}
 	void unmodify() {
-		statflags &= ~TILESTATE_MODIFIED;
+		statflags &= ~ static_cast<uint16_t>(TileState::MODIFIED);
 	}
 
 	// Get memory footprint size
@@ -129,18 +151,18 @@ public: // Functions
 
 	// Blocking?
 	bool isBlocking() const {
-		return testFlags(statflags, TILESTATE_BLOCKING);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::BLOCKING));
 	}
 
 	// PZ
 	bool isPZ() const {
-		return testFlags(mapflags, TILESTATE_PROTECTIONZONE);
+		return testFlags(mapflags, static_cast<uint16_t>(TileState::PROTECTIONZONE));
 	}
 	void setPZ(bool pz) {
 		if (pz) {
-			mapflags |= TILESTATE_PROTECTIONZONE;
+			mapflags |= static_cast<uint16_t>(TileState::PROTECTIONZONE);
 		} else {
-			mapflags &= ~TILESTATE_PROTECTIONZONE;
+			mapflags &= ~ static_cast<uint16_t>(TileState::PROTECTIONZONE);
 		}
 	}
 
@@ -152,10 +174,10 @@ public: // Functions
 	void addItem(std::unique_ptr<Item> item);
 
 	bool isSelected() const {
-		return testFlags(statflags, TILESTATE_SELECTED);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::SELECTED));
 	}
 	bool hasUniqueItem() const {
-		return testFlags(statflags, TILESTATE_UNIQUE);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::UNIQUE));
 	}
 
 	uint8_t getMiniMapColor() const;
@@ -172,35 +194,35 @@ public: // Functions
 	GroundBrush* getGroundBrush() const;
 
 	bool hasTable() const {
-		return testFlags(statflags, TILESTATE_HAS_TABLE);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::HAS_TABLE));
 	}
 	Item* getTable() const;
 
 	bool hasCarpet() const {
-		return testFlags(statflags, TILESTATE_HAS_CARPET);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::HAS_CARPET));
 	}
 	Item* getCarpet() const;
 
 	bool hasHookSouth() const {
-		return testFlags(statflags, TILESTATE_HOOK_SOUTH);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::HOOK_SOUTH));
 	}
 
 	bool hasHookEast() const {
-		return testFlags(statflags, TILESTATE_HOOK_EAST);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::HOOK_EAST));
 	}
 
 	bool hasLight() const {
-		return testFlags(statflags, TILESTATE_HAS_LIGHT);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::HAS_LIGHT));
 	}
 
 	bool hasOptionalBorder() const {
-		return testFlags(statflags, TILESTATE_OP_BORDER);
+		return testFlags(statflags, static_cast<uint16_t>(TileState::OP_BORDER));
 	}
 	void setOptionalBorder(bool b) {
 		if (b) {
-			statflags |= TILESTATE_OP_BORDER;
+			statflags |= static_cast<uint16_t>(TileState::OP_BORDER);
 		} else {
-			statflags &= ~TILESTATE_OP_BORDER;
+			statflags &= ~ static_cast<uint16_t>(TileState::OP_BORDER);
 		}
 	}
 

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -34,10 +34,10 @@ namespace TileOperations {
 
 		void UpdateItemFlags(const Item* i, uint16_t& statflags, uint8_t& minimapColor) {
 			if (i->isSelected()) {
-				statflags |= TILESTATE_SELECTED;
+				statflags |= static_cast<uint16_t>(TileState::SELECTED);
 			}
 			if (i->getUniqueID() != 0) {
-				statflags |= TILESTATE_UNIQUE;
+				statflags |= static_cast<uint16_t>(TileState::UNIQUE);
 			}
 			if (i->getMiniMapColor() != 0) {
 				minimapColor = i->getMiniMapColor();
@@ -45,25 +45,25 @@ namespace TileOperations {
 
 			const ItemType& it_type = g_items[i->getID()];
 			if (it_type.unpassable) {
-				statflags |= TILESTATE_BLOCKING;
+				statflags |= static_cast<uint16_t>(TileState::BLOCKING);
 			}
 			if (it_type.isOptionalBorder) {
-				statflags |= TILESTATE_OP_BORDER;
+				statflags |= static_cast<uint16_t>(TileState::OP_BORDER);
 			}
 			if (it_type.isTable) {
-				statflags |= TILESTATE_HAS_TABLE;
+				statflags |= static_cast<uint16_t>(TileState::HAS_TABLE);
 			}
 			if (it_type.isCarpet) {
-				statflags |= TILESTATE_HAS_CARPET;
+				statflags |= static_cast<uint16_t>(TileState::HAS_CARPET);
 			}
 			if (it_type.hookSouth) {
-				statflags |= TILESTATE_HOOK_SOUTH;
+				statflags |= static_cast<uint16_t>(TileState::HOOK_SOUTH);
 			}
 			if (it_type.hookEast) {
-				statflags |= TILESTATE_HOOK_EAST;
+				statflags |= static_cast<uint16_t>(TileState::HOOK_EAST);
 			}
 			if (i->hasLight()) {
-				statflags |= TILESTATE_HAS_LIGHT;
+				statflags |= static_cast<uint16_t>(TileState::HAS_LIGHT);
 			}
 		}
 
@@ -240,7 +240,7 @@ namespace TileOperations {
 			i->select();
 		});
 
-		tile->statflags |= TILESTATE_SELECTED;
+		tile->statflags |= static_cast<uint16_t>(TileState::SELECTED);
 	}
 
 	void deselect(Tile* tile) {
@@ -258,7 +258,7 @@ namespace TileOperations {
 			i->deselect();
 		});
 
-		tile->statflags &= ~TILESTATE_SELECTED;
+		tile->statflags &= ~ static_cast<uint16_t>(TileState::SELECTED);
 	}
 
 	void selectGround(Tile* tile) {
@@ -274,7 +274,7 @@ namespace TileOperations {
 		}
 
 		if (selected_) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= static_cast<uint16_t>(TileState::SELECTED);
 		}
 	}
 
@@ -387,35 +387,35 @@ namespace TileOperations {
 	}
 
 	void update(Tile* tile) {
-		tile->statflags &= TILESTATE_MODIFIED;
+		tile->statflags &= static_cast<uint16_t>(TileState::MODIFIED);
 
 		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= static_cast<uint16_t>(TileState::SELECTED);
 		}
 		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= static_cast<uint16_t>(TileState::SELECTED);
 		}
 
 		tile->minimapColor = 0; // Reset to "no color" (valid)
 
 		if (tile->ground) {
 			if (tile->ground->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
+				tile->statflags |= static_cast<uint16_t>(TileState::SELECTED);
 			}
 			if (tile->ground->isBlocking()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= static_cast<uint16_t>(TileState::BLOCKING);
 			}
 			if (tile->ground->getUniqueID() != 0) {
-				tile->statflags |= TILESTATE_UNIQUE;
+				tile->statflags |= static_cast<uint16_t>(TileState::UNIQUE);
 			}
 			if (tile->ground->getMiniMapColor() != 0) {
 				tile->minimapColor = tile->ground->getMiniMapColor();
 			}
 			if (tile->ground->hasLight()) {
-				tile->statflags |= TILESTATE_HAS_LIGHT;
+				tile->statflags |= static_cast<uint16_t>(TileState::HAS_LIGHT);
 			}
 		} else {
-			tile->mapflags = TILESTATE_NONE;
+			tile->mapflags = TileState::NONE;
 			tile->house_id = 0;
 		}
 
@@ -423,9 +423,9 @@ namespace TileOperations {
 			UpdateItemFlags(i.get(), tile->statflags, tile->minimapColor);
 		});
 
-		if ((tile->statflags & TILESTATE_BLOCKING) == 0) {
+		if ((tile->statflags & static_cast<uint16_t>(TileState::BLOCKING)) == 0) {
 			if (tile->ground == nullptr && tile->items.empty()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= static_cast<uint16_t>(TileState::BLOCKING);
 			}
 		}
 	}

--- a/source/rendering/core/editor_sprite.cpp
+++ b/source/rendering/core/editor_sprite.cpp
@@ -6,8 +6,8 @@
 #include "rendering/core/editor_sprite.h"
 
 EditorSprite::EditorSprite(std::unique_ptr<wxBitmap> b16x16, std::unique_ptr<wxBitmap> b32x32) {
-	bm[SPRITE_SIZE_16x16] = std::move(b16x16);
-	bm[SPRITE_SIZE_32x32] = std::move(b32x32);
+	bm[SpriteSize::SPRITE_SIZE_16x16] = std::move(b16x16);
+	bm[SpriteSize::SPRITE_SIZE_32x32] = std::move(b32x32);
 }
 
 EditorSprite::~EditorSprite() {
@@ -23,6 +23,6 @@ void EditorSprite::DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int
 }
 
 void EditorSprite::unloadDC() {
-	bm[SPRITE_SIZE_16x16].reset();
-	bm[SPRITE_SIZE_32x32].reset();
+	bm[SpriteSize::SPRITE_SIZE_16x16].reset();
+	bm[SpriteSize::SPRITE_SIZE_32x32].reset();
 }

--- a/source/rendering/core/editor_sprite.h
+++ b/source/rendering/core/editor_sprite.h
@@ -20,7 +20,7 @@ public:
 	}
 
 protected:
-	std::unique_ptr<wxBitmap> bm[SPRITE_SIZE_COUNT];
+	std::unique_ptr<wxBitmap> bm[static_cast<int>(SpriteSize::SPRITE_SIZE_COUNT)];
 };
 
 #endif

--- a/source/rendering/core/game_sprite.cpp
+++ b/source/rendering/core/game_sprite.cpp
@@ -47,10 +47,10 @@ void CreatureSprite::unloadDC() {
 		key.lookMountLegs = outfit.lookMountLegs;
 		key.lookMountFeet = outfit.lookMountFeet;
 
-		key.size = SPRITE_SIZE_16x16;
+		key.size = SpriteSize::SPRITE_SIZE_16x16;
 		parent->colored_dc.erase(key);
 
-		key.size = SPRITE_SIZE_32x32;
+		key.size = SpriteSize::SPRITE_SIZE_32x32;
 		parent->colored_dc.erase(key);
 	}
 }
@@ -122,12 +122,12 @@ void GameSprite::clean(time_t time, int longevity) {
 }
 
 void GameSprite::unloadDC() {
-	dc[SPRITE_SIZE_16x16].reset();
-	dc[SPRITE_SIZE_32x32].reset();
-	dc[SPRITE_SIZE_64x64].reset();
-	bm[SPRITE_SIZE_16x16].reset();
-	bm[SPRITE_SIZE_32x32].reset();
-	bm[SPRITE_SIZE_64x64].reset();
+	dc[SpriteSize::SPRITE_SIZE_16x16].reset();
+	dc[SpriteSize::SPRITE_SIZE_32x32].reset();
+	dc[SpriteSize::SPRITE_SIZE_64x64].reset();
+	bm[SpriteSize::SPRITE_SIZE_16x16].reset();
+	bm[SpriteSize::SPRITE_SIZE_32x32].reset();
+	bm[SpriteSize::SPRITE_SIZE_64x64].reset();
 	colored_dc.clear();
 }
 
@@ -290,7 +290,7 @@ const AtlasRegion* GameSprite::getAtlasRegion(int _x, int _y, int _dir, int _add
 }
 
 wxMemoryDC* GameSprite::getDC(SpriteSize size) {
-	ASSERT(size == SPRITE_SIZE_16x16 || size == SPRITE_SIZE_32x32);
+	ASSERT(size == SpriteSize::SPRITE_SIZE_16x16 || size == SpriteSize::SPRITE_SIZE_32x32);
 
 	if (!dc[size]) {
 		wxBitmap bmp = SpriteIconGenerator::Generate(this, size);
@@ -304,7 +304,7 @@ wxMemoryDC* GameSprite::getDC(SpriteSize size) {
 }
 
 wxMemoryDC* GameSprite::getDC(SpriteSize size, const Outfit& outfit) {
-	ASSERT(size == SPRITE_SIZE_16x16 || size == SPRITE_SIZE_32x32);
+	ASSERT(size == SpriteSize::SPRITE_SIZE_16x16 || size == SpriteSize::SPRITE_SIZE_32x32);
 
 	RenderKey key;
 	key.size = size;
@@ -335,7 +335,7 @@ wxMemoryDC* GameSprite::getDC(SpriteSize size, const Outfit& outfit) {
 }
 
 void GameSprite::DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int width, int height) {
-	const int sprite_dim = (sz == SPRITE_SIZE_64x64) ? 64 : (sz == SPRITE_SIZE_32x32 ? 32 : 16);
+	const int sprite_dim = (sz == SpriteSize::SPRITE_SIZE_64x64) ? 64 : (sz == SpriteSize::SPRITE_SIZE_32x32 ? 32 : 16);
 	int src_width = sprite_dim;
 	int src_height = sprite_dim;
 
@@ -357,7 +357,7 @@ void GameSprite::DrawTo(wxDC* dc, SpriteSize sz, int start_x, int start_y, int w
 }
 
 void GameSprite::DrawTo(wxDC* dc, SpriteSize sz, const Outfit& outfit, int start_x, int start_y, int width, int height) {
-	const int sprite_dim = (sz == SPRITE_SIZE_64x64) ? 64 : (sz == SPRITE_SIZE_32x32 ? 32 : 16);
+	const int sprite_dim = (sz == SpriteSize::SPRITE_SIZE_64x64) ? 64 : (sz == SpriteSize::SPRITE_SIZE_32x32 ? 32 : 16);
 	int src_width = sprite_dim;
 	int src_height = sprite_dim;
 

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -25,7 +25,7 @@
 #include <wx/bitmap.h>
 #include <wx/dcmemory.h>
 
-enum SpriteSize {
+enum class SpriteSize : uint8_t {
 	SPRITE_SIZE_16x16,
 	// SPRITE_SIZE_24x24,
 	SPRITE_SIZE_32x32,
@@ -118,8 +118,8 @@ protected:
 	TemplateImage* getTemplateImage(int sprite_index, const Outfit& outfit);
 
 	uint32_t id;
-	std::unique_ptr<wxMemoryDC> dc[SPRITE_SIZE_COUNT];
-	std::unique_ptr<wxBitmap> bm[SPRITE_SIZE_COUNT];
+	std::unique_ptr<wxMemoryDC> dc[static_cast<int>(SpriteSize::SPRITE_SIZE_COUNT)];
+	std::unique_ptr<wxBitmap> bm[static_cast<int>(SpriteSize::SPRITE_SIZE_COUNT)];
 
 public:
 	// GameSprite info

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -80,14 +80,14 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							r /= 2;
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_PVPZONE) {
+						if (options.show_special_tiles && tile->getMapFlags() & static_cast<uint16_t>(TileState::PVPZONE)) {
 							r = r / 3 * 2;
 							b = r / 3 * 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+						if (options.show_special_tiles && tile->getMapFlags() & static_cast<uint16_t>(TileState::NOLOGOUT)) {
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOPVP) {
+						if (options.show_special_tiles && tile->getMapFlags() & static_cast<uint16_t>(TileState::NOPVP)) {
 							g /= 2;
 						}
 						if (tile->ground) {

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -65,16 +65,16 @@ void TileColorCalculator::Calculate(const Tile* tile, const DrawingOptions& opti
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_PVPZONE) {
+	if (showspecial && tile->getMapFlags() & static_cast<uint16_t>(TileState::PVPZONE)) {
 		g = r >> 2;
 		b = (b * 171) >> 8;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+	if (showspecial && tile->getMapFlags() & static_cast<uint16_t>(TileState::NOLOGOUT)) {
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOPVP) {
+	if (showspecial && tile->getMapFlags() & static_cast<uint16_t>(TileState::NOPVP)) {
 		g >>= 1;
 	}
 }

--- a/source/rendering/ui/popup_action_handler.cpp
+++ b/source/rendering/ui/popup_action_handler.cpp
@@ -33,7 +33,7 @@
 void PopupActionHandler::RotateItem(Editor& editor) {
 	Tile* tile = editor.selection.getSelectedTile();
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_ROTATE_ITEM);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_ROTATE_ITEM);
 
 	std::unique_ptr<Tile> new_tile(TileOperations::deepCopy(tile, editor.map));
 
@@ -62,7 +62,7 @@ void PopupActionHandler::GotoDestination(Editor& editor) {
 void PopupActionHandler::SwitchDoor(Editor& editor) {
 	Tile* tile = editor.selection.getSelectedTile();
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_SWITCHDOOR);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_SWITCHDOOR);
 
 	std::unique_ptr<Tile> new_tile(TileOperations::deepCopy(tile, editor.map));
 
@@ -93,7 +93,7 @@ void PopupActionHandler::BrowseTile(Editor& editor, int cursor_x, int cursor_y) 
 
 	int ret = w->ShowModal();
 	if (ret != 0) {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DELETE_TILES);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DELETE_TILES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor.addAction(std::move(action));
 	}
@@ -144,7 +144,7 @@ void PopupActionHandler::SelectMoveTo(Editor& editor) {
 
 	int ret = w->ShowModal();
 	if (ret != 0) {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor.addAction(std::move(action));
 

--- a/source/rendering/utilities/sprite_icon_generator.cpp
+++ b/source/rendering/utilities/sprite_icon_generator.cpp
@@ -52,11 +52,11 @@ wxBitmap SpriteIconGenerator::Generate(GameSprite* sprite, SpriteSize size, bool
 	}
 
 	// Now comes the resizing / antialiasing
-	if (rescale && (size == SPRITE_SIZE_16x16 || size == SPRITE_SIZE_64x64 || image.GetWidth() > SPRITE_PIXELS || image.GetHeight() > SPRITE_PIXELS)) {
+	if (rescale && (size == SpriteSize::SPRITE_SIZE_16x16 || size == SpriteSize::SPRITE_SIZE_64x64 || image.GetWidth() > SPRITE_PIXELS || image.GetHeight() > SPRITE_PIXELS)) {
 		int new_size = 32;
-		if (size == SPRITE_SIZE_16x16) {
+		if (size == SpriteSize::SPRITE_SIZE_16x16) {
 			new_size = 16;
-		} else if (size == SPRITE_SIZE_64x64) {
+		} else if (size == SpriteSize::SPRITE_SIZE_64x64) {
 			new_size = 64;
 		}
 		image.Rescale(new_size, new_size, wxIMAGE_QUALITY_HIGH);
@@ -189,11 +189,11 @@ wxBitmap SpriteIconGenerator::Generate(GameSprite* sprite, SpriteSize size, cons
 	}
 
 	// Now comes the resizing / antialiasing
-	if (rescale && (size == SPRITE_SIZE_16x16 || size == SPRITE_SIZE_64x64 || image.GetWidth() > SPRITE_PIXELS || image.GetHeight() > SPRITE_PIXELS)) {
+	if (rescale && (size == SpriteSize::SPRITE_SIZE_16x16 || size == SpriteSize::SPRITE_SIZE_64x64 || image.GetWidth() > SPRITE_PIXELS || image.GetHeight() > SPRITE_PIXELS)) {
 		int new_size = 32;
-		if (size == SPRITE_SIZE_16x16) {
+		if (size == SpriteSize::SPRITE_SIZE_16x16) {
 			new_size = 16;
-		} else if (size == SPRITE_SIZE_64x64) {
+		} else if (size == SpriteSize::SPRITE_SIZE_64x64) {
 			new_size = 64;
 		}
 		image.Rescale(new_size, new_size, wxIMAGE_QUALITY_HIGH);

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -199,9 +199,9 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
 	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & static_cast<uint16_t>(TileState::NOPVP))), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & static_cast<uint16_t>(TileState::NOLOGOUT))), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & static_cast<uint16_t>(TileState::PVPZONE))), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
 
 	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());

--- a/source/ui/dat_debug_view.cpp
+++ b/source/ui/dat_debug_view.cpp
@@ -56,7 +56,7 @@ DatDebugViewListBox::~DatDebugViewListBox() {
 
 void DatDebugViewListBox::OnDrawItem(wxDC& dc, const wxRect& rect, size_t n) const {
 	if (n < sprites.size()) {
-		sprites[n]->DrawTo(&dc, SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
+		sprites[n]->DrawTo(&dc, SpriteSize::SPRITE_SIZE_32x32, rect.GetX(), rect.GetY(), rect.GetWidth(), rect.GetHeight());
 	}
 
 	if (IsSelected(n)) {

--- a/source/ui/dialog_helper.cpp
+++ b/source/ui/dialog_helper.cpp
@@ -73,7 +73,7 @@ void DialogHelper::OpenProperties(Editor& editor, Tile* tile) {
 	if (w) {
 		int ret = w->ShowModal();
 		if (ret != 0) {
-			std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor.addAction(std::move(action));
 		}

--- a/source/ui/dialogs/outfit_preview_panel.cpp
+++ b/source/ui/dialogs/outfit_preview_panel.cpp
@@ -45,7 +45,7 @@ void OutfitPreviewPanel::OnPaint(wxPaintEvent& event) {
 			dir = WEST;
 		}
 
-		wxBitmap bmp = SpriteIconGenerator::Generate(spr, SPRITE_SIZE_32x32, draw_outfit, false, dir);
+		wxBitmap bmp = SpriteIconGenerator::Generate(spr, SpriteSize::SPRITE_SIZE_32x32, draw_outfit, false, dir);
 		if (bmp.IsOk()) {
 			std::unique_ptr<wxGraphicsContext> gc(wxGraphicsContext::Create(dc));
 			if (gc) {

--- a/source/ui/dialogs/outfit_selection_grid.cpp
+++ b/source/ui/dialogs/outfit_selection_grid.cpp
@@ -111,7 +111,7 @@ int OutfitSelectionGrid::GetOrCreateOutfitImage(NVGcontext* vg, int lookType, co
 		return 0;
 	}
 
-	wxBitmap bmp = SpriteIconGenerator::Generate(spr, SPRITE_SIZE_64x64, outfit);
+	wxBitmap bmp = SpriteIconGenerator::Generate(spr, SpriteSize::SPRITE_SIZE_64x64, outfit);
 	wxImage img = bmp.ConvertToImage();
 
 	if (!img.IsOk()) {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -59,13 +59,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -411,7 +411,7 @@ void ReplaceItemsDialog::OnExecuteButtonClicked(wxCommandEvent& WXUNUSED(event))
 		std::vector<std::pair<Tile*, Item*>>& result = finder.result;
 
 		if (!result.empty()) {
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_REPLACE_ITEMS);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_REPLACE_ITEMS);
 			for (const auto& [tile, itemToReplace] : result) {
 				std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(tile, editor->map);
 				int index = tile->getIndexOf(itemToReplace);

--- a/source/ui/tile_properties/browse_field_list.cpp
+++ b/source/ui/tile_properties/browse_field_list.cpp
@@ -243,7 +243,7 @@ void BrowseFieldList::OnClickUp(wxCommandEvent& event) {
 		std::swap(new_tile->items[index_in_items], new_tile->items[index_in_items - 1]);
 		new_tile->items[index_in_items - 1]->select();
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}
@@ -269,7 +269,7 @@ void BrowseFieldList::OnClickDown(wxCommandEvent& event) {
 		std::swap(new_tile->items[index_in_items], new_tile->items[index_in_items + 1]);
 		new_tile->items[index_in_items + 1]->select();
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}
@@ -304,7 +304,7 @@ void BrowseFieldList::OnClickDelete(wxCommandEvent& event) {
 			new_tile->items[0]->select();
 		}
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}

--- a/source/ui/tile_properties/container_property_panel.cpp
+++ b/source/ui/tile_properties/container_property_panel.cpp
@@ -128,7 +128,7 @@ void ContainerPropertyPanel::OnAddItem(wxCommandEvent& WXUNUSED(event)) {
 							contents.push_back(std::move(new_sub_item));
 						}
 
-						std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+						std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 						action->addChange(std::make_unique<Change>(std::move(new_tile)));
 						editor->addAction(std::move(action));
 					}
@@ -185,7 +185,7 @@ void ContainerPropertyPanel::OnEditItem(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	if (d->ShowModal() == wxID_OK) {
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 		// Selection change callback will trigger RebuildGrid
@@ -231,7 +231,7 @@ void ContainerPropertyPanel::OnRemoveItem(wxCommandEvent& WXUNUSED(event)) {
 			if (sub_index < contents.size()) {
 				contents.erase(contents.begin() + sub_index);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/creature_property_panel.cpp
+++ b/source/ui/tile_properties/creature_property_panel.cpp
@@ -84,7 +84,7 @@ void CreaturePropertyPanel::OnSpawnTimeChange(wxSpinEvent& event) {
 		if (new_tile->creature) {
 			new_tile->creature->setSpawnTime(spawntime_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -103,7 +103,7 @@ void CreaturePropertyPanel::OnDirectionChange(wxCommandEvent& event) {
 			int new_dir = (int)(intptr_t)direction_choice->GetClientData(direction_choice->GetSelection());
 			new_tile->creature->setDirection((Direction)new_dir);
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();

--- a/source/ui/tile_properties/depot_property_panel.cpp
+++ b/source/ui/tile_properties/depot_property_panel.cpp
@@ -86,7 +86,7 @@ void DepotPropertyPanel::OnDepotIdChange(wxCommandEvent& event) {
 				int new_depotid = (int)(intptr_t)depot_id_field->GetClientData(depot_id_field->GetSelection());
 				depot->setDepotID(new_depotid);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/door_property_panel.cpp
+++ b/source/ui/tile_properties/door_property_panel.cpp
@@ -63,7 +63,7 @@ void DoorPropertyPanel::OnDoorIdChange(wxSpinEvent& event) {
 				Door* door = static_cast<Door*>(new_item);
 				door->setDoorID(door_id_spin->GetValue());
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/item_property_panel.cpp
+++ b/source/ui/tile_properties/item_property_panel.cpp
@@ -154,7 +154,7 @@ void ItemPropertyPanel::OnActionIdChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setActionID(action_id_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -174,7 +174,7 @@ void ItemPropertyPanel::OnUniqueIdChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setUniqueID(unique_id_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -194,7 +194,7 @@ void ItemPropertyPanel::OnCountChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setSubtype(count_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -215,7 +215,7 @@ void ItemPropertyPanel::OnSplashTypeChange(wxCommandEvent& event) {
 			int new_type = (int)(intptr_t)splash_type_choice->GetClientData(splash_type_choice->GetSelection());
 			new_item->setSubtype(new_type);
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();
@@ -240,7 +240,7 @@ void ItemPropertyPanel::OnTextChange(wxEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setText(nstr(text_ctrl->GetValue()));
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}

--- a/source/ui/tile_properties/map_flags_panel.cpp
+++ b/source/ui/tile_properties/map_flags_panel.cpp
@@ -44,9 +44,9 @@ void MapFlagsPanel::SetTile(Tile* tile, Map* map) {
 
 	if (tile) {
 		chk_pz->SetValue(tile->isPZ());
-		chk_nopvp->SetValue(tile->getMapFlags() & TILESTATE_NOPVP);
-		chk_nologout->SetValue(tile->getMapFlags() & TILESTATE_NOLOGOUT);
-		chk_pvpzone->SetValue(tile->getMapFlags() & TILESTATE_PVPZONE);
+		chk_nopvp->SetValue(tile->getMapFlags() & static_cast<uint16_t>(TileState::NOPVP));
+		chk_nologout->SetValue(tile->getMapFlags() & static_cast<uint16_t>(TileState::NOLOGOUT));
+		chk_pvpzone->SetValue(tile->getMapFlags() & static_cast<uint16_t>(TileState::PVPZONE));
 
 		chk_pz->Enable(true);
 		chk_nopvp->Enable(true);
@@ -79,25 +79,25 @@ void MapFlagsPanel::OnToggleFlag(wxCommandEvent& event) {
 	new_tile->setPZ(chk_pz->GetValue());
 
 	if (chk_nopvp->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOPVP);
+		new_tile->setMapFlags(static_cast<uint16_t>(TileState::NOPVP));
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOPVP);
+		new_tile->unsetMapFlags(static_cast<uint16_t>(TileState::NOPVP));
 	}
 
 	if (chk_nologout->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->setMapFlags(static_cast<uint16_t>(TileState::NOLOGOUT));
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->unsetMapFlags(static_cast<uint16_t>(TileState::NOLOGOUT));
 	}
 
 	if (chk_pvpzone->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_PVPZONE);
+		new_tile->setMapFlags(static_cast<uint16_t>(TileState::PVPZONE));
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_PVPZONE);
+		new_tile->unsetMapFlags(static_cast<uint16_t>(TileState::PVPZONE));
 	}
 
 	Tile* old_ptr = new_tile.get();
-	std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+	std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 	action->addChange(std::make_unique<Change>(std::move(new_tile)));
 	editor->addAction(std::move(action));
 	current_tile = editor->map.getTile(old_ptr->getPosition());

--- a/source/ui/tile_properties/spawn_creature_panel.cpp
+++ b/source/ui/tile_properties/spawn_creature_panel.cpp
@@ -63,7 +63,7 @@ void SpawnCreaturePanel::SetTile(Tile* tile) {
 		creature_text->SetLabelText(wxString(tile->creature->getName()));
 		GameSprite* spr = g_gui.gfx.getCreatureSprite(tile->creature->getLookType().lookType);
 		if (spr) {
-			wxBitmap bmp = SpriteIconGenerator::Generate(spr, SPRITE_SIZE_32x32, tile->creature->getLookType(), false, SOUTH);
+			wxBitmap bmp = SpriteIconGenerator::Generate(spr, SpriteSize::SPRITE_SIZE_32x32, tile->creature->getLookType(), false, SOUTH);
 			creature_bitmap->SetBitmap(bmp);
 		} else {
 			creature_bitmap->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, FROM_DIP(this, wxSize(32, 32))));

--- a/source/ui/tile_properties/spawn_property_panel.cpp
+++ b/source/ui/tile_properties/spawn_property_panel.cpp
@@ -63,7 +63,7 @@ void SpawnPropertyPanel::OnRadiusChange(wxSpinEvent& event) {
 		if (new_tile->spawn) {
 			new_tile->spawn->setSize(radius_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();

--- a/source/ui/tile_properties/teleport_property_panel.cpp
+++ b/source/ui/tile_properties/teleport_property_panel.cpp
@@ -78,7 +78,7 @@ void TeleportPropertyPanel::OnDestChange(wxSpinEvent& event) {
 				Position dest(x_spin->GetValue(), y_spin->GetValue(), z_spin->GetValue());
 				teleport->setDestination(dest);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -247,10 +247,10 @@ void ToolOptionsSurface::DrawToolIcon(wxDC& dc, const ToolRect& tr) {
 
 		if (s) {
 			// Center the sprite in the rect
-			// Assuming 32x32 icon size for now, which matches SPRITE_SIZE_32x32 (32x32)
+			// Assuming 32x32 icon size for now, which matches SpriteSize::SPRITE_SIZE_32x32 (32x32)
 			int x_off = r.x + (r.width - 32) / 2;
 			int y_off = r.y + (r.height - 32) / 2;
-			s->DrawTo(&dc, SPRITE_SIZE_32x32, x_off, y_off);
+			s->DrawTo(&dc, SpriteSize::SPRITE_SIZE_32x32, x_off, y_off);
 		} else {
 			// Fallback text/color if no sprite
 			wxString label = tr.tooltip.Left(1);

--- a/source/util/nanovg_canvas.cpp
+++ b/source/util/nanovg_canvas.cpp
@@ -300,11 +300,11 @@ int NanoVGCanvas::CreateGenericSpriteTexture(NVGcontext* vg, Sprite* sprite, uin
 	int h = sz.y;
 
 	// Determine best SpriteSize for DrawTo
-	SpriteSize drawSize = SPRITE_SIZE_32x32;
+	SpriteSize drawSize = SpriteSize::SPRITE_SIZE_32x32;
 	if (w <= 16 && h <= 16) {
-		drawSize = SPRITE_SIZE_16x16;
+		drawSize = SpriteSize::SPRITE_SIZE_16x16;
 	} else if (w > 32 || h > 32) {
-		drawSize = SPRITE_SIZE_64x64;
+		drawSize = SpriteSize::SPRITE_SIZE_64x64;
 	}
 
 	wxBitmap bmp(w, h);


### PR DESCRIPTION
# Upgrader 🔄 - C++20 Modernization Specialist

Applying DOD, SRP, KISS, and DRY principles by modernizing unscoped C-style enums into strongly-typed C++11/20 `enum class`.

### Changes made
1. **`ChangeType`** (in `source/editor/action.h`): Upgraded from `enum` to `enum class ChangeType : uint8_t`. Updated all callers in `.cpp` implementations.
2. **`ActionIdentifier`** (in `source/editor/action.h`): Upgraded from `enum` to `enum class ActionIdentifier : uint8_t`. Updated all callers.
3. **`TileState`** (in `source/map/tile.h`): Converted the anonymous `TILESTATE_` bitmask enum into `enum class TileState : uint16_t`. Defined `constexpr` bitwise operators (`|`, `&`, `~`, `|=`, `&=`) for `TileState`. Used `static_cast<uint16_t>` inside internal `testFlags` and bitwise assignments to preserve API behavior.
4. **`SpriteSize`** (in `source/rendering/core/game_sprite.h`): Upgraded to `enum class SpriteSize : uint8_t` and updated array sizes using `static_cast<int>(SpriteSize::SPRITE_SIZE_COUNT)`.
5. **Macro cleanup**: Removed the legacy and unused `#define EVT_ON_UPDATE_MENUS` macro in `source/ui/gui.h`.

---
*PR created automatically by Jules for task [480936887902712597](https://jules.google.com/task/480936887902712597) started by @karolak6612*