### PR TITLE
🖥️ OpenGL: Map Light SSBO directly via glMapNamedBufferRange

### DIFF
--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -93,50 +93,60 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 	}
 
 	// 2. Prepare Lights
-	// Filter and convert lights to GPU format
-	gpu_lights_.clear();
-	gpu_lights_.reserve(light_buffer.lights.size());
+	// Filter and convert lights to GPU format directly into mapped buffer
+	size_t worst_case_size = light_buffer.lights.size() * sizeof(GPULight);
 
-	for (const auto& light : light_buffer.lights) {
-		int lx_px = light.map_x * TILE_SIZE + TILE_SIZE / 2;
-		int ly_px = light.map_y * TILE_SIZE + TILE_SIZE / 2;
-
-		float map_pos_x = static_cast<float>(lx_px - view.view_scroll_x);
-		float map_pos_y = static_cast<float>(ly_px - view.view_scroll_y);
-
-		// Convert to Screen Pixels
-		float screen_x = map_pos_x / view.zoom;
-		float screen_y = map_pos_y / view.zoom;
-		float screen_radius = (light.intensity * TILE_SIZE) / view.zoom;
-
-		// Check overlap with Screen Rect
-		if (screen_x + screen_radius < 0 || screen_x - screen_radius > buffer_w || screen_y + screen_radius < 0 || screen_y - screen_radius > buffer_h) {
-			continue;
+	if (worst_case_size > light_ssbo_capacity_) {
+		light_ssbo_capacity_ = std::max(worst_case_size, static_cast<size_t>(light_ssbo_capacity_ * 1.5));
+		if (light_ssbo_capacity_ < 1024) {
+			light_ssbo_capacity_ = 1024;
 		}
-
-		wxColor c = colorFromEightBit(light.color);
-
-		gpu_lights_.push_back({ .position = { screen_x, screen_y }, .intensity = static_cast<float>(light.intensity), .padding = 0.0f,
-								// Pre-multiply intensity here if needed, or in shader
-								.color = { (c.Red() / 255.0f) * light_intensity, (c.Green() / 255.0f) * light_intensity, (c.Blue() / 255.0f) * light_intensity, 1.0f } });
+		// Destroy and recreate buffer for Immutable Storage with GL_MAP_WRITE_BIT
+		light_ssbo = std::make_unique<GLBuffer>();
+		glNamedBufferStorage(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_DYNAMIC_STORAGE_BIT | GL_MAP_WRITE_BIT);
 	}
 
-	if (gpu_lights_.empty()) {
-		// Just render ambient? We still need to clear the FBO/screen area or simpy fill it.
-		// If no lights, the overlay should just be ambient color.
-	} else {
-		// Upload Lights
-		size_t needed_size = gpu_lights_.size() * sizeof(GPULight);
-		if (needed_size > light_ssbo_capacity_) {
-			light_ssbo_capacity_ = std::max(needed_size, static_cast<size_t>(light_ssbo_capacity_ * 1.5));
-			if (light_ssbo_capacity_ < 1024) {
-				light_ssbo_capacity_ = 1024;
+	size_t active_lights = 0;
+
+	if (worst_case_size > 0) {
+		GPULight* mapped_lights = static_cast<GPULight*>(glMapNamedBufferRange(
+			light_ssbo->GetID(),
+			0,
+			worst_case_size,
+			GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT
+		));
+
+		if (mapped_lights) {
+			for (const auto& light : light_buffer.lights) {
+				int lx_px = light.map_x * TILE_SIZE + TILE_SIZE / 2;
+				int ly_px = light.map_y * TILE_SIZE + TILE_SIZE / 2;
+
+				float map_pos_x = static_cast<float>(lx_px - view.view_scroll_x);
+				float map_pos_y = static_cast<float>(ly_px - view.view_scroll_y);
+
+				// Convert to Screen Pixels
+				float screen_x = map_pos_x / view.zoom;
+				float screen_y = map_pos_y / view.zoom;
+				float screen_radius = (light.intensity * TILE_SIZE) / view.zoom;
+
+				// Check overlap with Screen Rect
+				if (screen_x + screen_radius < 0 || screen_x - screen_radius > buffer_w || screen_y + screen_radius < 0 || screen_y - screen_radius > buffer_h) {
+					continue;
+				}
+
+				wxColor c = colorFromEightBit(light.color);
+
+				mapped_lights[active_lights++] = {
+					.position = { screen_x, screen_y },
+					.intensity = static_cast<float>(light.intensity),
+					.padding = 0.0f,
+					// Pre-multiply intensity here if needed, or in shader
+					.color = { (c.Red() / 255.0f) * light_intensity, (c.Green() / 255.0f) * light_intensity, (c.Blue() / 255.0f) * light_intensity, 1.0f }
+				};
 			}
-			// Destroy and recreate buffer for Immutable Storage
-			light_ssbo = std::make_unique<GLBuffer>();
-			glNamedBufferStorage(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_DYNAMIC_STORAGE_BIT);
+
+			glUnmapNamedBuffer(light_ssbo->GetID());
 		}
-		glNamedBufferSubData(light_ssbo->GetID(), 0, needed_size, gpu_lights_.data());
 	}
 
 	// 3. Render to FBO
@@ -160,7 +170,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 		// Actually, for "Max" blending, we want to start with Ambient.
 		glClear(GL_COLOR_BUFFER_BIT);
 
-		if (!gpu_lights_.empty()) {
+		if (active_lights > 0) {
 			shader->Use();
 
 			// Setup Projection for FBO: Ortho 0..buffer_w, buffer_h..0 (Y-down)
@@ -177,11 +187,11 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 				ScopedGLCapability blendCap(GL_BLEND);
 				ScopedGLBlend blendState(GL_ONE, GL_ONE, GL_MAX); // Factors don't matter much for MAX, but usually 1,1 is safe
 
-				if (gpu_lights_.size() > static_cast<size_t>(std::numeric_limits<GLsizei>::max())) {
+				if (active_lights > static_cast<size_t>(std::numeric_limits<GLsizei>::max())) {
 					spdlog::error("Too many lights for glDrawArraysInstanced");
 					return;
 				}
-				glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(gpu_lights_.size()));
+				glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(active_lights));
 			}
 
 			glBindVertexArray(0);

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -58,8 +58,6 @@ private:
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 
-	std::vector<GPULight> gpu_lights_;
-
 	std::unique_ptr<GLFramebuffer> fbo;
 	std::unique_ptr<GLTextureResource> fbo_texture;
 	int buffer_width = 0;


### PR DESCRIPTION
Follows the OpenGL agent guidelines by eliminating the intermediate CPU-side `std::vector<GPULight>` in `LightDrawer`. Directly maps the GPU SSBO and writes culled light instances directly into memory using `glMapNamedBufferRange`, removing redundant allocations and copying.

---
*PR created automatically by Jules for task [12866281837218482921](https://jules.google.com/task/12866281837218482921) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced light rendering efficiency by optimizing GPU buffer management and streamlining light data processing, improving performance during complex lighting scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->