### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcuts, tooltips, and status feedback

### DIFF
--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -350,7 +350,7 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 		nvgFontFace(vg, "sans");
 		nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
 		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "Please enter your search string.", nullptr);
+		nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, "Please enter your search string (2+ chars).", nullptr);
 	} else {
 		ASSERT(n < brushlist.size());
 		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -39,11 +39,11 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxBoxSizer* options_box_sizer = newd wxBoxSizer(wxVERTICAL);
 
-	wxString radio_boxChoices[] = { "Find by Server ID",
-									"Find by Client ID",
-									"Find by Name",
-									"Find by Types",
-									"Find by Properties" };
+	wxString radio_boxChoices[] = { "Find by &Server ID",
+									"Find by &Client ID",
+									"Find by &Name",
+									"Find by &Types",
+									"Find by &Properties" };
 
 	int radio_boxNChoices = sizeof(radio_boxChoices) / sizeof(wxString);
 	options_radio_box = newd wxRadioBox(this, wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, radio_boxNChoices, radio_boxChoices, 1, wxRA_SPECIFY_COLS);
@@ -96,16 +96,16 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* type_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Types"), wxVERTICAL);
 
-	wxString types_choices[] = { "Depot",
-								 "Mailbox",
-								 "Trash Holder",
-								 "Container",
-								 "Door",
-								 "Magic Field",
-								 "Teleport",
-								 "Bed",
-								 "Key",
-								 "Podium" };
+	wxString types_choices[] = { "&Depot",
+								 "&Mailbox",
+								 "Trash &Holder",
+								 "&Container",
+								 "D&oor",
+								 "Magic &Field",
+								 "Tele&port",
+								 "Be&d",
+								 "&Key",
+								 "Podiu&m" };
 
 	int types_choices_count = sizeof(types_choices) / sizeof(wxString);
 	types_radio_box = newd wxRadioBox(type_box_sizer->GetStaticBox(), wxID_ANY, wxEmptyString, wxDefaultPosition, wxDefaultSize, types_choices_count, types_choices, 1, wxRA_SPECIFY_COLS);
@@ -119,65 +119,65 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* properties_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Properties"), wxVERTICAL);
 
-	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unpassable", wxDefaultPosition, wxDefaultSize, 0);
+	unpassable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "&Unpassable", wxDefaultPosition, wxDefaultSize, 0);
 	unpassable->SetToolTip("Item blocks movement");
 	properties_box_sizer->Add(unpassable, 0, wxALL, 5);
 
-	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Unmovable", wxDefaultPosition, wxDefaultSize, 0);
+	unmovable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Un&movable", wxDefaultPosition, wxDefaultSize, 0);
 	unmovable->SetToolTip("Item cannot be moved");
 	properties_box_sizer->Add(unmovable, 0, wxALL, 5);
 
-	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Missiles", wxDefaultPosition, wxDefaultSize, 0);
+	block_missiles = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block &Missiles", wxDefaultPosition, wxDefaultSize, 0);
 	block_missiles->SetToolTip("Item blocks projectiles");
 	properties_box_sizer->Add(block_missiles, 0, wxALL, 5);
 
-	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathfinder", wxDefaultPosition, wxDefaultSize, 0);
+	block_pathfinder = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Block Pathf&inder", wxDefaultPosition, wxDefaultSize, 0);
 	block_pathfinder->SetToolTip("Item blocks pathfinding");
 	properties_box_sizer->Add(block_pathfinder, 0, wxALL, 5);
 
-	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Readable", wxDefaultPosition, wxDefaultSize, 0);
+	readable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rea&dable", wxDefaultPosition, wxDefaultSize, 0);
 	readable->SetToolTip("Item has text");
 	properties_box_sizer->Add(readable, 0, wxALL, 5);
 
-	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writeable", wxDefaultPosition, wxDefaultSize, 0);
+	writeable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Writ&eable", wxDefaultPosition, wxDefaultSize, 0);
 	writeable->SetToolTip("Item can be written on");
 	properties_box_sizer->Add(writeable, 0, wxALL, 5);
 
-	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pickupable", wxDefaultPosition, wxDefaultSize, 0);
+	pickupable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Pick&upable", wxDefaultPosition, wxDefaultSize, 0);
 	pickupable->SetToolTip("Item can be picked up");
 	pickupable->SetValue(only_pickupables);
 	pickupable->Enable(!only_pickupables);
 	properties_box_sizer->Add(pickupable, 0, wxALL, 5);
 
