### PR TITLE
✨ Designer: Grid view for Find Dialogs & Tool Options organization

### DIFF
--- a/source/ui/dialogs/find_dialog.cpp
+++ b/source/ui/dialogs/find_dialog.cpp
@@ -48,6 +48,13 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	search_field->SetFocus();
 	sizer->Add(search_field, 0, wxEXPAND);
 
+	wxBoxSizer* list_header_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	list_header_sizer->AddStretchSpacer();
+	list_mode_btn = newd wxToggleButton(this, wxID_ANY, "List Mode");
+	list_mode_btn->SetToolTip("Toggle between grid and list views");
+	list_header_sizer->Add(list_mode_btn, 0, wxBOTTOM, 5);
+	sizer->Add(list_header_sizer, 0, wxEXPAND | wxRIGHT | wxLEFT, 5);
+
 	item_list = newd FindDialogListBox(this, JUMP_DIALOG_LIST);
 	item_list->SetMinSize(FROM_DIP(item_list, wxSize(470, 400)));
 	item_list->SetToolTip("Double click to select.");
@@ -74,6 +81,7 @@ FindDialog::FindDialog(wxWindow* parent, wxString title) :
 	Bind(wxEVT_LISTBOX_DCLICK, &FindDialog::OnClickList, this, JUMP_DIALOG_LIST);
 	Bind(wxEVT_BUTTON, &FindDialog::OnClickOK, this, wxID_OK);
 	Bind(wxEVT_BUTTON, &FindDialog::OnClickCancel, this, wxID_CANCEL);
+	Bind(wxEVT_TOGGLEBUTTON, &FindDialog::OnToggleListMode, this);
 
 	// We can't call it here since it calls an abstract function, call in child constructors instead.
 	// RefreshContents();
