### PR TITLE
🖥️ OpenGL: Fix glGetError handling by draining error queue

### DIFF
--- a/source/rendering/core/texture_atlas.cpp
+++ b/source/rendering/core/texture_atlas.cpp
@@ -117,17 +117,21 @@ bool TextureAtlas::addLayer() {
 
 		glTextureStorage3D(new_texture->GetID(), 1, GL_RGBA8, ATLAS_SIZE, ATLAS_SIZE, new_allocated);
 
-		GLenum err = glGetError();
-		if (err != GL_NO_ERROR) {
+		GLenum err;
+		bool has_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glTextureStorage3D failed during expansion (err={}). VRAM might be full.", err);
+			has_error = true;
+		}
+		if (has_error) {
 			return false;
 		}
 
 		// Copy existing layers using glCopyImageSubData (GL 4.3+)
 		glCopyImageSubData(texture_id_->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, new_texture->GetID(), GL_TEXTURE_2D_ARRAY, 0, 0, 0, 0, ATLAS_SIZE, ATLAS_SIZE, allocated_layers_);
 
-		err = glGetError();
-		if (err != GL_NO_ERROR) {
+		has_error = false;
+		while ((err = glGetError()) != GL_NO_ERROR) {
 			spdlog::error("TextureAtlas: glCopyImageSubData failed (err={}). Texture data lost!", err);
 			// We can't easily recover here, but at least we know why sprites are black.
 		}

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -160,9 +160,11 @@ void MinimapRenderer::resize(int width, int height) {
 	texture_id_ = std::make_unique<GLTextureResource>(GL_TEXTURE_2D_ARRAY);
 	glTextureStorage3D(texture_id_->GetID(), 1, GL_R8UI, TILE_SIZE, TILE_SIZE, num_layers);
 
-	GLenum error = glGetError();
-	if (error != GL_NO_ERROR) {
+	GLenum error;
+	bool has_error = false;
+	while ((error = glGetError()) != GL_NO_ERROR) {
 		spdlog::error("MinimapRenderer: FAILED to create texture array {}x{}x{}! Error: {}", TILE_SIZE, TILE_SIZE, num_layers, error);
+		has_error = true;
 	}
 
 	glTextureParameteri(texture_id_->GetID(), GL_TEXTURE_MIN_FILTER, GL_NEAREST);


### PR DESCRIPTION
Changed glGetError() calls in `minimap_renderer.cpp` and `texture_atlas.cpp` from single `if` checks to `while` loops that poll until `GL_NO_ERROR`. This ensures that all queued OpenGL errors are cleared accurately and appropriately mimics the recommended OpenGL practice.

---
*PR created automatically by Jules for task [14258745273013200613](https://jules.google.com/task/14258745273013200613) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for texture rendering operations to better detect and report issues, increasing graphics pipeline reliability and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->