### PR TITLE
👃 Smeller: Fix TILESTATE_ enums overlapping in tile.h

### DIFF
--- a/source/brushes/brush.cpp
+++ b/source/brushes/brush.cpp
@@ -95,10 +95,10 @@ void Brushes::init() {
 	addManagedBrush(g_brush_manager.house_exit_brush);
 	addManagedBrush(g_brush_manager.waypoint_brush);
 
-	addManagedBrush(g_brush_manager.pz_brush, TILESTATE_PROTECTIONZONE);
-	addManagedBrush(g_brush_manager.rook_brush, TILESTATE_NOPVP);
-	addManagedBrush(g_brush_manager.nolog_brush, TILESTATE_NOLOGOUT);
-	addManagedBrush(g_brush_manager.pvp_brush, TILESTATE_PVPZONE);
+	addManagedBrush(g_brush_manager.pz_brush, static_cast<uint32_t>(TileMapFlags::PROTECTIONZONE));
+	addManagedBrush(g_brush_manager.rook_brush, static_cast<uint32_t>(TileMapFlags::NOPVP));
+	addManagedBrush(g_brush_manager.nolog_brush, static_cast<uint32_t>(TileMapFlags::NOLOGOUT));
+	addManagedBrush(g_brush_manager.pvp_brush, static_cast<uint32_t>(TileMapFlags::PVPZONE));
 
 	GroundBrush::init();
 	WallBrush::init();

--- a/source/brushes/doodad/doodad_brush_loader.cpp
+++ b/source/brushes/doodad/doodad_brush_loader.cpp
@@ -68,7 +68,7 @@ bool DoodadBrushLoader::load(pugi::xml_node node, DoodadBrushItems& items, Dooda
 		if (!settings.do_new_borders) {
 			warnings.push_back("remove_optional_border will not work without redo_borders\n");
 		}
-		settings.clear_statflags |= TILESTATE_OP_BORDER;
+		settings.clear_statflags |= static_cast<uint16_t>(TileStatFlags::OP_BORDER);
 	}
 
 	const std::string& thicknessString = node.attribute("thickness").as_string();

--- a/source/brushes/flag/flag_brush.cpp
+++ b/source/brushes/flag/flag_brush.cpp
@@ -19,10 +19,10 @@ FlagBrush::FlagBrush(uint32_t flag) :
 }
 
 std::string FlagBrush::getName() const {
-	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { TILESTATE_PROTECTIONZONE, "PZ brush (0x01)" },
-																						  { TILESTATE_NOPVP, "No combat zone brush (0x04)" },
-																						  { TILESTATE_NOLOGOUT, "No logout zone brush (0x08)" },
-																						  { TILESTATE_PVPZONE, "PVP Zone brush (0x10)" } } };
+	static constexpr std::array<std::pair<uint32_t, std::string_view>, 4> flagNames = { { { static_cast<uint32_t>(TileMapFlags::PROTECTIONZONE), "PZ brush (0x01)" },
+																						  { static_cast<uint32_t>(TileMapFlags::NOPVP), "No combat zone brush (0x04)" },
+																						  { static_cast<uint32_t>(TileMapFlags::NOLOGOUT), "No logout zone brush (0x08)" },
+																						  { static_cast<uint32_t>(TileMapFlags::PVPZONE), "PVP Zone brush (0x10)" } } };
 
 	auto it = std::ranges::find_if(flagNames, [this](const auto& p) { return p.first == flag; });
 	if (it != flagNames.end()) {
@@ -32,10 +32,10 @@ std::string FlagBrush::getName() const {
 }
 
 int FlagBrush::getLookID() const {
-	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { TILESTATE_PROTECTIONZONE, EDITOR_SPRITE_PZ_TOOL },
-																			   { TILESTATE_NOPVP, EDITOR_SPRITE_NOPVP_TOOL },
-																			   { TILESTATE_NOLOGOUT, EDITOR_SPRITE_NOLOG_TOOL },
-																			   { TILESTATE_PVPZONE, EDITOR_SPRITE_PVPZ_TOOL } } };
+	static constexpr std::array<std::pair<uint32_t, int>, 4> flagSprites = { { { static_cast<uint32_t>(TileMapFlags::PROTECTIONZONE), EDITOR_SPRITE_PZ_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlags::NOPVP), EDITOR_SPRITE_NOPVP_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlags::NOLOGOUT), EDITOR_SPRITE_NOLOG_TOOL },
+																			   { static_cast<uint32_t>(TileMapFlags::PVPZONE), EDITOR_SPRITE_PVPZ_TOOL } } };
 
 	auto it = std::ranges::find_if(flagSprites, [this](const auto& p) { return p.first == flag; });
 	if (it != flagSprites.end()) {
@@ -52,11 +52,11 @@ bool FlagBrush::canDraw(BaseMap* map, const Position& position) const {
 }
 
 void FlagBrush::undraw(BaseMap* /*map*/, Tile* tile) {
-	tile->unsetMapFlags(static_cast<uint16_t>(flag));
+	tile->unsetMapFlags(static_cast<TileMapFlags>(flag));
 }
 
 void FlagBrush::draw(BaseMap* /*map*/, Tile* tile, void* /*parameter*/) {
 	if (tile->hasGround()) {
-		tile->setMapFlags(static_cast<uint16_t>(flag));
+		tile->setMapFlags(static_cast<TileMapFlags>(flag));
 	}
 }

--- a/source/editor/operations/copy_operations.cpp
+++ b/source/editor/operations/copy_operations.cpp
@@ -97,7 +97,7 @@ void CopyOperations::cut(Editor& editor, CopyBuffer& buffer, int floor) {
 			copied_tile->house_id = newtile->house_id;
 			newtile->house_id = 0;
 			copied_tile->setMapFlags(tile->getMapFlags());
-			newtile->setMapFlags(TILESTATE_NONE);
+			newtile->setMapFlags(TileMapFlags::NONE);
 		}
 
 		auto tile_selection = TileOperations::popSelectedItems(newtile.get());

--- a/source/editor/operations/selection_operations.cpp
+++ b/source/editor/operations/selection_operations.cpp
@@ -123,7 +123,7 @@ void SelectionOperations::moveSelection(Editor& editor, Position offset) {
 			tmp_storage_tile->house_id = new_src_tile->house_id;
 			new_src_tile->house_id = 0;
 			tmp_storage_tile->setMapFlags(new_src_tile->getMapFlags());
-			new_src_tile->setMapFlags(TILESTATE_NONE);
+			new_src_tile->setMapFlags(TileMapFlags::NONE);
 			doborders = true;
 		}
 

--- a/source/map/tile.cpp
+++ b/source/map/tile.cpp
@@ -43,8 +43,8 @@ Tile::Tile(int x, int y, int z) :
 	location(nullptr),
 	ground(nullptr),
 	house_id(0),
-	mapflags(0),
-	statflags(0),
+	mapflags(TileMapFlags::NONE),
+	statflags(TileStatFlags::NONE),
 	minimapColor(INVALID_MINIMAP_COLOR) {
 	////
 }
@@ -53,8 +53,8 @@ Tile::Tile(TileLocation& loc) :
 	location(&loc),
 	ground(nullptr),
 	house_id(0),
-	mapflags(0),
-	statflags(0),
+	mapflags(TileMapFlags::NONE),
+	statflags(TileStatFlags::NONE),
 	minimapColor(INVALID_MINIMAP_COLOR) {
 	////
 }
@@ -134,7 +134,7 @@ int Tile::size() const {
 	if (house_id != 0) {
 		++sz;
 	}
-	if (mapflags) {
+	if (mapflags != TileMapFlags::NONE) {
 		++sz;
 	}
 	if (location) {

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -37,26 +37,45 @@ class Map;
 
 // TileOperations functions are now in tile_operations.h
 
-enum {
-	TILESTATE_NONE = 0x0000,
-	TILESTATE_PROTECTIONZONE = 0x0001,
-	TILESTATE_DEPRECATED = 0x0002, // Reserved
-	TILESTATE_NOPVP = 0x0004,
-	TILESTATE_NOLOGOUT = 0x0008,
-	TILESTATE_PVPZONE = 0x0010,
-	TILESTATE_REFRESH = 0x0020,
-	// Internal
-	TILESTATE_SELECTED = 0x0001,
-	TILESTATE_UNIQUE = 0x0002,
-	TILESTATE_BLOCKING = 0x0004,
-	TILESTATE_OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
-	TILESTATE_HAS_TABLE = 0x0010,
-	TILESTATE_HAS_CARPET = 0x0020,
-	TILESTATE_MODIFIED = 0x0040,
-	TILESTATE_HOOK_SOUTH = 0x0080,
-	TILESTATE_HOOK_EAST = 0x0100,
-	TILESTATE_HAS_LIGHT = 0x0200,
+enum class TileMapFlags : uint16_t {
+	NONE = 0x0000,
+	PROTECTIONZONE = 0x0001,
+	DEPRECATED = 0x0002, // Reserved
+	NOPVP = 0x0004,
+	NOLOGOUT = 0x0008,
+	PVPZONE = 0x0010,
+	REFRESH = 0x0020
 };
+
+constexpr TileMapFlags operator|(TileMapFlags a, TileMapFlags b) { return static_cast<TileMapFlags>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b)); }
+constexpr TileMapFlags operator&(TileMapFlags a, TileMapFlags b) { return static_cast<TileMapFlags>(static_cast<uint16_t>(a) & static_cast<uint16_t>(b)); }
+constexpr TileMapFlags operator^(TileMapFlags a, TileMapFlags b) { return static_cast<TileMapFlags>(static_cast<uint16_t>(a) ^ static_cast<uint16_t>(b)); }
+constexpr TileMapFlags operator~(TileMapFlags a) { return static_cast<TileMapFlags>(~static_cast<uint16_t>(a)); }
+constexpr TileMapFlags& operator|=(TileMapFlags& a, TileMapFlags b) { a = a | b; return a; }
+constexpr TileMapFlags& operator&=(TileMapFlags& a, TileMapFlags b) { a = a & b; return a; }
+constexpr TileMapFlags& operator^=(TileMapFlags& a, TileMapFlags b) { a = a ^ b; return a; }
+
+enum class TileStatFlags : uint16_t {
+	NONE = 0x0000,
+	SELECTED = 0x0001,
+	UNIQUE = 0x0002,
+	BLOCKING = 0x0004,
+	OP_BORDER = 0x0008, // If this is true, gravel will be placed on the tile!
+	HAS_TABLE = 0x0010,
+	HAS_CARPET = 0x0020,
+	MODIFIED = 0x0040,
+	HOOK_SOUTH = 0x0080,
+	HOOK_EAST = 0x0100,
+	HAS_LIGHT = 0x0200
+};
+
+constexpr TileStatFlags operator|(TileStatFlags a, TileStatFlags b) { return static_cast<TileStatFlags>(static_cast<uint16_t>(a) | static_cast<uint16_t>(b)); }
+constexpr TileStatFlags operator&(TileStatFlags a, TileStatFlags b) { return static_cast<TileStatFlags>(static_cast<uint16_t>(a) & static_cast<uint16_t>(b)); }
+constexpr TileStatFlags operator^(TileStatFlags a, TileStatFlags b) { return static_cast<TileStatFlags>(static_cast<uint16_t>(a) ^ static_cast<uint16_t>(b)); }
+constexpr TileStatFlags operator~(TileStatFlags a) { return static_cast<TileStatFlags>(~static_cast<uint16_t>(a)); }
+constexpr TileStatFlags& operator|=(TileStatFlags& a, TileStatFlags b) { a = a | b; return a; }
+constexpr TileStatFlags& operator&=(TileStatFlags& a, TileStatFlags b) { a = a & b; return a; }
+constexpr TileStatFlags& operator^=(TileStatFlags& a, TileStatFlags b) { a = a ^ b; return a; }
 
 enum : uint8_t {
 	INVALID_MINIMAP_COLOR = 0xFF
@@ -70,8 +89,8 @@ public: // Members
 	std::unique_ptr<Creature> creature;
 	std::unique_ptr<Spawn> spawn;
 	uint32_t house_id; // House id for this tile (pointer not safe)
-	uint16_t mapflags;
-	uint16_t statflags;
+	TileMapFlags mapflags;
+	TileStatFlags statflags;
 	uint8_t minimapColor;
 
 public:
@@ -110,13 +129,13 @@ public: // Functions
 
 	// Has tile been modified since the map was loaded/created?
 	bool isModified() const {
-		return testFlags(statflags, TILESTATE_MODIFIED);
+		return testFlags(statflags, TileStatFlags::MODIFIED);
 	}
 	void modify() {
-		statflags |= TILESTATE_MODIFIED;
+		statflags |= TileStatFlags::MODIFIED;
 	}
 	void unmodify() {
-		statflags &= ~TILESTATE_MODIFIED;
+		statflags &= ~TileStatFlags::MODIFIED;
 	}
 
 	// Get memory footprint size
@@ -129,18 +148,18 @@ public: // Functions
 
 	// Blocking?
 	bool isBlocking() const {
-		return testFlags(statflags, TILESTATE_BLOCKING);
+		return testFlags(statflags, TileStatFlags::BLOCKING);
 	}
 
 	// PZ
 	bool isPZ() const {
-		return testFlags(mapflags, TILESTATE_PROTECTIONZONE);
+		return testFlags(mapflags, TileMapFlags::PROTECTIONZONE);
 	}
 	void setPZ(bool pz) {
 		if (pz) {
-			mapflags |= TILESTATE_PROTECTIONZONE;
+			mapflags |= TileMapFlags::PROTECTIONZONE;
 		} else {
-			mapflags &= ~TILESTATE_PROTECTIONZONE;
+			mapflags &= ~TileMapFlags::PROTECTIONZONE;
 		}
 	}
 
@@ -152,10 +171,10 @@ public: // Functions
 	void addItem(std::unique_ptr<Item> item);
 
 	bool isSelected() const {
-		return testFlags(statflags, TILESTATE_SELECTED);
+		return testFlags(statflags, TileStatFlags::SELECTED);
 	}
 	bool hasUniqueItem() const {
-		return testFlags(statflags, TILESTATE_UNIQUE);
+		return testFlags(statflags, TileStatFlags::UNIQUE);
 	}
 
 	uint8_t getMiniMapColor() const;
@@ -172,35 +191,35 @@ public: // Functions
 	GroundBrush* getGroundBrush() const;
 
 	bool hasTable() const {
-		return testFlags(statflags, TILESTATE_HAS_TABLE);
+		return testFlags(statflags, TileStatFlags::HAS_TABLE);
 	}
 	Item* getTable() const;
 
 	bool hasCarpet() const {
-		return testFlags(statflags, TILESTATE_HAS_CARPET);
+		return testFlags(statflags, TileStatFlags::HAS_CARPET);
 	}
 	Item* getCarpet() const;
 
 	bool hasHookSouth() const {
-		return testFlags(statflags, TILESTATE_HOOK_SOUTH);
+		return testFlags(statflags, TileStatFlags::HOOK_SOUTH);
 	}
 
 	bool hasHookEast() const {
-		return testFlags(statflags, TILESTATE_HOOK_EAST);
+		return testFlags(statflags, TileStatFlags::HOOK_EAST);
 	}
 
 	bool hasLight() const {
-		return testFlags(statflags, TILESTATE_HAS_LIGHT);
+		return testFlags(statflags, TileStatFlags::HAS_LIGHT);
 	}
 
 	bool hasOptionalBorder() const {
-		return testFlags(statflags, TILESTATE_OP_BORDER);
+		return testFlags(statflags, TileStatFlags::OP_BORDER);
 	}
 	void setOptionalBorder(bool b) {
 		if (b) {
-			statflags |= TILESTATE_OP_BORDER;
+			statflags |= TileStatFlags::OP_BORDER;
 		} else {
-			statflags &= ~TILESTATE_OP_BORDER;
+			statflags &= ~TileStatFlags::OP_BORDER;
 		}
 	}
 
@@ -221,14 +240,14 @@ public: // Functions
 	void setHouse(House* house);
 
 	// Mapflags (PZ, PVPZONE etc.)
-	void setMapFlags(uint16_t _flags);
-	void unsetMapFlags(uint16_t _flags);
-	uint16_t getMapFlags() const;
+	void setMapFlags(TileMapFlags _flags);
+	void unsetMapFlags(TileMapFlags _flags);
+	TileMapFlags getMapFlags() const;
 
 	// Statflags (You really ought not to touch this)
-	void setStatFlags(uint16_t _flags);
-	void unsetStatFlags(uint16_t _flags);
-	uint16_t getStatFlags() const;
+	void setStatFlags(TileStatFlags _flags);
+	void unsetStatFlags(TileStatFlags _flags);
+	TileStatFlags getStatFlags() const;
 };
 
 bool tilePositionLessThan(const Tile* a, const Tile* b);
@@ -251,27 +270,27 @@ inline uint32_t Tile::getHouseID() const {
 	return house_id;
 }
 
-inline void Tile::setMapFlags(uint16_t _flags) {
-	mapflags = _flags | mapflags;
+inline void Tile::setMapFlags(TileMapFlags _flags) {
+	mapflags |= _flags;
 }
 
-inline void Tile::unsetMapFlags(uint16_t _flags) {
+inline void Tile::unsetMapFlags(TileMapFlags _flags) {
 	mapflags &= ~_flags;
 }
 
-inline uint16_t Tile::getMapFlags() const {
+inline TileMapFlags Tile::getMapFlags() const {
 	return mapflags;
 }
 
-inline void Tile::setStatFlags(uint16_t _flags) {
-	statflags = _flags | statflags;
+inline void Tile::setStatFlags(TileStatFlags _flags) {
+	statflags |= _flags;
 }
 
-inline void Tile::unsetStatFlags(uint16_t _flags) {
+inline void Tile::unsetStatFlags(TileStatFlags _flags) {
 	statflags &= ~_flags;
 }
 
-inline uint16_t Tile::getStatFlags() const {
+inline TileStatFlags Tile::getStatFlags() const {
 	return statflags;
 }
 

--- a/source/map/tile_operations.cpp
+++ b/source/map/tile_operations.cpp
@@ -33,12 +33,12 @@ namespace TileOperations {
 			items.erase(first_to_remove, items.end());
 		}
 
-		void UpdateItemFlags(const Item* i, uint16_t& statflags, uint8_t& minimapColor) {
+		void UpdateItemFlags(const Item* i, TileStatFlags& statflags, uint8_t& minimapColor) {
 			if (i->isSelected()) {
-				statflags |= TILESTATE_SELECTED;
+				statflags |= TileStatFlags::SELECTED;
 			}
 			if (i->getUniqueID() != 0) {
-				statflags |= TILESTATE_UNIQUE;
+				statflags |= TileStatFlags::UNIQUE;
 			}
 			if (i->getMiniMapColor() != 0) {
 				minimapColor = i->getMiniMapColor();
@@ -46,25 +46,25 @@ namespace TileOperations {
 
 			const auto it_type = i->getDefinition();
 			if (it_type.hasFlag(ItemFlag::Unpassable)) {
-				statflags |= TILESTATE_BLOCKING;
+				statflags |= TileStatFlags::BLOCKING;
 			}
 			if (it_type.hasFlag(ItemFlag::IsOptionalBorder)) {
-				statflags |= TILESTATE_OP_BORDER;
+				statflags |= TileStatFlags::OP_BORDER;
 			}
 			if (it_type.hasFlag(ItemFlag::IsTable)) {
-				statflags |= TILESTATE_HAS_TABLE;
+				statflags |= TileStatFlags::HAS_TABLE;
 			}
 			if (it_type.hasFlag(ItemFlag::IsCarpet)) {
-				statflags |= TILESTATE_HAS_CARPET;
+				statflags |= TileStatFlags::HAS_CARPET;
 			}
 			if (it_type.hasFlag(ItemFlag::HookSouth)) {
-				statflags |= TILESTATE_HOOK_SOUTH;
+				statflags |= TileStatFlags::HOOK_SOUTH;
 			}
 			if (it_type.hasFlag(ItemFlag::HookEast)) {
-				statflags |= TILESTATE_HOOK_EAST;
+				statflags |= TileStatFlags::HOOK_EAST;
 			}
 			if (i->hasLight()) {
-				statflags |= TILESTATE_HAS_LIGHT;
+				statflags |= TileStatFlags::HAS_LIGHT;
 			}
 		}
 
@@ -241,7 +241,7 @@ namespace TileOperations {
 			i->select();
 		});
 
-		tile->statflags |= TILESTATE_SELECTED;
+		tile->statflags |= TileStatFlags::SELECTED;
 	}
 
 	void deselect(Tile* tile) {
@@ -259,7 +259,7 @@ namespace TileOperations {
 			i->deselect();
 		});
 
-		tile->statflags &= ~TILESTATE_SELECTED;
+		tile->statflags &= ~TileStatFlags::SELECTED;
 	}
 
 	void selectGround(Tile* tile) {
@@ -275,7 +275,7 @@ namespace TileOperations {
 		}
 
 		if (selected_) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlags::SELECTED;
 		}
 	}
 
@@ -388,35 +388,35 @@ namespace TileOperations {
 	}
 
 	void update(Tile* tile) {
-		tile->statflags &= TILESTATE_MODIFIED;
+		tile->statflags &= TileStatFlags::MODIFIED;
 
 		if (tile->spawn && tile->spawn->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlags::SELECTED;
 		}
 		if (tile->creature && tile->creature->isSelected()) {
-			tile->statflags |= TILESTATE_SELECTED;
+			tile->statflags |= TileStatFlags::SELECTED;
 		}
 
 		tile->minimapColor = 0; // Reset to "no color" (valid)
 
 		if (tile->ground) {
 			if (tile->ground->isSelected()) {
-				tile->statflags |= TILESTATE_SELECTED;
+				tile->statflags |= TileStatFlags::SELECTED;
 			}
 			if (tile->ground->isBlocking()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlags::BLOCKING;
 			}
 			if (tile->ground->getUniqueID() != 0) {
-				tile->statflags |= TILESTATE_UNIQUE;
+				tile->statflags |= TileStatFlags::UNIQUE;
 			}
 			if (tile->ground->getMiniMapColor() != 0) {
 				tile->minimapColor = tile->ground->getMiniMapColor();
 			}
 			if (tile->ground->hasLight()) {
-				tile->statflags |= TILESTATE_HAS_LIGHT;
+				tile->statflags |= TileStatFlags::HAS_LIGHT;
 			}
 		} else {
-			tile->mapflags = TILESTATE_NONE;
+			tile->mapflags = TileMapFlags::NONE;
 			tile->house_id = 0;
 		}
 
@@ -424,9 +424,9 @@ namespace TileOperations {
 			UpdateItemFlags(i.get(), tile->statflags, tile->minimapColor);
 		});
 
-		if ((tile->statflags & TILESTATE_BLOCKING) == 0) {
+		if ((tile->statflags & TileStatFlags::BLOCKING) == TileStatFlags::NONE) {
 			if (tile->ground == nullptr && tile->items.empty()) {
-				tile->statflags |= TILESTATE_BLOCKING;
+				tile->statflags |= TileStatFlags::BLOCKING;
 			}
 		}
 	}

--- a/source/rendering/drawers/overlays/preview_drawer.cpp
+++ b/source/rendering/drawers/overlays/preview_drawer.cpp
@@ -80,14 +80,14 @@ void PreviewDrawer::draw(SpriteBatch& sprite_batch, MapCanvas* canvas, const Ren
 							r /= 2;
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_PVPZONE) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlags::PVPZONE) != TileMapFlags::NONE) {
 							r = r / 3 * 2;
 							b = r / 3 * 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlags::NOLOGOUT) != TileMapFlags::NONE) {
 							b /= 2;
 						}
-						if (options.show_special_tiles && tile->getMapFlags() & TILESTATE_NOPVP) {
+						if (options.show_special_tiles && (tile->getMapFlags() & TileMapFlags::NOPVP) != TileMapFlags::NONE) {
 							g /= 2;
 						}
 						if (tile->ground) {

--- a/source/rendering/drawers/tiles/tile_color_calculator.cpp
+++ b/source/rendering/drawers/tiles/tile_color_calculator.cpp
@@ -65,16 +65,16 @@ void TileColorCalculator::Calculate(const Tile* tile, const DrawingOptions& opti
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_PVPZONE) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlags::PVPZONE) != TileMapFlags::NONE) {
 		g = r >> 2;
 		b = (b * 171) >> 8;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOLOGOUT) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlags::NOLOGOUT) != TileMapFlags::NONE) {
 		b >>= 1;
 	}
 
-	if (showspecial && tile->getMapFlags() & TILESTATE_NOPVP) {
+	if (showspecial && (tile->getMapFlags() & TileMapFlags::NOPVP) != TileMapFlags::NONE) {
 		g >>= 1;
 	}
 }

--- a/source/ui/browse_tile_window.cpp
+++ b/source/ui/browse_tile_window.cpp
@@ -199,9 +199,9 @@ BrowseTileWindow::BrowseTileWindow(wxWindow* parent, Tile* tile, wxPoint positio
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Position:  " + pos), wxSizerFlags(0).Left());
 	infoSizer->Add(item_count_txt = newd wxStaticText(this, wxID_ANY, "Item count:  " + i2ws(item_list->GetItemCount())), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "Protection zone:  " + b2yn(tile->isPZ())), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn(tile->getMapFlags() & TILESTATE_NOPVP)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn(tile->getMapFlags() & TILESTATE_NOLOGOUT)), wxSizerFlags(0).Left());
-	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn(tile->getMapFlags() & TILESTATE_PVPZONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No PvP:  " + b2yn((tile->getMapFlags() & TileMapFlags::NOPVP) != TileMapFlags::NONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "No logout:  " + b2yn((tile->getMapFlags() & TileMapFlags::NOLOGOUT) != TileMapFlags::NONE)), wxSizerFlags(0).Left());
+	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "PvP zone:  " + b2yn((tile->getMapFlags() & TileMapFlags::PVPZONE) != TileMapFlags::NONE)), wxSizerFlags(0).Left());
 	infoSizer->Add(newd wxStaticText(this, wxID_ANY, "House:  " + b2yn(tile->isHouseTile())), wxSizerFlags(0).Left());
 
 	sizer->Add(infoSizer, wxSizerFlags(0).Left().DoubleBorder());

--- a/source/ui/tile_properties/map_flags_panel.cpp
+++ b/source/ui/tile_properties/map_flags_panel.cpp
@@ -44,9 +44,9 @@ void MapFlagsPanel::SetTile(Tile* tile, Map* map) {
 
 	if (tile) {
 		chk_pz->SetValue(tile->isPZ());
-		chk_nopvp->SetValue(tile->getMapFlags() & TILESTATE_NOPVP);
-		chk_nologout->SetValue(tile->getMapFlags() & TILESTATE_NOLOGOUT);
-		chk_pvpzone->SetValue(tile->getMapFlags() & TILESTATE_PVPZONE);
+		chk_nopvp->SetValue((tile->getMapFlags() & TileMapFlags::NOPVP) != TileMapFlags::NONE);
+		chk_nologout->SetValue((tile->getMapFlags() & TileMapFlags::NOLOGOUT) != TileMapFlags::NONE);
+		chk_pvpzone->SetValue((tile->getMapFlags() & TileMapFlags::PVPZONE) != TileMapFlags::NONE);
 
 		chk_pz->Enable(true);
 		chk_nopvp->Enable(true);
@@ -79,21 +79,21 @@ void MapFlagsPanel::OnToggleFlag(wxCommandEvent& event) {
 	new_tile->setPZ(chk_pz->GetValue());
 
 	if (chk_nopvp->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOPVP);
+		new_tile->setMapFlags(TileMapFlags::NOPVP);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOPVP);
+		new_tile->unsetMapFlags(TileMapFlags::NOPVP);
 	}
 
 	if (chk_nologout->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->setMapFlags(TileMapFlags::NOLOGOUT);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_NOLOGOUT);
+		new_tile->unsetMapFlags(TileMapFlags::NOLOGOUT);
 	}
 
 	if (chk_pvpzone->GetValue()) {
-		new_tile->setMapFlags(TILESTATE_PVPZONE);
+		new_tile->setMapFlags(TileMapFlags::PVPZONE);
 	} else {
-		new_tile->unsetMapFlags(TILESTATE_PVPZONE);
+		new_tile->unsetMapFlags(TileMapFlags::PVPZONE);
 	}
 
 	Tile* old_ptr = new_tile.get();


### PR DESCRIPTION
👃 Smeller: Fix TILESTATE_ enums overlapping in tile.h

The `TILESTATE_` macros inside `source/map/tile.h` were inside an unnamed `enum` with two blocks containing overlapping values (`mapflags` and `statflags`).
These have been separated into distinct strongly-typed enums (`TileMapFlags` and `TileStatFlags` with `uint16_t` underlying types) to prevent overlapping value ranges and logic errors, bringing it up to modern C++ standards.
Bitwise operators have been implemented for seamless flag manipulation.
Various calls to `TILESTATE_` constants have been updated with their modern `TileMapFlags` and `TileStatFlags` equivalents.

---
*PR created automatically by Jules for task [4844115165410714511](https://jules.google.com/task/4844115165410714511) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modernized the internal tile flag system to use strongly-typed enumerations for improved code safety and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->