@@ -153,6 +161,10 @@ void FindDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 
 void FindDialog::OnClickCancel(wxCommandEvent& WXUNUSED(event)) {
 	EndModal(0);
+}
+
+void FindDialog::OnToggleListMode(wxCommandEvent& WXUNUSED(event)) {
+	item_list->SetListMode(list_mode_btn->GetValue());
 }
 
 void FindDialog::RefreshContents() {
@@ -292,7 +304,16 @@ void FindBrushDialog::RefreshContentsInternal() {
 FindDialogListBox::FindDialogListBox(wxWindow* parent, wxWindowID id) :
 	NanoVGListBox(parent, id, wxLB_SINGLE),
 	cleared(false),
-	no_matches(false) {
+	no_matches(false),
+	is_list_mode(false),
+	columns(1),
+	item_size(32),
+	padding(4) {
+
+	Bind(wxEVT_SIZE, &FindDialogListBox::OnSize, this);
+	Bind(wxEVT_LEFT_DOWN, &FindDialogListBox::OnMouseDown, this);
+	Bind(wxEVT_MOTION, &FindDialogListBox::OnMotion, this);
+
 	Clear();
 }
 
@@ -300,11 +321,231 @@ FindDialogListBox::~FindDialogListBox() {
 	////
 }
 
+void FindDialogListBox::SetListMode(bool is_list) {
+	if (is_list_mode != is_list) {
+		is_list_mode = is_list;
+		UpdateLayout();
+		Refresh();
+	}
+}
+
+void FindDialogListBox::UpdateLayout() {
+	int width = GetClientSize().x;
+	if (width <= 0) {
+		width = 200;
+	}
+
+	if (is_list_mode || cleared || no_matches) {
+		columns = 1;
+		int rows = static_cast<int>(brushlist.empty() ? 1 : brushlist.size());
+		int contentHeight = rows * OnMeasureItem(0) + padding;
+		NanoVGCanvas::UpdateScrollbar(contentHeight);
+	} else {
+		columns = std::max(1, (width - padding) / (item_size + padding));
+		int rows = (static_cast<int>(brushlist.size()) + columns - 1) / columns;
+		int contentHeight = rows * (item_size + padding) + padding;
+		NanoVGCanvas::UpdateScrollbar(contentHeight);
+	}
+}
+
+wxSize FindDialogListBox::DoGetBestClientSize() const {
+	return FromDIP(wxSize(200, 300));
+}
+
+void FindDialogListBox::OnSize(wxSizeEvent& event) {
+	UpdateLayout();
+	Refresh();
+	event.Skip();
+}
+
+wxRect FindDialogListBox::GetItemRect(int index) const {
+	if (is_list_mode || cleared || no_matches) {
+		int width = GetClientSize().x - 2 * padding;
+		int itemHeight = OnMeasureItem(0);
+		return wxRect(padding, padding + index * itemHeight, width, itemHeight);
+	} else {
+		int row = index / columns;
+		int col = index % columns;
+
+		return wxRect(
+			padding + col * (item_size + padding),
+			padding + row * (item_size + padding),
+			item_size,
+			item_size
+		);
+	}
+}
+
+int FindDialogListBox::HitTest(int x, int y) const {
+	int scrollPos = GetScrollPosition();
+	int realY = y + scrollPos;
+	int realX = x;
+
+	if (is_list_mode || cleared || no_matches) {
+		int itemHeight = OnMeasureItem(0);
+		int row = (realY - padding) / itemHeight;
+
+		int max_items = brushlist.empty() ? 1 : static_cast<int>(brushlist.size());
+		if (row < 0 || row >= max_items) {
+			return -1;
+		}
+
+		if (realX >= padding && realX <= GetClientSize().x - padding) {
+			return row;
+		}
+		return -1;
+	} else {
+		int col = (realX - padding) / (item_size + padding);
+		int row = (realY - padding) / (item_size + padding);
+
+		if (col < 0 || col >= columns || row < 0) {
+			return -1;
+		}
+
+		int index = row * columns + col;
+		if (index >= 0 && index < static_cast<int>(brushlist.size())) {
+			wxRect rect = GetItemRect(index);
+			rect.y -= scrollPos;
+			if (rect.Contains(x, y)) {
+				return index;
+			}
+		}
+		return -1;
+	}
+}
+
+void FindDialogListBox::OnMouseDown(wxMouseEvent& event) {
+	if (cleared || no_matches) return;
+
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1) {
+		Select(index, true);
+		SendSelectionEvent();
+		Refresh();
+
+		if (event.LeftDClick()) {
+			wxCommandEvent doubleClickEvent(wxEVT_LISTBOX_DCLICK, GetId());
+			doubleClickEvent.SetEventObject(this);
+			doubleClickEvent.SetInt(index);
+			ProcessWindowEvent(doubleClickEvent);
+		}
+	}
+	SetFocus();
+}
+
+void FindDialogListBox::OnMotion(wxMouseEvent& event) {
+	if (cleared || no_matches) return;
+
+	int index = HitTest(event.GetX(), event.GetY());
+	if (index != m_hoverIndex) {
+		m_hoverIndex = index;
+		Refresh();
+	}
+
+	if (index != -1 && !is_list_mode && index < static_cast<int>(brushlist.size())) {
+		Brush* brush = brushlist[index];
+		if (brush) {
+			wxString tip = wxstr(brush->getName());
+			if (GetToolTipText() != tip) {
+				SetToolTip(tip);
+			}
+		}
+	} else {
+		UnsetToolTip();
+	}
+
+	event.Skip();
+}
+
+void FindDialogListBox::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
+	if (m_count == 0) {
+		return;
+	}
+
+	int scrollPos = GetScrollPosition();
+
+	if (is_list_mode || cleared || no_matches) {
+		int itemHeight = OnMeasureItem(0);
+		int startRow = scrollPos / itemHeight;
+		int endRow = (scrollPos + height + itemHeight - 1) / itemHeight;
+
+		startRow = std::max(0, startRow);
+		endRow = std::min(static_cast<int>(m_count), endRow);
+
+		for (int i = startRow; i < endRow; ++i) {
+			wxRect rect = GetItemRect(i);
+
+			bool selected = IsSelected(i);
+			bool hover = (i == m_hoverIndex);
+			bool focused = (i == m_focusIndex);
+
+			if (selected || hover || focused) {
+				nvgBeginPath(vg);
+				nvgRect(vg, rect.x, rect.y, rect.width, rect.height);
+				wxColour c;
+				if (selected) {
+					c = Theme::Get(Theme::Role::Accent);
+				} else if (focused) {
+					c = Theme::Get(Theme::Role::Selected);
+				} else {
+					c = Theme::Get(Theme::Role::CardBaseHover);
+				}
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), c.Alpha()));
+				nvgFill(vg);
+			}
+
+			OnDrawItem(vg, rect, i);
+		}
+	} else {
+		int rowHeight = item_size + padding;
+		int startRow = scrollPos / rowHeight;
+		int endRow = (scrollPos + height + rowHeight - 1) / rowHeight + 1;
+
+		int startIdx = startRow * columns;
+		int endIdx = std::min(static_cast<int>(brushlist.size()), endRow * columns);
+
+		for (int i = startIdx; i < endIdx; ++i) {
+			wxRect rect = GetItemRect(i);
+
+			bool selected = IsSelected(i);
+			bool hover = (i == m_hoverIndex);
+
+			// Background
+			nvgBeginPath(vg);
+			nvgRoundedRect(vg, rect.x, rect.y, rect.width, rect.height, 4.0f);
+			if (selected) {
+				wxColour c = Theme::Get(Theme::Role::Accent);
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), 255));
+			} else if (hover) {
+				wxColour c = Theme::Get(Theme::Role::CardBaseHover);
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), 255));
+			} else {
+				wxColour c = Theme::Get(Theme::Role::CardBase);
+				nvgFillColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), 255));
+			}
+			nvgFill(vg);
+
+			// Selection border
+			if (selected) {
+				nvgBeginPath(vg);
+				nvgRoundedRect(vg, rect.x + 0.5f, rect.y + 0.5f, rect.width - 1.0f, rect.height - 1.0f, 4.0f);
+				wxColour c = Theme::Get(Theme::Role::Accent);
+				nvgStrokeColor(vg, nvgRGBA(c.Red(), c.Green(), c.Blue(), 255));
+				nvgStrokeWidth(vg, 2.0f);
+				nvgStroke(vg);
+			}
+
+			OnDrawItem(vg, rect, i);
+		}
+	}
+}
+
 void FindDialogListBox::Clear() {
 	cleared = true;
 	no_matches = false;
 	brushlist.clear();
 	SetItemCount(1);
+	UpdateLayout();
 }
 
 void FindDialogListBox::SetNoMatches() {
@@ -312,6 +553,7 @@ void FindDialogListBox::SetNoMatches() {
 	no_matches = true;
 	brushlist.clear();
 	SetItemCount(1);
+	UpdateLayout();
 }
 
 void FindDialogListBox::AddBrush(Brush* brush) {
@@ -326,6 +568,7 @@ void FindDialogListBox::CommitUpdates() {
 	} else {
 		SetItemCount(brushlist.size());
 	}
+	UpdateLayout();
 	Refresh();
 }
 
@@ -354,31 +597,37 @@ void FindDialogListBox::OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t n)
 	} else {
 		ASSERT(n < brushlist.size());
 		Sprite* spr = g_gui.gfx.getSprite(brushlist[n]->getLookID());
+
+		int icon_size = is_list_mode ? rect.height : (item_size - 4);
+		int iconX = is_list_mode ? rect.x : (rect.x + 2);
+		int iconY = is_list_mode ? rect.y : (rect.y + 2);
+
 		if (spr) {
 			int tex = GetOrCreateSpriteTexture(vg, spr);
 			if (tex > 0) {
-				int icon_size = rect.height;
-				NVGpaint imgPaint = nvgImagePattern(vg, rect.x, rect.y, icon_size, icon_size, 0, tex, 1.0f);
+				NVGpaint imgPaint = nvgImagePattern(vg, iconX, iconY, icon_size, icon_size, 0, tex, 1.0f);
 				nvgBeginPath(vg);
-				nvgRect(vg, rect.x, rect.y, icon_size, icon_size);
+				nvgRoundedRect(vg, iconX, iconY, icon_size, icon_size, 3.0f);
 				nvgFillPaint(vg, imgPaint);
 				nvgFill(vg);
 			}
 		}
 
-		if (IsSelected(n)) {
-			textColour = Theme::Get(Theme::Role::TextOnAccent);
-			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		} else {
-			textColour = Theme::Get(Theme::Role::Text);
-			nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
-		}
+		if (is_list_mode) {
+			if (IsSelected(n)) {
+				textColour = Theme::Get(Theme::Role::TextOnAccent);
+				nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+			} else {
+				textColour = Theme::Get(Theme::Role::Text);
+				nvgFillColor(vg, nvgRGBA(textColour.Red(), textColour.Green(), textColour.Blue(), 255));
+			}
 
-		nvgFontSize(vg, 12.0f);
-		nvgFontFace(vg, "sans");
-		nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
-		wxString name = wxstr(brushlist[n]->getName());
-		nvgText(vg, rect.x + rect.height + 8, rect.y + rect.height / 2.0f, name.ToUTF8().data(), nullptr);
+			nvgFontSize(vg, 12.0f);
+			nvgFontFace(vg, "sans");
+			nvgTextAlign(vg, NVG_ALIGN_LEFT | NVG_ALIGN_MIDDLE);
+			wxString name = wxstr(brushlist[n]->getName());
+			nvgText(vg, rect.x + rect.height + 8, rect.y + rect.height / 2.0f, name.ToUTF8().data(), nullptr);
+		}
 	}
 }
 

