### PR TITLE
👻 Phantom: Modernize UI Controls, Layouts, and Locks

### DIFF
--- a/source/app/managers/version_manager.cpp
+++ b/source/app/managers/version_manager.cpp
@@ -43,7 +43,7 @@ bool VersionManager::LoadVersion(ClientVersionID version, wxString& error, std::
 		}
 
 		// Disable all rendering so the data is not accessed while reloading
-		UnnamedRenderingLock();
+		UnnamedRenderingLock(g_gui);
 		g_gui.DestroyPalettes();
 		g_gui.DestroyMinimap();
 
@@ -164,7 +164,7 @@ bool VersionManager::LoadDataFiles(wxString& error, std::vector<std::string>& wa
 }
 
 void VersionManager::UnloadVersion() {
-	UnnamedRenderingLock();
+	UnnamedRenderingLock(g_gui);
 	g_gui.gfx.clear();
 	if (g_gui.tool_options) {
 		g_gui.tool_options->Clear();

--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/editor/editor.cpp
+++ b/source/editor/editor.cpp
@@ -81,7 +81,7 @@ Editor::~Editor() {
 		live_manager.CloseServer();
 	}
 
-	UnnamedRenderingLock();
+	UnnamedRenderingLock(g_gui);
 	selection.clear();
 	spdlog::info("Editor destroyed [Editor={}]", (void*)this);
 }

--- a/source/editor/operations/map_version_changer.cpp
+++ b/source/editor/operations/map_version_changer.cpp
@@ -57,7 +57,7 @@ bool MapVersionChanger::changeMapVersion(wxWindow* parent, Editor& editor, MapVe
 			if (ret != wxID_YES) {
 				return false;
 			}
-			UnnamedRenderingLock();
+			UnnamedRenderingLock(g_gui);
 
 			// Remember all creatures types on the map
 			MapConversionContext conversion_context;
@@ -95,7 +95,7 @@ bool MapVersionChanger::changeMapVersion(wxWindow* parent, Editor& editor, MapVe
 
 			map.cleanInvalidTiles(true);
 		} else {
-			UnnamedRenderingLock();
+			UnnamedRenderingLock(g_gui);
 			ClientVersion* target = ClientVersion::getBestMatch(new_ver.client);
 			if (!target || !g_version.LoadVersion(target->getID(), error, warnings)) {
 				DialogUtil::ListDialog(parent, "Warnings", warnings);

--- a/source/ui/find_item_window.cpp
+++ b/source/ui/find_item_window.cpp
@@ -398,7 +398,7 @@ void FindItemDialog::RefreshContentsInternal() {
 		items_list->SetNoMatches();
 	}
 
-	items_list->Refresh();
+	items_list->CommitUpdates();
 }
 
 void FindItemDialog::OnOptionChange(wxCommandEvent& WXUNUSED(event)) {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -60,13 +60,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"
@@ -367,18 +360,21 @@ extern GUI g_gui;
 
 class RenderingLock {
 	bool acquired;
+	GUI& gui;
 
 public:
-	RenderingLock() :
-		acquired(true) {
-		g_gui.DisableRendering();
+	RenderingLock(GUI& gui) :
+		acquired(true), gui(gui) {
+		gui.DisableRendering();
 	}
 	~RenderingLock() {
 		release();
 	}
 	void release() {
-		g_gui.EnableRendering();
-		acquired = false;
+		if (acquired) {
+			gui.EnableRendering();
+			acquired = false;
+		}
 	}
 };
 
@@ -405,7 +401,7 @@ public:
 	}
 };
 
-#define UnnamedRenderingLock() RenderingLock __unnamed_rendering_lock_##__LINE__
+#define UnnamedRenderingLock(gui) RenderingLock __unnamed_rendering_lock_##__LINE__(gui)
 
 void SetWindowToolTip(wxWindow* a, const wxString& tip);
 void SetWindowToolTip(wxWindow* a, wxWindow* b, const wxString& tip);

--- a/source/ui/main_frame.cpp
+++ b/source/ui/main_frame.cpp
@@ -273,7 +273,7 @@ bool MainFrame::DoQuerySave(bool doclose) {
 	}
 
 	if (doclose) {
-		UnnamedRenderingLock();
+		UnnamedRenderingLock(g_gui);
 		g_gui.CloseCurrentEditor();
 	}
 

--- a/source/ui/tool_options_surface.cpp
+++ b/source/ui/tool_options_surface.cpp
@@ -71,7 +71,11 @@ void ToolOptionsSurface::DoSetSizeHints(int minW, int minH, int maxW, int maxH, 
 	wxControl::DoSetSizeHints(minW, minH, maxW, maxH, incW, incH);
 }
 
+#include <wx/wupdlock.h>
+
 void ToolOptionsSurface::RebuildLayout() {
+	wxWindowUpdateLocker noUpdates(this);
+
 	tool_rects.clear();
 	interactables.size_slider_rect = wxRect();
 	interactables.thickness_slider_rect = wxRect();

--- a/source/ui/welcome/startup_button.cpp
+++ b/source/ui/welcome/startup_button.cpp
@@ -80,7 +80,7 @@ StartupButton::StartupButton(wxWindow* parent, wxWindowID id, const wxString& la
 	Bind(wxEVT_MOUSE_CAPTURE_LOST, &StartupButton::OnMouseCaptureLost, this);
 }
 
-void StartupButton::SetBitmap(const wxBitmap& bitmap) {
+void StartupButton::SetBitmapBundle(const wxBitmapBundle& bitmap) {
 	m_icon = bitmap;
 	InvalidateBestSize();
 	Refresh();
@@ -95,10 +95,12 @@ wxSize StartupButton::DoGetBestClientSize() const {
 	wxClientDC dc(const_cast<StartupButton*>(this));
 	dc.SetFont(GetFont());
 
+	wxBitmap icon_bmp = m_icon.IsOk() ? m_icon.GetBitmapFor(this) : wxNullBitmap;
+
 	const wxSize text_size = dc.GetTextExtent(GetLabel());
-	const int icon_width = m_icon.IsOk() ? m_icon.GetWidth() + FromDIP(8) : 0;
+	const int icon_width = icon_bmp.IsOk() ? icon_bmp.GetWidth() + FromDIP(8) : 0;
 	const int width = text_size.x + icon_width + FromDIP(30);
-	const int height = std::max(text_size.y, m_icon.IsOk() ? m_icon.GetHeight() : 0) + FromDIP(16);
+	const int height = std::max(text_size.y, icon_bmp.IsOk() ? icon_bmp.GetHeight() : 0) + FromDIP(16);
 	return { std::max(width, FromDIP(120)), std::max(height, FromDIP(42)) };
 }
 
@@ -117,15 +119,17 @@ void StartupButton::OnPaint(wxPaintEvent& WXUNUSED(event)) {
 	dc.SetFont(GetFont());
 	dc.SetTextForeground(palette.text);
 
+	wxBitmap icon_bmp = m_icon.IsOk() ? m_icon.GetBitmapFor(this) : wxNullBitmap;
+
 	const wxSize text_size = dc.GetTextExtent(GetLabel());
-	const int content_width = text_size.x + (m_icon.IsOk() ? m_icon.GetWidth() + FromDIP(8) : 0);
+	const int content_width = text_size.x + (icon_bmp.IsOk() ? icon_bmp.GetWidth() + FromDIP(8) : 0);
 	int x = rect.x + (rect.width - content_width) / 2;
 	const int y = rect.y + (rect.height - text_size.y) / 2;
 
-	if (m_icon.IsOk()) {
-		const int icon_y = rect.y + (rect.height - m_icon.GetHeight()) / 2;
-		dc.DrawBitmap(m_icon, x, icon_y, true);
-		x += m_icon.GetWidth() + FromDIP(8);
+	if (icon_bmp.IsOk()) {
+		const int icon_y = rect.y + (rect.height - icon_bmp.GetHeight()) / 2;
+		dc.DrawBitmap(icon_bmp, x, icon_y, true);
+		x += icon_bmp.GetWidth() + FromDIP(8);
 	}
 
 	dc.DrawText(GetLabel(), x, y);

--- a/source/ui/welcome/startup_button.h
+++ b/source/ui/welcome/startup_button.h
@@ -13,7 +13,7 @@ class StartupButton : public wxControl {
 public:
 	StartupButton(wxWindow* parent, wxWindowID id, const wxString& label, StartupButtonVariant variant, const wxPoint& pos = wxDefaultPosition, const wxSize& size = wxDefaultSize);
 
-	void SetBitmap(const wxBitmap& bitmap);
+	void SetBitmapBundle(const wxBitmapBundle& bitmap);
 	void SetVariant(StartupButtonVariant variant);
 
 	wxSize DoGetBestClientSize() const override;
@@ -23,7 +23,7 @@ private:
 	void OnMouse(wxMouseEvent& event);
 	void OnMouseCaptureLost(wxMouseCaptureLostEvent& event);
 
-	wxBitmap m_icon;
+	wxBitmapBundle m_icon;
 	StartupButtonVariant m_variant;
 	bool m_hovered = false;
 	bool m_pressed = false;

--- a/source/ui/welcome_dialog.cpp
+++ b/source/ui/welcome_dialog.cpp
@@ -151,7 +151,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	header_sizer->Add(title_sizer, 1, wxALIGN_CENTER_VERTICAL | wxTOP | wxBOTTOM, FromDIP(16));
 
 	auto* preferences_button = new StartupButton(header_panel, wxID_PREFERENCES, "Preferences", StartupButtonVariant::Secondary);
-	preferences_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_GEAR, FromDIP(wxSize(18, 18))));
+	preferences_button->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_GEAR, FromDIP(wxSize(18, 18))));
 	preferences_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnPreferences, this);
 	header_sizer->Add(preferences_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(14));
 
@@ -165,12 +165,12 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	auto* actions_card = new StartupCardPanel(content_panel, "Quick Actions");
 	actions_card->SetMinSize(wxSize(FromDIP(170), -1));
 	auto* new_map_button = new StartupButton(actions_card, wxID_NEW, "New Map", StartupButtonVariant::Primary);
-	new_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_NEW, FromDIP(wxSize(18, 18))));
+	new_map_button->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_NEW, FromDIP(wxSize(18, 18))));
 	new_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnNewMap, this);
 	actions_card->GetBodySizer()->Add(new_map_button, 0, wxEXPAND | wxBOTTOM, FromDIP(10));
 
 	auto* browse_map_button = new StartupButton(actions_card, wxID_OPEN, "Browse Map", StartupButtonVariant::Secondary);
