### PR TITLE
🔧 WxFixer: Fix 12 wxWidgets violations in Replace Tool

### DIFF
--- a/source/ui/replace_tool/replace_tool_window.cpp
+++ b/source/ui/replace_tool/replace_tool_window.cpp
@@ -164,21 +164,21 @@ void ReplaceToolWindow::InitLayout() {
 	wxBoxSizer* manageBtnsSizer = new wxBoxSizer(wxHORIZONTAL);
 
 	m_addRuleBtn = new wxButton(actionsCard, wxID_ANY, "ADD", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
-	m_addRuleBtn->SetBackgroundColour(wxColour(40, 180, 40)); // Green
-	m_addRuleBtn->SetForegroundColour(*wxWHITE);
+	m_addRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, FromDIP(wxSize(16, 16))));
+	m_addRuleBtn->SetBackgroundColour(Theme::Get(Theme::Role::Success)); // Green
+	m_addRuleBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	m_addRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_editRuleBtn = new wxButton(actionsCard, wxID_ANY, "EDIT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
-	m_editRuleBtn->SetBackgroundColour(wxColour(80, 80, 80)); // Neutral Dark Gray
-	m_editRuleBtn->SetForegroundColour(*wxWHITE);
+	m_editRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, FromDIP(wxSize(16, 16))));
+	m_editRuleBtn->SetBackgroundColour(Theme::Get(Theme::Role::ButtonFace)); // Neutral Dark Gray
+	m_editRuleBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	m_editRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	m_deleteRuleBtn = new wxButton(actionsCard, wxID_ANY, "DEL", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
-	m_deleteRuleBtn->SetBackgroundColour(wxColour(180, 40, 40)); // Red
-	m_deleteRuleBtn->SetForegroundColour(*wxWHITE);
+	m_deleteRuleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, FromDIP(wxSize(16, 16))));
+	m_deleteRuleBtn->SetBackgroundColour(Theme::Get(Theme::Role::Error)); // Red
+	m_deleteRuleBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	m_deleteRuleBtn->SetFont(Theme::GetFont(9, true));
 
 	manageBtnsSizer->Add(m_addRuleBtn, wxSizerFlags(1).Border(wxRIGHT, 2));
@@ -188,16 +188,16 @@ void ReplaceToolWindow::InitLayout() {
 	actionsSizer->Add(manageBtnsSizer, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	m_addVisibleBtn = new wxButton(actionsCard, wxID_ANY, "ADD VISIBLE FROM VIEWPORT", wxDefaultPosition, FromDIP(wxSize(-1, 28)));
-	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, wxSize(16, 16)));
-	m_addVisibleBtn->SetBackgroundColour(wxColour(45, 120, 180)); // Sky Blue
-	m_addVisibleBtn->SetForegroundColour(*wxWHITE);
+	m_addVisibleBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS_SQUARE, FromDIP(wxSize(16, 16))));
+	m_addVisibleBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Sky Blue
+	m_addVisibleBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	m_addVisibleBtn->SetFont(Theme::GetFont(9, true));
 	actionsSizer->Add(m_addVisibleBtn, wxSizerFlags(0).Expand().Border(wxLEFT | wxRIGHT | wxBOTTOM, padding));
 
 	// Scope Selection
 	wxBoxSizer* scopeSizer = new wxBoxSizer(wxHORIZONTAL);
 	wxStaticText* scopeLabel = new wxStaticText(actionsCard, wxID_ANY, "SCOPE:");
-	scopeLabel->SetForegroundColour(wxColour(180, 180, 180));
+	scopeLabel->SetForegroundColour(Theme::Get(Theme::Role::TextSubtle));
 	scopeLabel->SetFont(Theme::GetFont(9, true));
 
 	wxArrayString scopes;
@@ -219,18 +219,18 @@ void ReplaceToolWindow::InitLayout() {
 
 	// Execute Button
 	m_executeBtn = new wxButton(actionsCard, wxID_ANY, "EXECUTE REPLACE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, wxSize(16, 16)));
+	m_executeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLAY, FromDIP(wxSize(16, 16))));
 	m_executeBtn->SetDefault();
 	m_executeBtn->SetBackgroundColour(Theme::Get(Theme::Role::Accent)); // Blue
-	m_executeBtn->SetForegroundColour(*wxWHITE);
+	m_executeBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	m_executeBtn->SetFont(Theme::GetFont(10, true));
 	actionsSizer->Add(m_executeBtn, wxSizerFlags(0).Expand().Border(wxALL, padding));
 
 	// Close Button
 	wxButton* closeBtn = new wxButton(actionsCard, wxID_ANY, "CLOSE", wxDefaultPosition, FromDIP(wxSize(-1, 32)));
-	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, wxSize(16, 16)));
-	closeBtn->SetBackgroundColour(wxColour(120, 120, 120)); // Gray
-	closeBtn->SetForegroundColour(*wxWHITE);
+	closeBtn->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_XMARK, FromDIP(wxSize(16, 16))));
+	closeBtn->SetBackgroundColour(Theme::Get(Theme::Role::ButtonFace)); // Gray
+	closeBtn->SetForegroundColour(Theme::Get(Theme::Role::TextOnAccent));
 	closeBtn->SetFont(Theme::GetFont(10, true));
 	actionsSizer->Add(closeBtn, wxSizerFlags(0).Expand().Border(wxALL, padding));
 

--- a/source/ui/replace_tool/rule_list_control.cpp
+++ b/source/ui/replace_tool/rule_list_control.cpp
@@ -211,8 +211,8 @@ void RuleListControl::OnContextMenu(wxContextMenuEvent& event) {
 	}
 
 	wxMenu menu;
-	menu.Append(wxID_EDIT, "Edit Name")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, wxSize(16, 16)));
-	menu.Append(wxID_DELETE, "Delete")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, wxSize(16, 16)));
+	menu.Append(wxID_EDIT, "Edit Name")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PEN_TO_SQUARE, FromDIP(wxSize(16, 16))));
+	menu.Append(wxID_DELETE, "Delete")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TRASH_CAN, FromDIP(wxSize(16, 16))));
 
 	menu.Bind(wxEVT_MENU, [this, menuIdx](wxCommandEvent& e) {
 		if (menuIdx < 0 || menuIdx >= (int)m_ruleSetNames.size()) {


### PR DESCRIPTION
Fixes various UI sizing and coloring violations in the Replace Tool UI components according to the `.jules/newagents/wxwidgets.md` guidelines.

---
*PR created automatically by Jules for task [5621188853927707592](https://jules.google.com/task/5621188853927707592) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced DPI awareness to improve appearance on high-resolution displays with better icon scaling.
  * Replaced hard-coded colors with theme-driven styling for consistent visual appearance throughout the replace tool.
  * Improved UI consistency across buttons and menu items for a more cohesive user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->