--- a/source/ui/dialogs/find_dialog.h
+++ b/source/ui/dialogs/find_dialog.h
@@ -4,6 +4,7 @@
 #include "app/main.h"
 #include "util/nanovg_listbox.h"
 #include <wx/wx.h>
+#include <wx/tglbtn.h>
 #include <vector>
 
 class Brush;
@@ -30,13 +31,32 @@ public:
 	void CommitUpdates();
 	Brush* GetSelectedBrush();
 
+	void SetListMode(bool is_list);
+
 	void OnDrawItem(NVGcontext* vg, const wxRect& rect, size_t index) override;
 	int OnMeasureItem(size_t index) const override;
+
+	// Override some NanoVGCanvas things for grid layout
+	void OnNanoVGPaint(NVGcontext* vg, int width, int height) override;
+	wxSize DoGetBestClientSize() const override;
 
 protected:
 	bool cleared;
 	bool no_matches;
+	bool is_list_mode;
 	std::vector<Brush*> brushlist;
+
+	int columns;
+	int item_size;
+	int padding;
+
+	int HitTest(int x, int y) const;
+	wxRect GetItemRect(int index) const;
+	void UpdateLayout();
+
+	void OnSize(wxSizeEvent& event);
+	void OnMouseDown(wxMouseEvent& event);
+	void OnMotion(wxMouseEvent& event);
 };
 
 class FindDialog : public wxDialog {
@@ -50,6 +70,7 @@ public:
 	void OnClickList(wxCommandEvent&);
 	void OnClickOK(wxCommandEvent&);
 	void OnClickCancel(wxCommandEvent&);
+	void OnToggleListMode(wxCommandEvent&);
 
 	void RefreshContents();
 	virtual const Brush* getResult() const {
@@ -66,6 +87,7 @@ protected:
 
 	FindDialogListBox* item_list;
 	KeyForwardingTextCtrl* search_field;
+	wxToggleButton* list_mode_btn;
 	wxTimer idle_input_timer;
 	const Brush* result_brush;
 	int result_id;

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -187,8 +187,18 @@ FindItemDialog::FindItemDialog(wxWindow* parent, const wxString& title, bool onl
 
 	wxStaticBoxSizer* result_box_sizer = newd wxStaticBoxSizer(newd wxStaticBox(this, wxID_ANY, "Result"), wxVERTICAL);
 	items_list = newd FindDialogListBox(result_box_sizer->GetStaticBox(), wxID_ANY);
-	items_list->SetMinSize(wxSize(230, 512));
-	result_box_sizer->Add(items_list, 0, wxALL, 5);
+	items_list->SetMinSize(FromDIP(wxSize(400, 512)));
+
+	// Add a display mode toggle right above the items list
+	wxBoxSizer* mode_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	mode_sizer->AddStretchSpacer();
+	list_mode_btn = newd wxToggleButton(result_box_sizer->GetStaticBox(), wxID_ANY, "List Mode");
+	list_mode_btn->SetToolTip("Toggle between grid and list views");
+	list_mode_btn->Bind(wxEVT_TOGGLEBUTTON, &FindItemDialog::OnToggleListMode, this);
+	mode_sizer->Add(list_mode_btn, 0, wxBOTTOM, 5);
+	result_box_sizer->Add(mode_sizer, 0, wxEXPAND);
+
+	result_box_sizer->Add(items_list, 1, wxALL | wxEXPAND, 5);
 	box_sizer->Add(result_box_sizer, 1, wxALL | wxEXPAND, 5);
 
 	this->SetSizer(box_sizer);
@@ -447,4 +457,8 @@ void FindItemDialog::OnClickOK(wxCommandEvent& WXUNUSED(event)) {
 
 void FindItemDialog::OnClickCancel(wxCommandEvent& WXUNUSED(event)) {
 	EndModal(wxID_CANCEL);
+}
+
+void FindItemDialog::OnToggleListMode(wxCommandEvent& event) {
+	items_list->SetListMode(list_mode_btn->GetValue());
 }

--- a/source/ui/find_item_window.h
+++ b/source/ui/find_item_window.h
@@ -26,6 +26,7 @@
 #include <wx/checkbox.h>
 #include <wx/button.h>
 #include <wx/dialog.h>
+#include <wx/tglbtn.h>
 
 class FindDialogListBox;
 
@@ -78,6 +79,7 @@ private:
 	void OnInputTimer(wxTimerEvent& event);
 	void OnClickOK(wxCommandEvent& event);
 	void OnClickCancel(wxCommandEvent& event);
+	void OnToggleListMode(wxCommandEvent& event);
 
 	wxRadioBox* options_radio_box;
 
@@ -104,6 +106,7 @@ private:
 	wxCheckBox* floor_change;
 	wxCheckBox* invalid_item;
 
+	wxToggleButton* list_mode_btn;
 	FindDialogListBox* items_list;
 	wxStdDialogButtonSizer* buttons_box_sizer;
 	wxButton* ok_button;

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -38,29 +38,38 @@ wxSize ToolOptionsSurface::DoGetBestClientSize() const {
 	// Base padding
 	int h = FromDIP(8);
 
+	// Headers
+	if (!headers.empty()) {
+		int max_y = 0;
+		for (const auto& header : headers) {
+			max_y = std::max(max_y, header.rect.GetBottom());
+		}
+		h = std::max(h, max_y);
+	}
+
 	// Tools Section
 	if (!tool_rects.empty()) {
 		int max_y = 0;
 		for (const auto& tr : tool_rects) {
 			max_y = std::max(max_y, tr.rect.GetBottom());
 		}
-		h = max_y + FromDIP(SECTION_GAP);
+		h = std::max(h, max_y + FromDIP(SECTION_GAP));
 	}
 
 	// Sliders Section
 	if (interactables.size_slider_rect.height > 0) {
-		h += interactables.size_slider_rect.height + FromDIP(GRID_GAP);
+		h = std::max(h, interactables.size_slider_rect.GetBottom() + FromDIP(GRID_GAP));
 	}
 	if (interactables.thickness_slider_rect.height > 0) {
-		h += interactables.thickness_slider_rect.height + FromDIP(SECTION_GAP);
+		h = std::max(h, interactables.thickness_slider_rect.GetBottom() + FromDIP(SECTION_GAP));
 	}
 
 	// Checkboxes
 	if (interactables.preview_check_rect.height > 0) {
-		h += interactables.preview_check_rect.height + FromDIP(4);
+		h = std::max(h, interactables.preview_check_rect.GetBottom() + FromDIP(4));
 	}
 	if (interactables.lock_check_rect.height > 0) {
-		h += interactables.lock_check_rect.height + FromDIP(4);
+		h = std::max(h, interactables.lock_check_rect.GetBottom() + FromDIP(4));
 	}
 
 	// Min width 200 DIP?
@@ -73,6 +82,7 @@ void ToolOptionsSurface::DoSetSizeHints(int minW, int minH, int maxW, int maxH, 
 
 void ToolOptionsSurface::RebuildLayout() {
 	tool_rects.clear();
+	headers.clear();
 	interactables.size_slider_rect = wxRect();
 	interactables.thickness_slider_rect = wxRect();
 	interactables.preview_check_rect = wxRect();
@@ -82,11 +92,13 @@ void ToolOptionsSurface::RebuildLayout() {
 		return;
 	}
 
-	int x = FromDIP(4);
-	int y = FromDIP(4);
+	int x = FromDIP(8);
+	int y = FromDIP(8);
 	const int w = GetClientSize().GetWidth();
+	const int content_w = w - FromDIP(16);
 	const int icon_sz = FromDIP(ICON_SIZE_LG); // Defaulting to large for "Pro" look
 	const int gap = FromDIP(GRID_GAP);
+	const int header_h = FromDIP(24);
 
 	// 1. Tools
 	bool has_tools = (current_type == TILESET_TERRAIN || current_type == TILESET_COLLECTION);
@@ -137,50 +149,63 @@ void ToolOptionsSurface::RebuildLayout() {
 			brushes.push_back(g_brush_manager.archway_door_brush);
 		}
 
-		// Layout grid
-		int cur_x = x;
-		for (Brush* b : brushes) {
-			if (cur_x + icon_sz > w) {
-				cur_x = x;
-				y += icon_sz + gap;
-			}
-
-			ToolRect tr;
-			tr.rect = wxRect(cur_x, y, icon_sz, icon_sz);
-			tr.brush = b;
-			tr.tooltip = b->getName(); // Or specific label
-			tool_rects.push_back(tr);
-
-			cur_x += icon_sz + gap;
-		}
 		if (!brushes.empty()) {
+			headers.push_back({ wxRect(x, y, content_w, header_h), "TOOLS" });
+			y += header_h + FromDIP(4);
+
+			// Layout grid
+			int cur_x = x;
+			for (Brush* b : brushes) {
+				if (cur_x + icon_sz > w) {
+					cur_x = x;
+					y += icon_sz + gap;
+				}
+
+				ToolRect tr;
+				tr.rect = wxRect(cur_x, y, icon_sz, icon_sz);
+				tr.brush = b;
+				tr.tooltip = b->getName(); // Or specific label
+				tool_rects.push_back(tr);
+
+				cur_x += icon_sz + gap;
+			}
 			y += icon_sz + FromDIP(SECTION_GAP);
 		}
 	}
 
 	int slider_h = FromDIP(24);
-	int slider_w = w - FromDIP(8);
 
 	// 2. Size Slider
 	bool show_size = (current_type != TILESET_UNKNOWN); // Most show size
 	if (show_size) {
-		interactables.size_slider_rect = wxRect(x, y, slider_w, slider_h);
+		headers.push_back({ wxRect(x, y, content_w, header_h), "BRUSH SETTINGS" });
+		y += header_h + FromDIP(4);
+
+		interactables.size_slider_rect = wxRect(x, y, content_w, slider_h);
 		y += slider_h + gap;
 	}
 
 	// 3. Thickness Slider
 	bool show_thickness = (current_type == TILESET_COLLECTION || current_type == TILESET_DOODAD);
 	if (show_thickness) {
-		interactables.thickness_slider_rect = wxRect(x, y, slider_w, slider_h);
+		// Only add header if we haven't already
+		if (!show_size) {
+			headers.push_back({ wxRect(x, y, content_w, header_h), "BRUSH SETTINGS" });
+			y += header_h + FromDIP(4);
+		}
+		interactables.thickness_slider_rect = wxRect(x, y, content_w, slider_h);
 		y += slider_h + gap;
 	}
 
 	// 4. Options
-	y += FromDIP(8); // Extra spacer
 	if (has_tools) { // Assume terrain
-		interactables.preview_check_rect = wxRect(x, y, slider_w, FromDIP(20));
+		y += FromDIP(SECTION_GAP) - gap; // extra gap to separate settings from options
+		headers.push_back({ wxRect(x, y, content_w, header_h), "OPTIONS" });
+		y += header_h + FromDIP(4);
+
+		interactables.preview_check_rect = wxRect(x, y, content_w, FromDIP(20));
 		y += FromDIP(24);
-		interactables.lock_check_rect = wxRect(x, y, slider_w, FromDIP(20));
+		interactables.lock_check_rect = wxRect(x, y, content_w, FromDIP(20));
 	}
 
 	InvalidateBestSize();
@@ -194,6 +219,11 @@ void ToolOptionsSurface::OnPaint(wxPaintEvent& evt) {
 	wxColour bg = Theme::Get(Theme::Role::Surface);
 	dc.SetBackground(wxBrush(bg));
 	dc.Clear();
+
+	// 0. Draw Headers
+	for (const auto& header : headers) {
+		DrawSectionHeader(dc, header);
+	}
 
 	// 1. Draw Tools
 	for (const auto& tr : tool_rects) {
@@ -267,6 +297,25 @@ void ToolOptionsSurface::DrawToolIcon(wxDC& dc, const ToolRect& tr) {
 		dc.SetPen(wxPen(Theme::Get(Theme::Role::Border)));
 	}
 	dc.DrawRectangle(r);
+}
+
+void ToolOptionsSurface::DrawSectionHeader(wxDC& dc, const SectionHeader& header) {
+	wxFont font = Theme::GetFont(10, true);
+	dc.SetFont(font);
+	dc.SetTextForeground(Theme::Get(Theme::Role::TextSubtle));
+
+	wxSize extent = dc.GetTextExtent(header.title);
+	dc.DrawText(header.title, header.rect.GetLeft(), header.rect.GetTop() + (header.rect.height - extent.y) / 2);
+
+	// Draw line separator
+	int line_x = header.rect.GetLeft() + extent.x + FromDIP(8);
+	int line_y = header.rect.GetTop() + header.rect.height / 2;
+	int line_w = header.rect.GetRight() - line_x;
+
+	if (line_w > 0) {
+		dc.SetPen(wxPen(Theme::Get(Theme::Role::Border)));
+		dc.DrawLine(line_x, line_y, line_x + line_w, line_y);
+	}
 }
 
 void ToolOptionsSurface::DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active) {

--- a/source/ui/tool_options_surface.h
+++ b/source/ui/tool_options_surface.h
@@ -72,6 +72,12 @@ private:
 	};
 	std::vector<ToolRect> tool_rects;
 
+	struct SectionHeader {
+		wxRect rect;
+		wxString title;
+	};
+	std::vector<SectionHeader> headers;
+
 	// UI Elements State
 	struct {
 		wxRect size_slider_rect;
@@ -94,6 +100,7 @@ private:
 	// Internal Helpers
 	void RebuildLayout();
 	void DrawToolIcon(wxDC& dc, const ToolRect& tr);
+	void DrawSectionHeader(wxDC& dc, const SectionHeader& header);
 	void DrawSlider(wxDC& dc, const wxRect& rect, const wxString& label, int value, int min, int max, bool active);
 	void DrawCheckbox(wxDC& dc, const wxRect& rect, const wxString& label, bool value, bool hover);
 


### PR DESCRIPTION
Implemented UX/UI improvements according to the "Designer" agent instructions:
- Find Item and Find Brush dialogs now use a denser, hardware-accelerated grid view by default for displaying brushes and items.
- Added a "List Mode" toggle to these dialogs so users can still view text labels.
- Added clean section headers and dividers to `ToolOptionsSurface` to separate tools from settings and options, making the properties easier to read at a glance.

---
*PR created automatically by Jules for task [6769608906971662316](https://jules.google.com/task/6769608906971662316) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added "List Mode" toggle button to search dialogs, enabling users to switch between grid and list view layouts for displaying results.
  * Introduced section headers in Tool Options to organize and group related settings visually.

* **UI/UX Improvements**
  * Enhanced layout logic for Tool Options sections with improved sizing calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->