### PR TITLE
🎨 Palette: [UX improvement] Add keyboard shortcuts and UI feedback

### DIFF
--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -81,11 +81,11 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 	buttons_box_sizer = newd wxStdDialogButtonSizer();
 	ok_button = newd wxButton(this, wxID_OK);
 	ok_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_CHECK));
-	ok_button->SetToolTip("Select an item to confirm");
+	ok_button->SetToolTip("Select an item to confirm (Enter)");
 	buttons_box_sizer->AddButton(ok_button);
 	cancel_button = newd wxButton(this, wxID_CANCEL);
 	cancel_button->SetBitmap(IMAGE_MANAGER.GetBitmapBundle(ICON_XMARK));
-	cancel_button->SetToolTip("Cancel selection");
+	cancel_button->SetToolTip("Cancel selection (Esc)");
 	buttons_box_sizer->AddButton(cancel_button);
 	buttons_box_sizer->Realize();
 	options_box_sizer->Add(buttons_box_sizer, 0, wxALIGN_CENTER | wxALL, 5);
@@ -393,7 +393,7 @@ void FindItemDialog::RefreshContentsInternal() {
 	if (found_search_results) {
 		items_list->SetSelection(0);
 		ok_button->Enable(true);
-		ok_button->SetToolTip("Confirm selection");
+		ok_button->SetToolTip("Confirm selection (Enter)");
 	} else {
 		items_list->SetNoMatches();
 	}

--- a/source/ui/map_popup_menu.cpp
+++ b/source/ui/map_popup_menu.cpp
@@ -135,11 +135,11 @@ void MapPopupMenu::Update() {
 				if (topSelectedItem && (topSelectedItem->isBrushDoor() || topSelectedItem->isRoteable() || teleport)) {
 
 					if (topSelectedItem->isRoteable()) {
-						Append(MAP_POPUP_MENU_ROTATE, "&Rotate item", "Rotate this item")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ROTATE, wxSize(16, 16)));
+						Append(MAP_POPUP_MENU_ROTATE, "&Rotate item\tR", "Rotate this item")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ROTATE, wxSize(16, 16)));
 					}
 
 					if (teleport && teleport->hasDestination()) {
-						Append(MAP_POPUP_MENU_GOTO, "&Go To Destination", "Go to the destination of this teleport")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ARROW_RIGHT_TO_BRACKET, wxSize(16, 16)));
+						Append(MAP_POPUP_MENU_GOTO, "&Go To Destination\tG", "Go to the destination of this teleport")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_ARROW_RIGHT_TO_BRACKET, wxSize(16, 16)));
 					}
 
 					if (topSelectedItem->isDoor()) {
@@ -199,7 +199,7 @@ void MapPopupMenu::Update() {
 				}
 
 				AppendSeparator();
-				Append(MAP_POPUP_MENU_PROPERTIES, "&Properties", "Properties for the current object")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(16, 16)));
+				Append(MAP_POPUP_MENU_PROPERTIES, "&Properties\tALT+ENTER", "Properties for the current object")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(16, 16)));
 			} else {
 
 				if (topCreature) {
@@ -228,17 +228,17 @@ void MapPopupMenu::Update() {
 
 				if (tile->hasGround() || topCreature || topSpawn) {
 					AppendSeparator();
-					Append(MAP_POPUP_MENU_PROPERTIES, "&Properties", "Properties for the current object")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(16, 16)));
+					Append(MAP_POPUP_MENU_PROPERTIES, "&Properties\tALT+ENTER", "Properties for the current object")->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, wxSize(16, 16)));
 				}
 			}
 
 			AppendSeparator();
 
-			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "Browse Field", "Navigate from tile items");
+			wxMenuItem* browseTile = Append(MAP_POPUP_MENU_BROWSE_TILE, "Browse Field\tB", "Navigate from tile items");
 			browseTile->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_SEARCH, wxSize(16, 16)));
 			browseTile->Enable(anything_selected);
 