-	browse_map_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	browse_map_button->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN, FromDIP(wxSize(18, 18))));
 	browse_map_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnBrowseMap, this);
 	actions_card->GetBodySizer()->Add(browse_map_button, 0, wxEXPAND);
 	content_sizer->Add(actions_card, 0, wxEXPAND | wxALL, FromDIP(10));
@@ -208,7 +208,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	auto* footer_actions = new wxBoxSizer(wxHORIZONTAL);
 	auto* footer_left = new wxBoxSizer(wxHORIZONTAL);
 	auto* exit_button = new StartupButton(footer_panel, wxID_EXIT, "Exit", StartupButtonVariant::Secondary);
-	exit_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_POWER_OFF, FromDIP(wxSize(18, 18))));
+	exit_button->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_POWER_OFF, FromDIP(wxSize(18, 18))));
 	exit_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnExit, this);
 	footer_left->Add(exit_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_left, 1, wxALIGN_CENTER_VERTICAL);
@@ -232,7 +232,7 @@ void WelcomeDialog::BuildInterface(const wxString& title_text, const wxString& v
 	footer_right->Add(m_force_load_checkbox, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(12));
 
 	m_load_button = new StartupButton(footer_panel, ID_LOAD_BUTTON, "Load Map", StartupButtonVariant::Primary);
-	m_load_button->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_OPEN, FromDIP(wxSize(18, 18))));
+	m_load_button->SetBitmapBundle(IMAGE_MANAGER.GetBitmapBundle(ICON_OPEN, FromDIP(wxSize(18, 18))));
 	m_load_button->Bind(wxEVT_BUTTON, &WelcomeDialog::OnLoadRequested, this);
 	footer_right->Add(m_load_button, 0, wxALL | wxALIGN_CENTER_VERTICAL, FromDIP(10));
 	footer_actions->Add(footer_right, 1, wxEXPAND);


### PR DESCRIPTION
Autonomously executed instructions from `phantom.md` to modernize and fix remaining wxWidgets UI code issues in the map editor. This PR handles legacy event bindings, fixes hardcoded global object usages in locking mechanisms, adds High-DPI support to custom widgets (`wxBitmapBundle` instead of `wxBitmap`), and improves responsiveness of UI bulk updates (`CommitUpdates`, `wxWindowUpdateLocker`).

---
*PR created automatically by Jules for task [4025335539361129463](https://jules.google.com/task/4025335539361129463) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance**
  * Improved rendering responsiveness during version changes and map operations.
  * Reduced UI flickering during layout rebuilding in tool options.

* **Improvements**
  * Enhanced icon and bitmap scaling support for better display clarity across different screen densities.

* **Refactor**
  * Streamlined internal rendering lock management and event handling systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->