### PR TITLE
🔄 Upgrader: Modernize enums to enum class and cleanup classes

### DIFF
--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -30,25 +30,25 @@
 #include <ctime>
 
 Change::Change() :
-	type(CHANGE_NONE), data(std::monostate {}) {
+	type(ChangeType::CHANGE_NONE), data(std::monostate {}) {
 	////
 }
 
 Change::Change(std::unique_ptr<Tile> t) :
-	type(CHANGE_TILE), data(std::move(t)) {
+	type(ChangeType::CHANGE_TILE), data(std::move(t)) {
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
 Change* Change::Create(House* house, const Position& where) {
 	Change* c = newd Change();
-	c->type = CHANGE_MOVE_HOUSE_EXIT;
+	c->type = ChangeType::CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
 Change* Change::Create(Waypoint* wp, const Position& where) {
 	Change* c = newd Change();
-	c->type = CHANGE_MOVE_WAYPOINT;
+	c->type = ChangeType::CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;
 }
@@ -58,7 +58,7 @@ Change::~Change() {
 }
 
 void Change::clear() {
-	type = CHANGE_NONE;
+	type = ChangeType::CHANGE_NONE;
 	data = std::monostate {};
 }
 
@@ -120,7 +120,7 @@ void Action::commit(DirtyList* dirty_list) {
 	while (it != changes.end()) {
 		Change* c = it->get();
 		switch (c->type) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				auto& uptr = std::get<std::unique_ptr<Tile>>(c->data);
 				ASSERT(uptr);
 				Tile* newtile = uptr.get();
@@ -202,14 +202,14 @@ void Action::commit(DirtyList* dirty_list) {
 				newtile->modify();
 
 				// Update client dirty list
-				if (editor.live_manager.IsClient() && dirty_list && type != ACTION_REMOTE) {
+				if (editor.live_manager.IsClient() && dirty_list && type != ActionIdentifier::ACTION_REMOTE) {
 					// Local action, assemble changes
 					dirty_list->AddChange(c);
 				}
 				break;
 			}
 
-			case CHANGE_MOVE_HOUSE_EXIT: {
+			case ChangeType::CHANGE_MOVE_HOUSE_EXIT: {
 				auto& p = std::get<HouseExitChangeData>(c->data);
 				House* whathouse = editor.map.houses.getHouse(p.houseId);
 
@@ -221,7 +221,7 @@ void Action::commit(DirtyList* dirty_list) {
 				break;
 			}
 
-			case CHANGE_MOVE_WAYPOINT: {
+			case ChangeType::CHANGE_MOVE_WAYPOINT: {
 				auto& p = std::get<WaypointChangeData>(c->data);
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 
@@ -267,7 +267,7 @@ void Action::undo(DirtyList* dirty_list) {
 	while (it != changes.rend()) {
 		Change* c = it->get();
 		switch (c->type) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				auto& uptr = std::get<std::unique_ptr<Tile>>(c->data);
 				std::unique_ptr<Tile> old_uptr = std::move(uptr);
 				ASSERT(old_uptr);
@@ -331,14 +331,14 @@ void Action::undo(DirtyList* dirty_list) {
 				uptr = std::move(newtile_uptr);
 
 				// Update client dirty list
-				if (editor.live_manager.IsClient() && dirty_list && type != ACTION_REMOTE) {
+				if (editor.live_manager.IsClient() && dirty_list && type != ActionIdentifier::ACTION_REMOTE) {
 					// Local action, assemble changes
 					dirty_list->AddChange(c);
 				}
 				break;
 			}
 
-			case CHANGE_MOVE_HOUSE_EXIT: {
+			case ChangeType::CHANGE_MOVE_HOUSE_EXIT: {
 				auto& p = std::get<HouseExitChangeData>(c->data);
 				House* whathouse = editor.map.houses.getHouse(p.houseId);
 				if (whathouse) {
@@ -349,7 +349,7 @@ void Action::undo(DirtyList* dirty_list) {
 				break;
 			}
 
-			case CHANGE_MOVE_WAYPOINT: {
+			case ChangeType::CHANGE_MOVE_WAYPOINT: {
 				auto& p = std::get<WaypointChangeData>(c->data);
 				Waypoint* wp = editor.map.waypoints.getWaypoint(p.name);
 

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -38,7 +38,7 @@ class Action;
 class BatchAction;
 class ActionQueue;
 
-enum ChangeType {
+enum class ChangeType : uint8_t {
 	CHANGE_NONE,
 	CHANGE_TILE,
 	CHANGE_MOVE_HOUSE_EXIT,
@@ -87,7 +87,7 @@ using ChangeList = std::vector<std::unique_ptr<Change>>;
 
 class DirtyList;
 
-enum ActionIdentifier {
+enum class ActionIdentifier : uint8_t {
 	ACTION_MOVE,
 	ACTION_REMOTE,
 	ACTION_SELECT,

--- a/source/editor/action_queue.cpp
+++ b/source/editor/action_queue.cpp
@@ -70,7 +70,7 @@ void ActionQueue::addBatch(std::unique_ptr<BatchAction> batch, int stacking_dela
 		editor.notifyStateChange();
 	}
 
-	if (batch->getType() == ACTION_REMOTE) {
+	if (batch->getType() == ActionIdentifier::ACTION_REMOTE) {
 		return;
 	}
 

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -82,7 +82,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 	int item_count = 0;
 	buffer.copyPos = Position(0xFFFF, 0xFFFF, floor);
 
-	std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_CUT_TILES);
+	std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_CUT_TILES);
 	std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 	PositionList tilestoborder;
@@ -172,7 +172,7 @@ void CopyOperations::paste(Editor& editor, CopyBuffer& buffer, const Position& t
 		return;
 	}
 
-	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ACTION_PASTE_TILES);
+	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ActionIdentifier::ACTION_PASTE_TILES);
 	std::unique_ptr<Action> action = editor.actionQueue->createAction(batchAction.get());
 	for (TileLocation& location : *buffer.tiles) {
 		Tile* buffer_tile = location.get();

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -28,7 +28,7 @@
 namespace {
 
 	void drawDoodad(Editor& editor, DoodadBrush* brush, Position offset, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		BaseMap* buffer_map = g_doodad_preview.GetBufferMap();
 
@@ -126,7 +126,7 @@ namespace {
 
 	template <typename T>
 	void drawGroundOrEraserImpl(Editor& editor, T* brush, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		std::pair<bool, GroundBrush*> param_obj;
@@ -210,7 +210,7 @@ namespace {
 	}
 
 	void drawWall(Editor& editor, WallBrush* brush, const PositionVector& tilestodraw, PositionVector& tilestoborder, bool alt, bool dodraw) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		if (alt && dodraw) {
@@ -307,7 +307,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 			return;
 		}
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
 		batch->addAndCommitAction(std::move(action));
@@ -323,13 +323,13 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 			return;
 		}
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		// This will only occur with a size 0, when clicking on a tile (not drawing)
 		Tile* tile = editor.map.getTile(offset);
@@ -350,7 +350,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<SpawnBrush>() || brush->is<CreatureBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		Tile* tile = editor.map.getTile(offset);
@@ -388,7 +388,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, boo
 	}
 #endif
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DRAW);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DRAW);
 
 	if (brush->is<OptionalBorderBrush>()) {
 		// We actually need to do borders, but on the same tiles we draw to
@@ -451,7 +451,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 	} else if (brush->is<EraserBrush>()) {
 		drawGroundOrEraser(editor, brush->as<EraserBrush>(), tilestodraw, tilestoborder, alt, dodraw);
 	} else if (brush->is<TableBrush>() || brush->is<CarpetBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		for (const auto& drawPos : tilestodraw) {
@@ -499,7 +499,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 	} else if (brush->is<WallBrush>()) {
 		drawWall(editor, brush->as<WallBrush>(), tilestodraw, tilestoborder, alt, dodraw);
 	} else if (brush->is<DoorBrush>()) {
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 		DoorBrush* door_brush = brush->as<DoorBrush>();
 
@@ -546,7 +546,7 @@ void DrawOperations::draw(Editor& editor, const PositionVector& tilestodraw, Pos
 
 		editor.addBatch(std::move(batch), 2);
 	} else {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DRAW);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DRAW);
 		for (const auto& drawPos : tilestodraw) {
 			auto* location = editor.map.createTileL(drawPos);
 			auto* tile = location->get();

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -48,7 +48,7 @@ void SelectionOperations::borderizeSelection(Editor& editor) {
 		g_gui.SetStatusText("No items selected. Can't borderize.");
 	}
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_BORDERIZE);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_BORDERIZE);
 	for (Tile* tile : editor.selection) {
 		std::unique_ptr<Tile> newTile = TileOperations::deepCopy(tile, editor.map);
 		TileOperations::borderize(newTile.get(), &editor.map);
@@ -63,7 +63,7 @@ void SelectionOperations::randomizeSelection(Editor& editor) {
 		g_gui.SetStatusText("No items selected. Can't randomize.");
 	}
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_RANDOMIZE);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_RANDOMIZE);
 	for (Tile* tile : editor.selection) {
 		std::unique_ptr<Tile> newTile = TileOperations::deepCopy(tile, editor.map);
 		GroundBrush* groundBrush = newTile->getGroundBrush();
@@ -85,7 +85,7 @@ void SelectionOperations::randomizeSelection(Editor& editor) {
 }
 
 void SelectionOperations::moveSelection(Editor& editor, Position offset) {
-	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ACTION_MOVE); // Our saved action batch, for undo!
+	std::unique_ptr<BatchAction> batchAction = editor.actionQueue->createBatch(ActionIdentifier::ACTION_MOVE); // Our saved action batch, for undo!
 	std::unique_ptr<Action> action;
 
 	// Remove tiles from the map
@@ -341,7 +341,7 @@ void SelectionOperations::destroySelection(Editor& editor) {
 		int item_count = 0;
 		PositionList tilestoborder;
 
-		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DELETE_TILES);
+		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ActionIdentifier::ACTION_DELETE_TILES);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
 
 		for (Tile* tile : editor.selection) {

--- a/source/editor/selection.cpp
+++ b/source/editor/selection.cpp
@@ -351,9 +351,9 @@ void Selection::start(SessionFlags flags) {
 		if (flags & SUBTHREAD) {
 			;
 		} else {
-			session = std::move(editor.actionQueue->createBatch(ACTION_SELECT));
+			session = std::move(editor.actionQueue->createBatch(ActionIdentifier::ACTION_SELECT));
 		}
-		subsession = editor.actionQueue->createAction(ACTION_SELECT);
+		subsession = editor.actionQueue->createAction(ActionIdentifier::ACTION_SELECT);
 	} else {
 		deferred = true;
 		pending_adds.clear();
@@ -373,7 +373,7 @@ void Selection::commit() {
 		tmp->addAndCommitAction(std::move(subsession));
 
 		// Create a newd action for subsequent selects
-		subsession = editor.actionQueue->createAction(ACTION_SELECT);
+		subsession = editor.actionQueue->createAction(ActionIdentifier::ACTION_SELECT);
 		session = std::move(tmp);
 	}
 }

--- a/source/game/item_attributes.cpp
+++ b/source/game/item_attributes.cpp
@@ -168,19 +168,19 @@ ItemAttribute::ItemAttribute() :
 }
 
 ItemAttribute::ItemAttribute(const std::string& str) :
-	type(ItemAttribute::STRING), m_value(str) {
+	type(ItemAttribute::Type::STRING), m_value(str) {
 }
 
 ItemAttribute::ItemAttribute(int32_t i) :
-	type(ItemAttribute::INTEGER), m_value(i) {
+	type(ItemAttribute::Type::INTEGER), m_value(i) {
 }
 
 ItemAttribute::ItemAttribute(double f) :
-	type(ItemAttribute::DOUBLE), m_value(f) {
+	type(ItemAttribute::Type::DOUBLE), m_value(f) {
 }
 
 ItemAttribute::ItemAttribute(bool b) :
-	type(ItemAttribute::BOOLEAN), m_value(b) {
+	type(ItemAttribute::Type::BOOLEAN), m_value(b) {
 }
 
 ItemAttribute::ItemAttribute(const ItemAttribute& o) :
@@ -205,22 +205,22 @@ void ItemAttribute::clear() {
 }
 
 void ItemAttribute::set(const std::string& str) {
-	type = STRING;
+	type = Type::STRING;
 	m_value = str;
 }
 
 void ItemAttribute::set(int32_t i) {
-	type = INTEGER;
+	type = Type::INTEGER;
 	m_value = i;
 }
 
 void ItemAttribute::set(double y) {
-	type = DOUBLE;
+	type = Type::DOUBLE;
 	m_value = y;
 }
 
 void ItemAttribute::set(bool b) {
-	type = BOOLEAN;
+	type = Type::BOOLEAN;
 	m_value = b;
 }
 
@@ -290,7 +290,7 @@ bool ItemAttribute::unserialize(const IOMap& maphandle, BinaryNode* stream) {
 
 	// Read contents
 	switch (rtype) {
-		case STRING: {
+		case Type::STRING: {
 			std::string str;
 			if (!stream->getLongString(str)) {
 				return false;
@@ -298,7 +298,7 @@ bool ItemAttribute::unserialize(const IOMap& maphandle, BinaryNode* stream) {
 			set(str);
 			break;
 		}
-		case INTEGER: {
+		case Type::INTEGER: {
 			uint32_t u32;
 			if (!stream->getU32(u32)) {
 				return false;
@@ -307,7 +307,7 @@ bool ItemAttribute::unserialize(const IOMap& maphandle, BinaryNode* stream) {
 			set(static_cast<int32_t>(u32));
 			break;
 		}
-		case FLOAT: {
+		case Type::FLOAT: {
 			uint32_t u32;
 			if (!stream->getU32(u32)) {
 				return false;
@@ -318,7 +318,7 @@ bool ItemAttribute::unserialize(const IOMap& maphandle, BinaryNode* stream) {
 			set(static_cast<double>(f));
 			break;
 		}
-		case DOUBLE: {
+		case Type::DOUBLE: {
 			uint64_t u64;
 			if (!stream->getU64(u64)) {
 				return false;
@@ -329,7 +329,7 @@ bool ItemAttribute::unserialize(const IOMap& maphandle, BinaryNode* stream) {
 			set(d);
 			break;
 		}
-		case BOOLEAN: {
+		case Type::BOOLEAN: {
 			uint8_t b;
 			if (!stream->getU8(b)) {
 				return false;
@@ -349,20 +349,20 @@ void ItemAttribute::serialize(const IOMap& maphandle, NodeFileWriteHandle& f) co
 
 	// Write contents
 	switch (type) {
-		case STRING:
+		case Type::STRING:
 			f.addLongString(*getString());
 			break;
-		case INTEGER:
+		case Type::INTEGER:
 			f.addU32(static_cast<uint32_t>(*getInteger()));
 			break;
-		case DOUBLE: {
+		case Type::DOUBLE: {
 			double d = *getFloat();
 			uint64_t u64;
 			std::memcpy(&u64, &d, sizeof(double));
 			f.addU64(u64);
 			break;
 		}
-		case BOOLEAN:
+		case Type::BOOLEAN:
 			f.addU8(static_cast<uint8_t>(*getBoolean()));
 			break;
 		default:

--- a/source/game/item_attributes.h
+++ b/source/game/item_attributes.h
@@ -43,7 +43,7 @@ public:
 	ItemAttribute& operator=(const ItemAttribute& o);
 	~ItemAttribute();
 
-	enum Type {
+	enum class Type : uint8_t {
 		STRING = 1,
 		INTEGER = 2,
 		FLOAT = 3,

--- a/source/live/live_action.cpp
+++ b/source/live/live_action.cpp
@@ -58,7 +58,7 @@ void NetworkedBatchAction::addAndCommitAction(std::unique_ptr<Action> action) {
 	}
 
 	// Add it!
-	action->commit(type != (ActionIdentifier)ACTION_SELECT ? &dirty_list : nullptr);
+	action->commit(type != ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 	batch.push_back(std::move(action));
 	timestamp = time(nullptr);
 
@@ -73,7 +73,7 @@ void NetworkedBatchAction::commit() {
 	for (const auto& action_ptr : batch) {
 		NetworkedAction* action = static_cast<NetworkedAction*>(action_ptr.get());
 		if (!action->isCommited()) {
-			action->commit(type != ACTION_SELECT ? &dirty_list : nullptr);
+			action->commit(type != ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 			if (action->owner != 0) {
 				dirty_list.owner = action->owner;
 			}
@@ -88,7 +88,7 @@ void NetworkedBatchAction::undo() {
 	DirtyList dirty_list;
 
 	for (auto& action_ptr : std::ranges::reverse_view(batch)) {
-		action_ptr->undo(type != ACTION_SELECT ? &dirty_list : nullptr);
+		action_ptr->undo(type != ActionIdentifier::ACTION_SELECT ? &dirty_list : nullptr);
 	}
 	// Broadcast changes!
 	queue.broadcast(dirty_list);

--- a/source/live/live_client.cpp
+++ b/source/live/live_client.cpp
@@ -288,7 +288,7 @@ void LiveClient::sendChanges(DirtyList& dirtyList) {
 	mapWriter.reset();
 	for (const auto& change : changeList) {
 		switch (change->getType()) {
-			case CHANGE_TILE: {
+			case ChangeType::CHANGE_TILE: {
 				const Position& position = change->getTile()->getPosition();
 				sendTile(mapWriter, editor->map.getTile(position), &position);
 				break;
@@ -432,7 +432,7 @@ void LiveClient::parseNode(NetworkMessage& message) {
 	int32_t ndy = (ind >> 4) & 0x3FFF;
 	bool underground = ind & 1;
 
-	std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_REMOTE);
+	std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_REMOTE);
 	receiveNode(message, *editor, action.get(), ndx, ndy, underground);
 	editor->actionQueue->addAction(std::move(action));
 

--- a/source/live/live_peer.cpp
+++ b/source/live/live_peer.cpp
@@ -272,7 +272,7 @@ void LivePeer::parseReceiveChanges(NetworkMessage& message) {
 
 	// We need ownership of the action, but createAction returns unique_ptr.
 	// We'll move it into a temporary unique_ptr, get the raw pointer for metadata, then move to queue.
-	std::unique_ptr<Action> rawAction = editor.actionQueue->createAction(ACTION_REMOTE);
+	std::unique_ptr<Action> rawAction = editor.actionQueue->createAction(ActionIdentifier::ACTION_REMOTE);
 	NetworkedAction* action = static_cast<NetworkedAction*>(rawAction.get());
 	action->owner = clientId;
 

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -58,9 +58,7 @@ enum {
 	TILESTATE_HAS_LIGHT = 0x0200,
 };
 
-enum : uint8_t {
-	INVALID_MINIMAP_COLOR = 0xFF
-};
+constexpr uint8_t INVALID_MINIMAP_COLOR = 0xFF;
 
 class Tile {
 public: // Members

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -45,9 +45,8 @@ public:
 	virtual void unloadDC() = 0;
 	virtual wxSize GetSize() const = 0;
 
-private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
+Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
 };
 
 class GameSprite;

--- a/source/rendering/ui/popup_action_handler.cpp
+++ b/source/rendering/ui/popup_action_handler.cpp
@@ -33,7 +33,7 @@
 void PopupActionHandler::RotateItem(Editor& editor) {
 	Tile* tile = editor.selection.getSelectedTile();
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_ROTATE_ITEM);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_ROTATE_ITEM);
 
 	std::unique_ptr<Tile> new_tile(TileOperations::deepCopy(tile, editor.map));
 
@@ -62,7 +62,7 @@ void PopupActionHandler::GotoDestination(Editor& editor) {
 void PopupActionHandler::SwitchDoor(Editor& editor) {
 	Tile* tile = editor.selection.getSelectedTile();
 
-	std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_SWITCHDOOR);
+	std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_SWITCHDOOR);
 
 	std::unique_ptr<Tile> new_tile(TileOperations::deepCopy(tile, editor.map));
 
@@ -93,7 +93,7 @@ void PopupActionHandler::BrowseTile(Editor& editor, int cursor_x, int cursor_y) 
 
 	int ret = w->ShowModal();
 	if (ret != 0) {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_DELETE_TILES);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_DELETE_TILES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor.addAction(std::move(action));
 	}
@@ -144,7 +144,7 @@ void PopupActionHandler::SelectMoveTo(Editor& editor) {
 
 	int ret = w->ShowModal();
 	if (ret != 0) {
-		std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor.addAction(std::move(action));
 

--- a/source/ui/dialog_helper.cpp
+++ b/source/ui/dialog_helper.cpp
@@ -73,7 +73,7 @@ void DialogHelper::OpenProperties(Editor& editor, Tile* tile) {
 	if (w) {
 		int ret = w->ShowModal();
 		if (ret != 0) {
-			std::unique_ptr<Action> action = editor.actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor.actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor.addAction(std::move(action));
 		}

--- a/source/ui/properties/attribute_service.cpp
+++ b/source/ui/properties/attribute_service.cpp
@@ -15,19 +15,19 @@ void AttributeService::setGridValue(wxGrid* grid, int rowIndex, const std::strin
 
 	grid->SetCellValue(rowIndex, 0, label);
 	switch (attr.type) {
-		case ItemAttribute::STRING: {
+		case ItemAttribute::Type::STRING: {
 			grid->SetCellValue(rowIndex, 1, "String");
 			grid->SetCellValue(rowIndex, 2, wxstr(*attr.getString()));
 			break;
 		}
-		case ItemAttribute::INTEGER: {
+		case ItemAttribute::Type::INTEGER: {
 			grid->SetCellValue(rowIndex, 1, "Number");
 			grid->SetCellValue(rowIndex, 2, i2ws(*attr.getInteger()));
 			grid->SetCellEditor(rowIndex, 2, new wxGridCellNumberEditor);
 			break;
 		}
-		case ItemAttribute::DOUBLE:
-		case ItemAttribute::FLOAT: {
+		case ItemAttribute::Type::DOUBLE:
+		case ItemAttribute::Type::FLOAT: {
 			grid->SetCellValue(rowIndex, 1, "Float");
 			wxString f;
 			f << *attr.getFloat();
@@ -35,7 +35,7 @@ void AttributeService::setGridValue(wxGrid* grid, int rowIndex, const std::strin
 			grid->SetCellEditor(rowIndex, 2, new wxGridCellFloatEditor);
 			break;
 		}
-		case ItemAttribute::BOOLEAN: {
+		case ItemAttribute::Type::BOOLEAN: {
 			grid->SetCellValue(rowIndex, 1, "Boolean");
 			grid->SetCellValue(rowIndex, 2, *attr.getBoolean() ? "1" : "");
 			grid->SetCellRenderer(rowIndex, 2, new wxGridCellBoolRenderer);

--- a/source/ui/replace_items_window.cpp
+++ b/source/ui/replace_items_window.cpp
@@ -411,7 +411,7 @@ void ReplaceItemsDialog::OnExecuteButtonClicked(wxCommandEvent& WXUNUSED(event))
 		std::vector<std::pair<Tile*, Item*>>& result = finder.result;
 
 		if (!result.empty()) {
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_REPLACE_ITEMS);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_REPLACE_ITEMS);
 			for (const auto& [tile, itemToReplace] : result) {
 				std::unique_ptr<Tile> new_tile = TileOperations::deepCopy(tile, editor->map);
 				int index = tile->getIndexOf(itemToReplace);

--- a/source/ui/tile_properties/browse_field_list.cpp
+++ b/source/ui/tile_properties/browse_field_list.cpp
@@ -243,7 +243,7 @@ void BrowseFieldList::OnClickUp(wxCommandEvent& event) {
 		std::swap(new_tile->items[index_in_items], new_tile->items[index_in_items - 1]);
 		new_tile->items[index_in_items - 1]->select();
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}
@@ -269,7 +269,7 @@ void BrowseFieldList::OnClickDown(wxCommandEvent& event) {
 		std::swap(new_tile->items[index_in_items], new_tile->items[index_in_items + 1]);
 		new_tile->items[index_in_items + 1]->select();
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}
@@ -304,7 +304,7 @@ void BrowseFieldList::OnClickDelete(wxCommandEvent& event) {
 			new_tile->items[0]->select();
 		}
 
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 	}

--- a/source/ui/tile_properties/container_property_panel.cpp
+++ b/source/ui/tile_properties/container_property_panel.cpp
@@ -128,7 +128,7 @@ void ContainerPropertyPanel::OnAddItem(wxCommandEvent& WXUNUSED(event)) {
 							contents.push_back(std::move(new_sub_item));
 						}
 
-						std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+						std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 						action->addChange(std::make_unique<Change>(std::move(new_tile)));
 						editor->addAction(std::move(action));
 					}
@@ -185,7 +185,7 @@ void ContainerPropertyPanel::OnEditItem(wxCommandEvent& WXUNUSED(event)) {
 	}
 
 	if (d->ShowModal() == wxID_OK) {
-		std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+		std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 		action->addChange(std::make_unique<Change>(std::move(new_tile)));
 		editor->addAction(std::move(action));
 		// Selection change callback will trigger RebuildGrid
@@ -231,7 +231,7 @@ void ContainerPropertyPanel::OnRemoveItem(wxCommandEvent& WXUNUSED(event)) {
 			if (sub_index < contents.size()) {
 				contents.erase(contents.begin() + sub_index);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/creature_property_panel.cpp
+++ b/source/ui/tile_properties/creature_property_panel.cpp
@@ -84,7 +84,7 @@ void CreaturePropertyPanel::OnSpawnTimeChange(wxSpinEvent& event) {
 		if (new_tile->creature) {
 			new_tile->creature->setSpawnTime(spawntime_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -103,7 +103,7 @@ void CreaturePropertyPanel::OnDirectionChange(wxCommandEvent& event) {
 			int new_dir = (int)(intptr_t)direction_choice->GetClientData(direction_choice->GetSelection());
 			new_tile->creature->setDirection((Direction)new_dir);
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();

--- a/source/ui/tile_properties/depot_property_panel.cpp
+++ b/source/ui/tile_properties/depot_property_panel.cpp
@@ -86,7 +86,7 @@ void DepotPropertyPanel::OnDepotIdChange(wxCommandEvent& event) {
 				int new_depotid = (int)(intptr_t)depot_id_field->GetClientData(depot_id_field->GetSelection());
 				depot->setDepotID(new_depotid);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/door_property_panel.cpp
+++ b/source/ui/tile_properties/door_property_panel.cpp
@@ -63,7 +63,7 @@ void DoorPropertyPanel::OnDoorIdChange(wxSpinEvent& event) {
 				Door* door = static_cast<Door*>(new_item);
 				door->setDoorID(door_id_spin->GetValue());
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}

--- a/source/ui/tile_properties/item_property_panel.cpp
+++ b/source/ui/tile_properties/item_property_panel.cpp
@@ -154,7 +154,7 @@ void ItemPropertyPanel::OnActionIdChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setActionID(action_id_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -174,7 +174,7 @@ void ItemPropertyPanel::OnUniqueIdChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setUniqueID(unique_id_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -194,7 +194,7 @@ void ItemPropertyPanel::OnCountChange(wxSpinEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setSubtype(count_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}
@@ -215,7 +215,7 @@ void ItemPropertyPanel::OnSplashTypeChange(wxCommandEvent& event) {
 			int new_type = (int)(intptr_t)splash_type_choice->GetClientData(splash_type_choice->GetSelection());
 			new_item->setSubtype(new_type);
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();
@@ -240,7 +240,7 @@ void ItemPropertyPanel::OnTextChange(wxEvent& event) {
 			Item* new_item = new_tile->getItemAt(index);
 			new_item->setText(nstr(text_ctrl->GetValue()));
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 		}

--- a/source/ui/tile_properties/map_flags_panel.cpp
+++ b/source/ui/tile_properties/map_flags_panel.cpp
@@ -97,7 +97,7 @@ void MapFlagsPanel::OnToggleFlag(wxCommandEvent& event) {
 	}
 
 	Tile* old_ptr = new_tile.get();
-	std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+	std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 	action->addChange(std::make_unique<Change>(std::move(new_tile)));
 	editor->addAction(std::move(action));
 	current_tile = editor->map.getTile(old_ptr->getPosition());

--- a/source/ui/tile_properties/spawn_property_panel.cpp
+++ b/source/ui/tile_properties/spawn_property_panel.cpp
@@ -63,7 +63,7 @@ void SpawnPropertyPanel::OnRadiusChange(wxSpinEvent& event) {
 		if (new_tile->spawn) {
 			new_tile->spawn->setSize(radius_spin->GetValue());
 
-			std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+			std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 			action->addChange(std::make_unique<Change>(std::move(new_tile)));
 			editor->addAction(std::move(action));
 			g_gui.RefreshView();

--- a/source/ui/tile_properties/teleport_property_panel.cpp
+++ b/source/ui/tile_properties/teleport_property_panel.cpp
@@ -78,7 +78,7 @@ void TeleportPropertyPanel::OnDestChange(wxSpinEvent& event) {
 				Position dest(x_spin->GetValue(), y_spin->GetValue(), z_spin->GetValue());
 				teleport->setDestination(dest);
 
-				std::unique_ptr<Action> action = editor->actionQueue->createAction(ACTION_CHANGE_PROPERTIES);
+				std::unique_ptr<Action> action = editor->actionQueue->createAction(ActionIdentifier::ACTION_CHANGE_PROPERTIES);
 				action->addChange(std::make_unique<Change>(std::move(new_tile)));
 				editor->addAction(std::move(action));
 			}


### PR DESCRIPTION
Autonomously ran Upgrader.md to identify new modernization opportunities in the codebase and executed 4 targeted refactors.
- Refactored enums ChangeType and ActionIdentifier in `source/editor/action.h` to `enum class` and updated all relevant occurrences.
- Refactored `ItemAttribute::Type` in `source/game/item_attributes.h` to `enum class` and updated all usages.
- Replaced the legacy `INVALID_MINIMAP_COLOR` `enum` in `source/map/tile.h` with `constexpr uint8_t`.
- Modernized the `Sprite` base class by using explicit `= delete` instead of the old-style private, unimplemented copy ctor/assignment declarations.

---
*PR created automatically by Jules for task [14496467642945988999](https://jules.google.com/task/14496467642945988999) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved type safety by converting internal enumerations to scoped enums with explicit underlying types across action and change handling systems.
  * Updated all related code references to use the new type-safe enum structure.

*Note: No user-facing changes in this release.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->