### PR TITLE
🗝️ Keeper: Modernize ownership and RAII patterns

### DIFF
--- a/source/app/rme_forward_declarations.h
+++ b/source/app/rme_forward_declarations.h
@@ -50,9 +50,9 @@ class ReplaceToolWindow;
 #include <vector>
 
 using HouseExitList = std::vector<uint32_t>;
-using TileVector = std::vector<Tile*>;
-using TileSet = std::vector<Tile*>;
-using ItemVector = std::vector<Item*>;
-using BrushVector = std::vector<Brush*>;
+using TileVector = std::vector<Tile*>; // Non-owning observers
+using TileSet = std::vector<Tile*>; // Non-owning observers
+using ItemVector = std::vector<Item*>; // Non-owning observers
+using BrushVector = std::vector<Brush*>; // Non-owning observers
 
 #endif

--- a/source/editor/action.cpp
+++ b/source/editor/action.cpp
@@ -39,15 +39,15 @@ Change::Change(std::unique_ptr<Tile> t) :
 	ASSERT(std::get<std::unique_ptr<Tile>>(data));
 }
 
-Change* Change::Create(House* house, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(House* house, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_HOUSE_EXIT;
 	c->data = HouseExitChangeData { .houseId = house->getID(), .pos = where };
 	return c;
 }
 
-Change* Change::Create(Waypoint* wp, const Position& where) {
-	Change* c = newd Change();
+std::unique_ptr<Change> Change::Create(Waypoint* wp, const Position& where) {
+	std::unique_ptr<Change> c(newd Change());
 	c->type = CHANGE_MOVE_WAYPOINT;
 	c->data = WaypointChangeData { .name = wp->name, .pos = where };
 	return c;

--- a/source/editor/action.h
+++ b/source/editor/action.h
@@ -65,8 +65,8 @@ private:
 
 public:
 	explicit Change(std::unique_ptr<Tile> tile);
-	static Change* Create(House* house, const Position& where);
-	static Change* Create(Waypoint* wp, const Position& where);
+	static std::unique_ptr<Change> Create(House* house, const Position& where);
+	static std::unique_ptr<Change> Create(Waypoint* wp, const Position& where);
 	~Change();
 	void clear();
 

--- a/source/editor/operations/draw_operations.cpp
+++ b/source/editor/operations/draw_operations.cpp
@@ -309,7 +309,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(house, offset)));
+		action->addChange(Change::Create(house, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WaypointBrush>()) {
@@ -325,7 +325,7 @@ void DrawOperations::draw(Editor& editor, Position offset, bool alt, bool dodraw
 
 		std::unique_ptr<BatchAction> batch = editor.actionQueue->createBatch(ACTION_DRAW);
 		std::unique_ptr<Action> action = editor.actionQueue->createAction(batch.get());
-		action->addChange(std::unique_ptr<Change>(Change::Create(waypoint, offset)));
+		action->addChange(Change::Create(waypoint, offset));
 		batch->addAndCommitAction(std::move(action));
 		editor.addBatch(std::move(batch), 2);
 	} else if (brush->is<WallBrush>()) {

--- a/source/editor/selection.h
+++ b/source/editor/selection.h
@@ -127,6 +127,7 @@ private:
 	// We use std::vector here instead of std::set for performance reasons.
 	// Selections are typically small, and std::vector provides better cache locality
 	// and fewer allocations. We maintain sorted order to allow O(log n) lookups.
+	// These are non-owning observers.
 	std::vector<Tile*> tiles;
 	std::vector<Tile*> pending_adds;
 	std::vector<Tile*> pending_removes;

--- a/source/ingame_preview/ingame_preview_renderer.cpp
+++ b/source/ingame_preview/ingame_preview_renderer.cpp
@@ -29,7 +29,7 @@ namespace IngamePreview {
 		sprite_batch = std::make_unique<SpriteBatch>();
 		primitive_renderer = std::make_unique<PrimitiveRenderer>();
 		light_buffer = std::make_unique<LightBuffer>();
-		light_drawer = std::make_shared<LightDrawer>();
+		light_drawer = std::make_unique<LightDrawer>();
 		creature_drawer = std::make_unique<CreatureDrawer>();
 		creature_name_drawer = std::make_unique<CreatureNameDrawer>();
 		sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/ingame_preview/ingame_preview_renderer.h
+++ b/source/ingame_preview/ingame_preview_renderer.h
@@ -64,7 +64,7 @@ namespace IngamePreview {
 		std::unique_ptr<SpriteBatch> sprite_batch;
 		std::unique_ptr<PrimitiveRenderer> primitive_renderer;
 		std::unique_ptr<LightBuffer> light_buffer;
-		std::shared_ptr<LightDrawer> light_drawer;
+		std::unique_ptr<LightDrawer> light_drawer;
 
 		// Drawers
 		std::unique_ptr<CreatureDrawer> creature_drawer;

--- a/source/map/tile.h
+++ b/source/map/tile.h
@@ -64,7 +64,7 @@ enum : uint8_t {
 
 class Tile {
 public: // Members
-	TileLocation* location;
+	TileLocation* location; // Non-owning observer
 	std::unique_ptr<Item> ground;
 	std::vector<std::unique_ptr<Item>> items;
 	std::unique_ptr<Creature> creature;
@@ -235,9 +235,9 @@ bool tilePositionLessThan(const Tile* a, const Tile* b);
 // This sorts them by draw order
 bool tilePositionVisualLessThan(const Tile* a, const Tile* b);
 
-using TileVector = std::vector<Tile*>;
-using TileSet = std::vector<Tile*>;
-using TileList = std::list<Tile*>;
+using TileVector = std::vector<Tile*>; // Non-owning observers
+using TileSet = std::vector<Tile*>; // Non-owning observers
+using TileList = std::list<Tile*>; // Non-owning observers
 
 inline bool Tile::hasWall() const {
 	return getWall() != nullptr;

--- a/source/rendering/core/game_sprite.h
+++ b/source/rendering/core/game_sprite.h
@@ -45,9 +45,8 @@ public:
 	virtual void unloadDC() = 0;
 	virtual wxSize GetSize() const = 0;
 
-private:
-	Sprite(const Sprite&);
-	Sprite& operator=(const Sprite&);
+	Sprite(const Sprite&) = delete;
+	Sprite& operator=(const Sprite&) = delete;
 };
 
 class GameSprite;

--- a/source/rendering/core/image.cpp
+++ b/source/rendering/core/image.cpp
@@ -8,7 +8,7 @@ Image::Image() :
 }
 
 void Image::visit() const {
-	lastaccess.store(static_cast<int64_t>(g_gui.gfx.getCachedTime()), std::memory_order_relaxed);
+	lastaccess.store(static_cast<int64_t>(g_gui.gfx.getCachedTime()), std::memory_order_release);
 }
 
 void Image::clean(time_t time, int longevity) {

--- a/source/rendering/core/normal_image.cpp
+++ b/source/rendering/core/normal_image.cpp
@@ -39,7 +39,7 @@ void NormalImage::clean(time_t time, int longevity) {
 	if (longevity == -1) {
 		longevity = g_settings.getInteger(Config::TEXTURE_LONGEVITY);
 	}
-	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > longevity) {
+	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_acquire)) > longevity) {
 		if (g_gui.gfx.hasAtlasManager()) {
 			g_gui.gfx.getAtlasManager()->removeSprite(id);
 		}
@@ -56,7 +56,7 @@ void NormalImage::clean(time_t time, int longevity) {
 		g_gui.gfx.collector.NotifyTextureUnloaded();
 	}
 
-	if (time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > 5 && !g_settings.getInteger(Config::USE_MEMCACHED_SPRITES)) { // We keep dumps around for 5 seconds.
+	if (time - static_cast<time_t>(lastaccess.load(std::memory_order_acquire)) > 5 && !g_settings.getInteger(Config::USE_MEMCACHED_SPRITES)) { // We keep dumps around for 5 seconds.
 		dump.reset();
 	}
 }

--- a/source/rendering/core/template_image.cpp
+++ b/source/rendering/core/template_image.cpp
@@ -33,7 +33,7 @@ void TemplateImage::clean(time_t time, int longevity) {
 	if (longevity == -1) {
 		longevity = g_settings.getInteger(Config::TEXTURE_LONGEVITY);
 	}
-	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_relaxed)) > longevity) {
+	if (isGLLoaded && time - static_cast<time_t>(lastaccess.load(std::memory_order_acquire)) > longevity) {
 		if (g_gui.gfx.hasAtlasManager()) {
 			g_gui.gfx.getAtlasManager()->removeSprite(texture_id);
 		}

--- a/source/rendering/map_drawer.cpp
+++ b/source/rendering/map_drawer.cpp
@@ -88,7 +88,7 @@ void main() {
 MapDrawer::MapDrawer(MapCanvas* canvas) :
 	canvas(canvas), editor(canvas->editor) {
 
-	light_drawer = std::make_shared<LightDrawer>();
+	light_drawer = std::make_unique<LightDrawer>();
 	tooltip_drawer = std::make_unique<TooltipDrawer>();
 
 	sprite_drawer = std::make_unique<SpriteDrawer>();

--- a/source/rendering/map_drawer.h
+++ b/source/rendering/map_drawer.h
@@ -65,7 +65,7 @@ class MapDrawer {
 	Editor& editor;
 	DrawingOptions options;
 	RenderView view;
-	std::shared_ptr<LightDrawer> light_drawer;
+	std::unique_ptr<LightDrawer> light_drawer;
 	LightBuffer light_buffer;
 	std::unique_ptr<TooltipDrawer> tooltip_drawer;
 	std::unique_ptr<GridDrawer> grid_drawer;


### PR DESCRIPTION
Implemented autonomous code-quality maintenance based on the rules and targets established in `keeper.md`.

*   **Tile raw pointers:** Added comments explicitly identifying non-owning observers (`TileLocation`, `TileVector`, `TileSet`, `TileList`) for clearer intent.
*   **Action/Change Factory:** Refactored `Change::Create` to return `std::unique_ptr<Change>` rather than a raw pointer to enforce explicit ownership boundaries and prevent memory leaks. Also updated dependent callers like `draw_operations.cpp`.
*   **LightDrawer:** Converted `std::shared_ptr<LightDrawer>` to `std::unique_ptr<LightDrawer>` in both `MapDrawer` and `IngamePreviewRenderer` as shared ownership was unnecessary and added overhead.
*   **Memory Ordering:** Fixed relaxed atomic loads/stores on `GameSprite::Image::lastaccess` to use explicit `std::memory_order_acquire` and `std::memory_order_release` to properly establish memory bounds and prevent thread concurrency issues.
*   **Sprite:** Explicitly deleted the copy constructor and assignment operator for `Sprite` using `= delete` according to modern C++ conventions instead of declaring them private and undefined.

---
*PR created automatically by Jules for task [5913716827641881219](https://jules.google.com/task/5913716827641881219) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Updated internal memory management to use smart pointers, improving resource ownership clarity and safety.
  * Optimized synchronization mechanisms for improved thread-safety in rendering operations.
  * Enhanced code annotations for better documentation of non-owning references throughout the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->