### PR TITLE
Refactor wxWidgets event macros

### DIFF
--- a/source/app/updater.h
+++ b/source/app/updater.h
@@ -24,13 +24,6 @@
 
 wxDECLARE_EVENT(EVT_UPDATE_CHECK_FINISHED, wxCommandEvent);
 
-		#define EVT_ON_UPDATE_CHECK_FINISHED(id, fn)                                                    \
-			DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-				EVT_UPDATE_CHECK_FINISHED, id, wxID_ANY,                                                \
-				(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-				(wxObject*)nullptr                                                                      \
-			),
-
 class wxURL;
 
 class UpdateChecker {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -60,13 +60,6 @@ class TilePropertiesPanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
-#define EVT_ON_UPDATE_MENUS(id, fn)                                                             \
-	DECLARE_EVENT_TABLE_ENTRY(                                                                  \
-		EVT_UPDATE_MENUS, id, wxID_ANY,                                                         \
-		(wxObjectEventFunction)(wxEventFunction)wxStaticCastEvent(wxCommandEventFunction, &fn), \
-		(wxObject*)nullptr                                                                      \
-	),
-
 #include <mutex>
 #include "brushes/managers/brush_manager.h"
 #include "palette/managers/palette_manager.h"


### PR DESCRIPTION
Refactor wxWidgets event macros

- Removed legacy `DECLARE_EVENT_TABLE_ENTRY` from `gui.h` and `updater.h`.
- Confirmed that `Bind()` is already used for these custom events (`EVT_UPDATE_MENUS` and `EVT_UPDATE_CHECK_FINISHED`).

---
*PR created automatically by Jules for task [14348775324800358783](https://jules.google.com/task/14348775324800358783) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal event handling code organization by removing convenience macros for event binding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->