### PR TITLE
👃 Smeller: Fix unnamed overlapping enum smell in map/tile.h

### DIFF
--- a/source/brushes/brush.cpp
+++ b/source/brushes/brush.cpp
@@ -95,10 +95,10 @@ void Brushes::init() {
 	addManagedBrush(g_brush_manager.house_exit_brush);
 	addManagedBrush(g_brush_manager.waypoint_brush);
 
-	addManagedBrush(g_brush_manager.pz_brush, TILESTATE_PROTECTIONZONE);
-	addManagedBrush(g_brush_manager.rook_brush, TILESTATE_NOPVP);
-	addManagedBrush(g_brush_manager.nolog_brush, TILESTATE_NOLOGOUT);
-	addManagedBrush(g_brush_manager.pvp_brush, TILESTATE_PVPZONE);
+	addManagedBrush(g_brush_manager.pz_brush, TileMapFlag::ProtectionZone);
+	addManagedBrush(g_brush_manager.rook_brush, TileMapFlag::NoPvp);
+	addManagedBrush(g_brush_manager.nolog_brush, TileMapFlag::NoLogout);
+	addManagedBrush(g_brush_manager.pvp_brush, TileMapFlag::PvpZone);
 
 	GroundBrush::init();
 	WallBrush::init();

--- a/source/brushes/doodad/doodad_brush_loader.cpp
+++ b/source/brushes/doodad/doodad_brush_loader.cpp
@@ -68,7 +68,7 @@ bool DoodadBrushLoader::load(pugi::xml_node node, DoodadBrushItems& items, Dooda
 		if (!settings.do_new_borders) {
 			warnings.push_back("remove_optional_border will not work without redo_borders\n");
 		}
-		settings.clear_statflags |= TILESTATE_OP_BORDER;
+		settings.clear_statflags |= TileStatFlag::OpBorder;
 	}
 
 	const std::string& thicknessString = node.attribute("thickness").as_string();

--- a/source/brushes/doodad/doodad_brush_types.h
+++ b/source/brushes/doodad/doodad_brush_types.h
@@ -23,8 +23,8 @@ struct DoodadBrushSettings {
 	bool do_new_borders = false;
 	bool one_size = false;
 	bool draggable = false;
-	uint16_t clear_mapflags = 0;
-	uint16_t clear_statflags = 0;
+	TileMapFlag clear_mapflags = TileMapFlag::None;
+	TileStatFlag clear_statflags = TileStatFlag::None;
 	int thickness = 0;
 	int thickness_ceiling = 0;
 	uint16_t look_id = 0;

--- a/source/brushes/flag/flag_brush.cpp
+++ b/source/brushes/flag/flag_brush.cpp
@@ -19,10 +19,10 @@ FlagBrush::FlagBrush(uint32_t flag) :
 }
 
 std::string FlagBrush::getName() const {
-	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { TILESTATE_PROTECTIONZONE, "PZ brush (0x01)" },
-																						  { TILESTATE_NOPVP, "No combat zone brush (0x04)" },
-																						  { TILESTATE_NOLOGOUT, "No logout zone brush (0x08)" },
-																						  { TILESTATE_PVPZONE, "PVP Zone brush (0x10)" } } };
+	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { TileMapFlag::ProtectionZone, "PZ brush (0x01)" },
+																						  { TileMapFlag::NoPvp, "No combat zone brush (0x04)" },
+																						  { TileMapFlag::NoLogout, "No logout zone brush (0x08)" },
+																						  { TileMapFlag::PvpZone, "PVP Zone brush (0x10)" } } };
 
 	auto it = std::ranges::find_if(flagNames, [this](const auto& p) { return p.first == flag; });
 	if (it != flagNames.end()) {
@@ -32,10 +32,10 @@ std::string FlagBrush::getName() const {
 }
 
 int FlagBrush::getLookID() const {
-	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { TILESTATE_PROTECTIONZONE, EDITOR_SPRITE_PZ_TOOL },
-																			   { TILESTATE_NOPVP, EDITOR_SPRITE_NOPVP_TOOL },
-																			   { TILESTATE_NOLOGOUT, EDITOR_SPRITE_NOLOG_TOOL },
-																			   { TILESTATE_PVPZONE, EDITOR_SPRITE_PVPZ_TOOL } } };
+	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { TileMapFlag::ProtectionZone, EDITOR_SPRITE_PZ_TOOL },
+																			   { TileMapFlag::NoPvp, EDITOR_SPRITE_NOPVP_TOOL },
+																			   { TileMapFlag::NoLogout, EDITOR_SPRITE_NOLOG_TOOL },
+																			   { TileMapFlag::PvpZone, EDITOR_SPRITE_PVPZ_TOOL } } };
 
 	auto it = std::ranges::find_if(flagSprites, [this](const auto& p) { return p.first == flag; });
 	if (it != flagSprites.end()) {

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -97,7 +97,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 			copied_tile->house_id = newtile->house_id;
 			newtile->house_id = 0;
 			copied_tile->setMapFlags(tile->getMapFlags());
-			newtile->setMapFlags(TILESTATE_NONE);
+			newtile->setMapFlags(TileMapFlag::None);
 		}
 
 		auto tile_selection = TileOperations::popSelectedItems(newtile.get());

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -123,7 +123,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 			tmp_storage_tile->house_id = new_src_tile->house_id;
 			new_src_tile->house_id = 0;
 			tmp_storage_tile->setMapFlags(new_src_tile->getMapFlags());