-	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stackable", wxDefaultPosition, wxDefaultSize, 0);
+	stackable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Stac&kable", wxDefaultPosition, wxDefaultSize, 0);
 	stackable->SetToolTip("Item is stackable");
 	properties_box_sizer->Add(stackable, 0, wxALL, 5);
 
-	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Rotatable", wxDefaultPosition, wxDefaultSize, 0);
+	rotatable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "&Rotatable", wxDefaultPosition, wxDefaultSize, 0);
 	rotatable->SetToolTip("Item can be rotated");
 	properties_box_sizer->Add(rotatable, 0, wxALL, 5);
 
-	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hangable", wxDefaultPosition, wxDefaultSize, 0);
+	hangable = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Han&gable", wxDefaultPosition, wxDefaultSize, 0);
 	hangable->SetToolTip("Item can be hung on walls");
 	properties_box_sizer->Add(hangable, 0, wxALL, 5);
 
-	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook East", wxDefaultPosition, wxDefaultSize, 0);
+	hook_east = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook &East", wxDefaultPosition, wxDefaultSize, 0);
 	hook_east->SetToolTip("Item hooks to the east");
 	properties_box_sizer->Add(hook_east, 0, wxALL, 5);
 
-	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook South", wxDefaultPosition, wxDefaultSize, 0);
+	hook_south = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Hook &South", wxDefaultPosition, wxDefaultSize, 0);
 	hook_south->SetToolTip("Item hooks to the south");
 	properties_box_sizer->Add(hook_south, 0, wxALL, 5);
 
-	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Elevation", wxDefaultPosition, wxDefaultSize, 0);
+	has_elevation = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Has Ele&vation", wxDefaultPosition, wxDefaultSize, 0);
 	has_elevation->SetToolTip("Item has height (elevation)");
 	properties_box_sizer->Add(has_elevation, 0, wxALL, 5);
 
-	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore Look", wxDefaultPosition, wxDefaultSize, 0);
+	ignore_look = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Ignore &Look", wxDefaultPosition, wxDefaultSize, 0);
 	ignore_look->SetToolTip("Item is ignored when looking");
 	properties_box_sizer->Add(ignore_look, 0, wxALL, 5);
 
-	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Change", wxDefaultPosition, wxDefaultSize, 0);
+	floor_change = newd wxCheckBox(properties_box_sizer->GetStaticBox(), wxID_ANY, "Floor Chan&ge", wxDefaultPosition, wxDefaultSize, 0);
 	floor_change->SetToolTip("Item causes floor change");
 	properties_box_sizer->Add(floor_change, 0, wxALL, 5);
 

