### PR TITLE
🖥️ OpenGL: Optimize buffer uploads using direct mapping

### DIFF
--- a/source/rendering/core/multi_draw_indirect_renderer.cpp
+++ b/source/rendering/core/multi_draw_indirect_renderer.cpp
@@ -4,7 +4,6 @@
 #include <utility>
 
 MultiDrawIndirectRenderer::MultiDrawIndirectRenderer() {
-	commands_.reserve(MAX_COMMANDS);
 }
 
 MultiDrawIndirectRenderer::~MultiDrawIndirectRenderer() {
@@ -13,8 +12,12 @@ MultiDrawIndirectRenderer::~MultiDrawIndirectRenderer() {
 
 MultiDrawIndirectRenderer::MultiDrawIndirectRenderer(MultiDrawIndirectRenderer&& other) noexcept
 	:
-	commands_(std::move(other.commands_)),
+	num_commands_(other.num_commands_),
 	command_buffer_(std::move(other.command_buffer_)), available_(other.available_), initialized_(other.initialized_) {
+	for (size_t i = 0; i < num_commands_; ++i) {
+		commands_[i] = other.commands_[i];
+	}
+	other.num_commands_ = 0;
 	other.available_ = false;
 	other.initialized_ = false;
 }
@@ -22,10 +25,14 @@ MultiDrawIndirectRenderer::MultiDrawIndirectRenderer(MultiDrawIndirectRenderer&&
 MultiDrawIndirectRenderer& MultiDrawIndirectRenderer::operator=(MultiDrawIndirectRenderer&& other) noexcept {
 	if (this != &other) {
 		cleanup();
-		commands_ = std::move(other.commands_);
+		num_commands_ = other.num_commands_;
+		for (size_t i = 0; i < num_commands_; ++i) {
+			commands_[i] = other.commands_[i];
+		}
 		command_buffer_ = std::move(other.command_buffer_);
 		available_ = other.available_;
 		initialized_ = other.initialized_;
+		other.num_commands_ = 0;
 		other.available_ = false;
 		other.initialized_ = false;
 	}
@@ -49,7 +56,7 @@ bool MultiDrawIndirectRenderer::initialize() {
 	command_buffer_ = std::make_unique<GLBuffer>();
 
 	// Pre-allocate buffer storage
-	glNamedBufferStorage(command_buffer_->GetID(), MAX_COMMANDS * sizeof(DrawElementsIndirectCommand), nullptr, GL_DYNAMIC_STORAGE_BIT);
+	glNamedBufferStorage(command_buffer_->GetID(), MAX_COMMANDS * sizeof(DrawElementsIndirectCommand), nullptr, GL_MAP_WRITE_BIT | GL_DYNAMIC_STORAGE_BIT);
 
 	initialized_ = true;
 	return true;
@@ -57,16 +64,16 @@ bool MultiDrawIndirectRenderer::initialize() {
 
 void MultiDrawIndirectRenderer::cleanup() {
 	command_buffer_.reset();
-	commands_.clear();
+	num_commands_ = 0;
 	initialized_ = false;
 }
 
 void MultiDrawIndirectRenderer::clear() {
-	commands_.clear();
+	num_commands_ = 0;
 }
 
 void MultiDrawIndirectRenderer::addDrawCommand(GLuint count, GLuint instanceCount, GLuint firstIndex, GLuint baseVertex, GLuint baseInstance) {
-	if (commands_.size() >= MAX_COMMANDS) {
+	if (num_commands_ >= MAX_COMMANDS) {
 		// Max commands reached, ignoring
 		return;
 	}
@@ -75,26 +82,30 @@ void MultiDrawIndirectRenderer::addDrawCommand(GLuint count, GLuint instanceCoun
 		return; // Skip empty draws
 	}
 
-	DrawElementsIndirectCommand cmd;
+	DrawElementsIndirectCommand& cmd = commands_[num_commands_++];
 	cmd.count = count;
 	cmd.instanceCount = instanceCount;
 	cmd.firstIndex = firstIndex;
 	cmd.baseVertex = baseVertex;
 	cmd.baseInstance = baseInstance;
-
-	commands_.push_back(cmd);
 }
 
 void MultiDrawIndirectRenderer::upload() {
-	if (commands_.empty() || !initialized_) {
+	if (num_commands_ == 0 || !initialized_) {
 		return;
 	}
 
-	glNamedBufferSubData(command_buffer_->GetID(), 0, commands_.size() * sizeof(DrawElementsIndirectCommand), commands_.data());
+	void* ptr = glMapNamedBufferRange(command_buffer_->GetID(), 0, num_commands_ * sizeof(DrawElementsIndirectCommand), GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT);
+	if (ptr) {
+		for (size_t i = 0; i < num_commands_; ++i) {
+			static_cast<DrawElementsIndirectCommand*>(ptr)[i] = commands_[i];
+		}
+		glUnmapNamedBuffer(command_buffer_->GetID());
+	}
 }
 
 void MultiDrawIndirectRenderer::execute() {
-	if (commands_.empty() || !available_ || !initialized_) {
+	if (num_commands_ == 0 || !available_ || !initialized_) {
 		return;
 	}
 
@@ -102,6 +113,6 @@ void MultiDrawIndirectRenderer::execute() {
 	glBindBuffer(GL_DRAW_INDIRECT_BUFFER, command_buffer_->GetID());
 	glMultiDrawElementsIndirect(GL_TRIANGLES, GL_UNSIGNED_INT,
 								nullptr, // Offset 0 in bound buffer
-								static_cast<GLsizei>(commands_.size()), sizeof(DrawElementsIndirectCommand));
+								static_cast<GLsizei>(num_commands_), sizeof(DrawElementsIndirectCommand));
 	glBindBuffer(GL_DRAW_INDIRECT_BUFFER, 0);
 }

--- a/source/rendering/core/multi_draw_indirect_renderer.h
+++ b/source/rendering/core/multi_draw_indirect_renderer.h
@@ -79,7 +79,7 @@ public:
 	 * Get number of pending commands.
 	 */
 	size_t getCommandCount() const {
-		return commands_.size();
+		return num_commands_;
 	}
 
 	/**
@@ -90,7 +90,8 @@ public:
 	}
 
 private:
-	std::vector<DrawElementsIndirectCommand> commands_;
+	DrawElementsIndirectCommand commands_[MAX_COMMANDS];
+	size_t num_commands_ = 0;
 	std::unique_ptr<GLBuffer> command_buffer_;
 	bool available_ = false;
 	bool initialized_ = false;

--- a/source/rendering/drawers/minimap_renderer.cpp
+++ b/source/rendering/drawers/minimap_renderer.cpp
@@ -87,7 +87,7 @@ bool MinimapRenderer::initialize() {
 
 	// Pre-allocate instance buffer
 	instance_vbo_capacity_ = 1024;
-	glNamedBufferStorage(instance_vbo_->GetID(), instance_vbo_capacity_ * sizeof(InstanceData), nullptr, GL_DYNAMIC_STORAGE_BIT);
+	glNamedBufferStorage(instance_vbo_->GetID(), instance_vbo_capacity_ * sizeof(InstanceData), nullptr, GL_MAP_WRITE_BIT | GL_DYNAMIC_STORAGE_BIT);
 
 	// Setup VAO (DSA)
 	GLuint vao = vao_->GetID();
@@ -309,43 +309,45 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 	end_row = std::min(rows_ - 1, end_row);
 
 	// Collect instances
-	instance_data_.clear();
-	instance_data_.reserve((end_row - start_row + 1) * (end_col - start_col + 1));
+	size_t needed_instances = static_cast<size_t>((end_row - start_row + 1) * (end_col - start_col + 1));
 
-	for (int r = start_row; r <= end_row; ++r) {
-		for (int c = start_col; c <= end_col; ++c) {
-			int tile_x = c * TILE_SIZE;
-			int tile_y = r * TILE_SIZE;
-
-			// Calculate screen position (dest rect)
-			float screen_tile_x = x + (tile_x - map_x) * scale_x;
-			float screen_tile_y = y + (tile_y - map_y) * scale_y;
-			float screen_tile_w = TILE_SIZE * scale_x;
-			float screen_tile_h = TILE_SIZE * scale_y;
-
-			int layer = r * cols_ + c;
-
-			instance_data_.push_back({ .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = static_cast<float>(layer) });
-		}
-	}
-
-	if (instance_data_.empty()) {
+	if (needed_instances == 0) {
 		return;
 	}
 
 	// Resize buffer if needed
-	// Resize buffer if needed
-	if (instance_data_.size() > instance_vbo_capacity_) {
-		instance_vbo_capacity_ = instance_data_.size() * 2; // Grow strategy
+	if (needed_instances > instance_vbo_capacity_) {
+		instance_vbo_capacity_ = needed_instances * 2; // Grow strategy
 		instance_vbo_ = std::make_unique<GLBuffer>();
-		glNamedBufferStorage(instance_vbo_->GetID(), instance_vbo_capacity_ * sizeof(InstanceData), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glNamedBufferStorage(instance_vbo_->GetID(), instance_vbo_capacity_ * sizeof(InstanceData), nullptr, GL_MAP_WRITE_BIT | GL_DYNAMIC_STORAGE_BIT);
 
 		// Update VAO binding
 		glVertexArrayVertexBuffer(vao_->GetID(), 1, instance_vbo_->GetID(), 0, sizeof(InstanceData));
 	}
 
-	// Upload data
-	glNamedBufferSubData(instance_vbo_->GetID(), 0, instance_data_.size() * sizeof(InstanceData), instance_data_.data());
+	num_instances_ = 0;
+
+	InstanceData* mapped_instances = static_cast<InstanceData*>(glMapNamedBufferRange(instance_vbo_->GetID(), 0, instance_vbo_capacity_ * sizeof(InstanceData), GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT));
+
+	if (mapped_instances) {
+		for (int r = start_row; r <= end_row; ++r) {
+			for (int c = start_col; c <= end_col; ++c) {
+				int tile_x = c * TILE_SIZE;
+				int tile_y = r * TILE_SIZE;
+
+				// Calculate screen position (dest rect)
+				float screen_tile_x = x + (tile_x - map_x) * scale_x;
+				float screen_tile_y = y + (tile_y - map_y) * scale_y;
+				float screen_tile_w = TILE_SIZE * scale_x;
+				float screen_tile_h = TILE_SIZE * scale_y;
+
+				int layer = r * cols_ + c;
+
+				mapped_instances[num_instances_++] = { .x = screen_tile_x, .y = screen_tile_y, .w = screen_tile_w, .h = screen_tile_h, .layer = static_cast<float>(layer) };
+			}
+		}
+		glUnmapNamedBuffer(instance_vbo_->GetID());
+	}
 
 	// Render
 	{
@@ -363,7 +365,7 @@ void MinimapRenderer::render(const glm::mat4& projection, int x, int y, int w, i
 		shader_->SetInt("uPaletteTexture", 1);
 
 		glBindVertexArray(vao_->GetID());
-		glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, static_cast<GLsizei>(instance_data_.size()));
+		glDrawElementsInstanced(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0, static_cast<GLsizei>(num_instances_));
 		glBindVertexArray(0);
 	}
 }

--- a/source/rendering/drawers/minimap_renderer.h
+++ b/source/rendering/drawers/minimap_renderer.h
@@ -76,8 +76,8 @@ private:
 	std::unique_ptr<GLVertexArray> vao_;
 
 	std::unique_ptr<GLBuffer> instance_vbo_;
-	std::vector<InstanceData> instance_data_;
 	size_t instance_vbo_capacity_ = 0;
+	size_t num_instances_ = 0;
 
 	int width_ = 0;
 	int height_ = 0;

--- a/source/rendering/utilities/light_drawer.cpp
+++ b/source/rendering/utilities/light_drawer.cpp
@@ -94,49 +94,48 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 
 	// 2. Prepare Lights
 	// Filter and convert lights to GPU format
-	gpu_lights_.clear();
-	gpu_lights_.reserve(light_buffer.lights.size());
-
-	for (const auto& light : light_buffer.lights) {
-		int lx_px = light.map_x * TILE_SIZE + TILE_SIZE / 2;
-		int ly_px = light.map_y * TILE_SIZE + TILE_SIZE / 2;
-
-		float map_pos_x = static_cast<float>(lx_px - view.view_scroll_x);
-		float map_pos_y = static_cast<float>(ly_px - view.view_scroll_y);
-
-		// Convert to Screen Pixels
-		float screen_x = map_pos_x / view.zoom;
-		float screen_y = map_pos_y / view.zoom;
-		float screen_radius = (light.intensity * TILE_SIZE) / view.zoom;
-
-		// Check overlap with Screen Rect
-		if (screen_x + screen_radius < 0 || screen_x - screen_radius > buffer_w || screen_y + screen_radius < 0 || screen_y - screen_radius > buffer_h) {
-			continue;
+	size_t needed_size = light_buffer.lights.size() * sizeof(GPULight);
+	if (needed_size > light_ssbo_capacity_) {
+		light_ssbo_capacity_ = std::max(needed_size, static_cast<size_t>(light_ssbo_capacity_ * 1.5));
+		if (light_ssbo_capacity_ < 1024) {
+			light_ssbo_capacity_ = 1024;
 		}
-
-		wxColor c = colorFromEightBit(light.color);
-
-		gpu_lights_.push_back({ .position = { screen_x, screen_y }, .intensity = static_cast<float>(light.intensity), .padding = 0.0f,
-								// Pre-multiply intensity here if needed, or in shader
-								.color = { (c.Red() / 255.0f) * light_intensity, (c.Green() / 255.0f) * light_intensity, (c.Blue() / 255.0f) * light_intensity, 1.0f } });
+		// Destroy and recreate buffer for Immutable Storage
+		light_ssbo = std::make_unique<GLBuffer>();
+		glNamedBufferStorage(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_MAP_WRITE_BIT | GL_DYNAMIC_STORAGE_BIT);
 	}
 
-	if (gpu_lights_.empty()) {
-		// Just render ambient? We still need to clear the FBO/screen area or simpy fill it.
-		// If no lights, the overlay should just be ambient color.
-	} else {
-		// Upload Lights
-		size_t needed_size = gpu_lights_.size() * sizeof(GPULight);
-		if (needed_size > light_ssbo_capacity_) {
-			light_ssbo_capacity_ = std::max(needed_size, static_cast<size_t>(light_ssbo_capacity_ * 1.5));
-			if (light_ssbo_capacity_ < 1024) {
-				light_ssbo_capacity_ = 1024;
+	num_lights_ = 0;
+
+	if (needed_size > 0) {
+		GPULight* mapped_lights = static_cast<GPULight*>(glMapNamedBufferRange(light_ssbo->GetID(), 0, light_ssbo_capacity_, GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT));
+
+		if (mapped_lights) {
+			for (const auto& light : light_buffer.lights) {
+				int lx_px = light.map_x * TILE_SIZE + TILE_SIZE / 2;
+				int ly_px = light.map_y * TILE_SIZE + TILE_SIZE / 2;
+
+				float map_pos_x = static_cast<float>(lx_px - view.view_scroll_x);
+				float map_pos_y = static_cast<float>(ly_px - view.view_scroll_y);
+
+				// Convert to Screen Pixels
+				float screen_x = map_pos_x / view.zoom;
+				float screen_y = map_pos_y / view.zoom;
+				float screen_radius = (light.intensity * TILE_SIZE) / view.zoom;
+
+				// Check overlap with Screen Rect
+				if (screen_x + screen_radius < 0 || screen_x - screen_radius > buffer_w || screen_y + screen_radius < 0 || screen_y - screen_radius > buffer_h) {
+					continue;
+				}
+
+				wxColor c = colorFromEightBit(light.color);
+
+				mapped_lights[num_lights_++] = { .position = { screen_x, screen_y }, .intensity = static_cast<float>(light.intensity), .padding = 0.0f,
+												// Pre-multiply intensity here if needed, or in shader
+												.color = { (c.Red() / 255.0f) * light_intensity, (c.Green() / 255.0f) * light_intensity, (c.Blue() / 255.0f) * light_intensity, 1.0f } };
 			}
-			// Destroy and recreate buffer for Immutable Storage
-			light_ssbo = std::make_unique<GLBuffer>();
-			glNamedBufferStorage(light_ssbo->GetID(), light_ssbo_capacity_, nullptr, GL_DYNAMIC_STORAGE_BIT);
+			glUnmapNamedBuffer(light_ssbo->GetID());
 		}
-		glNamedBufferSubData(light_ssbo->GetID(), 0, needed_size, gpu_lights_.data());
 	}
 
 	// 3. Render to FBO
@@ -160,7 +159,7 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 		// Actually, for "Max" blending, we want to start with Ambient.
 		glClear(GL_COLOR_BUFFER_BIT);
 
-		if (!gpu_lights_.empty()) {
+		if (num_lights_ > 0) {
 			shader->Use();
 
 			// Setup Projection for FBO: Ortho 0..buffer_w, buffer_h..0 (Y-down)
@@ -177,11 +176,11 @@ void LightDrawer::draw(const RenderView& view, bool fog, const LightBuffer& ligh
 				ScopedGLCapability blendCap(GL_BLEND);
 				ScopedGLBlend blendState(GL_ONE, GL_ONE, GL_MAX); // Factors don't matter much for MAX, but usually 1,1 is safe
 
-				if (gpu_lights_.size() > static_cast<size_t>(std::numeric_limits<GLsizei>::max())) {
+				if (num_lights_ > std::numeric_limits<GLsizei>::max()) {
 					spdlog::error("Too many lights for glDrawArraysInstanced");
 					return;
 				}
-				glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(gpu_lights_.size()));
+				glDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, static_cast<GLsizei>(num_lights_));
 			}
 
 			glBindVertexArray(0);

--- a/source/rendering/utilities/light_drawer.h
+++ b/source/rendering/utilities/light_drawer.h
@@ -58,7 +58,7 @@ private:
 	std::unique_ptr<GLBuffer> light_ssbo;
 	size_t light_ssbo_capacity_ = 0; // Track capacity in bytes
 
-	std::vector<GPULight> gpu_lights_;
+	int num_lights_ = 0;
 
 	std::unique_ptr<GLFramebuffer> fbo;
 	std::unique_ptr<GLTextureResource> fbo_texture;


### PR DESCRIPTION
This PR optimizes CPU-to-GPU data uploads by replacing intermediate `std::vector` instances with direct mapped buffer writes. 

### Changes
*   **`MultiDrawIndirectRenderer`**: Switched command buffer upload to map `command_buffer_` directly using `glMapNamedBufferRange(..., GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT)`. Removed the intermediate `commands_` vector for a fixed-size internal C array to track max command bounds dynamically.
*   **`MinimapRenderer`**: Adapted `instance_vbo_` to map directly using `glMapNamedBufferRange(..., GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT)`. Replaced intermediate `instance_data_` array with mapped instances written iteratively during the spatial hash evaluation.
*   **`LightDrawer`**: Migrated `light_ssbo` logic to map SSBO bounds directly via `glMapNamedBufferRange(..., GL_MAP_WRITE_BIT | GL_MAP_INVALIDATE_BUFFER_BIT)` instead of pushing lights to a `std::vector<GPULight>` and then executing `glNamedBufferSubData`.
*   Added `GL_MAP_WRITE_BIT` to each renderer's initial `glNamedBufferStorage` calls to support direct memory mapped operations.

---
*PR created automatically by Jules for task [12410824329638627922](https://jules.google.com/task/12410824329638627922) started by @karolak6612*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced rendering performance by optimizing GPU memory management for draw command batching, minimap rendering, and light calculations through improved buffer allocation and data handling strategies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->