-			new_src_tile->setMapFlags(TILESTATE_NONE);
+			new_src_tile->setMapFlags(TileMapFlag::None);
 			doborders = true;
 		}
 

--- a/source/io/otbm/tile_serialization_otbm.cpp
+++ b/source/io/otbm/tile_serialization_otbm.cpp
@@ -196,9 +196,9 @@ void TileSerializationOTBM::serializeTile(const IOMapOTBM& iomap, const Tile* sa
 		f.addU32(save_tile->getHouseID());
 	}
 
-	if (save_tile->getMapFlags()) {
+	if (save_tile->getMapFlags() != TileMapFlag::None) {
 		f.addU8(OTBM_ATTR_TILE_FLAGS);
-		f.addU32(save_tile->getMapFlags());
+		f.addU32(static_cast<uint32_t>(save_tile->getMapFlags()));
 	}
 
 	if (save_tile->ground) {

--- a/source/live/live_socket.cpp
+++ b/source/live/live_socket.cpp
@@ -246,9 +246,9 @@ void LiveSocket::sendTile(MemoryNodeFileWriteHandle& writer, Tile* tile, const P
 		writer.addU32(tile->getHouseID());
 	}
 
-	if (tile->getMapFlags()) {
+	if (tile->getMapFlags() != TileMapFlag::None) {
 		writer.addByte(OTBM_ATTR_TILE_FLAGS);
-		writer.addU32(tile->getMapFlags());
+		writer.addU32(static_cast<uint32_t>(tile->getMapFlags()));
 	}
 
 	Item* ground = tile->ground.get();

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -43,8 +43,8 @@ Tile::Tile(int x, int y, int z) :
 	location(nullptr),
 	ground(nullptr),
 	house_id(0),
-	mapflags(0),
-	statflags(0),
+	mapflags(TileMapFlag::None),
+	statflags(TileStatFlag::None),
 	minimapColor(INVALID_MINIMAP_COLOR) {
 	////
 }
@@ -53,8 +53,8 @@ Tile::Tile(TileLocation& loc) :
 	location(&loc),
 	ground(nullptr),
 	house_id(0),
-	mapflags(0),
-	statflags(0),
+	mapflags(TileMapFlag::None),
+	statflags(TileStatFlag::None),
 	minimapColor(INVALID_MINIMAP_COLOR) {
 	////
 }
@@ -134,7 +134,7 @@ int Tile::size() const {
 	if (house_id != 0) {
 		++sz;
 	}
-	if (mapflags) {
+	if (mapflags != TileMapFlag::None) {
 		++sz;
 	}
 	if (location) {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -37,26 +37,43 @@ class Map;
 
 // TileOperations functions are now in tile_operations.h
 
-enum {
-	TILESTATE_NONE = 0x0000,
-	TILESTATE_PROTECTIONZONE = 0x0001,
-	TILESTATE_DEPRECATED = 0x0002, // Reserved
-	TILESTATE_NOPVP = 0x0004,
-	TILESTATE_NOLOGOUT = 0x0008,
-	TILESTATE_PVPZONE = 0x0010,
-	TILESTATE_REFRESH = 0x0020,
-	// Internal
-	TILESTATE_SELECTED = 0x0001,
-	TILESTATE_UNIQUE = 0x0002,
-	TILESTATE_BLOCKING = 0x0004,
-	TILESTATE_OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
-	TILESTATE_HAS_TABLE = 0x0010,
-	TILESTATE_HAS_CARPET = 0x0020,
-	TILESTATE_MODIFIED = 0x0040,
-	TILESTATE_HOOK_SOUTH = 0x0080,
-	TILESTATE_HOOK_EAST = 0x0100,
-	TILESTATE_HAS_LIGHT = 0x0200,
+enum class TileMapFlag : uint16_t {
+	None = 0x0000,
+	ProtectionZone = 0x0001,
+	Deprecated = 0x0002, // Reserved
+	NoPvp = 0x0004,
+	NoLogout = 0x0008,
+	PvpZone = 0x0010,
+	Refresh = 0x0020,
 };
+
+enum class TileStatFlag : uint16_t {
+	None = 0x0000,
+	Selected = 0x0001,
+	Unique = 0x0002,
+	Blocking = 0x0004,
+	OpBorder = 0x0008, // If this is true, gravel will be placed on the tile!
+	HasTable = 0x0010,
+	HasCarpet = 0x0020,
+	Modified = 0x0040,
+	HookSouth = 0x0080,
+	HookEast = 0x0100,
+	HasLight = 0x0200,
+};
+
+#define DECLARE_ENUM_FLAGS_MACRO(Type) \
+	constexpr Type operator|(Type a, Type b) { return static_cast<Type>(static_cast<std::underlying_type_t<Type>>(a) | static_cast<std::underlying_type_t<Type>>(b)); } \
+	constexpr Type operator&(Type a, Type b) { return static_cast<Type>(static_cast<std::underlying_type_t<Type>>(a) & static_cast<std::underlying_type_t<Type>>(b)); } \
+	constexpr Type operator^(Type a, Type b) { return static_cast<Type>(static_cast<std::underlying_type_t<Type>>(a) ^ static_cast<std::underlying_type_t<Type>>(b)); } \
+	constexpr Type operator~(Type a) { return static_cast<Type>(~static_cast<std::underlying_type_t<Type>>(a)); } \
+	constexpr Type& operator|=(Type& a, Type b) { a = a | b; return a; } \
+	constexpr Type& operator&=(Type& a, Type b) { a = a & b; return a; } \
+	constexpr Type& operator^=(Type& a, Type b) { a = a ^ b; return a; }
+
+DECLARE_ENUM_FLAGS_MACRO(TileMapFlag)
+DECLARE_ENUM_FLAGS_MACRO(TileStatFlag)
+
+#undef DECLARE_ENUM_FLAGS_MACRO
 
 enum : uint8_t {
 	INVALID_MINIMAP_COLOR = 0xFF
@@ -70,8 +87,8 @@ public: // Members
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)
-	uint16_t mapflags;
-	uint16_t statflags;
+	TileMapFlag mapflags;
+	TileStatFlag statflags;
 	uint8_t minimapColor;
 
 public:
@@ -110,13 +127,13 @@ public: // Functions
 
 	// Has tile been modified since the map was loaded/created?
 	bool isModified() const {
-		return testFlags(statflags, TILESTATE_MODIFIED);
+		return testFlags(statflags, TileStatFlag::Modified);
 	}
 	void modify() {
-		statflags |= TILESTATE_MODIFIED;
+		statflags |= TileStatFlag::Modified;
 	}
 	void unmodify() {
-		statflags &= ~TILESTATE_MODIFIED;
+		statflags &= ~TileStatFlag::Modified;
 	}
 
 	// Get memory footprint size
@@ -129,18 +146,18 @@ public: // Functions
 
 	// Blocking?
 	bool isBlocking() const {
-		return testFlags(statflags, TILESTATE_BLOCKING);
+		return testFlags(statflags, TileStatFlag::Blocking);
 	}
 
 	// PZ
 	bool isPZ() const {
-		return testFlags(mapflags, TILESTATE_PROTECTIONZONE);
+		return testFlags(mapflags, TileMapFlag::ProtectionZone);
 	}
 	void setPZ(bool pz) {
 		if (pz) {
-			mapflags |= TILESTATE_PROTECTIONZONE;
+			mapflags |= TileMapFlag::ProtectionZone;
 		} else {
-			mapflags &= ~TILESTATE_PROTECTIONZONE;
+			mapflags &= ~TileMapFlag::ProtectionZone;
 		}
 	}
 
@@ -152,10 +169,10 @@ public: // Functions
 	void addItem(std::unique_ptr<Item> item);
 
 	bool isSelected() const {
-		return testFlags(statflags, TILESTATE_SELECTED);
+		return testFlags(statflags, TileStatFlag::Selected);
 	}
 	bool hasUniqueItem() const {
-		return testFlags(statflags, TILESTATE_UNIQUE);
+		return testFlags(statflags, TileStatFlag::Unique);
 	}
 
 	uint8_t getMiniMapColor() const;
@@ -172,35 +189,35 @@ public: // Functions
 	GroundBrush* getGroundBrush() const;
 
 	bool hasTable() const {
-		return testFlags(statflags, TILESTATE_HAS_TABLE);
+		return testFlags(statflags, TileStatFlag::HasTable);
 	}
 	Item* getTable() const;
 
 	bool hasCarpet() const {
-		return testFlags(statflags, TILESTATE_HAS_CARPET);
+		return testFlags(statflags, TileStatFlag::HasCarpet);
 	}
 	Item* getCarpet() const;
 
 	bool hasHookSouth() const {
-		return testFlags(statflags, TILESTATE_HOOK_SOUTH);
+		return testFlags(statflags, TileStatFlag::HookSouth);
 	}
 
 	bool hasHookEast() const {
-		return testFlags(statflags, TILESTATE_HOOK_EAST);
+		return testFlags(statflags, TileStatFlag::HookEast);
 	}
 
 	bool hasLight() const {
-		return testFlags(statflags, TILESTATE_HAS_LIGHT);
+		return testFlags(statflags, TileStatFlag::HasLight);
 	}
 
 	bool hasOptionalBorder() const {
-		return testFlags(statflags, TILESTATE_OP_BORDER);
+		return testFlags(statflags, TileStatFlag::OpBorder);
 	}
 	void setOptionalBorder(bool b) {
 		if (b) {
-			statflags |= TILESTATE_OP_BORDER;
+			statflags |= TileStatFlag::OpBorder;
 		} else {
-			statflags &= ~TILESTATE_OP_BORDER;
+			statflags &= ~TileStatFlag::OpBorder;
 		}
 	}
 
@@ -221,14 +238,14 @@ public: // Functions
 	void setHouse(House* house);
 
 	// Mapflags (PZ, PVPZONE etc.)
-	void setMapFlags(uint16_t _flags);
-	void unsetMapFlags(uint16_t _flags);
-	uint16_t getMapFlags() const;
+	void setMapFlags(TileMapFlag _flags);
+	void unsetMapFlags(TileMapFlag _flags);
+	TileMapFlag getMapFlags() const;
 
 	// Statflags (You really ought not to touch this)
-	void setStatFlags(uint16_t _flags);
-	void unsetStatFlags(uint16_t _flags);
-	uint16_t getStatFlags() const;
+	void setStatFlags(TileStatFlag _flags);
+	void unsetStatFlags(TileStatFlag _flags);
+	TileStatFlag getStatFlags() const;
 };
 
 bool tilePositionLessThan(const Tile* a, const Tile* b);
@@ -251,27 +268,27 @@ inline uint32_t Tile::getHouseID() const {
 	return house_id;
 }
 
-inline void Tile::setMapFlags(uint16_t _flags) {
+inline void Tile::setMapFlags(TileMapFlag _flags) {
 	mapflags = _flags | mapflags;
 }
 
-inline void Tile::unsetMapFlags(uint16_t _flags) {
+inline void Tile::unsetMapFlags(TileMapFlag _flags) {
 	mapflags &= ~_flags;
 }
 
-inline uint16_t Tile::getMapFlags() const {
+inline TileMapFlag Tile::getMapFlags() const {
 	return mapflags;
 }
 
-inline void Tile::setStatFlags(uint16_t _flags) {
+inline void Tile::setStatFlags(TileStatFlag _flags) {
 	statflags = _flags | statflags;
 }
 
-inline void Tile::unsetStatFlags(uint16_t _flags) {
+inline void Tile::unsetStatFlags(TileStatFlag _flags) {
 	statflags &= ~_flags;
 }
 
-inline uint16_t Tile::getStatFlags() const {
+inline TileStatFlag Tile::getStatFlags() const {
 	return statflags;
 }
 

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -33,12 +33,12 @@ namespace TileOperations {
 			items.erase(first_to_remove, items.end());
 		}
 
-		void UpdateItemFlags(const Item* i, uint16_t& statflags, uint8_t& minimapColor) {
+		void UpdateItemFlags(const Item* i, TileStatFlag& statflags, uint8_t& minimapColor) {
 			if (i->isSelected()) {
-				statflags |= TILESTATE_SELECTED;
+				statflags |= TileStatFlag::Selected;
 			}
 			if (i->getUniqueID() != 0) {
-				statflags |= TILESTATE_UNIQUE;
+				statflags |= TileStatFlag::Unique;
 			}
 			if (i->getMiniMapColor() != 0) {
 				minimapColor = i->getMiniMapColor();
@@ -46,25 +46,25 @@ namespace TileOperations {
 
 			const auto it_type = i->getDefinition();
 			if (it_type.hasFlag(ItemFlag::Unpassable)) {
-				statflags |= TILESTATE_BLOCKING;
+				statflags |= TileStatFlag::Blocking;
 			}
 			if (it_type.hasFlag(ItemFlag::IsOptionalBorder)) {
-				statflags |= TILESTATE_OP_BORDER;
+				statflags |= TileStatFlag::OpBorder;
 			}
 			if (it_type.hasFlag(ItemFlag::IsTable)) {
-				statflags |= TILESTATE_HAS_TABLE;
+				statflags |= TileStatFlag::HasTable;
 			}
 			if (it_type.hasFlag(ItemFlag::IsCarpet)) {
-				statflags |= TILESTATE_HAS_CARPET;
+				statflags |= TileStatFlag::HasCarpet;
 			}
 			if (it_type.hasFlag(ItemFlag::HookSouth)) {
-				statflags |= TILESTATE_HOOK_SOUTH;
+				statflags |= TileStatFlag::HookSouth;
 			}
 			if (it_type.hasFlag(ItemFlag::HookEast)) {
-				statflags |= TILESTATE_HOOK_EAST;
+				statflags |= TileStatFlag::HookEast;
 			}
 			if (i->hasLight()) {
-				statflags |= TILESTATE_HAS_LIGHT;
+				statflags |= TileStatFlag::HasLight;
 			}
 		}
 
@@ -241,7 +241,7 @@ namespace TileOperations {
 			i->select();
 		});
 
-		tile->statflags |= TILESTATE_SELECTED;
+		tile->statflags |= TileStatFlag::Selected;
 	}
 
 	void deselect(Tile* tile) {
@@ -259,7 +259,7 @@ namespace TileOperations {
 			i->deselect();
 		});
 
-		tile->statflags &= ~TILESTATE_SELECTED;
+		tile->statflags &= ~TileStatFlag::Selected;
 	}
 
 	void selectGround(Tile* tile) {
@@ -275,7 +275,7 @@ namespace TileOperations {
 		}
 
 		if (selected_) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::Selected;
 		}
 	}
 
@@ -388,35 +388,35 @@ namespace TileOperations {
 	}
 
 	void update(Tile* tile) {
-		tile->statflags &= TILESTATE_MODIFIED;
+		tile->statflags &= TileStatFlag::Modified;
 
 		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::Selected;
 		}
 		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlag::Selected;
 		}
 
 		tile->minimapColor = 0; // Reset to "no color" (valid)
 
 		if (tile->ground) {
 			if (tile->ground->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
+				tile->statflags |= TileStatFlag::Selected;
 			}
 			if (tile->ground->isBlocking()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlag::Blocking;
 			}
 			if (tile->ground->getUniqueID() != 0) {
-				tile->statflags |= TILESTATE_UNIQUE;
+				tile->statflags |= TileStatFlag::Unique;
 			}
 			if (tile->ground->getMiniMapColor() != 0) {
 				tile->minimapColor = tile->ground->getMiniMapColor();
 			}
 			if (tile->ground->hasLight()) {
-				tile->statflags |= TILESTATE_HAS_LIGHT;
+				tile->statflags |= TileStatFlag::HasLight;
 			}
 		} else {
-			tile->mapflags = TILESTATE_NONE;
+			tile->mapflags = TileMapFlag::None;
 			tile->house_id = 0;
 		}
 
@@ -424,9 +424,9 @@ namespace TileOperations {
 			UpdateItemFlags(i.get(), tile->statflags, tile->minimapColor);
 		});
 
-		if ((tile->statflags & TILESTATE_BLOCKING) == 0) {
+		if (!testFlags(tile->statflags, TileStatFlag::Blocking)) {
 			if (tile->ground == nullptr && tile->items.empty()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlag::Blocking;
 			}
 		}
 	}

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -80,14 +80,14 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							r /= 2;
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_PVPZONE) {
+						if (options.show_special_tiles && testFlags(tile->getMapFlags(), TileMapFlag::PvpZone)) {
 							r = r / 3 * 2;
 							b = r / 3 * 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+						if (options.show_special_tiles && testFlags(tile->getMapFlags(), TileMapFlag::NoLogout)) {
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOPVP) {
+						if (options.show_special_tiles && testFlags(tile->getMapFlags(), TileMapFlag::NoPvp)) {
 							g /= 2;
 						}
 						if (tile->ground) {

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -65,16 +65,16 @@ void TileColorCalculator::Calculate(const Tile* tile, const DrawingOptions& opti
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_PVPZONE) {
+	if (showspecial && testFlags(tile->getMapFlags(), TileMapFlag::PvpZone)) {
 		g = r >> 2;
 		b = (b * 171) >> 8;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+	if (showspecial && testFlags(tile->getMapFlags(), TileMapFlag::NoLogout)) {
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOPVP) {
+	if (showspecial && testFlags(tile->getMapFlags(), TileMapFlag::NoPvp)) {
 		g >>= 1;
 	}
 }

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -199,9 +199,9 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
 	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(testFlags(tile->getMapFlags(), TileMapFlag::NoPvp))), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(testFlags(tile->getMapFlags(), TileMapFlag::NoLogout))), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(testFlags(tile->getMapFlags(), TileMapFlag::PvpZone))), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
 
 	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());

--- a/source/ui/tile_properties/map_flags_panel.cpp
+++ b/source/ui/tile_properties/map_flags_panel.cpp
@@ -44,9 +44,9 @@ void MapFlagsPanel::SetTile(Tile* tile, Map* map) {
 
 	if (tile) {
 		chk_pz->SetValue(tile->isPZ());
-		chk_nopvp->SetValue(tile->getMapFlags() & TILESTATE_NOPVP);
-		chk_nologout->SetValue(tile->getMapFlags() & TILESTATE_NOLOGOUT);
-		chk_pvpzone->SetValue(tile->getMapFlags() & TILESTATE_PVPZONE);
+		chk_nopvp->SetValue(testFlags(tile->getMapFlags(), TileMapFlag::NoPvp));
+		chk_nologout->SetValue(testFlags(tile->getMapFlags(), TileMapFlag::NoLogout));
+		chk_pvpzone->SetValue(testFlags(tile->getMapFlags(), TileMapFlag::PvpZone));
 
 		chk_pz->Enable(true);
 		chk_nopvp->Enable(true);
@@ -79,21 +79,21 @@ void MapFlagsPanel::OnToggleFlag(wxCommandEvent& event) {
 	new_tile->setPZ(chk_pz->GetValue());
 
 	if (chk_nopvp->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOPVP);
+		new_tile->setMapFlags(TileMapFlag::NoPvp);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOPVP);
+		new_tile->unsetMapFlags(TileMapFlag::NoPvp);
 	}
 
 	if (chk_nologout->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->setMapFlags(TileMapFlag::NoLogout);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->unsetMapFlags(TileMapFlag::NoLogout);
 	}
 
 	if (chk_pvpzone->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_PVPZONE);
+		new_tile->setMapFlags(TileMapFlag::PvpZone);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_PVPZONE);
+		new_tile->unsetMapFlags(TileMapFlag::PvpZone);
 	}
 
 	Tile* old_ptr = new_tile.get();


### PR DESCRIPTION
This PR implements the requested autonomous run of the Smeller agent.

**Smell Identified**:
The `TILESTATE_` macro used an unnamed enum block spanning 17 variables, with overlapping constant scopes for both `mapflags` and `statflags`. Values like `TILESTATE_SELECTED` mapped to `0x0001` within the same unnamed group as `TILESTATE_PROTECTIONZONE = 0x0001`, leading to error-prone type coercions and zero type-safety. Furthermore, `mapflags` and `statflags` were declared as plain `uint16_t`.

**Refactor**:
- Separated variables into two independent, strongly-typed C++20 `enum class` declarations, `TileMapFlag : uint16_t` and `TileStatFlag : uint16_t`.
- Added a `DECLARE_ENUM_FLAGS_MACRO` generator mapping overloaded C++ bitwise operators (`|`, `&`, `~`, `^`, etc.) to both newly declared enum classes.
- Changed `Tile` attributes (`mapflags`, `statflags`) to strictly typed `TileMapFlag` and `TileStatFlag`.
- Refactored all corresponding integer checks (`b2yn(tile->getMapFlags() & TILESTATE_NOPVP)`) to strictly use explicitly cast enum evaluations like `b2yn(testFlags(tile->getMapFlags(), TileMapFlag::NoPvp))` across rendering, brushes, and serializers.
- Changed signature of `UpdateItemFlags(..., uint16_t& statflags, ...)` into `UpdateItemFlags(..., TileStatFlag& statflags, ...)`.

---
*PR created automatically by Jules for task [17458807362406921750](https://jules.google.com/task/17458807362406921750) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved internal type safety for tile flag handling throughout the codebase, replacing generic bitflags with strongly-typed enums for better code maintainability and error prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->