--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -153,49 +153,49 @@ void MapPopupMenu::Update() {
 				}
 
 				if (topCreature) {
-					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select &Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
 				}
 
 				if (topSpawn) {
-					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select S&pawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
+				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select &RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 
 				if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
-					Append(MAP_POPUP_MENU_MOVE_TO_TILESET, "Move To Tileset", "Move this item to any tileset")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHARE_FROM_SQUARE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_MOVE_TO_TILESET, "Move To &Tileset", "Move this item to any tileset")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SHARE_FROM_SQUARE, wxSize(16, 16)));
 				}
 
 				if (hasWall) {
-					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select &Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
 
 				if (hasCarpet) {
-					Append(MAP_POPUP_MENU_SELECT_CARPET_BRUSH, "Select Carpetbrush", "Uses the current item as a carpetbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_RUG, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_CARPET_BRUSH, "Select &Carpetbrush", "Uses the current item as a carpetbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_RUG, wxSize(16, 16)));
 				}
 
 				if (hasTable) {
-					Append(MAP_POPUP_MENU_SELECT_TABLE_BRUSH, "Select Tablebrush", "Uses the current item as a tablebrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TABLE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_TABLE_BRUSH, "Select &Tablebrush", "Uses the current item as a tablebrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TABLE, wxSize(16, 16)));
 				}
 
 				if (topSelectedItem && topSelectedItem->getDoodadBrush() && topSelectedItem->getDoodadBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_DOODAD_BRUSH, "Select Doodadbrush", "Use this doodad brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TREE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_DOODAD_BRUSH, "Select &Doodadbrush", "Use this doodad brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_TREE, wxSize(16, 16)));
 				}
 
 				if (topSelectedItem && topSelectedItem->isBrushDoor() && topSelectedItem->getDoorBrush()) {
-					Append(MAP_POPUP_MENU_SELECT_DOOR_BRUSH, "Select Doorbrush", "Use this door brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_DOOR_BRUSH, "Select D&oorbrush", "Use this door brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DOOR_CLOSED, wxSize(16, 16)));
 				}
 
 				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current item as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select &Groundbrush", "Uses the current item as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (hasCollection || topSelectedItem && topSelectedItem->hasCollectionBrush() || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
-					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select C&ollection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (tile->isHouseTile()) {
-					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select &House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
 				}
 
 				AppendSeparator();
@@ -203,27 +203,27 @@ void MapPopupMenu::Update() {
 			} else {
 
 				if (topCreature) {
-					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_CREATURE_BRUSH, "Select &Creature", "Uses the current creature as a creature brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DRAGON, wxSize(16, 16)));
 				}
 
 				if (topSpawn) {
-					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select Spawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_SPAWN_BRUSH, "Select S&pawn", "Select the spawn brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_FIRE, wxSize(16, 16)));
 				}
 
-				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
+				Append(MAP_POPUP_MENU_SELECT_RAW_BRUSH, "Select &RAW", "Uses the top item as a RAW brush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_CUBE, wxSize(16, 16)));
 				if (hasWall) {
-					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_WALL_BRUSH, "Select &Wallbrush", "Uses the current item as a wallbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_DUNGEON, wxSize(16, 16)));
 				}
 				if (tile->hasGround() && tile->getGroundBrush() && tile->getGroundBrush()->visibleInPalette()) {
-					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select Groundbrush", "Uses the current tile as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_GROUND_BRUSH, "Select &Groundbrush", "Uses the current tile as a groundbrush")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (hasCollection || tile->getGroundBrush() && tile->getGroundBrush()->hasCollection()) {
-					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select Collection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_COLLECTION_BRUSH, "Select C&ollection", "Use this collection")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LAYER_GROUP, wxSize(16, 16)));
 				}
 
 				if (tile->isHouseTile()) {
-					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_SELECT_HOUSE_BRUSH, "Select &House", "Draw with the house on this tile.")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_HOUSE, wxSize(16, 16)));
 				}
 
 				if (tile->hasGround() || topCreature || topSpawn) {
@@ -234,11 +234,11 @@ void MapPopupMenu::Update() {
 
 			AppendSeparator();
 
-			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "Browse Field", "Navigate from tile items");
+			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "&Browse Field", "Navigate from tile items");
 			browseTile->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
 			browseTile->Enable(anything_selected);
 
-			wxMenuItem* tileProps = Append(MAP_POPUP_MENU_TILE_PROPERTIES, "Tile Properties", "Show tile properties panel");
+			wxMenuItem* tileProps = Append(MAP_POPUP_MENU_TILE_PROPERTIES, "Tile &Properties", "Show tile properties panel");
 			tileProps->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LIST, wxSize(16, 16)));
 			tileProps->Enable(anything_selected);
 		}

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -393,11 +393,13 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 		} else if (interactables.preview_check_rect.Contains(m_hoverPos)) {
 			show_preview = !show_preview;
 			g_settings.setInteger(Config::SHOW_AUTOBORDER_PREVIEW, show_preview);
+			g_gui.SetStatusText(std::format("Preview Border: {}", show_preview ? "On" : "Off"));
 			Refresh();
 		} else if (interactables.lock_check_rect.Contains(m_hoverPos)) {
 			lock_doors = !lock_doors;
 			g_settings.setInteger(Config::DRAW_LOCKED_DOOR, lock_doors);
 			g_brush_manager.SetDoorLocked(lock_doors);
+			g_gui.SetStatusText(std::format("Lock Doors: {}", lock_doors ? "On" : "Off"));
 			Refresh();
 		} else if (hover_brush) {
 			SelectBrush(hover_brush);
@@ -449,10 +451,12 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 	// Hover states for checkboxes
 	if (interactables.preview_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_preview = true;
+		SetToolTip("Toggle automatic border preview");
 		hand_cursor = true;
 	}
 	if (interactables.lock_check_rect.Contains(m_hoverPos)) {
 		interactables.hover_lock = true;
+		SetToolTip("Toggle placing doors in a locked state (Shift)");
 		hand_cursor = true;
 	}
 

--- a/source/ui/toolbar/position_toolbar.cpp
+++ b/source/ui/toolbar/position_toolbar.cpp
@@ -20,17 +20,17 @@ PositionToolBar::PositionToolBar(wxWindow* parent) {
 	toolbar->SetToolBitmapSize(icon_size);
 
 	x_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_WIDTH, wxTE_PROCESS_ENTER, "X", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
-	x_control->SetToolTip("X Coordinate");
+	x_control->SetToolTip("X Coordinate (Tab to next)");
 
 	y_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_HEIGHT, wxTE_PROCESS_ENTER, "Y", wxDefaultPosition, FROM_DIP(parent, wxSize(60, 20)));
-	y_control->SetToolTip("Y Coordinate");
+	y_control->SetToolTip("Y Coordinate (Tab to next)");
 
 	z_control = newd NumberTextCtrl(toolbar, wxID_ANY, 0, 0, MAP_MAX_LAYER, wxTE_PROCESS_ENTER, "Z", wxDefaultPosition, FROM_DIP(parent, wxSize(35, 20)));
-	z_control->SetToolTip("Z Coordinate");
+	z_control->SetToolTip("Z Coordinate (Tab to next)");
 
 	go_button = newd wxButton(toolbar, TOOLBAR_POSITION_GO, wxEmptyString, wxDefaultPosition, parent->FromDIP(wxSize(22, 20)));
 	go_button->SetBitmap(go_bitmap);
-	go_button->SetToolTip("Go To Position");
+	go_button->SetToolTip("Go To Position (Enter)");
 
 	toolbar->AddControl(x_control);
 	toolbar->AddControl(y_control);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -116,6 +116,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 
 	auto* preferences_button = new StartupButton(header_panel, wxID_PREFERENCES, "Preferences", StartupButtonVariant::Secondary);
 	preferences_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(18, 18))));