-			wxMenuItem* tileProps = Append(MAP_POPUP_MENU_TILE_PROPERTIES, "Tile Properties", "Show tile properties panel");
+			wxMenuItem* tileProps = Append(MAP_POPUP_MENU_TILE_PROPERTIES, "Tile Properties\tT", "Show tile properties panel");
 			tileProps->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_LIST, wxSize(16, 16)));
 			tileProps->Enable(anything_selected);
 		}

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -393,11 +393,13 @@ void ToolOptionsSurface::OnMouse(wxMouseEvent& evt) {
 		} else if (interactables.preview_check_rect.Contains(m_hoverPos)) {
 			show_preview = !show_preview;
 			g_settings.setInteger(Config::SHOW_AUTOBORDER_PREVIEW, show_preview);
+			g_gui.SetStatusText(std::format("Auto-border preview: {}", show_preview ? "ON" : "OFF"));
 			Refresh();
 		} else if (interactables.lock_check_rect.Contains(m_hoverPos)) {
 			lock_doors = !lock_doors;
 			g_settings.setInteger(Config::DRAW_LOCKED_DOOR, lock_doors);
 			g_brush_manager.SetDoorLocked(lock_doors);
+			g_gui.SetStatusText(std::format("Door lock: {}", lock_doors ? "ON" : "OFF"));
 			Refresh();
 		} else if (hover_brush) {
 			SelectBrush(hover_brush);

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -152,6 +152,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 
 	auto* preferences_button = new StartupButton(header_panel, wxID_PREFERENCES, "Preferences", StartupButtonVariant::Secondary);
 	preferences_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(18, 18))));
+	preferences_button->SetToolTip("Open preferences window (Ctrl+P)");
 	preferences_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnPreferences, this);
 	header_sizer->Add(preferences_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(14));
 
@@ -166,11 +167,13 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	actions_card->SetMinSize(wxSize(FromDIP(170), -1));
 	auto* new_map_button = new StartupButton(actions_card, wxID_NEW, "New Map", StartupButtonVariant::Primary);
 	new_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(18, 18))));
+	new_map_button->SetToolTip("Create a new map (Ctrl+N)");
 	new_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnNewMap, this);
 	actions_card->GetBodySizer()->Add(new_map_button, 0, wxEXPAND | wxBOTTOM, FromDIP(10));
 
 	auto* browse_map_button = new StartupButton(actions_card, wxID_OPEN, "Browse Map", StartupButtonVariant::Secondary);
 	browse_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	browse_map_button->SetToolTip("Browse for an existing map file (Ctrl+O)");
 	browse_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnBrowseMap, this);
 	actions_card->GetBodySizer()->Add(browse_map_button, 0, wxEXPAND);
 	content_sizer->Add(actions_card, 0, wxEXPAND | wxALL, FromDIP(10));
@@ -209,6 +212,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	auto* footer_left = new wxBoxSizer(wxHORIZONTAL);
 	auto* exit_button = new StartupButton(footer_panel, wxID_EXIT, "Exit", StartupButtonVariant::Secondary);
 	exit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(18, 18))));
+	exit_button->SetToolTip("Exit the application (Alt+F4)");
 	exit_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnExit, this);
 	footer_left->Add(exit_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_left, 1, wxALIGN_CENTER_VERTICAL);
@@ -228,11 +232,13 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	m_force_load_checkbox = new wxCheckBox(footer_panel, ID_FORCE_LOAD, "Force Load");
 	m_force_load_checkbox->SetForegroundColour(Theme::Get(Theme::Role::Text));
 	m_force_load_checkbox->SetBackgroundColour(footer_panel->GetBackgroundColour());
+	m_force_load_checkbox->SetToolTip("Force loading the map even if the client version does not match");
 	m_force_load_checkbox->Bind(wxEVT_CHECKBOX, &WelcomeDialog::OnForceLoadChanged, this);
 	footer_right->Add(m_force_load_checkbox, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
 
 	m_load_button = new StartupButton(footer_panel, ID_LOAD_BUTTON, "Load Map", StartupButtonVariant::Primary);
 	m_load_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	m_load_button->SetToolTip("Load the selected map (Enter)");
 	m_load_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnLoadRequested, this);
 	footer_right->Add(m_load_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_right, 1, wxEXPAND);


### PR DESCRIPTION
This change brings in a set of UX and accessibility polish based on the Palette agent instructions:
1.  Context Menus (`map_popup_menu.cpp`) now correctly show `\tHOTKEY` strings so users can see bindings like `Alt+Enter` for Properties or `R` for Rotate.
2.  Major buttons on standard dialogs (`welcome_dialog.cpp`, `find_item_window.cpp`) have been updated with tooltips that explicitly state the associated keyboard shortcut (e.g., `(Enter)`, `(Ctrl+N)`).
3.  Tool options checkboxes (`tool_options_surface.cpp`) now provide immediate visual feedback via `g_gui.SetStatusText` when activated by the user, explicitly displaying the toggled state in the application status bar.

---
*PR created automatically by Jules for task [11894165673481004974](https://jules.google.com/task/11894165673481004974) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Keyboard shortcuts now displayed in tooltips across multiple UI windows and dialogs, enhancing accessibility and feature discoverability
  * Map popup menu items now display keyboard accelerators for rapid access to common operations and functions
  * Tool options panel provides real-time status feedback when toggling settings and selecting different tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->