+	preferences_button->SetToolTip("Open Preferences (Ctrl+P)");
 	preferences_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnPreferences, this);
 	header_sizer->Add(preferences_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(14));
 
@@ -130,11 +131,13 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	actions_card->SetMinSize(wxSize(FromDIP(170), -1));
 	auto* new_map_button = new StartupButton(actions_card, wxID_NEW, "New Map", StartupButtonVariant::Primary);
 	new_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(18, 18))));
+	new_map_button->SetToolTip("Create a new map (Ctrl+N)");
 	new_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnNewMap, this);
 	actions_card->GetBodySizer()->Add(new_map_button, 0, wxEXPAND | wxBOTTOM, FromDIP(10));
 
 	auto* browse_map_button = new StartupButton(actions_card, wxID_OPEN, "Browse Map", StartupButtonVariant::Secondary);
 	browse_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	browse_map_button->SetToolTip("Browse for an existing map (Ctrl+O)");
 	browse_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnBrowseMap, this);
 	actions_card->GetBodySizer()->Add(browse_map_button, 0, wxEXPAND);
 	content_sizer->Add(actions_card, 0, wxEXPAND | wxALL, FromDIP(10));
@@ -173,6 +176,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	auto* footer_left = new wxBoxSizer(wxHORIZONTAL);
 	auto* exit_button = new StartupButton(footer_panel, wxID_EXIT, "Exit", StartupButtonVariant::Secondary);
 	exit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(18, 18))));
+	exit_button->SetToolTip("Exit application (Alt+F4)");
 	exit_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnExit, this);
 	footer_left->Add(exit_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_left, 1, wxALIGN_CENTER_VERTICAL);
@@ -197,6 +201,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 
 	m_load_button = new StartupButton(footer_panel, ID_LOAD_BUTTON, "Load Map", StartupButtonVariant::Primary);
 	m_load_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	m_load_button->SetToolTip("Load selected map (Enter)");
 	m_load_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnLoadRequested, this);
 	footer_right->Add(m_load_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_right, 1, wxEXPAND);


### PR DESCRIPTION
This PR addresses UX polish tasks aligned with the "Palette" persona.
Key changes:
- Adds keyboard shortcut hints and interaction tips to various dialog tooltips.
- Leverages the status bar for more immediate state feedback.
- Uses `&` mnemonics in the context menu and find dialogs to improve accessibility.

---
*PR created automatically by Jules for task [7885479618629138214](https://jules.google.com/task/7885479618629138214) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added keyboard mnemonics to menu and dialog options for improved keyboard navigation.
  * Added tooltips throughout the interface displaying keyboard shortcuts and navigation hints.
  * Enhanced user feedback with status messages for preview and door settings changes.

* **Style**
  * Improved search input requirement messaging for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->