### PR TITLE
Brush_builders

### DIFF
--- a/scripts/border_studio/border_draft.lua
+++ b/scripts/border_studio/border_draft.lua
@@ -1,0 +1,183 @@
+local Common = dofile("common.lua")
+
+local BorderDraft = {}
+BorderDraft.__index = BorderDraft
+
+local function clone_table(value)
+    return Common.clone(value)
+end
+
+local function read_item_id(raw_item)
+    if type(raw_item) == "table" then
+        return tonumber(raw_item.itemId or raw_item.item_id or raw_item.id or raw_item.rawId or 0) or 0
+    end
+    return tonumber(raw_item or 0) or 0
+end
+
+local function build_raw_reference(raw_item)
+    local item_id = read_item_id(raw_item)
+    if item_id <= 0 then
+        return nil
+    end
+
+    local info = Common.safe_item_info(item_id)
+    local source = type(raw_item) == "table" and raw_item or {}
+
+    return {
+        itemId = item_id,
+        rawId = tonumber(source.rawId or source.raw_id or item_id) or item_id,
+        lookId = tonumber(source.lookId or source.look_id or source.clientId or (info and info.clientId) or 0) or 0,
+        name = source.name or (info and info.name) or ("Item " .. tostring(item_id)),
+    }
+end
+
+local function fresh_slots()
+    local slots = {}
+    for _, slot_name in ipairs(Common.slot_order) do
+        slots[slot_name] = nil
+    end
+    return slots
+end
+
+function BorderDraft.new(init)
+    local self = setmetatable({}, BorderDraft)
+    self.borderId = tonumber((init and (init.borderId or init.id)) or 0) or 0
+    self.name = tostring((init and init.name) or "")
+    self.group = tonumber((init and init.group) or 0) or 0
+    self.isNew = init and (init.isNew == true or init.is_new == true) or false
+    self.status = init and init.status or nil
+    self.slots = fresh_slots()
+
+    for slot_name, raw_item in pairs((init and init.slots) or {}) do
+        self:assignSlot(slot_name, raw_item)
+    end
+
+    return self
+end
+
+function BorderDraft.isValidSlotName(_, slot_name)
+    return Common.is_valid_slot_name(slot_name)
+end
+
+function BorderDraft:getSlotAssignment(slot_name)
+    if not self:isValidSlotName(slot_name) then
+        return nil
+    end
+    return self.slots[slot_name]
+end
+
+function BorderDraft:getSlotItemId(slot_name)
+    local assignment = self:getSlotAssignment(slot_name)
+    return assignment and assignment.itemId or 0
+end
+
+function BorderDraft:clear()
+    self.slots = fresh_slots()
+end
+
+function BorderDraft:isEmpty()
+    for _, slot_name in ipairs(Common.slot_order) do
+        if self:getSlotItemId(slot_name) > 0 then
+            return false
+        end
+    end
+    return true
+end
+
+function BorderDraft:assignSlot(slot_name, raw_item)
+    if not self:isValidSlotName(slot_name) then
+        return false, "Invalid border slot: " .. tostring(slot_name)
+    end
+
+    local reference = build_raw_reference(raw_item)
+    if not reference then
+        return false, "RAW item is missing or invalid."
+    end
+
+    self.slots[slot_name] = reference
+    return true
+end
+
+function BorderDraft:clearSlot(slot_name)
+    if not self:isValidSlotName(slot_name) then
+        return false, "Invalid border slot: " .. tostring(slot_name)
+    end
+
+    self.slots[slot_name] = nil
+    return true
+end
+
+function BorderDraft:getAssignedSlots()
+    local assigned = {}
+    for _, slot_name in ipairs(Common.slot_order) do
+        local assignment = self.slots[slot_name]
+        if assignment then
+            assigned[slot_name] = clone_table(assignment)
+        end
+    end
+    return assigned
+end
+
+function BorderDraft:getEmptySlots()
+    local empty_slots = {}
+    for _, slot_name in ipairs(Common.slot_order) do
+        if self:getSlotItemId(slot_name) <= 0 then
+            table.insert(empty_slots, slot_name)
+        end
+    end
+    return empty_slots
+end
+
+function BorderDraft:getValidation()
+    local has_data = not self:isEmpty()
+    return {
+        hasAssignments = has_data,
+        hasData = has_data,
+        emptySlots = self:getEmptySlots(),
+        invalidSlots = {},
+    }
+end
+
+function BorderDraft:hasRequiredDataForSave()
+    return self.borderId > 0 and not self:isEmpty()
+end
+
+function BorderDraft:clone()
+    return BorderDraft.new({
+        borderId = self.borderId,
+        name = self.name,
+        group = self.group,
+        isNew = self.isNew,
+        status = self.status,
+        slots = self:getAssignedSlots(),
+    })
+end
+
+function BorderDraft:toBorderItemEntries()
+    local entries = {}
+    for _, slot_name in ipairs(Common.slot_order) do
+        local assignment = self.slots[slot_name]
+        if assignment and assignment.itemId and assignment.itemId > 0 then
+            table.insert(entries, {
+                slotName = slot_name,
+                edge = Common.slot_meta[slot_name].edge,
+                itemId = assignment.itemId,
+                raw = clone_table(assignment),
+            })
+        end
+    end
+    return entries
+end
+
+function BorderDraft:toXmlExportData()
+    return {
+        borderId = self.borderId,
+        name = self.name,
+        slots = self:getAssignedSlots(),
+        borderItems = self:toBorderItemEntries(),
+        emptySlots = self:getEmptySlots(),
+        hasRequiredDataForSave = self:hasRequiredDataForSave(),
+    }
+end
+
+return BorderDraft

--- a/scripts/border_studio/border_loader.lua
+++ b/scripts/border_studio/border_loader.lua
@@ -1,0 +1,102 @@
+local Common = dofile("common.lua")
+local BorderDraft = dofile("border_draft.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+local TILE_INDEX_TO_EDGE = {
+    [2] = "n",
+    [3] = "e",
+    [4] = "s",
+    [5] = "w",
+    [6] = "cnw",
+    [7] = "cne",
+    [8] = "csw",
+    [9] = "cse",
+    [10] = "dnw",
+    [11] = "dne",
+    [12] = "dse",
+    [13] = "dsw",
+}
+
+local function fallback_name(border_id)
+    return "Border #" .. tostring(border_id)
+end
+
+local function build_status(draft)
+    return Common.assigned_slot_count(draft) == #Common.slot_order and "complete" or "partial"
+end
+
+function M.apply_edge_map(draft, edge_map, border_id)
+    local warnings = {}
+
+    for edge_name, raw_item in pairs(edge_map or {}) do
+        if Common.is_valid_slot_name(edge_name) then
+            local ok, message = draft:assignSlot(edge_name, raw_item)
+            if not ok then
+                table.insert(warnings, string.format("Border %d: %s", border_id or 0, message))
+            end
+        else
+            table.insert(warnings, string.format("Border %d: unsupported edge '%s' was skipped.", border_id or 0, tostring(edge_name)))
+        end
+    end
+
+    return warnings
+end
+
+function M.draft_from_border_table(border)
+    local border_id = tonumber((border and (border.id or border.borderId)) or 0) or 0
+    Logger.log("loader", string.format("draft_from_border_table start border_id=%d", border_id))
+    local draft = BorderDraft.new({
+        borderId = border_id,
+        name = (border and border.name) or fallback_name(border_id),
+        group = tonumber((border and border.group) or 0) or 0,
+        isNew = false,
+    })
+
+    local edge_map = {}
+    local tiles = (border and border.tiles) or {}
+    for tile_index, edge_name in pairs(TILE_INDEX_TO_EDGE) do
+        local item_id = tonumber(tiles[tile_index] or 0) or 0
+        if item_id > 0 then
+            edge_map[edge_name] = item_id
+        end
+    end
+
+    local warnings = M.apply_edge_map(draft, edge_map, border_id)
+    draft.status = build_status(draft)
+    Logger.log("loader", string.format("draft_from_border_table done border_id=%d assigned=%d status=%s", border_id, Common.assigned_slot_count(draft), draft.status))
+    return draft, warnings
+end
+
+function M.read_library(border_table)
+    Logger.log("loader", "read_library start")
+    local repository = {
+        by_id = {},
+        ordered = {},
+        warnings = {},
+    }
+
+    for id, border in pairs(border_table or {}) do
+        local entry, warnings = M.draft_from_border_table(border)
+        if entry and entry.borderId > 0 then
+            repository.by_id[entry.borderId] = entry
+            table.insert(repository.ordered, entry)
+        end
+
+        for _, warning in ipairs(warnings or {}) do
+            table.insert(repository.warnings, warning)
+            Common.log_warning(warning)
+        end
+    end
+
+    table.sort(repository.ordered, function(left, right)
+        return left.borderId < right.borderId
+    end)
+
+    Logger.log("loader", string.format("read_library done count=%d warnings=%d", #repository.ordered, #repository.warnings))
+
+    return repository
+end
+
+return M

--- a/scripts/border_studio/border_repository.lua
+++ b/scripts/border_studio/border_repository.lua
@@ -1,0 +1,113 @@
+local Common = dofile("common.lua")
+local BorderDraft = dofile("border_draft.lua")
+local BorderLoader = dofile("border_loader.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+local function copy_border(border)
+    if not border then
+        return nil
+    end
+    if border.clone then
+        return border:clone()
+    end
+    return BorderDraft.new(border)
+end
+
+local function rebuild_ordered(repository)
+    repository.ordered = {}
+    for _, border in pairs(repository.by_id or {}) do
+        table.insert(repository.ordered, border)
+    end
+    table.sort(repository.ordered, function(left, right)
+        return left.borderId < right.borderId
+    end)
+    return repository
+end
+
+function M.read(session_borders, border_table)
+    Logger.log("repository", "read start")
+    local repository = BorderLoader.read_library(border_table or app.borders or {})
+
+    for id, border in pairs(session_borders or {}) do
+        repository.by_id[id] = copy_border(border)
+        repository.by_id[id].isNew = false
+        repository.by_id[id].status = Common.border_status(repository.by_id[id])
+    end
+
+    rebuild_ordered(repository)
+    Logger.log("repository", string.format("read done count=%d", #repository.ordered))
+    return repository
+end
+
+function M.copy(border)
+    return copy_border(border)
+end
+
+function M.next_border_id(repository, session_borders, extra_id)
+    local max_id = 0
+
+    for id in pairs((repository and repository.by_id) or {}) do
+        if id > max_id then
+            max_id = id
+        end
+    end
+
+    for id in pairs(session_borders or {}) do
+        if id > max_id then
+            max_id = id
+        end
+    end
+
+    extra_id = tonumber(extra_id or 0) or 0
+    if extra_id > max_id then
+        max_id = extra_id
+    end
+
+    return max_id + 1
+end
+
+function M.border_sources(repository)
+    local sources = {}
+
+    for _, border in ipairs((repository and repository.ordered) or {}) do
+        local display_name = border.name ~= "" and border.name or ("Border #" .. tostring(border.borderId))
+        table.insert(sources, {
+            borderId = border.borderId,
+            name = display_name,
+            group = border.group or 0,
+            status = Common.border_status(border),
+            title = Common.format_border_title(border),
+            sampleItemId = Common.primary_item_id(border),
+            assignedSlotCount = Common.assigned_slot_count(border),
+            tooltip = string.format(
+                "Border %d\n%s\nGroup %d\nStatus: %s\nAssigned slots: %d",
+                border.borderId,
+                display_name,
+                border.group or 0,
+                Common.border_status(border),
+                Common.assigned_slot_count(border)
+            ),
+        })
+    end
+
+    return sources
+end
+
+function M.find_border_source(repository, border_id)
+    border_id = tonumber(border_id or 0) or 0
+    if border_id <= 0 then
+        return nil
+    end
+
+    for _, source in ipairs(M.border_sources(repository)) do
+        if source.borderId == border_id then
+            return source
+        end
+    end
+
+    return nil
+end
+
+return M

--- a/scripts/border_studio/common.lua
+++ b/scripts/border_studio/common.lua
@@ -1,0 +1,370 @@
+local M = {}
+M._image_cache = M._image_cache or {}
+
+M.palette = {
+    header = "#1F2937",
+    panel = "#243447",
+    panel_alt = "#2C3E50",
+    accent = "#D97706",
+    accent_soft = "#F59E0B",
+    success = "#2F855A",
+    text = "#F8FAFC",
+    muted = "#CBD5E1",
+    subtle = "#94A3B8",
+    border = "#475569",
+}
+
+M.slot_order = {
+    "n", "e", "s", "w",
+    "cnw", "cne", "csw", "cse",
+    "dnw", "dne", "dsw", "dse",
+}
+
+M.slot_set = {}
+for _, slot_name in ipairs(M.slot_order) do
+    M.slot_set[slot_name] = true
+end
+
+M.slot_meta = {
+    n = { short = "N", full = "North", edge = "n" },
+    e = { short = "E", full = "East", edge = "e" },
+    s = { short = "S", full = "South", edge = "s" },
+    w = { short = "W", full = "West", edge = "w" },
+    cnw = { short = "CNW", full = "Corner North-West", edge = "cnw" },
+    cne = { short = "CNE", full = "Corner North-East", edge = "cne" },
+    csw = { short = "CSW", full = "Corner South-West", edge = "csw" },
+    cse = { short = "CSE", full = "Corner South-East", edge = "cse" },
+    dnw = { short = "DNW", full = "Diagonal North-West", edge = "dnw" },
+    dne = { short = "DNE", full = "Diagonal North-East", edge = "dne" },
+    dsw = { short = "DSW", full = "Diagonal South-West", edge = "dsw" },
+    dse = { short = "DSE", full = "Diagonal South-East", edge = "dse" },
+    c = { short = "C", full = "Center Reference", edge = nil },
+}
+
+M.slot_layout = {
+    "dnw", nil,   nil,   nil,   "dne",
+    nil,   "cnw", "n",   "cne", nil,
+    nil,   "w",   "c",   "e",   nil,
+    nil,   "csw", "s",   "cse", nil,
+    "dsw", nil,   nil,   nil,   "dse",
+}
+M.slot_layout_count = 25
+
+-- The XML/app.borders slot names are stored from the border brush perspective.
+-- In the editor we want to show the patch from the map/player perspective,
+-- so the visual slot on screen needs to read from the opposite stored edge.
+M.preview_slot_source = {
+    n = "s",
+    e = "w",
+    s = "n",
+    w = "e",
+    cnw = "cse",
+    cne = "csw",
+    csw = "cne",
+    cse = "cnw",
+    dnw = "dse",
+    dne = "dsw",
+    dsw = "dne",
+    dse = "dnw",
+}
+
+function M.clone(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, inner in pairs(value) do
+        copy[key] = M.clone(inner)
+    end
+    return copy
+end
+
+function M.new_slots()
+    local slots = {}
+    for _, key in ipairs(M.slot_order) do
+        slots[key] = nil
+    end
+    return slots
+end
+
+function M.is_valid_slot_name(slot_name)
+    return M.slot_set[slot_name] == true
+end
+
+function M.slot_name_from_layout(index)
+    local key = M.slot_layout[index]
+    if key == "c" then
+        return nil
+    end
+    return key
+end
+
+function M.visual_slot_name_from_layout(index)
+    return M.slot_name_from_layout(index)
+end
+
+function M.storage_slot_name(slot_name)
+    if not slot_name then
+        return nil
+    end
+    return M.preview_slot_source[slot_name] or slot_name
+end
+
+function M.storage_slot_name_from_layout(index)
+    local visual_key = M.visual_slot_name_from_layout(index)
+    return M.storage_slot_name(visual_key)
+end
+
+function M.slot_item_id(border, slot_name)
+    if not border or not slot_name then
+        return 0
+    end
+
+    if border.getSlotAssignment then
+        local assignment = border:getSlotAssignment(slot_name)
+        return assignment and (assignment.itemId or 0) or 0
+    end
+
+    if not border.slots then
+        return 0
+    end
+
+    local value = border.slots[slot_name]
+    if type(value) == "table" then
+        return tonumber(value.itemId or value.item_id or value.id or 0) or 0
+    end
+
+    return tonumber(value or 0) or 0
+end
+
+function M.primary_item_id(border)
+    if not border or not border.slots then
+        return 0
+    end
+
+    for _, key in ipairs(M.slot_order) do
+        local item_id = M.slot_item_id(border, key)
+        if item_id > 0 then
+            return item_id
+        end
+    end
+
+    return 0
+end
+
+function M.assigned_slot_count(border)
+    local count = 0
+    if not border or not border.slots then
+        return count
+    end
+
+    for _, key in ipairs(M.slot_order) do
+        if M.slot_item_id(border, key) > 0 then
+            count = count + 1
+        end
+    end
+    return count
+end
+
+function M.format_border_title(border)
+    if not border then
+        return "No border"
+    end
+
+    local border_id = border.borderId or border.id or 0
+    local group = border.group or 0
+    local is_new = border.isNew
+    if is_new == nil then
+        is_new = border.is_new
+    end
+
+    local suffix = is_new and " (new)" or ""
+    return string.format("Border %d  |  Group %d%s", border_id, group, suffix)
+end
+
+function M.normalize_path(path)
+    path = tostring(path or ""):gsub("\\", "/")
+    return string.lower(path)
+end
+
+function M.path_starts_with(path, prefix)
+    local lhs = M.normalize_path(path)
+    local rhs = M.normalize_path(prefix)
+    return lhs:sub(1, #rhs) == rhs
+end
+
+function M.safe_item_name(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return ""
+    end
+    return Items.getName(item_id) or ""
+end
+
+function M.safe_item_info(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    return Items.getInfo(item_id)
+end
+
+function M.safe_image(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+    if not M._image_cache[item_id] then
+        M._image_cache[item_id] = Image.fromItemSprite(item_id)
+    end
+    return M._image_cache[item_id]
+end
+
+function M.active_raw_brush_id()
+    local brush = app and app.brush or nil
+    if not brush or brush.type ~= "raw" then
+        return 0
+    end
+
+    local brush_name = tostring(brush.name or "")
+    local parsed = tonumber(brush_name:match("^(%d+)"))
+    if parsed and parsed > 0 then
+        return parsed
+    end
+
+    local fallback = tonumber(brush.id or 0) or 0
+    if fallback > 0 and Items and Items.exists and Items.exists(fallback) then
+        return fallback
+    end
+
+    return 0
+end
+
+function M.log_warning(message)
+    print("[Border Studio] Warning: " .. tostring(message))
+end
+
+function M.border_status(border)
+    if border and border.status then
+        return border.status
+    end
+    return M.assigned_slot_count(border) == #M.slot_order and "complete" or "partial"
+end
+
+function M.assignment_snapshot(border)
+    if not border then
+        return "no draft"
+    end
+
+    local parts = {}
+    for _, key in ipairs(M.slot_order) do
+        local item_id = M.slot_item_id(border, key)
+        if item_id > 0 then
+            table.insert(parts, string.format("%s=%d", key, item_id))
+        else
+            table.insert(parts, string.format("%s=-", key))
+        end
+    end
+    return table.concat(parts, ", ")
+end
+
+function M.assignment_preview(border, limit)
+    if not border then
+        return "no draft"
+    end
+
+    limit = tonumber(limit or 6) or 6
+    local parts = {}
+    for _, key in ipairs(M.slot_order) do
+        local item_id = M.slot_item_id(border, key)
+        if item_id > 0 then
+            table.insert(parts, string.format("%s=%d", key, item_id))
+        end
+        if #parts >= limit then
+            break
+        end
+    end
+
+    if #parts == 0 then
+        return "no assigned slots"
+    end
+
+    if M.assigned_slot_count(border) > #parts then
+        table.insert(parts, "...")
+    end
+    return table.concat(parts, ", ")
+end
+
+function M.slot_matrix_lines(border, selected_raw_id)
+    local lines = {}
+    local cells = {}
+
+    for index = 1, M.slot_layout_count do
+        local key = M.slot_layout[index]
+        local text = "     "
+        if key == "c" then
+            local item_id = tonumber(selected_raw_id or 0) or 0
+            text = item_id > 0 and string.format("C:%-3d", item_id) or "C:---"
+        elseif key then
+            local item_id = M.slot_item_id(border, key)
+            local short = (M.slot_meta[key] and M.slot_meta[key].short) or tostring(key)
+            if #short > 3 then
+                short = short:sub(1, 3)
+            end
+            text = item_id > 0 and string.format("%s:%-3d", short, item_id) or string.format("%s:---", short)
+        end
+        table.insert(cells, text)
+
+        if index % 5 == 0 then
+            table.insert(lines, table.concat(cells, "  "))
+            cells = {}
+        end
+    end
+
+    return lines
+end
+
+function M.slot_matrix_text(border, selected_raw_id)
+    return table.concat(M.slot_matrix_lines(border, selected_raw_id), "\n")
+end
+
+function M.slot_layout_texts(border, selected_raw_id)
+    local texts = {}
+
+    for index = 1, M.slot_layout_count do
+        local key = M.slot_layout[index]
+        if key == nil then
+            table.insert(texts, "")
+        else
+            local short = (M.slot_meta[key] and M.slot_meta[key].short) or tostring(key)
+            table.insert(texts, short)
+        end
+    end
+
+    return texts
+end
+
+function M.current_step(state)
+    if not state.draft or state.draft:isEmpty() then
+        return 1
+    end
+    local raw_id = tonumber(state.selected_raw_id or 0) or 0
+    local active_raw = M.active_raw_brush_id()
+    if active_raw > 0 then
+        raw_id = active_raw
+    end
+    if raw_id <= 0 then
+        return 2
+    end
+    if state.dirty then
+        return 3
+    end
+    if state.draft:hasRequiredDataForSave() then
+        return 5
+    end
+    return 4
+end
+
+return M

--- a/scripts/border_studio/draft_adapter.lua
+++ b/scripts/border_studio/draft_adapter.lua
@@ -1,0 +1,200 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+local function empty_cell()
+    return {
+        kind = "empty",
+        label = "",
+    }
+end
+
+local function fill_cell()
+    return {
+        kind = "fill",
+        label = "AREA",
+        tooltip = "Filled area reference",
+    }
+end
+
+local function slot_cell(draft, slot_name)
+    local meta = Common.slot_meta[slot_name]
+    local item_id = draft and draft:getSlotItemId(slot_name) or 0
+    local missing = item_id <= 0
+
+    return {
+        kind = missing and "missing" or "slot",
+        slotName = slot_name,
+        label = meta and meta.short or tostring(slot_name),
+        tooltip = meta and meta.full or tostring(slot_name),
+        itemId = item_id,
+    }
+end
+
+local function build_scenario_cells(draft, rows)
+    local cells = {}
+    for _, row in ipairs(rows) do
+        local next_row = {}
+        for _, token in ipairs(row) do
+            if token == "." then
+                table.insert(next_row, empty_cell())
+            elseif token == "#" then
+                table.insert(next_row, fill_cell())
+            else
+                table.insert(next_row, slot_cell(draft, token))
+            end
+        end
+        table.insert(cells, next_row)
+    end
+    return cells
+end
+
+function M.slot_name_from_layout(index)
+    return Common.storage_slot_name_from_layout(index)
+end
+
+function M.visual_slot_name_from_layout(index)
+    return Common.visual_slot_name_from_layout(index)
+end
+
+function M.slot_grid_items(draft, selected_raw_id, options)
+    options = options or {}
+    local show_images = options.showImages == true
+    local items = {}
+
+    for index = 1, Common.slot_layout_count do
+        local visual_key = Common.slot_layout[index]
+        if not visual_key then
+            table.insert(items, { text = "", tooltip = "" })
+        else
+            local meta = Common.slot_meta[visual_key]
+            local item_id = 0
+
+            if visual_key ~= "c" and draft then
+                item_id = draft:getSlotItemId(Common.storage_slot_name(visual_key))
+            end
+
+            local tooltip = meta.full
+            if visual_key == "c" then
+                tooltip = "Center Reference"
+            elseif item_id > 0 then
+                tooltip = string.format("%s\nItem ID %d", meta.full, item_id)
+            else
+                tooltip = meta.full .. "\nEmpty slot"
+            end
+
+            table.insert(items, {
+                text = meta.short,
+                tooltip = tooltip,
+                image = show_images and Common.safe_image(item_id) or nil,
+            })
+        end
+    end
+
+    return items
+end
+
+function M.preview_state(draft)
+    local validation = draft and draft:getValidation() or {
+        hasAssignments = false,
+        emptySlots = Common.clone(Common.slot_order),
+    }
+
+    return {
+        hasAssignments = validation.hasAssignments == true,
+        emptySlots = validation.emptySlots or {},
+        assignedCount = draft and Common.assigned_slot_count(draft) or 0,
+    }
+end
+
+function M.usage_preview_state(draft)
+    local state = M.preview_state(draft)
+    local is_complete = #state.emptySlots == 0 and state.hasAssignments
+
+    return {
+        isComplete = is_complete,
+        statusLabel = is_complete and "border kompletny" or "border niepelny",
+        missingSlots = state.emptySlots,
+        missingLabel = #state.emptySlots > 0 and table.concat(state.emptySlots, ", ") or "none",
+    }
+end
+
+function M.usage_scenarios(draft)
+    local missing_slots = draft and draft:getEmptySlots() or Common.clone(Common.slot_order)
+    local partial_tokens = {
+        missing_slots[1] or "dne",
+        missing_slots[2] or "dsw",
+        missing_slots[3] or "cnw",
+        missing_slots[4] or "cse",
+    }
+
+    local scenarios = {
+        {
+            id = "single_edge",
+            title = "1. Pojedyncza krawedz",
+            subtitle = "Single edge sample",
+            rows = {
+                { ".", "n", "." },
+                { ".", "#", "." },
+                { ".", ".", "." },
+            },
+        },
+        {
+            id = "outer_corner",
+            title = "2. Naroznik zewnetrzny",
+            subtitle = "Outer corner sample",
+            rows = {
+                { "cnw", "n", "." },
+                { "w", "#", "." },
+                { ".", ".", "." },
+            },
+        },
+        {
+            id = "inner_corner",
+            title = "3. Naroznik wewnetrzny",
+            subtitle = "Inner corner sample",
+            rows = {
+                { "#", "#", "e" },
+                { "#", "cse", "s" },
+                { ".", ".", "." },
+            },
+        },
+        {
+            id = "diagonal",
+            title = "4. Diagonal",
+            subtitle = "Diagonal sample",
+            rows = {
+                { ".", "#", "dne" },
+                { ".", ".", "#" },
+                { ".", ".", "." },
+            },
+        },
+        {
+            id = "rectangle",
+            title = "5. Prostokat",
+            subtitle = "Closed area sample",
+            rows = {
+                { "cnw", "n", "cne" },
+                { "w", "#", "e" },
+                { "csw", "s", "cse" },
+            },
+        },
+        {
+            id = "partial",
+            title = "6. Partial / brak",
+            subtitle = #missing_slots > 0 and "Missing slots highlighted" or "No missing slots right now",
+            rows = {
+                { partial_tokens[1], partial_tokens[2] },
+                { partial_tokens[3], partial_tokens[4] },
+            },
+        },
+    }
+
+    for _, scenario in ipairs(scenarios) do
+        scenario.cells = build_scenario_cells(draft, scenario.rows)
+    end
+
+    return scenarios
+end
+
+return M

--- a/scripts/border_studio/ground_draft.lua
+++ b/scripts/border_studio/ground_draft.lua
@@ -1,0 +1,181 @@
+local Common = dofile("common.lua")
+
+local GroundDraft = {}
+GroundDraft.__index = GroundDraft
+
+local function build_ground_reference(raw_item)
+    if type(raw_item) == "table" then
+        local item_id = tonumber(raw_item.itemId or raw_item.item_id or raw_item.id or 0) or 0
+        if item_id <= 0 then
+            return nil
+        end
+
+        local info = Common.safe_item_info(item_id)
+        return {
+            itemId = item_id,
+            rawId = tonumber(raw_item.rawId or raw_item.raw_id or item_id) or item_id,
+            lookId = tonumber(raw_item.lookId or raw_item.look_id or raw_item.clientId or (info and info.clientId) or 0) or 0,
+            name = raw_item.name or (info and info.name) or ("Item " .. tostring(item_id)),
+        }
+    end
+
+    local item_id = tonumber(raw_item or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+local function normalize_align(value)
+    value = string.lower(tostring(value or "outer"))
+    if value ~= "inner" then
+        return "outer"
+    end
+    return value
+end
+
+local function normalize_friend(value)
+    local text = tostring(value or ""):match("^%s*(.-)%s*$")
+    if text == "" then
+        return nil
+    end
+    return text
+end
+
+function GroundDraft.new(init)
+    local self = setmetatable({}, GroundDraft)
+    self.name = tostring((init and init.name) or "")
+    self.centerGroundItem = build_ground_reference(init and (init.centerGroundItem or init.center_ground_item))
+    self.linkedBorderId = tonumber((init and (init.linkedBorderId or init.linked_border_id)) or 0) or 0
+    self.borderTargetBrushName = tostring((init and (init.borderTargetBrushName or init.border_target_brush_name)) or "")
+    self.align = normalize_align(init and (init.align or init.alignMode or init.align_mode))
+    self.friends = {}
+    self.zOrder = tonumber((init and (init.zOrder or init.z_order)) or 0) or 0
+
+    for _, friend_name in ipairs((init and init.friends) or {}) do
+        self:addFriend(friend_name)
+    end
+
+    return self
+end
+
+function GroundDraft:setName(name)
+    self.name = tostring(name or "")
+end
+
+function GroundDraft:setCenterGroundItem(raw_item)
+    self.centerGroundItem = build_ground_reference(raw_item)
+    return self.centerGroundItem ~= nil
+end
+
+function GroundDraft:clearCenterGroundItem()
+    self.centerGroundItem = nil
+end
+
+function GroundDraft:setLinkedBorderId(border_id)
+    self.linkedBorderId = tonumber(border_id or 0) or 0
+end
+
+function GroundDraft:setBorderTargetBrushName(name)
+    self.borderTargetBrushName = tostring(name or "")
+end
+
+function GroundDraft:setAlign(mode)
+    self.align = normalize_align(mode)
+end
+
+function GroundDraft:setFriends(friend_list)
+    self.friends = {}
+    for _, friend_name in ipairs(friend_list or {}) do
+        self:addFriend(friend_name)
+    end
+end
+
+function GroundDraft:addFriend(friend_name)
+    friend_name = normalize_friend(friend_name)
+    if not friend_name then
+        return false
+    end
+
+    for _, existing in ipairs(self.friends) do
+        if existing == friend_name then
+            return false
+        end
+    end
+
+    table.insert(self.friends, friend_name)
+    return true
+end
+
+function GroundDraft:removeFriend(friend_name)
+    friend_name = normalize_friend(friend_name)
+    if not friend_name then
+        return false
+    end
+
+    for index, existing in ipairs(self.friends) do
+        if existing == friend_name then
+            table.remove(self.friends, index)
+            return true
+        end
+    end
+
+    return false
+end
+
+function GroundDraft:clearFriends()
+    self.friends = {}
+end
+
+function GroundDraft:setZOrder(z_order)
+    self.zOrder = tonumber(z_order or 0) or 0
+end
+
+function GroundDraft:hasCenterGroundItem()
+    return self.centerGroundItem ~= nil and (self.centerGroundItem.itemId or 0) > 0
+end
+
+function GroundDraft:getValidation()
+    return {
+        hasCenterGroundItem = self:hasCenterGroundItem(),
+        hasLinkedBorder = self.linkedBorderId > 0,
+        hasBorderTargetBrush = self.borderTargetBrushName ~= "",
+        hasName = self.name ~= "",
+        align = self.align,
+        friendsCount = #self.friends,
+        zOrder = self.zOrder,
+    }
+end
+
+function GroundDraft:clone()
+    return GroundDraft.new({
+        name = self.name,
+        centerGroundItem = self.centerGroundItem and Common.clone(self.centerGroundItem) or nil,
+        linkedBorderId = self.linkedBorderId,
+        borderTargetBrushName = self.borderTargetBrushName,
+        align = self.align,
+        friends = Common.clone(self.friends),
+        zOrder = self.zOrder,
+    })
+end
+
+function GroundDraft:toGroundData()
+    return {
+        name = self.name,
+        centerGroundItem = self.centerGroundItem and Common.clone(self.centerGroundItem) or nil,
+        linkedBorderId = self.linkedBorderId,
+        borderTargetBrushName = self.borderTargetBrushName,
+        align = self.align,
+        friends = Common.clone(self.friends),
+        zOrder = self.zOrder,
+    }
+end
+
+return GroundDraft

--- a/scripts/border_studio/ground_support.lua
+++ b/scripts/border_studio/ground_support.lua
@@ -1,0 +1,22 @@
+local BorderRepository = dofile("border_repository.lua")
+local GroundDraft = dofile("ground_draft.lua")
+
+local M = {}
+
+function M.read_border_repository(session_borders, border_table)
+    return BorderRepository.read(session_borders, border_table or app.borders or {})
+end
+
+function M.border_sources(repository)
+    return BorderRepository.border_sources(repository)
+end
+
+function M.find_border_source(repository, border_id)
+    return BorderRepository.find_border_source(repository, border_id)
+end
+
+function M.new_ground_draft(init)
+    return GroundDraft.new(init)
+end
+
+return M

--- a/scripts/border_studio/library_panel.lua
+++ b/scripts/border_studio/library_panel.lua
@@ -1,0 +1,124 @@
+local Common = dofile("common.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    dlg:box({
+        label = "1. Wybierz Border",
+        orient = "vertical",
+        width = 300,
+        min_width = 280,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            text = "Wybierz gotowy border albo utworz nowy draft.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "library_filter",
+            label = "Search",
+            text = state.filter_text or "",
+            expand = true,
+            onchange = function(d)
+                actions.set_filter(d.data.library_filter or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "<",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.previous_library_page()
+                end,
+            })
+            dlg:label({
+                id = "library_page_label",
+                text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+                fgcolor = Common.palette.subtle,
+                min_width = 120,
+                align = "center",
+            })
+            dlg:button({
+                text = ">",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.next_library_page()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:list({
+            id = "border_library",
+            width = 460,
+            height = 440,
+            expand = true,
+            icon_size = 28,
+            item_height = 34,
+            items = state.library_items or {},
+            selection = tonumber(state.library_selection or 0) or 0,
+            onchange = function(d)
+                actions.handle_library_change(d.data.border_library or 0)
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Nowy Border",
+                bgcolor = Common.palette.accent,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.new_border()
+                end,
+            })
+            dlg:button({
+                text = "Duplikuj Border",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.duplicate_current()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Aktualnie edytujesz",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_border_title",
+                text = Common.format_border_title(state.draft),
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_border_status",
+                text = "Status: " .. Common.border_status(state.draft),
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/border_studio/logger.lua
+++ b/scripts/border_studio/logger.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+local STORE = app.storage("border_studio.log")
+local MAX_LINES = 400
+
+local function lines_buffer()
+    if type(_G.BORDER_STUDIO_LOG_LINES) ~= "table" then
+        _G.BORDER_STUDIO_LOG_LINES = {}
+    end
+    return _G.BORDER_STUDIO_LOG_LINES
+end
+
+local function now_ms()
+    if app and app.getTime then
+        local ok, value = pcall(app.getTime)
+        if ok then
+            return tonumber(value or 0) or 0
+        end
+    end
+    return 0
+end
+
+local function flush(lines)
+    if STORE and STORE.save then
+        STORE:save(table.concat(lines, "\n"))
+    end
+end
+
+function M.reset(reason)
+    local lines = lines_buffer()
+    for index = #lines, 1, -1 do
+        lines[index] = nil
+    end
+    if reason and reason ~= "" then
+        M.log("session", "reset: " .. tostring(reason))
+    else
+        flush(lines)
+    end
+end
+
+function M.log(scope, message)
+    local lines = lines_buffer()
+    local line = string.format("[%06d] [%s] %s", now_ms(), tostring(scope or "log"), tostring(message or ""))
+    table.insert(lines, line)
+    while #lines > MAX_LINES do
+        table.remove(lines, 1)
+    end
+
+    print("[Border Studio] " .. line)
+    flush(lines)
+end
+
+function M.path()
+    return STORE and STORE.path or "border_studio.log"
+end
+
+return M

--- a/scripts/border_studio/main.lua
+++ b/scripts/border_studio/main.lua
@@ -1,0 +1,3 @@
+local BorderStudioPage = dofile("page.lua")
+
+BorderStudioPage.open_standalone()

--- a/scripts/border_studio/manifest.lua
+++ b/scripts/border_studio/manifest.lua
@@ -1,0 +1,9 @@
+return {
+    name = "Border Studio",
+    description = "A focused step-by-step border set editor for RME.",
+    author = "Fr0st",
+    version = "0.1.0",
+    main = "main.lua",
+    shortcut = "Ctrl+Alt+B",
+    autorun = false
+}

--- a/scripts/border_studio/model.lua
+++ b/scripts/border_studio/model.lua
@@ -1,0 +1,334 @@
+local Common = dofile("common.lua")
+local BorderDraft = dofile("border_draft.lua")
+local BorderRepository = dofile("border_repository.lua")
+local XmlWriter = dofile("xml_writer.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+local SETTINGS_STORE = app.storage("settings.json")
+
+local function file_exists(path)
+    if not path or path == "" then
+        return false
+    end
+
+    local store = app.storage(path)
+    if store and store.exists then
+        return store:exists()
+    end
+
+    return true
+end
+
+local function read_file(path)
+    local store = app.storage(path)
+    if not store or not store.readText then
+        return nil, "This RME build does not expose raw file reads for backup."
+    end
+
+    local content, err = store:readText()
+    if not content then
+        return nil, err or "Could not open file."
+    end
+
+    return content
+end
+
+local function write_file(path, content)
+    local store = app.storage(path)
+    if not store or not store.save then
+        return false, "This RME build does not expose safe file writes."
+    end
+
+    local ok = store:save(content or "")
+    if not ok then
+        return false, "Could not write file."
+    end
+
+    return true
+end
+
+function M.load_settings()
+    return SETTINGS_STORE:load() or {}
+end
+
+function M.save_settings(state)
+    SETTINGS_STORE:save({
+        target_path = state.target_path or "",
+        recent_raw_ids = Common.clone(state.recent_raw_ids or {}),
+        selected_raw_id = state.selected_raw_id or 0,
+        last_border_id = state.draft and state.draft.borderId or 0,
+    })
+end
+
+function M.resolve_target_path(saved_path)
+    if saved_path and saved_path ~= "" and file_exists(saved_path) then
+        return saved_path
+    end
+
+    local data_dir = app.getDataDirectory()
+    local preferred = tostring(data_dir or "") .. "/1310/borders.xml"
+    if file_exists(preferred) then
+        return preferred
+    end
+
+    return preferred
+end
+
+function M.read_repository(session_borders)
+    Logger.log("model", "read_repository start")
+    local repository = BorderRepository.read(session_borders, app.borders or {})
+    Logger.log("model", string.format("read_repository done count=%d session_overlays=%d", #repository.ordered, session_borders and #session_borders or 0))
+
+    return repository
+end
+
+function M.next_border_id(repository, session_borders, extra_id)
+    return BorderRepository.next_border_id(repository, session_borders, extra_id)
+end
+
+function M.new_draft(repository, session_borders, extra_id)
+    local border_id = M.next_border_id(repository, session_borders, extra_id)
+    return BorderDraft.new({
+        borderId = border_id,
+        name = "Border #" .. tostring(border_id),
+        group = 0,
+        isNew = true,
+        status = "partial",
+    })
+end
+
+function M.load_draft(repository, border_id)
+    Logger.log("model", string.format("load_draft request border_id=%d", tonumber(border_id or 0) or 0))
+    local border = repository.by_id[border_id]
+    if not border then
+        Logger.log("model", string.format("load_draft missing border_id=%d", tonumber(border_id or 0) or 0))
+        return nil
+    end
+    local copy = BorderRepository.copy(border)
+    Logger.log("model", string.format("load_draft done border_id=%d assigned=%d", copy.borderId or 0, Common.assigned_slot_count(copy)))
+    return copy
+end
+
+function M.duplicate_draft(repository, session_borders, draft)
+    local duplicate = BorderRepository.copy(draft)
+    duplicate.borderId = M.next_border_id(repository, session_borders, draft and draft.borderId or 0)
+    duplicate.name = "Border #" .. tostring(duplicate.borderId)
+    duplicate.isNew = true
+    duplicate.status = Common.border_status(duplicate)
+    return duplicate
+end
+
+function M.make_raw_reference(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+function M.touch_recent(recent_raw_ids, item_id)
+    if not item_id or item_id <= 0 then
+        return recent_raw_ids
+    end
+
+    local next_list = {}
+    table.insert(next_list, item_id)
+
+    for _, existing in ipairs(recent_raw_ids or {}) do
+        if existing ~= item_id then
+            table.insert(next_list, existing)
+        end
+        if #next_list >= 8 then
+            break
+        end
+    end
+
+    return next_list
+end
+
+function M.library_items(repository, filter_text)
+    local items = {}
+    local visible_ids = {}
+    local needle = string.lower(filter_text or "")
+
+    for _, border in ipairs(repository.ordered or {}) do
+        local title = Common.format_border_title(border)
+        local status = Common.border_status(border)
+        local display_name = border.name ~= "" and border.name or ("Border #" .. tostring(border.borderId))
+        local sample_name = Common.safe_item_name(Common.primary_item_id(border))
+        local search_blob = string.lower(title .. " " .. display_name .. " " .. sample_name .. " " .. status)
+
+        if needle == "" or string.find(search_blob, needle, 1, true) then
+            local item_id = Common.primary_item_id(border)
+            local tooltip = string.format(
+                "Border %d\n%s\nGroup %d\nStatus: %s\nAssigned slots: %d",
+                border.borderId,
+                display_name,
+                border.group or 0,
+                status,
+                Common.assigned_slot_count(border)
+            )
+
+            table.insert(items, {
+                text = string.format("#%d  %s  |  %s", border.borderId, display_name, status),
+                tooltip = tooltip,
+                image = Common.safe_image(item_id),
+            })
+            table.insert(visible_ids, border.borderId)
+        end
+    end
+
+    return items, visible_ids
+end
+
+function M.prepare_export(draft)
+    if not draft then
+        return nil
+    end
+
+    return {
+        borderId = draft.borderId,
+        name = draft.name,
+        group = draft.group or 0,
+        status = Common.border_status(draft),
+        hasRequiredDataForSave = draft:hasRequiredDataForSave(),
+        emptySlots = draft:getEmptySlots(),
+        borderItems = draft:toBorderItemEntries(),
+    }
+end
+
+function M.save_intent(repository, draft, border_id, mode)
+    border_id = tonumber(border_id or 0) or 0
+    local exists = repository and repository.by_id and repository.by_id[border_id] ~= nil
+
+    if mode == "new" then
+        if border_id <= 0 then
+            return "Enter a valid Border ID to create a new border."
+        end
+        if exists then
+            return string.format("Save as new will fail because border #%d already exists.", border_id)
+        end
+        return string.format("Utworzy nowy border #%d.", border_id)
+    end
+
+    if border_id <= 0 then
+        return "Enter a valid Border ID to overwrite an existing border."
+    end
+    if not exists then
+        return string.format("Overwrite will fail because border #%d does not exist yet.", border_id)
+    end
+    return string.format("Nadpisze border #%d.", border_id)
+end
+
+function M.validate_save(repository, draft, border_id, mode, target_path)
+    border_id = tonumber(border_id or 0) or 0
+
+    if not target_path or target_path == "" then
+        return false, "Target borders.xml could not be resolved."
+    end
+    if not Common.path_starts_with(target_path, app.getDataDirectory()) then
+        return false, "Target borders.xml must stay inside the RME data directory."
+    end
+    if not tostring(target_path):lower():match("%.xml$") then
+        return false, "Target file must be an XML file."
+    end
+    if not file_exists(target_path) then
+        return false, "Target borders.xml does not exist."
+    end
+    if not draft or draft:isEmpty() then
+        return false, "Draft is empty. Assign at least one border slot before saving."
+    end
+    if border_id <= 0 then
+        return false, "Border ID must be a positive number."
+    end
+
+    local exists = repository and repository.by_id and repository.by_id[border_id] ~= nil
+    if mode == "new" and exists then
+        return false, string.format("Border #%d already exists, so Save as New is blocked.", border_id)
+    end
+    if mode == "overwrite" and not exists then
+        return false, string.format("Border #%d does not exist, so Overwrite is blocked.", border_id)
+    end
+
+    return true
+end
+
+function M.backup_xml(target_path)
+    local original, err = read_file(target_path)
+    if not original then
+        return false, nil, nil, "Could not read borders.xml before backup: " .. tostring(err)
+    end
+
+    local backup_path = string.format("%s.borderstudio.%s.bak", target_path, os.date("%Y%m%d_%H%M%S"))
+    local ok, backup_err = write_file(backup_path, original)
+    if not ok then
+        return false, nil, nil, "Could not write backup file: " .. tostring(backup_err)
+    end
+
+    return true, backup_path, original
+end
+
+function M.save_draft(repository, session_borders, draft, border_id, name, mode, target_path)
+    local ok, validation_message = M.validate_save(repository, draft, border_id, mode, target_path)
+    if not ok then
+        return false, validation_message
+    end
+
+    local backup_ok, backup_path, original_content, backup_message = M.backup_xml(target_path)
+    if not backup_ok then
+        return false, backup_message
+    end
+
+    local saved_draft = draft:clone()
+    saved_draft.borderId = tonumber(border_id or saved_draft.borderId) or saved_draft.borderId
+    saved_draft.name = tostring(name or "")
+    saved_draft.isNew = false
+    saved_draft.status = Common.border_status(saved_draft)
+
+    local writer = app.storage(target_path)
+    if not writer or not writer.upsertXml then
+        return false, "The current RME build does not expose XML upsert support."
+    end
+
+    local xml = XmlWriter.serialize_border(saved_draft)
+    local write_ok, write_mode = writer:upsertXml({
+        root = "materials",
+        parent = "materials",
+        tag = "border",
+        match_attr = "id",
+        match_value = tostring(saved_draft.borderId),
+        xml = xml,
+    })
+
+    if not write_ok then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, write_mode or "Saving failed while updating borders.xml."
+    end
+
+    session_borders[saved_draft.borderId] = saved_draft:clone()
+    session_borders[saved_draft.borderId].isNew = false
+
+    return true, {
+        draft = saved_draft,
+        backupPath = backup_path,
+        xmlMode = write_mode or mode,
+        message = string.format(
+            "Saved border #%d successfully.\nBackup: %s",
+            saved_draft.borderId,
+            backup_path
+        ),
+    }
+end
+
+return M

--- a/scripts/border_studio/page.lua
+++ b/scripts/border_studio/page.lua
@@ -6,6 +6,7 @@ local SlotsPanel = dofile("slots_panel.lua")
 local RawPanel = dofile("raw_panel.lua")
 local SavePanel = dofile("save_panel.lua")
 local Logger = dofile("logger.lua")
+local XmlTarget = dofile("xml_target_helper.lua")
 
 local BorderStudioPage = {}
 
@@ -898,6 +899,31 @@ end
 
 function actions.overwrite_existing()
     finalize_save("overwrite")
+end
+
+function actions.choose_target_path()
+    local chosen, err = XmlTarget.pick_xml_file("borders.xml", state.target_path, "Wybierz borders.xml")
+    if err then
+        app.alert({
+            title = "Nie mozna ustawic targetu",
+            text = err,
+            buttons = { "OK" },
+        })
+        return
+    end
+    if not chosen then
+        return
+    end
+
+    state.target_path = chosen
+    persist_settings()
+    soft_refresh_save_panel()
+end
+
+function actions.use_default_target_path()
+    state.target_path = Model.resolve_target_path("")
+    persist_settings()
+    soft_refresh_save_panel()
 end
 
 local function attach_brush_listener()

--- a/scripts/border_studio/page.lua
+++ b/scripts/border_studio/page.lua
@@ -1,0 +1,1038 @@
+local Common = dofile("common.lua")
+local Model = dofile("model.lua")
+local DraftAdapter = dofile("draft_adapter.lua")
+local LibraryPanel = dofile("library_panel.lua")
+local SlotsPanel = dofile("slots_panel.lua")
+local RawPanel = dofile("raw_panel.lua")
+local SavePanel = dofile("save_panel.lua")
+local Logger = dofile("logger.lua")
+
+local BorderStudioPage = {}
+
+local function create_page(options)
+    options = options or {}
+    if options.reset_logger then
+        Logger.reset("startup")
+    end
+    Logger.log("page", "Border Studio page create")
+
+    local settings = Model.load_settings()
+    local session = options.session or {}
+    local listener_id = nil
+    local dlg
+    local actions = {}
+
+    local state = {
+        filter_text = "",
+        selected_raw_id = settings.selected_raw_id or 0,
+        recent_raw_ids = settings.recent_raw_ids or {},
+        target_path = Model.resolve_target_path(settings.target_path or ""),
+        session_borders = {},
+        repository = nil,
+        library_filtered_items = {},
+        library_filtered_ids = {},
+        library_items = {},
+        library_visible_ids = {},
+        library_selection = 0,
+        library_selected_border_id = 0,
+        library_page = 1,
+        library_page_size = 18,
+        library_page_count = 1,
+        draft = nil,
+        save_border_id = 0,
+        save_name = "",
+        export_preview = nil,
+        export_checked = false,
+        status_message = "",
+        dirty = false,
+        rebuilding = false,
+        library_ignore_index = 0,
+        library_ignore_budget = 0,
+        library_skip_changes = 0,
+        highlighted_slot_index = 0,
+    }
+
+local function refresh_repository()
+    Logger.log("main", "refresh_repository")
+    state.repository = Model.read_repository(state.session_borders)
+end
+
+local function sync_library(preferred_border_id, allow_draft_fallback)
+    local filtered_items, filtered_ids = Model.library_items(state.repository, state.filter_text)
+    state.library_filtered_items = filtered_items
+    state.library_filtered_ids = filtered_ids
+    preferred_border_id = tonumber(preferred_border_id or state.library_selected_border_id or 0) or 0
+    if allow_draft_fallback ~= false and (not preferred_border_id or preferred_border_id <= 0) and state.draft and not state.draft.isNew then
+        preferred_border_id = state.draft.borderId
+    end
+
+    local filtered_count = #state.library_filtered_ids
+    local page_size = math.max(1, tonumber(state.library_page_size or 18) or 18)
+    state.library_page_count = math.max(1, math.ceil(filtered_count / page_size))
+
+    if preferred_border_id and preferred_border_id > 0 then
+        for absolute_index, border_id in ipairs(state.library_filtered_ids) do
+            if border_id == preferred_border_id then
+                state.library_page = math.ceil(absolute_index / page_size)
+                break
+            end
+        end
+    end
+
+    if state.library_page < 1 then
+        state.library_page = 1
+    end
+    if state.library_page > state.library_page_count then
+        state.library_page = state.library_page_count
+    end
+
+    local page_start = ((state.library_page - 1) * page_size) + 1
+    local page_end = math.min(filtered_count, page_start + page_size - 1)
+
+    state.library_items = {}
+    state.library_visible_ids = {}
+    for absolute_index = page_start, page_end do
+        table.insert(state.library_items, state.library_filtered_items[absolute_index])
+        table.insert(state.library_visible_ids, state.library_filtered_ids[absolute_index])
+    end
+
+    state.library_selection = 0
+    if preferred_border_id and preferred_border_id > 0 then
+        for index, border_id in ipairs(state.library_visible_ids) do
+            if border_id == preferred_border_id then
+                state.library_selection = index
+                break
+            end
+        end
+    end
+    Logger.log("main", string.format("sync_library filter='%s' filtered=%d page=%d/%d visible=%d selected_index=%d selected_border=%d", tostring(state.filter_text or ""), filtered_count, tonumber(state.library_page or 1), tonumber(state.library_page_count or 1), #state.library_visible_ids, tonumber(state.library_selection or 0), tonumber(state.library_selected_border_id or 0)))
+end
+
+local function soft_refresh_library()
+    if not dlg then
+        return
+    end
+
+    state.library_skip_changes = 4
+    dlg:modify({
+        border_library = {
+            items = state.library_items or {},
+            selection = tonumber(state.library_selection or 0) or 0,
+        },
+        library_page_label = {
+            text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+        },
+    })
+    dlg:layout()
+    dlg:repaint()
+end
+
+local function persist_settings()
+    Model.save_settings(state)
+end
+
+local function sync_session_out()
+    session.lastSelectedRaw = tonumber(state.selected_raw_id or 0) or 0
+    session.recentItems = session.recentItems or {}
+    session.recentItems.borderRawIds = state.recent_raw_ids
+    session.pageDirty = session.pageDirty or {}
+    session.pageDirty.borders = state.dirty
+    if state.draft and not state.draft.isNew then
+        session.selectedBorderForComposer = state.draft.borderId
+    end
+end
+
+local function sync_session_in()
+    local shared_raw = tonumber(session.lastSelectedRaw or 0) or 0
+    if shared_raw > 0 then
+        state.selected_raw_id = shared_raw
+    end
+end
+
+local function request_host_render()
+    sync_session_out()
+    if options.onRequestRender then
+        options.onRequestRender()
+        return true
+    end
+    return false
+end
+
+local function confirm_discard()
+    if not state.dirty then
+        return true
+    end
+
+    local choice = app.alert({
+        title = "Discard changes?",
+        text = "The current border draft has unsaved changes. Continue and discard them?",
+        buttons = { "Yes", "No" },
+    })
+    return choice == 1
+end
+
+local function helper_text()
+    local step = Common.current_step(state)
+    if step == 1 then
+        return "Krok 1: wybierz gotowy border albo utworz nowy."
+    end
+    if step == 2 then
+        return "Krok 2: wybierz RAW tile w glownej palecie RME."
+    end
+    if step == 3 then
+        return "Krok 3: kliknij slot. LPM przypisuje RAW, PPM czyści."
+    end
+    if step == 4 then
+        return "Krok 4: sprawdz podglad uzycia i brakujace sloty."
+    end
+    return "Krok 5: zapisz nowy border albo nadpisz istniejacy."
+end
+
+local function slot_summary_text()
+    local preview_state = DraftAdapter.preview_state(state.draft)
+    if preview_state.hasAssignments then
+        local empty_label = #preview_state.emptySlots > 0 and table.concat(preview_state.emptySlots, ", ") or "none"
+        return string.format("Ustawione sloty: %d. Puste sloty: %s", preview_state.assignedCount, empty_label)
+    end
+    return "Kliknij slot w podgladzie, aby przypisac tile."
+end
+
+local function selected_slot_name()
+    local key = DraftAdapter.visual_slot_name_from_layout(state.highlighted_slot_index)
+    return key
+end
+
+local function selected_slot_status_text()
+    local visual_key = selected_slot_name()
+    if not visual_key then
+        return "Nie wybrano zadnego slotu."
+    end
+
+    local meta = Common.slot_meta[visual_key]
+    local stored_key = Common.storage_slot_name(visual_key)
+    local item_id = state.draft and state.draft:getSlotItemId(stored_key) or 0
+    local status = item_id > 0 and "ustawiony" or "pusty"
+    return string.format("Wybrany slot: %s (%s) - %s", meta.full, meta.short, status)
+end
+
+local function preview_help_text()
+    local raw_id = Common.active_raw_brush_id()
+    if raw_id <= 0 then
+        raw_id = tonumber(state.selected_raw_id or 0) or 0
+    end
+    if raw_id <= 0 then
+        return "Najpierw wybierz RAW tile w glownej palecie."
+    end
+    if not state.draft or state.draft:isEmpty() then
+        return "Kliknij slot w podgladzie, aby przypisac tile."
+    end
+    return "LPM przypisuje aktualny RAW. PPM czyści wybrany slot."
+end
+
+local function save_hint_text()
+    if not state.save_border_id or state.save_border_id <= 0 then
+        return "Podaj ID, aby zapisac border."
+    end
+    if not state.draft or state.draft:isEmpty() then
+        return "Kliknij slot w podgladzie, aby przypisac tile przed zapisem."
+    end
+
+    local has_existing = state.repository and state.repository.by_id and state.repository.by_id[state.save_border_id] ~= nil
+    if has_existing then
+        return string.format("Nadpiszesz border #%d albo zapisz kopie pod nowym ID.", state.save_border_id)
+    end
+    return string.format("Ten ID utworzy nowy border #%d.", state.save_border_id)
+end
+
+local function current_raw_id()
+    local active = Common.active_raw_brush_id()
+    if active > 0 then
+        return active
+    end
+
+    local selected = tonumber(state.selected_raw_id or 0) or 0
+    if selected > 0 then
+        return selected
+    end
+
+    return 0
+end
+
+local function sync_selected_raw_from_brush(reason)
+    local active = Common.active_raw_brush_id()
+    local current = tonumber(state.selected_raw_id or 0) or 0
+    if active == current then
+        return false
+    end
+
+    state.selected_raw_id = active
+    Logger.log("main", string.format("sync_selected_raw_from_brush reason=%s raw=%d previous=%d", tostring(reason or "unknown"), active, current))
+    return true
+end
+
+local function save_panel_state()
+    local is_existing = state.draft and not state.draft.isNew
+    local dirty_label = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie"
+    local mode_label = is_existing
+        and string.format("Tryb: edycja istniejacego wpisu #%d", state.draft.borderId or 0)
+        or "Tryb: nowy border"
+    local target_label = state.target_path ~= "" and state.target_path or "No borders.xml target resolved."
+    return {
+        mode_label = mode_label,
+        dirty_label = dirty_label,
+        dirty_color = state.dirty and Common.palette.accent_soft or Common.palette.subtle,
+        target_label = "Target: " .. target_label,
+        hint_label = save_hint_text(),
+        intent_new = Model.save_intent(state.repository, state.draft, state.save_border_id, "new"),
+        intent_overwrite = Model.save_intent(state.repository, state.draft, state.save_border_id, "overwrite"),
+    }
+end
+
+local function soft_refresh_loaded_border()
+    if not dlg then
+        return
+    end
+
+    sync_session_out()
+    sync_selected_raw_from_brush("soft_refresh")
+    sync_library(state.draft and state.draft.borderId or state.library_selected_border_id, false)
+    Logger.log("main", string.format("soft_refresh start draft=%s", state.draft and state.draft.borderId or "nil"))
+    state.rebuilding = true
+    state.export_preview = Model.prepare_export(state.draft)
+
+    local save_state = save_panel_state()
+    local border_title = Common.format_border_title(state.draft)
+    local border_status = "Status: " .. Common.border_status(state.draft)
+    local slot_snapshot = Common.assignment_snapshot(state.draft)
+    local raw_info = Common.safe_item_info(state.selected_raw_id)
+    local raw_title = "Najpierw wybierz RAW tile"
+    local raw_meta = "Wybrany RAW z glownej palety RME pojawi sie tutaj automatycznie."
+    if raw_info then
+        raw_title = raw_info.name or ("Item " .. tostring(raw_info.id))
+        raw_meta = string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0)
+    end
+    Logger.log("main", string.format("soft_refresh draft_snapshot border_id=%s %s", state.draft and state.draft.borderId or "nil", slot_snapshot))
+
+    local updates = {
+        status_banner = {
+            text = state.status_message ~= "" and state.status_message or "",
+        },
+        border_library = {
+            items = state.library_items or {},
+            selection = tonumber(state.library_selection or 0) or 0,
+        },
+        library_page_label = {
+            text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+        },
+        current_border_title = {
+            text = border_title,
+        },
+        current_border_status = {
+            text = border_status,
+        },
+        preview_help_label = {
+            text = preview_help_text(),
+        },
+        selected_slot_status_label = {
+            text = selected_slot_status_text(),
+        },
+        slot_summary_label = {
+            text = slot_summary_text(),
+        },
+        usage_status_label = {
+            text = DraftAdapter.usage_preview_state(state.draft).statusLabel,
+        },
+        usage_missing_label = {
+            text = "Brakujace sloty: " .. DraftAdapter.usage_preview_state(state.draft).missingLabel,
+        },
+        save_mode_label = {
+            text = save_state.mode_label,
+        },
+        save_dirty_label = {
+            text = save_state.dirty_label,
+        },
+        save_target_label = {
+            text = save_state.target_label,
+        },
+        save_hint_label = {
+            text = save_state.hint_label,
+        },
+        save_border_id = {
+            value = tonumber(state.save_border_id or 0) or 0,
+        },
+        save_border_name = {
+            text = state.save_name or "",
+        },
+        save_intent_new = {
+            text = save_state.intent_new,
+        },
+        save_intent_overwrite = {
+            text = save_state.intent_overwrite,
+        },
+        slot_preview_grid = {
+            items = DraftAdapter.slot_grid_items(state.draft, state.selected_raw_id, { showImages = true }),
+            selection = tonumber(state.highlighted_slot_index or 0) or 0,
+        },
+        selected_raw_preview = {
+            image = Common.safe_image(state.selected_raw_id),
+            width = 48,
+            height = 48,
+            smooth = false,
+        },
+        selected_raw_title = {
+            text = raw_title,
+        },
+        selected_raw_meta = {
+            text = raw_meta,
+        },
+    }
+
+    state.library_skip_changes = 4
+    dlg:modify(updates)
+    dlg:repaint()
+    state.rebuilding = false
+    Logger.log("main", "soft_refresh done")
+end
+
+local function soft_refresh_save_panel()
+    if not dlg then
+        return
+    end
+
+    local save_state = save_panel_state()
+    Logger.log("main", string.format("soft_refresh_save_panel border_id=%d name='%s'", tonumber(state.save_border_id or 0) or 0, tostring(state.save_name or "")))
+    dlg:modify({
+        save_mode_label = {
+            text = save_state.mode_label,
+        },
+        save_dirty_label = {
+            text = save_state.dirty_label,
+        },
+        save_target_label = {
+            text = save_state.target_label,
+        },
+        save_hint_label = {
+            text = save_state.hint_label,
+        },
+        save_intent_new = {
+            text = save_state.intent_new,
+        },
+        save_intent_overwrite = {
+            text = save_state.intent_overwrite,
+        },
+    })
+    dlg:repaint()
+end
+
+local function render_steps()
+    local current = Common.current_step(state)
+    local steps = {
+        "1. Wybierz Border",
+        "2. Wybierz RAW",
+        "3. Kliknij Sloty",
+        "4. Sprawdz Podglad",
+        "5. Zapisz",
+    }
+
+    dlg:box({
+        orient = "horizontal",
+        expand = false,
+    })
+    for index, label in ipairs(steps) do
+        local active = index == current
+        dlg:panel({
+            bgcolor = active and Common.palette.accent or Common.palette.panel_alt,
+            padding = 5,
+            margin = 2,
+            expand = false,
+            min_width = 108,
+        })
+            dlg:label({
+                text = label,
+                fgcolor = active and Common.palette.text or Common.palette.muted,
+                font_weight = active and "bold" or "normal",
+                align = "center",
+            })
+        dlg:endpanel()
+    end
+    dlg:endbox()
+end
+
+local function render_page_content()
+    state.rebuilding = true
+    Logger.log("main", string.format("rebuild start draft=%s dirty=%s selected=%d", state.draft and state.draft.borderId or "nil", tostring(state.dirty), tonumber(state.library_selected_border_id or 0)))
+    state.filter_text = state.filter_text or ""
+    if not state.repository then
+        refresh_repository()
+    end
+    sync_library()
+    state.export_preview = Model.prepare_export(state.draft)
+
+    dlg:panel({
+        bgcolor = Common.palette.header,
+        padding = 8,
+        margin = 4,
+        expand = false,
+    })
+        dlg:label({
+            text = "BORDER STUDIO",
+            fgcolor = Common.palette.text,
+            font_size = 14,
+            font_weight = "bold",
+            align = "center",
+        })
+        dlg:newrow()
+        render_steps()
+        dlg:newrow()
+        dlg:label({
+            id = "status_banner",
+            text = state.status_message ~= "" and state.status_message or "",
+            fgcolor = Common.palette.muted,
+            align = "center",
+        })
+    dlg:endpanel()
+
+    dlg:box({
+        orient = "horizontal",
+        expand = true,
+    })
+        LibraryPanel.render(dlg, state, actions)
+        SlotsPanel.render(dlg, state, actions)
+        RawPanel.render(dlg, state, actions)
+    dlg:endbox()
+
+    dlg:separator()
+    SavePanel.render(dlg, state, actions)
+    state.library_skip_changes = 3
+    state.rebuilding = false
+    Logger.log("main", "rebuild done")
+end
+
+local function rebuild()
+    if not dlg then
+        return
+    end
+    if request_host_render() then
+        return
+    end
+
+    dlg:clear()
+    render_page_content()
+    dlg:layout()
+    dlg:repaint()
+end
+
+function actions.set_filter(text)
+    state.filter_text = text or ""
+    state.library_page = 1
+    Logger.log("main", string.format("set_filter text='%s'", tostring(state.filter_text)))
+    sync_library(0, false)
+    if dlg then
+        soft_refresh_library()
+    else
+        rebuild()
+    end
+end
+
+function actions.previous_library_page()
+    if state.library_page <= 1 then
+        return
+    end
+    state.library_page = state.library_page - 1
+    Logger.log("main", string.format("previous_library_page page=%d", tonumber(state.library_page or 1)))
+    sync_library(0, false)
+    soft_refresh_library()
+end
+
+function actions.next_library_page()
+    if state.library_page >= state.library_page_count then
+        return
+    end
+    state.library_page = state.library_page + 1
+    Logger.log("main", string.format("next_library_page page=%d", tonumber(state.library_page or 1)))
+    sync_library(0, false)
+    soft_refresh_library()
+end
+
+function actions.set_save_border_id(border_id)
+    if state.rebuilding then
+        return
+    end
+    state.save_border_id = tonumber(border_id or 0) or 0
+    Logger.log("main", string.format("set_save_border_id value=%d", state.save_border_id))
+    soft_refresh_save_panel()
+end
+
+function actions.set_save_name(name)
+    if state.rebuilding then
+        return
+    end
+    state.save_name = tostring(name or "")
+    Logger.log("main", string.format("set_save_name value='%s'", state.save_name))
+    soft_refresh_save_panel()
+end
+
+function actions.set_library_selection(index)
+    if state.rebuilding then
+        return
+    end
+
+    index = tonumber(index or 0) or 0
+    state.library_selection = index
+    state.library_selected_border_id = state.library_visible_ids[index] or 0
+    Logger.log("main", string.format("set_library_selection index=%d resolved_border=%d", index, tonumber(state.library_selected_border_id or 0)))
+end
+
+function actions.handle_library_change(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 then
+        Logger.log("main", "handle_library_change ignored empty selection")
+        return
+    end
+    if state.library_skip_changes > 0 then
+        state.library_skip_changes = state.library_skip_changes - 1
+        Logger.log("main", string.format("handle_library_change ignored programmatic index=%d remaining=%d", index, state.library_skip_changes))
+        return
+    end
+    if state.library_ignore_budget > 0 and index == state.library_ignore_index then
+        state.library_ignore_budget = state.library_ignore_budget - 1
+        Logger.log("main", string.format("handle_library_change ignored stale index=%d remaining=%d", index, state.library_ignore_budget))
+        return
+    end
+
+    actions.set_library_selection(index)
+    Logger.log("main", string.format("handle_library_change open index=%d border_id=%d", index, tonumber(state.library_selected_border_id or 0)))
+
+    local border_id = state.library_selected_border_id
+    if border_id and border_id > 0 then
+        actions.open_border(border_id)
+    end
+end
+
+function actions.handle_library_leftclick(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 then
+        Logger.log("main", "handle_library_leftclick ignored empty index")
+        return
+    end
+    Logger.log("main", string.format("handle_library_leftclick open index=%d", index))
+    actions.open_visible_border(index)
+end
+
+function actions.handle_library_doubleclick(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 then
+        Logger.log("main", "handle_library_doubleclick ignored empty index")
+        return
+    end
+    Logger.log("main", string.format("handle_library_doubleclick open index=%d", index))
+    actions.open_visible_border(index)
+end
+
+function actions.open_border(border_id)
+    border_id = tonumber(border_id or 0) or 0
+    Logger.log("main", string.format("open_border request border_id=%d", border_id))
+    if border_id <= 0 then
+        Logger.log("main", "open_border ignored invalid id")
+        return
+    end
+    if state.draft and state.draft.borderId == border_id and not state.dirty then
+        Logger.log("main", string.format("open_border skipped same border_id=%d", border_id))
+        return
+    end
+
+    if not confirm_discard() then
+        Logger.log("main", string.format("open_border cancelled by discard dialog border_id=%d", border_id))
+        return
+    end
+
+    local loaded = Model.load_draft(state.repository, border_id)
+    if not loaded then
+        Logger.log("main", string.format("open_border failed missing draft border_id=%d", border_id))
+        app.alert("This border could not be loaded from the current repository.")
+        return
+    end
+
+    Logger.log("main", string.format("open_border loaded border_id=%d assigned=%d", loaded.borderId or 0, Common.assigned_slot_count(loaded)))
+    Logger.log("main", string.format("open_border snapshot border_id=%d %s", loaded.borderId or 0, Common.assignment_snapshot(loaded)))
+    state.draft = loaded
+    state.draft.status = Common.border_status(state.draft)
+    state.library_selected_border_id = state.draft.borderId
+    state.save_border_id = state.draft.borderId
+    state.save_name = state.draft.name or ""
+    state.export_checked = false
+    state.status_message = string.format("Zaladowano border #%d do edycji.", state.draft.borderId)
+    state.dirty = false
+    state.highlighted_slot_index = 0
+    Logger.log("main", string.format("open_border before soft refresh border_id=%d", state.draft.borderId))
+    soft_refresh_loaded_border()
+end
+
+function actions.open_visible_border(index)
+    index = tonumber(index or 0) or 0
+    Logger.log("main", string.format("open_visible_border index=%d visible_count=%d current_selected=%d", index, #state.library_visible_ids, tonumber(state.library_selected_border_id or 0)))
+    actions.set_library_selection(index)
+    local border_id = state.library_visible_ids[index]
+    if border_id then
+        state.library_selected_border_id = border_id
+        local current_value = dlg and dlg.data and dlg.data.border_library or "nil"
+        Logger.log("main", string.format("open_visible_border resolved border_id=%d dlg_value=%s", border_id, tostring(current_value)))
+        actions.open_border(border_id)
+    else
+        Logger.log("main", string.format("open_visible_border missing index=%d", index))
+    end
+end
+
+function actions.new_border()
+    Logger.log("main", "new_border")
+    if not confirm_discard() then
+        return
+    end
+
+    state.draft = Model.new_draft(state.repository, state.session_borders)
+    state.export_preview = Model.prepare_export(state.draft)
+    state.export_checked = false
+    state.library_selected_border_id = 0
+    state.save_border_id = state.draft.borderId
+    state.save_name = state.draft.name or ""
+    state.status_message = string.format("Utworzono nowy draft bordera #%d.", state.draft.borderId)
+    state.dirty = false
+    state.highlighted_slot_index = 0
+    state.library_ignore_index = 0
+    state.library_ignore_budget = 0
+    rebuild()
+end
+
+function actions.duplicate_current()
+    Logger.log("main", "duplicate_current")
+    if not state.draft then
+        state.draft = Model.new_draft(state.repository, state.session_borders)
+    else
+        state.draft = Model.duplicate_draft(state.repository, state.session_borders, state.draft)
+    end
+
+    state.export_preview = Model.prepare_export(state.draft)
+    state.export_checked = false
+    state.library_selected_border_id = 0
+    state.save_border_id = state.draft.borderId
+    state.save_name = state.draft.name or ""
+    state.status_message = string.format("Zduplikowano border do nowego draftu #%d.", state.draft.borderId)
+    state.dirty = true
+    state.highlighted_slot_index = 0
+    state.library_ignore_index = 0
+    state.library_ignore_budget = 0
+    rebuild()
+end
+
+function actions.set_raw(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    Logger.log("main", string.format("set_raw item_id=%d", item_id))
+    state.selected_raw_id = item_id
+    state.recent_raw_ids = Model.touch_recent(state.recent_raw_ids, item_id)
+    if dlg then
+        soft_refresh_loaded_border()
+    else
+        rebuild()
+    end
+end
+
+function actions.clear_raw()
+    Logger.log("main", "clear_raw")
+    state.selected_raw_id = 0
+    if dlg then
+        soft_refresh_loaded_border()
+    else
+        rebuild()
+    end
+end
+
+function actions.pick_recent(index)
+    local item_id = state.recent_raw_ids[index]
+    if item_id then
+        actions.set_raw(item_id)
+    end
+end
+
+function actions.assign_layout_cell(index)
+    Logger.log("main", string.format("assign_layout_cell index=%s", tostring(index)))
+    local key = DraftAdapter.slot_name_from_layout(index)
+    local visual_key = DraftAdapter.visual_slot_name_from_layout(index)
+    state.highlighted_slot_index = tonumber(index or 0) or 0
+    if not key or not state.draft then
+        Logger.log("main", string.format("assign_layout_cell ignored index=%s key=%s has_draft=%s", tostring(index), tostring(key), tostring(state.draft ~= nil)))
+        return
+    end
+
+    local raw_id = current_raw_id()
+    Logger.log("main", string.format("assign_layout_cell visual=%s stored=%s raw_id=%d selected=%d active_brush=%d", tostring(visual_key), tostring(key), raw_id, tonumber(state.selected_raw_id or 0) or 0, Common.active_raw_brush_id()))
+    if raw_id <= 0 then
+        state.status_message = "Najpierw wybierz RAW tile."
+        soft_refresh_loaded_border()
+        return
+    end
+
+    if raw_id ~= (tonumber(state.selected_raw_id or 0) or 0) then
+        state.selected_raw_id = raw_id
+        state.recent_raw_ids = Model.touch_recent(state.recent_raw_ids, raw_id)
+    end
+
+    local ok, message = state.draft:assignSlot(key, Model.make_raw_reference(raw_id))
+    if not ok then
+        Logger.log("main", string.format("assign_layout_cell failed key=%s message=%s", tostring(key), tostring(message)))
+        app.alert(message)
+        return
+    end
+
+    state.draft.status = Common.border_status(state.draft)
+    state.recent_raw_ids = Model.touch_recent(state.recent_raw_ids, raw_id)
+    state.export_checked = false
+    state.status_message = string.format("Przypisano RAW %d do slotu %s.", raw_id, string.upper(visual_key or key))
+    state.dirty = true
+    Logger.log("main", string.format("assign_layout_cell success visual=%s stored=%s raw_id=%d", tostring(visual_key), tostring(key), raw_id))
+    soft_refresh_loaded_border()
+end
+
+function actions.clear_layout_cell(index)
+    Logger.log("main", string.format("clear_layout_cell index=%s", tostring(index)))
+    local key = DraftAdapter.slot_name_from_layout(index)
+    local visual_key = DraftAdapter.visual_slot_name_from_layout(index)
+    state.highlighted_slot_index = tonumber(index or 0) or 0
+    if not key or not state.draft then
+        Logger.log("main", string.format("clear_layout_cell ignored index=%s key=%s has_draft=%s", tostring(index), tostring(key), tostring(state.draft ~= nil)))
+        return
+    end
+
+    state.draft:clearSlot(key)
+    state.draft.status = Common.border_status(state.draft)
+    state.export_checked = false
+    state.status_message = string.format("Wyczyszczono slot %s.", string.upper(visual_key or key))
+    state.dirty = true
+    Logger.log("main", string.format("clear_layout_cell success visual=%s stored=%s", tostring(visual_key), tostring(key)))
+    soft_refresh_loaded_border()
+end
+
+function actions.clear_selected_slot()
+    local index = tonumber(state.highlighted_slot_index or 0) or 0
+    if index <= 0 then
+        state.status_message = "Najpierw wybierz slot, ktory chcesz wyczyscic."
+        soft_refresh_loaded_border()
+        return
+    end
+    actions.clear_layout_cell(index)
+end
+
+function actions.clear_draft()
+    if not state.draft then
+        return
+    end
+    if state.draft:isEmpty() then
+        state.status_message = "Draft jest juz pusty."
+        soft_refresh_loaded_border()
+        return
+    end
+
+    local choice = app.alert({
+        title = "Clear draft?",
+        text = "This will clear all assigned border slots in the current draft.",
+        buttons = { "Yes", "No" },
+    })
+    if choice ~= 1 then
+        return
+    end
+
+    state.draft:clear()
+    state.draft.status = Common.border_status(state.draft)
+    state.export_checked = false
+    state.dirty = true
+    state.highlighted_slot_index = 0
+    state.status_message = "Wyczyszczono caly draft."
+    soft_refresh_loaded_border()
+end
+
+local function finalize_save(mode)
+    local previous_border_id = state.draft and state.draft.borderId or 0
+    local ok, result = Model.save_draft(
+        state.repository,
+        state.session_borders,
+        state.draft,
+        state.save_border_id,
+        state.save_name,
+        mode,
+        state.target_path
+    )
+
+    if not ok then
+        app.alert({
+            title = "Save failed",
+            text = result,
+            buttons = { "OK" },
+        })
+        return
+    end
+
+    if previous_border_id ~= result.draft.borderId and state.session_borders[previous_border_id] and not (state.repository.by_id and state.repository.by_id[previous_border_id]) then
+        state.session_borders[previous_border_id] = nil
+    end
+
+    state.draft = result.draft
+    refresh_repository()
+    state.library_selected_border_id = result.draft.borderId
+    state.save_border_id = result.draft.borderId
+    state.save_name = result.draft.name or ""
+    state.export_checked = false
+    state.status_message = result.message
+    state.dirty = false
+    session.lastSavedBorder = result.draft.borderId
+    sync_session_out()
+    rebuild()
+    app.alert({
+        title = "Border saved",
+        text = result.message,
+        buttons = { "OK" },
+    })
+end
+
+function actions.save_as_new()
+    finalize_save("new")
+end
+
+function actions.overwrite_existing()
+    finalize_save("overwrite")
+end
+
+local function attach_brush_listener()
+    if listener_id or not app.events or not app.events.on then
+        return
+    end
+
+    listener_id = app.events:on("brushChange", function(brushName)
+        Logger.log("main", string.format("brushChange event brush=%s", tostring(brushName)))
+        if sync_selected_raw_from_brush("brushChange") and dlg then
+            sync_session_out()
+            soft_refresh_loaded_border()
+        end
+    end)
+end
+
+local function detach_brush_listener()
+    if listener_id and app.events and app.events.off then
+        pcall(function()
+            app.events:off(listener_id)
+        end)
+    end
+    listener_id = nil
+end
+
+local function initialize()
+    refresh_repository()
+    state.draft = settings.last_border_id and Model.load_draft(state.repository, settings.last_border_id) or nil
+    if not state.draft then
+        Logger.log("main", "initial draft missing, creating new")
+        state.draft = Model.new_draft(state.repository, state.session_borders)
+    end
+    state.save_border_id = state.draft.borderId
+    state.save_name = state.draft.name or ""
+    sync_session_in()
+    sync_selected_raw_from_brush("startup")
+    sync_session_out()
+    Logger.log("main", string.format("initial draft border_id=%d", state.draft.borderId or 0))
+end
+
+initialize()
+
+local page = {}
+
+function page.getTitle()
+    return "Borders"
+end
+
+function page.isDirty()
+    return state.dirty
+end
+
+function page.confirmLeave()
+    return confirm_discard()
+end
+
+function page.onEnter(shared_session)
+    session = shared_session or session
+    sync_session_in()
+    sync_session_out()
+    attach_brush_listener()
+end
+
+function page.onLeave(shared_session)
+    session = shared_session or session
+    sync_session_out()
+    persist_settings()
+    detach_brush_listener()
+end
+
+function page.render_into(dialog)
+    dlg = dialog
+    render_page_content()
+end
+
+function page.getSessionState()
+    sync_session_out()
+    return session
+end
+
+function page.getStatusText()
+    return state.status_message ~= "" and state.status_message or helper_text()
+end
+
+function page.getState()
+    return state
+end
+
+return page
+end
+
+function BorderStudioPage.create(options)
+    return create_page(options)
+end
+
+function BorderStudioPage.open_standalone()
+    local existing_dialog = _G.BORDER_STUDIO_DIALOG
+    if existing_dialog then
+        pcall(function()
+            existing_dialog:close()
+        end)
+        _G.BORDER_STUDIO_DIALOG = nil
+        _G.BORDER_STUDIO_OPEN = false
+        app.yield()
+    end
+
+    local page = create_page({
+        reset_logger = true,
+    })
+
+    local dlg = Dialog({
+        title = "Border Studio",
+        id = "border_studio_dock",
+        width = 1480,
+        height = 860,
+        resizable = true,
+        dockable = true,
+        onclose = function()
+            Logger.log("main", "dialog onclose")
+            page.onLeave({})
+            _G.BORDER_STUDIO_OPEN = false
+            _G.BORDER_STUDIO_DIALOG = nil
+        end,
+    })
+
+    _G.BORDER_STUDIO_OPEN = true
+    _G.BORDER_STUDIO_DIALOG = dlg
+    page.onEnter({})
+    dlg:clear()
+    page.render_into(dlg)
+    dlg:layout()
+    dlg:repaint()
+    Logger.log("main", "show dialog")
+    dlg:show({ wait = false, center = "screen" })
+    return page
+end
+
+return BorderStudioPage

--- a/scripts/border_studio/raw_panel.lua
+++ b/scripts/border_studio/raw_panel.lua
@@ -1,0 +1,59 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    local raw_info = Common.safe_item_info(state.selected_raw_id)
+    local raw_title = "Najpierw wybierz RAW tile"
+    local raw_meta = "Wybrany RAW z glownej palety RME pojawi sie tutaj automatycznie."
+
+    if raw_info then
+        raw_title = raw_info.name or ("Item " .. tostring(raw_info.id))
+        raw_meta = string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0)
+    end
+
+    dlg:box({
+        label = "2. Wybrany RAW",
+        orient = "vertical",
+        width = 280,
+        min_width = 260,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            text = "Aktualny RAW z glownej palety.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        dlg:image({
+            id = "selected_raw_preview",
+            label = "RAW",
+            image = Common.safe_image(state.selected_raw_id),
+            width = 48,
+            height = 48,
+            smooth = false,
+        })
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                id = "selected_raw_title",
+                text = raw_title,
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "selected_raw_meta",
+                text = raw_meta,
+                fgcolor = Common.palette.muted,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/border_studio/save_panel.lua
+++ b/scripts/border_studio/save_panel.lua
@@ -81,6 +81,28 @@ function M.render(dlg, state, actions)
             font_weight = "bold",
         })
         dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Zmien XML",
+                bgcolor = Common.palette.panel,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.choose_target_path()
+                end,
+            })
+            dlg:button({
+                text = "Domyslny XML",
+                bgcolor = Common.palette.panel,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.use_default_target_path()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
         dlg:label({
             id = "save_intent_new",
             text = intent_new,

--- a/scripts/border_studio/save_panel.lua
+++ b/scripts/border_studio/save_panel.lua
@@ -1,0 +1,122 @@
+local Common = dofile("common.lua")
+local Model = dofile("model.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    local is_existing = state.draft and not state.draft.isNew
+    local dirty_label = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie"
+    local mode_label = is_existing
+        and string.format("Tryb: edycja istniejacego wpisu #%d", state.draft.borderId or 0)
+        or "Tryb: nowy border"
+    local intent_new = Model.save_intent(state.repository, state.draft, state.save_border_id, "new")
+    local intent_overwrite = Model.save_intent(state.repository, state.draft, state.save_border_id, "overwrite")
+    local target_label = state.target_path ~= "" and state.target_path or "No borders.xml target resolved."
+
+    dlg:box({
+        orient = "vertical",
+        label = "5. Zapisz Border",
+        expand = false,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                id = "save_mode_label",
+                text = mode_label,
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "save_dirty_label",
+                text = dirty_label,
+                fgcolor = state.dirty and Common.palette.accent_soft or Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "save_target_label",
+                text = "Target: " .. target_label,
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+        dlg:endpanel()
+
+        dlg:number({
+            id = "save_border_id",
+            label = "Border ID",
+            value = tonumber(state.save_border_id or 0) or 0,
+            min = 0,
+            max = 65535,
+            onchange = function(d)
+                local next_id = d.data.save_border_id or 0
+                if tonumber(next_id or 0) ~= tonumber(state.save_border_id or 0) then
+                    actions.set_save_border_id(next_id)
+                end
+            end,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "save_border_name",
+            label = "Robocza nazwa",
+            text = state.save_name or "",
+            expand = true,
+            onchange = function(d)
+                local next_name = d.data.save_border_name or ""
+                if tostring(next_name or "") ~= tostring(state.save_name or "") then
+                    actions.set_save_name(next_name)
+                end
+            end,
+        })
+        dlg:newrow()
+        dlg:label({
+            id = "save_hint_label",
+            text = "Podaj ID, aby zapisac border.",
+            fgcolor = Common.palette.muted,
+            font_weight = "bold",
+        })
+        dlg:newrow()
+        dlg:label({
+            id = "save_intent_new",
+            text = intent_new,
+            fgcolor = Common.palette.subtle,
+            font_size = 8,
+        })
+        dlg:newrow()
+        dlg:label({
+            id = "save_intent_overwrite",
+            text = intent_overwrite,
+            fgcolor = Common.palette.subtle,
+            font_size = 8,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Zapisz Jako Nowy",
+                bgcolor = Common.palette.success,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.save_as_new()
+                end,
+            })
+            dlg:button({
+                text = "Nadpisz Istniejacy",
+                bgcolor = Common.palette.accent,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.overwrite_existing()
+                end,
+            })
+        dlg:endbox()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/border_studio/settings.json
+++ b/scripts/border_studio/settings.json
@@ -1,0 +1,15 @@
+{
+    "last_border_id": 226,
+    "recent_raw_ids": [
+        21480,
+        21483,
+        21481,
+        21482,
+        898,
+        21468,
+        21469,
+        21470
+    ],
+    "selected_raw_id": 0,
+    "target_path": "D:\\remeres-map-editor-redux-master\\data\\1310\\borders.xml"
+}

--- a/scripts/border_studio/slots_panel.lua
+++ b/scripts/border_studio/slots_panel.lua
@@ -1,0 +1,114 @@
+local Common = dofile("common.lua")
+local DraftAdapter = dofile("draft_adapter.lua")
+local TestPreviewPanel = dofile("test_preview_panel.lua")
+
+local M = {}
+
+local function render_slot_matrix(dlg, state, actions)
+    dlg:grid({
+        id = "slot_preview_grid",
+        width = 320,
+        height = 320,
+        expand = false,
+        icon_size = 42,
+        cell_size = 62,
+        show_text = true,
+        label_wrap = false,
+        items = DraftAdapter.slot_grid_items(state.draft, state.selected_raw_id, { showImages = true }),
+        selection = tonumber(state.highlighted_slot_index or 0) or 0,
+        onleftclick = function(_, info)
+            local index = tonumber(info and info.index or 0) or 0
+            if actions and actions.assign_layout_cell then
+                actions.assign_layout_cell(index)
+            end
+        end,
+        onrightclick = function(_, info)
+            local index = tonumber(info and info.index or 0) or 0
+            if actions and actions.clear_layout_cell then
+                actions.clear_layout_cell(index)
+            end
+        end,
+    })
+end
+
+function M.render(dlg, state, actions)
+    local preview_state = DraftAdapter.preview_state(state.draft)
+    local summary_text = preview_state.hasAssignments
+        and string.format(
+            "Ustawione sloty: %d. Puste sloty: %s",
+            preview_state.assignedCount,
+            #preview_state.emptySlots > 0 and table.concat(preview_state.emptySlots, ", ") or "none"
+        )
+        or "Kliknij slot w podgladzie, aby przypisac tile."
+
+    dlg:box({
+        label = "3. Kliknij Sloty",
+        orient = "vertical",
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            id = "preview_help_label",
+            text = "Najpierw wybierz RAW tile. LPM przypisuje, PPM czysci slot.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        render_slot_matrix(dlg, state, actions)
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Status slotow",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "selected_slot_status_label",
+                text = "Nie wybrano zadnego slotu.",
+                fgcolor = Common.palette.muted,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "slot_summary_label",
+                text = summary_text,
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Wyczysc Slot",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        if actions and actions.clear_selected_slot then
+                            actions.clear_selected_slot()
+                        end
+                    end,
+                })
+                dlg:button({
+                    text = "Wyczysc Caly Draft",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        if actions and actions.clear_draft then
+                            actions.clear_draft()
+                        end
+                    end,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+        dlg:newrow()
+        TestPreviewPanel.render(dlg, state.draft)
+    dlg:endbox()
+end
+
+return M

--- a/scripts/border_studio/test_preview_panel.lua
+++ b/scripts/border_studio/test_preview_panel.lua
@@ -1,0 +1,131 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+local PREVIEW_OUTSIDE = "#6B7280"
+local PREVIEW_INSIDE = "#65A30D"
+local PREVIEW_EMPTY = "#111827"
+
+local function render_patch_cell(dlg, draft, index)
+    local visual_key = Common.slot_layout[index]
+    local row = math.floor((index - 1) / 5) + 1
+    local col = ((index - 1) % 5) + 1
+    local inside_center = row == 3 and col == 3
+
+    local background = inside_center and PREVIEW_INSIDE or PREVIEW_OUTSIDE
+    if not visual_key then
+        background = PREVIEW_EMPTY
+    end
+
+    dlg:panel({
+        bgcolor = background,
+        padding = 2,
+        margin = 2,
+        width = 58,
+        height = 58,
+        expand = false,
+    })
+        if visual_key == "c" then
+            dlg:label({
+                text = "C",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+                align = "center",
+            })
+        elseif visual_key then
+            local stored_key = Common.storage_slot_name(visual_key)
+            local item_id = draft and draft:getSlotItemId(stored_key) or 0
+            dlg:image({
+                image = Common.safe_image(item_id),
+                width = 42,
+                height = 42,
+                smooth = false,
+            })
+            dlg:newrow()
+            dlg:label({
+                text = Common.slot_meta[visual_key].short,
+                fgcolor = Common.palette.text,
+                font_size = 7,
+                align = "center",
+            })
+        end
+    dlg:endpanel()
+end
+
+local function render_patch(dlg, draft)
+    dlg:box({
+        orient = "vertical",
+        expand = false,
+    })
+    for row = 1, 5 do
+        if row > 1 then
+            dlg:newrow()
+        end
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+        for col = 1, 5 do
+            local index = ((row - 1) * 5) + col
+            render_patch_cell(dlg, draft, index)
+        end
+        dlg:endbox()
+    end
+    dlg:endbox()
+end
+
+function M.render(dlg, draft)
+    local empty_slots = draft and draft:getEmptySlots() or Common.clone(Common.slot_order)
+    local is_complete = draft and #empty_slots == 0 and not draft:isEmpty()
+    local status_label = is_complete and "Podglad mapowy jest kompletny." or "Podglad mapowy pokazuje brakujace sloty."
+    local missing_label = #empty_slots > 0 and table.concat(empty_slots, ", ") or "none"
+
+    dlg:box({
+        label = "4. Sprawdz Podglad",
+        orient = "vertical",
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Podglad mapowy 5x5",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                text = "Ten widok pokazuje border tak, jak czytasz go na mapie: srodek jest polem area, sloty dookola sa odwrocone wzgledem zapisu XML.",
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        render_patch(dlg, draft)
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = status_label,
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                text = "Brakujace sloty: " .. missing_label,
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/border_studio/xml_target_helper.lua
+++ b/scripts/border_studio/xml_target_helper.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+local function normalize(path)
+    return tostring(path or ""):gsub("\\", "/")
+end
+
+local function lower_path(path)
+    return string.lower(normalize(path))
+end
+
+function M.is_xml_file(path)
+    return lower_path(path):match("%.xml$") ~= nil
+end
+
+function M.matches_expected_filename(path, expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return true
+    end
+    local normalized = lower_path(path)
+    local suffix = "/" .. string.lower(expected_filename)
+    return normalized:sub(-#suffix) == suffix or normalized == string.lower(expected_filename)
+end
+
+function M.is_inside_data_dir(path)
+    local data_dir = lower_path(app.getDataDirectory() or "")
+    local normalized = lower_path(path)
+    if data_dir == "" then
+        return false
+    end
+    if normalized == data_dir then
+        return true
+    end
+    return normalized:sub(1, #data_dir + 1) == (data_dir .. "/")
+end
+
+function M.default_xml_wildcard(expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return "XML files (*.xml)|*.xml|All files (*.*)|*.*"
+    end
+    return string.format("%s (%s)|%s|XML files (*.xml)|*.xml|All files (*.*)|*.*", expected_filename, expected_filename, expected_filename)
+end
+
+function M.pick_xml_file(expected_filename, current_path, title)
+    if not app or not app.chooseFile then
+        return nil, "This RME build does not expose file picker support."
+    end
+
+    local chosen = app.chooseFile({
+        title = title or "Select XML file",
+        path = normalize(current_path),
+        wildcard = M.default_xml_wildcard(expected_filename),
+    })
+
+    if not chosen or chosen == "" then
+        return nil
+    end
+
+    chosen = normalize(chosen)
+    if not M.is_xml_file(chosen) then
+        return nil, "Wybrany plik musi byc plikiem XML."
+    end
+    if not M.matches_expected_filename(chosen, expected_filename) then
+        return nil, string.format("Wybierz plik '%s'.", tostring(expected_filename or ""))
+    end
+    if not M.is_inside_data_dir(chosen) then
+        return nil, "Wybrany plik musi znajdowac sie w aktualnym katalogu data tego RME."
+    end
+
+    return chosen
+end
+
+return M

--- a/scripts/border_studio/xml_writer.lua
+++ b/scripts/border_studio/xml_writer.lua
@@ -1,0 +1,56 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+local function export_data(border_or_export)
+    if border_or_export and border_or_export.toBorderItemEntries then
+        return {
+            borderId = border_or_export.borderId,
+            group = border_or_export.group or 0,
+            borderItems = border_or_export:toBorderItemEntries(),
+        }
+    end
+    return border_or_export
+end
+
+function M.serialize_border(border_or_export)
+    local border = export_data(border_or_export) or {}
+    local attrs = string.format('id="%d"', border.borderId or border.id or 0)
+    if (border.group or 0) > 0 then
+        attrs = attrs .. string.format(' group="%d"', border.group)
+    end
+
+    local lines = {
+        string.format('\t<border %s>', attrs),
+    }
+
+    for _, entry in ipairs(border.borderItems or {}) do
+        table.insert(lines, string.format('\t\t<borderitem edge="%s" item="%d"/>', entry.edge, entry.itemId))
+    end
+
+    table.insert(lines, "\t</border>")
+    return table.concat(lines, "\n")
+end
+
+function M.serialize(border_map)
+    local ids = {}
+    for id in pairs(border_map) do
+        table.insert(ids, id)
+    end
+    table.sort(ids)
+
+    local lines = {
+        '<?xml version="1.0" encoding="utf-8"?>',
+        "<materials>",
+    }
+
+    for _, id in ipairs(ids) do
+        table.insert(lines, M.serialize_border(border_map[id]))
+    end
+
+    table.insert(lines, "</materials>")
+    table.insert(lines, "")
+    return table.concat(lines, "\n")
+end
+
+return M

--- a/scripts/brush_studio/composer_draft.lua
+++ b/scripts/brush_studio/composer_draft.lua
@@ -1,0 +1,173 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+
+local ComposerDraft = {}
+ComposerDraft.__index = ComposerDraft
+
+local function clone_reference(reference)
+    if type(reference) ~= "table" then
+        return nil
+    end
+    local copy = GroundCommon.clone(reference)
+    if type(reference.draft) == "table" and type(reference.draft.clone) == "function" then
+        copy.draft = reference.draft:clone()
+    end
+    return copy
+end
+
+local function normalize_align(value)
+    local text = string.lower(tostring(value or "outer"))
+    if text ~= "inner" then
+        return "outer"
+    end
+    return text
+end
+
+function ComposerDraft.new(init)
+    local self = setmetatable({}, ComposerDraft)
+    self.name = GroundCommon.trim(init and init.name or "")
+    self.selectedGround = clone_reference(init and init.selectedGround)
+    self.selectedBorder = clone_reference(init and init.selectedBorder)
+    self.toBrush = GroundCommon.trim(init and init.toBrush or "")
+    self.align = normalize_align(init and init.align)
+    self.friends = {}
+    self.dirty = GroundCommon.normalize_bool(init and init.dirty, false)
+    self.isNew = GroundCommon.normalize_bool(init and init.isNew, true)
+    self.sourceName = GroundCommon.trim(init and (init.sourceName or init.name) or "")
+    self.extraChildrenXml = tostring(init and init.extraChildrenXml or "")
+
+    for _, friend_name in ipairs((init and init.friends) or {}) do
+        local trimmed = GroundCommon.trim(friend_name)
+        if trimmed ~= "" then
+            table.insert(self.friends, trimmed)
+        end
+    end
+
+    return self
+end
+
+function ComposerDraft:clear()
+    self.name = ""
+    self.selectedGround = nil
+    self.selectedBorder = nil
+    self.toBrush = ""
+    self.align = "outer"
+    self.friends = {}
+    self.dirty = false
+    self.extraChildrenXml = ""
+end
+
+function ComposerDraft:isEmpty()
+    return not self.selectedGround and not self.selectedBorder and self.name == "" and #self.friends == 0 and self.toBrush == ""
+end
+
+function ComposerDraft:setGround(reference)
+    self.selectedGround = clone_reference(reference)
+    self.dirty = true
+    return self.selectedGround ~= nil
+end
+
+function ComposerDraft:setBorder(reference)
+    self.selectedBorder = clone_reference(reference)
+    self.dirty = true
+    return self.selectedBorder ~= nil
+end
+
+function ComposerDraft:setName(value)
+    self.name = GroundCommon.trim(value)
+    self.dirty = true
+end
+
+function ComposerDraft:setToBrush(value)
+    self.toBrush = GroundCommon.trim(value)
+    self.dirty = true
+end
+
+function ComposerDraft:setAlign(value)
+    self.align = normalize_align(value)
+    self.dirty = true
+end
+
+function ComposerDraft:addFriend(friend_name)
+    local trimmed = GroundCommon.trim(friend_name)
+    if trimmed == "" then
+        return false, "Podaj nazwe friend brush."
+    end
+    for _, existing in ipairs(self.friends) do
+        if string.lower(existing) == string.lower(trimmed) then
+            return false, "Ten friend jest juz dodany."
+        end
+    end
+    table.insert(self.friends, trimmed)
+    self.dirty = true
+    return true
+end
+
+function ComposerDraft:removeFriend(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #self.friends then
+        return false
+    end
+    table.remove(self.friends, index)
+    self.dirty = true
+    return true
+end
+
+function ComposerDraft:hasRequiredDataForSave()
+    if self.name == "" then
+        return false
+    end
+    if not self.selectedGround or not self.selectedGround.draft then
+        return false
+    end
+    if not self.selectedGround.draft.hasMainItem or not self.selectedGround.draft:hasMainItem() then
+        return false
+    end
+    if not self.selectedBorder or (tonumber(self.selectedBorder.borderId or 0) or 0) <= 0 then
+        return false
+    end
+    return true
+end
+
+function ComposerDraft:getValidation()
+    local errors = {}
+    local warnings = {}
+
+    if self.name == "" then
+        table.insert(errors, "Podaj nazwe, aby zapisac brush.")
+    end
+    if not self.selectedGround then
+        table.insert(errors, "Najpierw wybierz ground.")
+    elseif not self.selectedGround.draft or not self.selectedGround.draft.hasMainItem or not self.selectedGround.draft:hasMainItem() then
+        table.insert(errors, "Wybrany ground nie ma poprawnego main tile.")
+    end
+    if not self.selectedBorder or (tonumber(self.selectedBorder.borderId or 0) or 0) <= 0 then
+        table.insert(errors, "Najpierw wybierz border.")
+    end
+    if self.toBrush ~= "" and self.selectedGround and string.lower(self.toBrush) == string.lower(self.selectedGround.name or "") then
+        table.insert(warnings, "toBrush wskazuje na ten sam ground co zrodlo.")
+    end
+
+    return {
+        isValid = #errors == 0,
+        errors = errors,
+        warnings = warnings,
+    }
+end
+
+function ComposerDraft:clone()
+    return ComposerDraft.new({
+        name = self.name,
+        selectedGround = self.selectedGround,
+        selectedBorder = self.selectedBorder,
+        toBrush = self.toBrush,
+        align = self.align,
+        friends = self.friends,
+        dirty = self.dirty,
+        isNew = self.isNew,
+        sourceName = self.sourceName,
+        extraChildrenXml = self.extraChildrenXml,
+    })
+end
+
+return ComposerDraft

--- a/scripts/brush_studio/composer_page.lua
+++ b/scripts/brush_studio/composer_page.lua
@@ -4,8 +4,10 @@ local BorderCommon = Paths.load("border_studio/common.lua")
 local Logger = dofile("logger.lua")
 local ComposerDraft = dofile("composer_draft.lua")
 local ComposerRepository = dofile("composer_repository.lua")
+local XmlTarget = dofile("xml_target_helper.lua")
 
 local ComposerPage = {}
+local SETTINGS_STORE = app.storage("composer_settings.json")
 
 local palette = {
     header = "#233246",
@@ -43,10 +45,11 @@ local COMPOSED_PAGE_SIZE = 12
 local function create_page(options)
     options = options or {}
     local session = options.session or {}
+    local settings = SETTINGS_STORE:load() or {}
     local dlg
 
     local state = {
-        target_path = ComposerRepository.resolve_target_path and ComposerRepository.resolve_target_path("") or (app.getDataDirectory() .. "/1310/grounds.xml"),
+        target_path = ComposerRepository.resolve_target_path and ComposerRepository.resolve_target_path(settings.target_path or "") or (app.getDataDirectory() .. "/1310/grounds.xml"),
         repository = nil,
         selected_raw_id = 0,
         ground_filter = "",
@@ -100,6 +103,12 @@ local function create_page(options)
         else
             state.selected_raw_id = GroundCommon.active_raw_brush_id()
         end
+    end
+
+    local function persist_settings()
+        SETTINGS_STORE:save({
+            target_path = state.target_path or "",
+        })
     end
 
     local function request_host_render()
@@ -1146,6 +1155,35 @@ local function create_page(options)
         finalize_save("overwrite")
     end
 
+    function actions.choose_target_path()
+        local chosen, err = XmlTarget.pick_xml_file("grounds.xml", state.target_path, "Wybierz grounds.xml dla Composera")
+        if err then
+            app.alert({
+                title = "Nie mozna ustawic targetu",
+                text = err,
+                buttons = { "OK" },
+            })
+            return
+        end
+        if not chosen then
+            return
+        end
+
+        state.target_path = chosen
+        persist_settings()
+        refresh_repository()
+        sync_sources()
+        soft_refresh()
+    end
+
+    function actions.use_default_target_path()
+        state.target_path = ComposerRepository.resolve_target_path and ComposerRepository.resolve_target_path("") or (app.getDataDirectory() .. "/1310/grounds.xml")
+        persist_settings()
+        refresh_repository()
+        sync_sources()
+        soft_refresh()
+    end
+
     refresh_repository()
     sync_session_in()
     sync_sources()
@@ -1179,6 +1217,7 @@ local function create_page(options)
     function page.onLeave(shared_session)
         session = shared_session or session
         sync_session_out()
+        persist_settings()
     end
 
     function page.render_into(dialog)
@@ -1758,6 +1797,28 @@ local function create_page(options)
                         text = save_hint_text(),
                         fgcolor = palette.muted,
                     })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            text = "Zmien XML",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.choose_target_path()
+                            end,
+                        })
+                        dlg:button({
+                            text = "Domyslny XML",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.use_default_target_path()
+                            end,
+                        })
+                    dlg:endbox()
                     dlg:newrow()
                     dlg:button({
                         text = "Save as New",

--- a/scripts/brush_studio/composer_page.lua
+++ b/scripts/brush_studio/composer_page.lua
@@ -1,0 +1,1804 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+local BorderCommon = Paths.load("border_studio/common.lua")
+local Logger = dofile("logger.lua")
+local ComposerDraft = dofile("composer_draft.lua")
+local ComposerRepository = dofile("composer_repository.lua")
+
+local ComposerPage = {}
+
+local palette = {
+    header = "#233246",
+    panel = "#243447",
+    panel_alt = "#2C3E50",
+    sidebar = "#26282d",
+    accent = "#8B5CF6",
+    success = "#2F855A",
+    warning = "#D97706",
+    text = "#F8FAFC",
+    muted = "#CBD5E1",
+    subtle = "#94A3B8",
+    danger = "#C53030",
+}
+
+local preview_slot_map = {
+    n = "s",
+    e = "w",
+    s = "n",
+    w = "e",
+    cnw = "cse",
+    cne = "csw",
+    csw = "cne",
+    cse = "cnw",
+    dnw = "dse",
+    dne = "dsw",
+    dsw = "dne",
+    dse = "dnw",
+}
+
+local GROUND_PAGE_SIZE = 12
+local BORDER_PAGE_SIZE = 12
+local COMPOSED_PAGE_SIZE = 12
+
+local function create_page(options)
+    options = options or {}
+    local session = options.session or {}
+    local dlg
+
+    local state = {
+        target_path = ComposerRepository.resolve_target_path and ComposerRepository.resolve_target_path("") or (app.getDataDirectory() .. "/1310/grounds.xml"),
+        repository = nil,
+        selected_raw_id = 0,
+        ground_filter = "",
+        border_filter = "",
+        composed_filter = "",
+        ground_items = {},
+        ground_names = {},
+        ground_selection = 0,
+        ground_page = 1,
+        ground_skip_changes = 0,
+        last_ground_open_name = "",
+        border_items = {},
+        border_ids = {},
+        border_selection = 0,
+        border_page = 1,
+        border_skip_changes = 0,
+        last_border_open_id = 0,
+        composed_items = {},
+        composed_names = {},
+        composed_selection = 0,
+        composed_page = 1,
+        composed_skip_changes = 0,
+        last_composed_open_name = "",
+        friend_input = "",
+        friend_selection = 0,
+        source_stage = "ground",
+        draft = ComposerDraft.new({
+            align = "outer",
+            isNew = true,
+        }),
+        status_message = "Najpierw wybierz ground i border.",
+        dirty = false,
+    }
+
+    local actions = {}
+    local page = {}
+
+    local function sync_session_out()
+        session.lastSelectedRaw = tonumber(state.selected_raw_id or 0) or 0
+        session.pageDirty = session.pageDirty or {}
+        session.pageDirty.composer = state.dirty
+        if state.draft and state.draft.name ~= "" then
+            session.lastComposerName = state.draft.name
+        end
+    end
+
+    local function sync_session_in()
+        local shared_raw = tonumber(session.lastSelectedRaw or 0) or 0
+        if shared_raw > 0 then
+            state.selected_raw_id = shared_raw
+        else
+            state.selected_raw_id = GroundCommon.active_raw_brush_id()
+        end
+    end
+
+    local function request_host_render()
+        sync_session_out()
+        if options.onRequestRender then
+            options.onRequestRender()
+            return true
+        end
+        return false
+    end
+
+    local function confirm_discard()
+        if not state.dirty then
+            return true
+        end
+
+        local choice = app.alert({
+            title = "Discard changes?",
+            text = "The current composer draft has unsaved changes. Continue and discard them?",
+            buttons = { "Yes", "No" },
+        })
+        return choice == 1
+    end
+
+    local function current_ground_ref()
+        return state.draft and state.draft.selectedGround or nil
+    end
+
+    local function current_border_ref()
+        return state.draft and state.draft.selectedBorder or nil
+    end
+
+    local function current_ground_name()
+        local ref = current_ground_ref()
+        return ref and tostring(ref.name or "") or ""
+    end
+
+    local function current_border_id()
+        local ref = current_border_ref()
+        return ref and (tonumber(ref.borderId or 0) or 0) or 0
+    end
+
+    local function current_ground_z_order()
+        local ref = current_ground_ref()
+        if not ref or not ref.draft then
+            return 0
+        end
+        return tonumber(ref.draft.zOrder or 0) or 0
+    end
+
+    local function current_composed_name()
+        if state.draft and not state.draft.isNew then
+            return tostring(state.draft.sourceName or "")
+        end
+        return ""
+    end
+
+    local function effective_source_stage()
+        local stage = tostring(state.source_stage or "ground")
+        if stage ~= "ground" and stage ~= "border" and stage ~= "existing" then
+            stage = "ground"
+        end
+        if not current_ground_ref() and stage ~= "existing" then
+            return "ground"
+        end
+        if current_ground_ref() and not current_border_ref() and stage ~= "existing" then
+            return "border"
+        end
+        return stage
+    end
+
+    local function main_ground_item_id()
+        local ground_ref = current_ground_ref()
+        return ground_ref and ground_ref.draft and GroundCommon.primary_item_id(ground_ref.draft) or 0
+    end
+
+    local function ground_source_preview_item_id(name)
+        if not name or name == "" then
+            return 0
+        end
+        local draft = state.repository
+            and state.repository.ground_repository
+            and state.repository.ground_repository.by_name
+            and state.repository.ground_repository.by_name[name]
+            or nil
+        return GroundCommon.primary_item_id(draft)
+    end
+
+    local function border_source_preview_item_id(border_id)
+        border_id = tonumber(border_id or 0) or 0
+        if border_id <= 0 then
+            return 0
+        end
+        local source = state.repository
+            and state.repository.border_repository
+            and ComposerRepository.make_border_reference(state.repository, border_id)
+            or nil
+        return source and source.sampleItemId or 0
+    end
+
+    local function composed_source_preview_item_id(name)
+        if not name or name == "" then
+            return 0
+        end
+        local draft = state.repository
+            and state.repository.composed_by_name
+            and state.repository.composed_by_name[name]
+            or nil
+        local ground_ref = draft and draft.selectedGround or nil
+        if ground_ref and tonumber(ground_ref.sampleItemId or 0) > 0 then
+            return tonumber(ground_ref.sampleItemId or 0) or 0
+        end
+        return ground_ref and ground_ref.draft and GroundCommon.primary_item_id(ground_ref.draft) or 0
+    end
+
+    local function border_slot_item(slot_name)
+        local border_ref = current_border_ref()
+        if not border_ref or not border_ref.draft then
+            return 0
+        end
+        return BorderCommon.slot_item_id(border_ref.draft, slot_name)
+    end
+
+    local function refresh_repository()
+        state.repository = ComposerRepository.read(state.target_path)
+        Logger.log("composer", string.format(
+            "refresh_repository grounds=%d borders=%d composed=%d warnings=%d",
+            #((state.repository and state.repository.ground_repository and state.repository.ground_repository.ordered) or {}),
+            #((state.repository and state.repository.border_repository and state.repository.border_repository.ordered) or {}),
+            #((state.repository and state.repository.composed_ordered) or {}),
+            #((state.repository and state.repository.warnings) or {})
+        ))
+    end
+
+    local function page_count(total, page_size)
+        total = tonumber(total or 0) or 0
+        page_size = tonumber(page_size or 1) or 1
+        if total <= 0 then
+            return 1
+        end
+        return math.max(1, math.ceil(total / page_size))
+    end
+
+    local function clamp_page(page, total, page_size)
+        local max_page = page_count(total, page_size)
+        page = tonumber(page or 1) or 1
+        if page < 1 then
+            return 1
+        end
+        if page > max_page then
+            return max_page
+        end
+        return page
+    end
+
+    local function page_bounds(page, total, page_size)
+        page = clamp_page(page, total, page_size)
+        local first = ((page - 1) * page_size) + 1
+        local last = math.min(total, first + page_size - 1)
+        return first, last, page_count(total, page_size)
+    end
+
+    local function visible_ground_entry(slot)
+        local first, last = page_bounds(state.ground_page, #state.ground_names, GROUND_PAGE_SIZE)
+        local index = first + ((tonumber(slot or 1) or 1) - 1)
+        if index < first or index > last then
+            return nil, nil, nil
+        end
+        return index, state.ground_names[index], state.ground_items[index]
+    end
+
+    local function visible_border_entry(slot)
+        local first, last = page_bounds(state.border_page, #state.border_ids, BORDER_PAGE_SIZE)
+        local index = first + ((tonumber(slot or 1) or 1) - 1)
+        if index < first or index > last then
+            return nil, nil, nil
+        end
+        return index, tonumber(state.border_ids[index] or 0) or 0, state.border_items[index]
+    end
+
+    local function visible_composed_entry(slot)
+        local first, last = page_bounds(state.composed_page, #state.composed_names, COMPOSED_PAGE_SIZE)
+        local index = first + ((tonumber(slot or 1) or 1) - 1)
+        if index < first or index > last then
+            return nil, nil, nil
+        end
+        return index, state.composed_names[index], state.composed_items[index]
+    end
+
+    local function active_stage_page()
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            return tonumber(state.ground_page or 1) or 1, page_count(#state.ground_names, GROUND_PAGE_SIZE)
+        elseif stage == "border" then
+            return tonumber(state.border_page or 1) or 1, page_count(#state.border_ids, BORDER_PAGE_SIZE)
+        end
+        return tonumber(state.composed_page or 1) or 1, page_count(#state.composed_names, COMPOSED_PAGE_SIZE)
+    end
+
+    local function active_stage_title()
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            return "1. Wybierz Ground", "Ground search"
+        elseif stage == "border" then
+            return "2. Wybierz Border", "Border search"
+        end
+        return "3. Otworz gotowy Composer", "Existing composed"
+    end
+
+    local function active_stage_filter_text()
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            return state.ground_filter or ""
+        elseif stage == "border" then
+            return state.border_filter or ""
+        end
+        return state.composed_filter or ""
+    end
+
+    local function active_visible_entry(slot)
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            local _, name, item = visible_ground_entry(slot)
+            return {
+                text = item and item.text or name or " ",
+                fgcolor = name and palette.text or palette.subtle,
+                bgcolor = name and (name == current_ground_name() and palette.accent or palette.panel) or palette.sidebar,
+                image = GroundCommon.safe_image(ground_source_preview_item_id(name)),
+                present = name ~= nil,
+            }
+        elseif stage == "border" then
+            local _, border_id, item = visible_border_entry(slot)
+            local present = border_id and border_id > 0
+            return {
+                text = item and item.text or (present and ("Border #" .. tostring(border_id)) or " "),
+                fgcolor = present and palette.text or palette.subtle,
+                bgcolor = present and (border_id == current_border_id() and palette.accent or palette.panel) or palette.sidebar,
+                image = BorderCommon.safe_image(border_source_preview_item_id(border_id)),
+                present = present,
+            }
+        end
+        local _, name, item = visible_composed_entry(slot)
+        return {
+            text = item and item.text or name or " ",
+            fgcolor = name and palette.text or palette.subtle,
+            bgcolor = name and (name == current_composed_name() and palette.accent or palette.panel) or palette.sidebar,
+            image = GroundCommon.safe_image(composed_source_preview_item_id(name)),
+            present = name ~= nil,
+        }
+    end
+
+    local function sync_sources()
+        local previous_ground_name = state.ground_names[tonumber(state.ground_selection or 0) or 0]
+        local previous_border_id = state.border_ids[tonumber(state.border_selection or 0) or 0]
+        local previous_composed_name = state.composed_names[tonumber(state.composed_selection or 0) or 0]
+
+        state.ground_items, state.ground_names = ComposerRepository.ground_sources(state.repository, state.ground_filter)
+        state.border_items, state.border_ids = ComposerRepository.border_sources(state.repository, state.border_filter)
+        state.composed_items, state.composed_names = ComposerRepository.composed_sources(state.repository, state.composed_filter)
+
+        state.ground_page = clamp_page(state.ground_page, #state.ground_names, GROUND_PAGE_SIZE)
+        state.border_page = clamp_page(state.border_page, #state.border_ids, BORDER_PAGE_SIZE)
+        state.composed_page = clamp_page(state.composed_page, #state.composed_names, COMPOSED_PAGE_SIZE)
+
+        state.ground_selection = 0
+        if previous_ground_name then
+            for index, name in ipairs(state.ground_names) do
+                if name == previous_ground_name then
+                    state.ground_selection = index
+                    break
+                end
+            end
+        end
+        if state.ground_selection == 0 and current_ground_ref() then
+            for index, name in ipairs(state.ground_names) do
+                if name == current_ground_ref().name then
+                    state.ground_selection = index
+                    break
+                end
+            end
+        end
+
+        state.border_selection = 0
+        if previous_border_id then
+            for index, border_id in ipairs(state.border_ids) do
+                if border_id == previous_border_id then
+                    state.border_selection = index
+                    break
+                end
+            end
+        end
+        if state.border_selection == 0 and current_border_ref() then
+            for index, border_id in ipairs(state.border_ids) do
+                if border_id == current_border_ref().borderId then
+                    state.border_selection = index
+                    break
+                end
+            end
+        end
+
+        state.composed_selection = 0
+        if previous_composed_name then
+            for index, name in ipairs(state.composed_names) do
+                if name == previous_composed_name then
+                    state.composed_selection = index
+                    break
+                end
+            end
+        end
+        if state.composed_selection == 0 and not state.draft.isNew and state.draft.sourceName ~= "" then
+            for index, name in ipairs(state.composed_names) do
+                if name == state.draft.sourceName then
+                    state.composed_selection = index
+                    break
+                end
+            end
+        end
+    end
+
+    local function helper_text()
+        if not current_ground_ref() then
+            return "1. Wybierz ground. 2. Wybierz border. 3. Ustaw relacje. 4. Sprawdz preview. 5. Zapisz."
+        end
+        if not current_border_ref() then
+            return "Border jest jeszcze pusty. Wybierz border, aby zobaczyc przejscia."
+        end
+        if state.draft.align == "outer" then
+            return "Tryb OUTER rysuje border na sasiednim tile. Z-order tego grounda musi byc wyzszy niz otoczenie."
+        end
+        if GroundCommon.trim(state.draft.name or "") == "" then
+            return "Podaj nazwe, aby zapisac brush."
+        end
+        return "Composer pokazuje praktyczna symulacje polaczenia ground + border."
+    end
+
+    local function preview_status_text()
+        if not current_ground_ref() then
+            return "Najpierw wybierz ground."
+        end
+        if not current_border_ref() then
+            return "Najpierw wybierz border."
+        end
+        return string.format(
+            "Ground '%s' laczy sie z borderem #%d (%s).",
+            tostring(current_ground_ref().name or "?"),
+            tonumber(current_border_ref().borderId or 0) or 0,
+            tostring(state.draft.align or "outer")
+        )
+    end
+
+    local function save_hint_text()
+        local validation = state.draft:getValidation()
+        if not validation.isValid then
+            return validation.errors[1] or "Uzupelnij draft."
+        end
+        if state.draft.align == "outer" and current_ground_z_order() <= 1 then
+            return "OUTER zwykle wymaga wyzszego z-order niz otoczenie. Ustaw z-order > 1 albo uzyj preset OUTER."
+        end
+        return "Utworz nowy brush albo nadpisz istniejacy wpis w grounds.xml."
+    end
+
+    local function selected_ground_meta()
+        local ref = current_ground_ref()
+        if not ref then
+            return "Brak wybranego grounda"
+        end
+        local item_id = ref.sampleItemId or 0
+        return string.format("Main item %d  |  z-order %d%s", item_id, tonumber(ref.draft and ref.draft.zOrder or 0) or 0, ref.embedded and "  |  embedded source" or "")
+    end
+
+    local function selected_border_meta()
+        local ref = current_border_ref()
+        if not ref then
+            return "Brak wybranego bordera"
+        end
+        return string.format("Border #%d", tonumber(ref.borderId or 0) or 0)
+    end
+
+    local function composer_preview_items()
+        local items = {}
+        local center_item_id = main_ground_item_id()
+
+        for index = 1, BorderCommon.slot_layout_count do
+            local key = BorderCommon.slot_layout[index]
+            if not key then
+                table.insert(items, {
+                    text = "",
+                    tooltip = "",
+                })
+            else
+                local meta = BorderCommon.slot_meta[key]
+                local item_id = 0
+                local tooltip = meta and meta.full or ""
+
+                if key == "c" then
+                    item_id = center_item_id
+                    tooltip = center_item_id > 0
+                        and string.format("Main Ground\nItem ID %d", center_item_id)
+                        or "Main Ground\nNajpierw wybierz ground"
+                else
+                    local preview_key = preview_slot_map[key] or key
+                    item_id = border_slot_item(preview_key)
+                    if item_id > 0 then
+                        tooltip = string.format("%s\nPreview uses slot %s\nItem ID %d", meta.full, string.upper(preview_key), item_id)
+                    else
+                        tooltip = string.format("%s\nBrak tile w borderze", meta.full)
+                    end
+                end
+
+                table.insert(items, {
+                    text = meta and meta.short or "",
+                    tooltip = tooltip,
+                    image = GroundCommon.safe_image(item_id),
+                })
+            end
+        end
+
+        return items
+    end
+
+    local function soft_refresh_full()
+        sync_session_in()
+        sync_session_out()
+        if request_host_render() then
+            return
+        end
+    end
+
+    local function soft_refresh_local()
+        return false
+    end
+
+    local function refresh_source_lists()
+        if not dlg then
+            return
+        end
+
+        local updates = {}
+        local stage = effective_source_stage()
+        local current_page, total_pages = active_stage_page()
+        local title, search_label = active_stage_title()
+
+        updates.composer_stage_ground_button = {
+            bgcolor = stage == "ground" and palette.accent or palette.panel,
+        }
+        updates.composer_stage_border_button = {
+            bgcolor = stage == "border" and palette.accent or palette.panel,
+        }
+        updates.composer_stage_existing_button = {
+            bgcolor = stage == "existing" and palette.accent or palette.panel,
+        }
+        updates.composer_picker_title = {
+            text = title,
+        }
+        updates.composer_picker_search_label = {
+            text = search_label,
+        }
+        updates.composer_source_filter = {
+            text = active_stage_filter_text(),
+        }
+        updates.composer_source_prev_button = {
+            bgcolor = current_page > 1 and palette.panel or palette.sidebar,
+        }
+        updates.composer_source_page_label = {
+            text = string.format("Strona %d / %d", current_page, total_pages),
+        }
+        updates.composer_source_next_button = {
+            bgcolor = current_page < total_pages and palette.panel or palette.sidebar,
+        }
+
+        for slot = 1, math.max(GROUND_PAGE_SIZE, BORDER_PAGE_SIZE, COMPOSED_PAGE_SIZE) do
+            local entry = active_visible_entry(slot)
+            updates["composer_source_icon_" .. tostring(slot)] = {
+                image = entry.image,
+                width = 22,
+                height = 22,
+                smooth = false,
+            }
+            updates["composer_source_text_" .. tostring(slot)] = {
+                text = entry.text,
+                fgcolor = entry.fgcolor,
+            }
+            updates["composer_source_slot_" .. tostring(slot)] = {
+                bgcolor = entry.bgcolor,
+            }
+        end
+
+        dlg:modify(updates)
+        dlg:repaint()
+    end
+
+    local function soft_refresh(force_full)
+        sync_session_in()
+        sync_session_out()
+        if force_full or not soft_refresh_local() then
+            soft_refresh_full()
+        end
+    end
+
+    local function finalize_save(mode)
+        local ok, result = ComposerRepository.save_draft(state.repository, state.draft, mode, state.target_path)
+        if not ok then
+            app.alert({
+                title = "Save failed",
+                text = result,
+                buttons = { "OK" },
+            })
+            return
+        end
+
+        state.draft = result.draft
+        state.draft.dirty = false
+        state.dirty = false
+        session.lastSavedComposedBrush = result.draft.name
+        state.status_message = result.message
+        refresh_repository()
+        sync_sources()
+        soft_refresh(true)
+        app.alert({
+            title = "Composer saved",
+            text = result.message,
+            buttons = { "OK" },
+        })
+    end
+
+    function actions.set_ground_filter(text)
+        text = tostring(text or "")
+        if text == tostring(state.ground_filter or "") then
+            return
+        end
+        state.ground_filter = text
+        state.ground_page = 1
+        Logger.log("composer", string.format("set_ground_filter text='%s'", state.ground_filter))
+        sync_sources()
+        refresh_source_lists()
+    end
+
+    function actions.set_border_filter(text)
+        text = tostring(text or "")
+        if text == tostring(state.border_filter or "") then
+            return
+        end
+        state.border_filter = text
+        state.border_page = 1
+        Logger.log("composer", string.format("set_border_filter text='%s'", state.border_filter))
+        sync_sources()
+        refresh_source_lists()
+    end
+
+    function actions.set_composed_filter(text)
+        text = tostring(text or "")
+        if text == tostring(state.composed_filter or "") then
+            return
+        end
+        state.composed_filter = text
+        state.composed_page = 1
+        Logger.log("composer", string.format("set_composed_filter text='%s'", state.composed_filter))
+        sync_sources()
+        refresh_source_lists()
+    end
+
+    function actions.apply_active_filter(text)
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            actions.set_ground_filter(text)
+        elseif stage == "border" then
+            actions.set_border_filter(text)
+        else
+            actions.set_composed_filter(text)
+        end
+    end
+
+    function actions.clear_active_filter()
+        actions.apply_active_filter("")
+    end
+
+    function actions.prev_ground_page()
+        state.ground_page = math.max(1, (tonumber(state.ground_page or 1) or 1) - 1)
+        refresh_source_lists()
+    end
+
+    function actions.next_ground_page()
+        state.ground_page = clamp_page((tonumber(state.ground_page or 1) or 1) + 1, #state.ground_names, GROUND_PAGE_SIZE)
+        refresh_source_lists()
+    end
+
+    function actions.prev_border_page()
+        state.border_page = math.max(1, (tonumber(state.border_page or 1) or 1) - 1)
+        refresh_source_lists()
+    end
+
+    function actions.next_border_page()
+        state.border_page = clamp_page((tonumber(state.border_page or 1) or 1) + 1, #state.border_ids, BORDER_PAGE_SIZE)
+        refresh_source_lists()
+    end
+
+    function actions.prev_composed_page()
+        state.composed_page = math.max(1, (tonumber(state.composed_page or 1) or 1) - 1)
+        refresh_source_lists()
+    end
+
+    function actions.next_composed_page()
+        state.composed_page = clamp_page((tonumber(state.composed_page or 1) or 1) + 1, #state.composed_names, COMPOSED_PAGE_SIZE)
+        refresh_source_lists()
+    end
+
+    function actions.prev_active_page()
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            actions.prev_ground_page()
+        elseif stage == "border" then
+            actions.prev_border_page()
+        else
+            actions.prev_composed_page()
+        end
+    end
+
+    function actions.next_active_page()
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            actions.next_ground_page()
+        elseif stage == "border" then
+            actions.next_border_page()
+        else
+            actions.next_composed_page()
+        end
+    end
+
+    function actions.open_ground_visible_slot(slot)
+        local index, name = visible_ground_entry(slot)
+        if not index or not name then
+            return
+        end
+        state.ground_selection = index
+        actions.open_selected_ground()
+    end
+
+    function actions.open_border_visible_slot(slot)
+        local index, border_id = visible_border_entry(slot)
+        if not index or border_id <= 0 then
+            return
+        end
+        state.border_selection = index
+        actions.open_selected_border()
+    end
+
+    function actions.open_composed_visible_slot(slot)
+        local index, name = visible_composed_entry(slot)
+        if not index or not name then
+            return
+        end
+        state.composed_selection = index
+        actions.open_selected_composed()
+    end
+
+    function actions.open_active_visible_slot(slot)
+        local stage = effective_source_stage()
+        if stage == "ground" then
+            actions.open_ground_visible_slot(slot)
+        elseif stage == "border" then
+            actions.open_border_visible_slot(slot)
+        else
+            actions.open_composed_visible_slot(slot)
+        end
+    end
+
+    function actions.handle_ground_change(index)
+        index = tonumber(index or 0) or 0
+        if index <= 0 then
+            Logger.log("composer", "handle_ground_change ignored empty index")
+            return
+        end
+        if state.ground_skip_changes > 0 then
+            state.ground_skip_changes = state.ground_skip_changes - 1
+            Logger.log("composer", string.format("handle_ground_change skipped programmatic selection=%d remaining=%d", index, state.ground_skip_changes))
+            return
+        end
+        state.ground_selection = index
+        local name = tostring(state.ground_names[index] or "")
+        Logger.log("composer", string.format("handle_ground_change selection=%d name=%s", index, name))
+        if name ~= "" and name ~= current_ground_name() then
+            state.status_message = string.format("Zaznaczono ground '%s'. Dwuklik lub przycisk otwiera.", name)
+        end
+    end
+
+    function actions.open_selected_ground()
+        local index = tonumber(state.ground_selection or 0) or 0
+        local name = state.ground_names[index]
+        if not name then
+            Logger.log("composer", string.format("open_selected_ground missing selection index=%d", index))
+            state.status_message = "Najpierw zaznacz ground na liscie."
+            soft_refresh()
+            return
+        end
+        Logger.log("composer", string.format("open_selected_ground index=%d name='%s'", index, name))
+        local ref = ComposerRepository.make_ground_reference(state.repository, name)
+        if ref then
+            state.last_ground_open_name = name
+            state.draft:setGround(ref)
+            local linked_border, linked_from = ComposerRepository.find_linked_border_for_ground(state.repository, name)
+            if linked_border then
+                state.draft:setBorder(linked_border)
+                state.last_border_open_id = tonumber(linked_border.borderId or 0) or 0
+            else
+                state.draft:setBorder(nil)
+                state.last_border_open_id = 0
+            end
+            state.ground_selection = 0
+            state.border_selection = 0
+            state.dirty = true
+            if state.draft.name == "" then
+                state.draft:setName(name)
+            end
+            if linked_border then
+                state.status_message = string.format(
+                    "Wybrano ground '%s' i dolaczono powiazany border z '%s'.",
+                    name,
+                    tostring(linked_from or name)
+                )
+            else
+                state.status_message = string.format("Wybrano ground '%s'. Wybierz border, jesli nie ma powiazanego.", name)
+            end
+            state.source_stage = "border"
+            sync_sources()
+            soft_refresh()
+        else
+            Logger.log("composer", string.format("open_selected_ground failed missing name='%s'", name))
+        end
+    end
+
+    function actions.open_ground_by_name(name)
+        name = tostring(name or "")
+        for index, candidate in ipairs(state.ground_names or {}) do
+            if candidate == name then
+                state.ground_selection = index
+                actions.open_selected_ground()
+                return
+            end
+        end
+        Logger.log("composer", string.format("open_ground_by_name missing name='%s'", name))
+    end
+
+    function actions.handle_border_change(index)
+        index = tonumber(index or 0) or 0
+        if index <= 0 then
+            Logger.log("composer", "handle_border_change ignored empty index")
+            return
+        end
+        if state.border_skip_changes > 0 then
+            state.border_skip_changes = state.border_skip_changes - 1
+            Logger.log("composer", string.format("handle_border_change skipped programmatic selection=%d remaining=%d", index, state.border_skip_changes))
+            return
+        end
+        state.border_selection = index
+        local border_id = tonumber(state.border_ids[index] or 0) or 0
+        Logger.log("composer", string.format("handle_border_change selection=%d border_id=%s", index, tostring(border_id)))
+        if border_id > 0 and border_id ~= current_border_id() then
+            state.status_message = string.format("Zaznaczono border #%d. Dwuklik lub przycisk otwiera.", border_id)
+        end
+    end
+
+    function actions.open_selected_border()
+        local index = tonumber(state.border_selection or 0) or 0
+        local border_id = state.border_ids[index]
+        if not border_id then
+            Logger.log("composer", string.format("open_selected_border missing selection index=%d", index))
+            state.status_message = "Najpierw zaznacz border na liscie."
+            soft_refresh()
+            return
+        end
+        Logger.log("composer", string.format("open_selected_border index=%d border_id=%d", index, border_id))
+        local ref = ComposerRepository.make_border_reference(state.repository, border_id)
+        if ref then
+            state.last_border_open_id = border_id
+            state.draft:setBorder(ref)
+            state.border_selection = 0
+            state.dirty = true
+            state.status_message = string.format("Wybrano border #%d.", border_id)
+            state.source_stage = "border"
+            sync_sources()
+            soft_refresh()
+        else
+            Logger.log("composer", string.format("open_selected_border failed missing border_id=%d", border_id))
+        end
+    end
+
+    function actions.open_border_by_id(border_id)
+        border_id = tonumber(border_id or 0) or 0
+        for index, candidate in ipairs(state.border_ids or {}) do
+            if tonumber(candidate or 0) == border_id then
+                state.border_selection = index
+                actions.open_selected_border()
+                return
+            end
+        end
+        Logger.log("composer", string.format("open_border_by_id missing border_id=%d", border_id))
+    end
+
+    function actions.handle_composed_change(index)
+        index = tonumber(index or 0) or 0
+        if index <= 0 then
+            Logger.log("composer", "handle_composed_change ignored empty index")
+            return
+        end
+        if state.composed_skip_changes > 0 then
+            state.composed_skip_changes = state.composed_skip_changes - 1
+            Logger.log("composer", string.format("handle_composed_change skipped programmatic selection=%d remaining=%d", index, state.composed_skip_changes))
+            return
+        end
+        state.composed_selection = index
+        local name = tostring(state.composed_names[index] or "")
+        Logger.log("composer", string.format("handle_composed_change selection=%d name=%s", index, name))
+        if name ~= "" and name ~= current_composed_name() then
+            state.status_message = string.format("Zaznaczono composed brush '%s'. Dwuklik lub przycisk otwiera.", name)
+        end
+    end
+
+    function actions.open_selected_composed()
+        local index = tonumber(state.composed_selection or 0) or 0
+        local name = state.composed_names[index]
+        if not name then
+            Logger.log("composer", string.format("open_selected_composed missing selection index=%d", index))
+            state.status_message = "Najpierw zaznacz composed brush na liscie."
+            soft_refresh()
+            return
+        end
+        Logger.log("composer", string.format("open_selected_composed index=%d name='%s'", index, name))
+        if not confirm_discard() then
+            sync_sources()
+            soft_refresh()
+            return
+        end
+        local draft = ComposerRepository.load_composer(state.repository, name)
+        if draft then
+            state.last_composed_open_name = name
+            state.draft = draft
+            state.ground_selection = 0
+            state.border_selection = 0
+            state.composed_selection = 0
+            state.dirty = false
+            state.friend_selection = 0
+            state.status_message = string.format("Zaladowano composed brush '%s' do edycji.", name)
+            state.source_stage = "existing"
+            sync_sources()
+            soft_refresh()
+        else
+            Logger.log("composer", string.format("open_selected_composed failed name='%s'", name))
+        end
+    end
+
+    function actions.open_composed_by_name(name)
+        name = tostring(name or "")
+        for index, candidate in ipairs(state.composed_names or {}) do
+            if candidate == name then
+                state.composed_selection = index
+                actions.open_selected_composed()
+                return
+            end
+        end
+        Logger.log("composer", string.format("open_composed_by_name missing name='%s'", name))
+    end
+
+    function actions.new_composer()
+        if not confirm_discard() then
+            return
+        end
+        state.draft = ComposerRepository.new_draft()
+        state.friend_input = ""
+        state.friend_selection = 0
+        state.source_stage = "ground"
+        state.dirty = false
+        state.status_message = "Utworzono nowy composer draft."
+        sync_sources()
+        soft_refresh()
+    end
+
+    function actions.duplicate_current()
+        state.draft = ComposerRepository.duplicate_draft(state.repository, state.draft)
+        state.dirty = true
+        state.source_stage = "ground"
+        state.status_message = string.format("Zduplikowano composer do '%s'.", state.draft.name)
+        sync_sources()
+        soft_refresh()
+    end
+
+    function actions.use_last_saved_ground()
+        local name = GroundCommon.trim(session.lastSavedGround or "")
+        if name == "" then
+            state.status_message = "Brak ostatnio zapisanego grounda."
+            soft_refresh()
+            return
+        end
+        local ref = ComposerRepository.make_ground_reference(state.repository, name)
+        if not ref then
+            state.status_message = "Ostatnio zapisany ground nie jest dostepny w bibliotece."
+            soft_refresh()
+            return
+        end
+        state.draft:setGround(ref)
+        local linked_border, linked_from = ComposerRepository.find_linked_border_for_ground(state.repository, name)
+        if linked_border then
+            state.draft:setBorder(linked_border)
+        else
+            state.draft:setBorder(nil)
+        end
+        state.dirty = true
+        if state.draft.name == "" then
+            state.draft:setName(name)
+        end
+        if linked_border then
+            state.status_message = string.format(
+                "Uzyto ostatnio zapisanego grounda '%s' i dolaczono border z '%s'.",
+                name,
+                tostring(linked_from or name)
+            )
+        else
+            state.status_message = string.format("Uzyto ostatnio zapisanego grounda '%s'. Wybierz border, jesli nie ma powiazanego.", name)
+        end
+        state.source_stage = "border"
+        sync_sources()
+        soft_refresh()
+    end
+
+    function actions.use_last_saved_border()
+        local border_id = tonumber(session.lastSavedBorder or 0) or 0
+        if border_id <= 0 then
+            state.status_message = "Brak ostatnio zapisanego bordera."
+            soft_refresh()
+            return
+        end
+        local ref = ComposerRepository.make_border_reference(state.repository, border_id)
+        if not ref then
+            state.status_message = "Ostatnio zapisany border nie jest dostepny w bibliotece."
+            soft_refresh()
+            return
+        end
+        state.draft:setBorder(ref)
+        state.dirty = true
+        state.status_message = string.format("Uzyto ostatnio zapisanego bordera #%d.", border_id)
+        state.source_stage = "border"
+        sync_sources()
+        soft_refresh()
+    end
+
+    function actions.show_ground_stage()
+        state.source_stage = "ground"
+        refresh_source_lists()
+    end
+
+    function actions.show_border_stage()
+        state.source_stage = "border"
+        refresh_source_lists()
+    end
+
+    function actions.show_existing_stage()
+        state.source_stage = "existing"
+        refresh_source_lists()
+    end
+
+    function actions.set_name(value)
+        state.draft:setName(value)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_to_brush(value)
+        state.draft:setToBrush(value)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_align(value)
+        state.draft:setAlign(value)
+        state.dirty = true
+        soft_refresh()
+    end
+
+    function actions.set_ground_z_order(value)
+        local ref = current_ground_ref()
+        if not ref or not ref.draft or not ref.draft.setZOrder then
+            return
+        end
+        ref.draft:setZOrder(value)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.apply_outer_preset()
+        state.draft:setAlign("outer")
+        local ref = current_ground_ref()
+        if ref and ref.draft and ref.draft.setZOrder then
+            local current = tonumber(ref.draft.zOrder or 0) or 0
+            if current <= 1 then
+                ref.draft:setZOrder(2)
+            end
+        end
+        state.dirty = true
+        state.status_message = "Preset OUTER ustawiony. Border bedzie rysowany na zewnatrz, jesli z-order przewaza nad otoczeniem."
+        soft_refresh()
+    end
+
+    function actions.apply_inner_preset()
+        state.draft:setAlign("inner")
+        state.dirty = true
+        state.status_message = "Preset INNER ustawiony. Border bedzie rysowany po stronie aktualnego brusha."
+        soft_refresh()
+    end
+
+    function actions.set_friend_input(value)
+        state.friend_input = tostring(value or "")
+    end
+
+    function actions.add_friend()
+        local ok, message = state.draft:addFriend(state.friend_input)
+        state.status_message = ok and string.format("Dodano friend '%s'.", GroundCommon.trim(state.friend_input or "")) or message
+        if ok then
+            state.friend_input = ""
+            state.dirty = true
+        end
+        soft_refresh()
+    end
+
+    function actions.select_friend(index)
+        state.friend_selection = tonumber(index or 0) or 0
+        soft_refresh()
+    end
+
+    function actions.remove_selected_friend()
+        if state.draft:removeFriend(state.friend_selection) then
+            state.friend_selection = 0
+            state.dirty = true
+            state.status_message = "Usunieto friend."
+        else
+            state.status_message = "Najpierw wybierz friend do usuniecia."
+        end
+        soft_refresh()
+    end
+
+    function actions.save_as_new()
+        finalize_save("new")
+    end
+
+    function actions.overwrite_existing()
+        finalize_save("overwrite")
+    end
+
+    refresh_repository()
+    sync_session_in()
+    sync_sources()
+    if state.repository.api_missing then
+        state.status_message = "Brak API do odczytu grounds.xml: " .. tostring(state.repository.api_missing)
+    elseif #(state.repository.warnings or {}) > 0 then
+        state.status_message = state.repository.warnings[1]
+    end
+
+    function page.getTitle()
+        return "Composer"
+    end
+
+    function page.isDirty()
+        return state.dirty
+    end
+
+    function page.confirmLeave()
+        return confirm_discard()
+    end
+
+    function page.onEnter(shared_session)
+        session = shared_session or session
+        Logger.log("composer", "page onEnter")
+        refresh_repository()
+        sync_sources()
+        sync_session_in()
+        sync_session_out()
+    end
+
+    function page.onLeave(shared_session)
+        session = shared_session or session
+        sync_session_out()
+    end
+
+    function page.render_into(dialog)
+        dlg = dialog
+        sync_sources()
+        local source_stage = effective_source_stage()
+        local current_ground = current_ground_ref()
+        local current_border = current_border_ref()
+        local ground_first, ground_last, ground_pages = page_bounds(state.ground_page, #state.ground_names, GROUND_PAGE_SIZE)
+        local border_first, border_last, border_pages = page_bounds(state.border_page, #state.border_ids, BORDER_PAGE_SIZE)
+        local composed_first, composed_last, composed_pages = page_bounds(state.composed_page, #state.composed_names, COMPOSED_PAGE_SIZE)
+        local friend_items = {}
+        for _, friend_name in ipairs(state.draft.friends or {}) do
+            table.insert(friend_items, { text = friend_name })
+        end
+
+        dlg:panel({
+            bgcolor = palette.header,
+            padding = 10,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "COMPOSER",
+                fgcolor = palette.text,
+                font_size = 14,
+                font_weight = "bold",
+                align = "center",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "composer_helper_text",
+                text = helper_text(),
+                fgcolor = palette.muted,
+                align = "center",
+            })
+        dlg:endpanel()
+
+        dlg:panel({
+            bgcolor = palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                id = "composer_status_banner",
+                text = state.status_message ~= "" and state.status_message or helper_text(),
+                fgcolor = palette.text,
+            })
+        dlg:endpanel()
+
+        dlg:box({
+            orient = "horizontal",
+            expand = true,
+        })
+            dlg:box({
+                label = "1-2. Zrodla",
+                orient = "vertical",
+                width = 360,
+                min_width = 340,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Wybrane zrodla",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = true,
+                    })
+                        dlg:panel({
+                            bgcolor = palette.panel,
+                            padding = 6,
+                            margin = 2,
+                            min_width = 150,
+                            expand = true,
+                        })
+                            dlg:label({
+                                text = "Ground",
+                                fgcolor = palette.text,
+                                font_weight = "bold",
+                            })
+                            dlg:newrow()
+                            dlg:label({
+                                id = "composer_selected_ground_title",
+                                text = current_ground and current_ground.title or "Brak wybranego grounda",
+                                fgcolor = palette.text,
+                            })
+                            dlg:newrow()
+                            dlg:label({
+                                id = "composer_selected_ground_meta",
+                                text = selected_ground_meta(),
+                                fgcolor = palette.muted,
+                                font_size = 8,
+                            })
+                        dlg:endpanel()
+                        dlg:panel({
+                            bgcolor = palette.panel,
+                            padding = 6,
+                            margin = 2,
+                            min_width = 150,
+                            expand = true,
+                        })
+                            dlg:label({
+                                text = "Border",
+                                fgcolor = palette.text,
+                                font_weight = "bold",
+                            })
+                            dlg:newrow()
+                            dlg:label({
+                                id = "composer_selected_border_title",
+                                text = current_border and current_border.title or "Brak wybranego bordera",
+                                fgcolor = palette.text,
+                            })
+                            dlg:newrow()
+                            dlg:label({
+                                id = "composer_selected_border_meta",
+                                text = selected_border_meta(),
+                                fgcolor = palette.muted,
+                                font_size = 8,
+                            })
+                        dlg:endpanel()
+                    dlg:endbox()
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            text = "Use last saved ground",
+                            bgcolor = palette.accent,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.use_last_saved_ground()
+                            end,
+                        })
+                        dlg:button({
+                            text = "Use last saved border",
+                            bgcolor = palette.accent,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.use_last_saved_border()
+                            end,
+                        })
+                    dlg:endbox()
+                dlg:endpanel()
+
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        id = "composer_stage_ground_button",
+                        text = "Ground",
+                        bgcolor = source_stage == "ground" and palette.accent or palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.show_ground_stage()
+                        end,
+                    })
+                    dlg:button({
+                        id = "composer_stage_border_button",
+                        text = "Border",
+                        bgcolor = source_stage == "border" and palette.accent or palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.show_border_stage()
+                        end,
+                    })
+                    dlg:button({
+                        id = "composer_stage_existing_button",
+                        text = "Existing",
+                        bgcolor = source_stage == "existing" and palette.accent or palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.show_existing_stage()
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:label({
+                    id = "composer_picker_title",
+                    text = active_stage_title(),
+                    fgcolor = palette.text,
+                    font_weight = "bold",
+                })
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = true,
+                })
+                    dlg:label({
+                        id = "composer_picker_search_label",
+                        text = select(2, active_stage_title()),
+                        fgcolor = palette.text,
+                        min_width = 110,
+                    })
+                    dlg:input({
+                        id = "composer_source_filter",
+                        text = active_stage_filter_text(),
+                        expand = true,
+                    })
+                    dlg:button({
+                        text = "Search",
+                        bgcolor = palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function(d)
+                            actions.apply_active_filter(d.data.composer_source_filter or "")
+                        end,
+                    })
+                    dlg:button({
+                        text = "Clear",
+                        bgcolor = palette.sidebar,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.clear_active_filter()
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        id = "composer_source_prev_button",
+                        text = "<",
+                        bgcolor = palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.prev_active_page()
+                        end,
+                    })
+                    dlg:label({
+                        id = "composer_source_page_label",
+                        text = string.format("Strona %d / %d", select(1, active_stage_page()), select(2, active_stage_page())),
+                        fgcolor = palette.muted,
+                    })
+                    dlg:button({
+                        id = "composer_source_next_button",
+                        text = ">",
+                        bgcolor = palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.next_active_page()
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:panel({
+                    bgcolor = palette.sidebar,
+                    padding = 8,
+                    margin = 2,
+                    expand = true,
+                })
+                    for slot = 1, math.max(GROUND_PAGE_SIZE, BORDER_PAGE_SIZE, COMPOSED_PAGE_SIZE) do
+                        local entry = active_visible_entry(slot)
+                        dlg:box({
+                            orient = "horizontal",
+                            expand = false,
+                        })
+                            dlg:image({
+                                id = "composer_source_icon_" .. tostring(slot),
+                                image = entry.image,
+                                width = 22,
+                                height = 22,
+                                smooth = false,
+                            })
+                            dlg:panel({
+                                bgcolor = palette.sidebar,
+                                padding = 0,
+                                margin = 0,
+                                min_width = 240,
+                                max_width = 240,
+                                expand = false,
+                            })
+                                dlg:label({
+                                    id = "composer_source_text_" .. tostring(slot),
+                                    text = entry.text,
+                                    fgcolor = entry.fgcolor,
+                                    min_width = 240,
+                                    max_width = 240,
+                                })
+                            dlg:endpanel()
+                            dlg:button({
+                                id = "composer_source_slot_" .. tostring(slot),
+                                text = "Open",
+                                bgcolor = entry.bgcolor,
+                                fgcolor = palette.text,
+                                min_width = 80,
+                                max_width = 80,
+                                onclick = function()
+                                    actions.open_active_visible_slot(slot)
+                                end,
+                            })
+                        dlg:endbox()
+                        dlg:newrow()
+                    end
+                dlg:endpanel()
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        text = "New Composer",
+                        bgcolor = palette.panel_alt,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.new_composer()
+                        end,
+                    })
+                    dlg:button({
+                        text = "Duplicate Composer",
+                        bgcolor = palette.panel_alt,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.duplicate_current()
+                        end,
+                    })
+                dlg:endbox()
+            dlg:endbox()
+
+            dlg:box({
+                label = "3-4. Live Preview",
+                orient = "vertical",
+                min_width = 540,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Glowny podglad",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_preview_status",
+                        text = preview_status_text(),
+                        fgcolor = palette.muted,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_preview_ground_label",
+                        text = current_ground and ("Ground: " .. tostring(current_ground.name or "")) or "Najpierw wybierz ground",
+                        fgcolor = palette.subtle,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_preview_border_label",
+                        text = current_border and ("Border: " .. tostring(current_border.title or "")) or "Najpierw wybierz border",
+                        fgcolor = palette.subtle,
+                    })
+                dlg:endpanel()
+
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 10,
+                    margin = 4,
+                    expand = true,
+                })
+                    dlg:label({
+                        text = "Uklad 5x5",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:grid({
+                        id = "composer_preview_grid",
+                        width = 320,
+                        height = 320,
+                        expand = false,
+                        icon_size = 42,
+                        cell_size = 62,
+                        show_text = true,
+                        label_wrap = false,
+                        items = composer_preview_items(),
+                    })
+                dlg:endpanel()
+            dlg:endbox()
+
+            dlg:box({
+                label = "5. Relacje i Save",
+                orient = "vertical",
+                width = 380,
+                min_width = 360,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Wlasciwosci",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:input({
+                        id = "composer_name_input",
+                        label = "Brush name",
+                        text = state.draft.name or "",
+                        expand = true,
+                        onchange = function(d)
+                            actions.set_name(d.data.composer_name_input or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:input({
+                        id = "composer_to_brush_input",
+                        label = "To brush",
+                        text = state.draft.toBrush or "",
+                        expand = true,
+                        onchange = function(d)
+                            actions.set_to_brush(d.data.composer_to_brush_input or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:input({
+                        id = "composer_ground_z_order_input",
+                        label = "Ground z-order",
+                        text = tostring(current_ground_z_order()),
+                        expand = true,
+                        onchange = function(d)
+                            actions.set_ground_z_order(d.data.composer_ground_z_order_input or 0)
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            id = "composer_align_outer",
+                            text = state.draft.align == "outer" and "Align: OUTER" or "Align Outer",
+                            bgcolor = state.draft.align == "outer" and palette.accent or palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.set_align("outer")
+                            end,
+                        })
+                        dlg:button({
+                            id = "composer_align_inner",
+                            text = state.draft.align == "inner" and "Align: INNER" or "Align Inner",
+                            bgcolor = state.draft.align == "inner" and palette.accent or palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.set_align("inner")
+                            end,
+                        })
+                    dlg:endbox()
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            text = "Preset OUTER",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.apply_outer_preset()
+                            end,
+                        })
+                        dlg:button({
+                            text = "Preset INNER",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.apply_inner_preset()
+                            end,
+                        })
+                    dlg:endbox()
+                    dlg:newrow()
+                    dlg:label({
+                        text = state.draft.align == "outer"
+                            and "OUTER: border na sasiednim tile. Wymaga wyzszego z-order niz otoczenie."
+                            or "INNER: border na aktualnym tile, czyli wizualnie do srodka patcha.",
+                        fgcolor = palette.subtle,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = "Friends",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = true,
+                    })
+                        dlg:input({
+                            id = "composer_friend_input",
+                            text = state.friend_input or "",
+                            expand = true,
+                            onchange = function(d)
+                                actions.set_friend_input(d.data.composer_friend_input or "")
+                            end,
+                        })
+                        dlg:button({
+                            text = "Dodaj",
+                            bgcolor = palette.accent,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.add_friend()
+                            end,
+                        })
+                    dlg:endbox()
+                    dlg:newrow()
+                    dlg:list({
+                        id = "composer_friend_list",
+                        height = 160,
+                        expand = true,
+                        items = friend_items,
+                        selection = tonumber(state.friend_selection or 0) or 0,
+                        onchange = function(d)
+                            actions.select_friend(d.data.composer_friend_list or 0)
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:button({
+                        text = "Usun friend",
+                        bgcolor = palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.remove_selected_friend()
+                        end,
+                    })
+                dlg:endpanel()
+
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        id = "composer_save_mode",
+                        text = state.draft.isNew and "Tryb: nowy composed brush" or "Tryb: edycja istniejacego wpisu",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_save_dirty",
+                        text = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie",
+                        fgcolor = state.dirty and palette.warning or palette.muted,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_save_target",
+                        text = "Target: " .. tostring(state.target_path or ""),
+                        fgcolor = palette.subtle,
+                        font_size = 8,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "composer_save_hint",
+                        text = save_hint_text(),
+                        fgcolor = palette.muted,
+                    })
+                    dlg:newrow()
+                    dlg:button({
+                        text = "Save as New",
+                        bgcolor = palette.success,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.save_as_new()
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:button({
+                        text = "Overwrite Existing",
+                        bgcolor = palette.accent,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.overwrite_existing()
+                        end,
+                    })
+                dlg:endpanel()
+            dlg:endbox()
+        dlg:endbox()
+    end
+
+    function page.getSessionState()
+        sync_session_out()
+        return session
+    end
+
+    function page.getStatusText()
+        return state.status_message ~= "" and state.status_message or helper_text()
+    end
+
+    function page.getState()
+        return state
+    end
+
+    return page
+end
+
+function ComposerPage.create(options)
+    return create_page(options)
+end
+
+return ComposerPage

--- a/scripts/brush_studio/composer_repository.lua
+++ b/scripts/brush_studio/composer_repository.lua
@@ -1,0 +1,554 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+local GroundDraft = Paths.load("ground_studio/ground_draft.lua")
+local GroundRepository = Paths.load("ground_studio/repository.lua")
+local BorderRepository = Paths.load("border_studio/border_repository.lua")
+local BorderCommon = Paths.load("border_studio/common.lua")
+local ComposerDraft = dofile("composer_draft.lua")
+
+local M = {}
+
+local function parse_attributes(text)
+    local attrs = {}
+    for key, value in tostring(text or ""):gmatch('([%w_%-]+)%s*=%s*"([^"]-)"') do
+        attrs[key] = GroundCommon.unescape_xml(value)
+    end
+    return attrs
+end
+
+local function extract_brush_blocks(xml)
+    local blocks = {}
+    local cursor = 1
+
+    while true do
+        local start_index = xml:find("<brush%s", cursor)
+        if not start_index then
+            break
+        end
+        local tag_end = xml:find(">", start_index, true)
+        if not tag_end then
+            break
+        end
+
+        local open_tag = xml:sub(start_index, tag_end)
+        local self_closing = open_tag:match("/%s*>$") ~= nil
+        if self_closing then
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = "",
+            })
+            cursor = tag_end + 1
+        else
+            local close_start, close_end = xml:find("</brush>", tag_end + 1, true)
+            if not close_start then
+                break
+            end
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = xml:sub(tag_end + 1, close_start - 1),
+            })
+            cursor = close_end + 1
+        end
+    end
+
+    return blocks
+end
+
+local function normalize_extra_children(inner)
+    local extras = tostring(inner or "")
+    extras = extras:gsub("<item%s+.-%s*/>", "")
+    extras = extras:gsub("<border%s+.-%s*/>", "")
+    extras = extras:gsub("<friend%s+.-%s*/>", "")
+    extras = extras:gsub("\r\n", "\n")
+    extras = extras:gsub("^\n+", "")
+    extras = extras:gsub("\n+$", "")
+    return extras
+end
+
+local function collect_unsupported_child_warnings(inner, name, warnings)
+    local seen = {}
+    for tag in tostring(inner or ""):gmatch("<%s*([%w_%-]+)") do
+        local lower = string.lower(tag)
+        if lower ~= "item" and lower ~= "border" and lower ~= "friend" and lower ~= "!--" and not seen[lower] then
+            seen[lower] = true
+            table.insert(warnings, string.format("Composer brush '%s' contains unsupported child <%s>. It was preserved but not edited by Composer.", name, tag))
+        end
+    end
+end
+
+local function read_file(path)
+    local store = app.storage(path)
+    if not store or not store.readText then
+        return nil, "This RME build does not expose raw file reads for grounds.xml."
+    end
+    local content, err = store:readText()
+    if not content then
+        return nil, err or "Could not open file."
+    end
+    return content
+end
+
+local function write_file(path, content)
+    local store = app.storage(path)
+    if not store or not store.save then
+        return false, "This RME build does not expose safe file writes."
+    end
+    local ok = store:save(content or "")
+    if not ok then
+        return false, "Could not write file."
+    end
+    return true
+end
+
+function M.resolve_target_path(saved_path)
+    return GroundRepository.resolve_target_path(saved_path)
+end
+
+local function make_ground_reference(name, draft, embedded)
+    if not draft then
+        return nil
+    end
+    return {
+        name = GroundCommon.trim(name ~= "" and name or draft.name or "ground"),
+        title = draft.name ~= "" and draft.name or "ground",
+        sampleItemId = GroundCommon.primary_item_id(draft),
+        draft = draft:clone(),
+        embedded = embedded == true,
+    }
+end
+
+local function make_border_reference(repository, border_id)
+    border_id = tonumber(border_id or 0) or 0
+    if border_id <= 0 then
+        return nil
+    end
+
+    local source = BorderRepository.find_border_source(repository, border_id)
+    local draft = repository.by_id and repository.by_id[border_id] and BorderRepository.copy(repository.by_id[border_id]) or nil
+    return {
+        borderId = border_id,
+        title = source and source.title or ("Border #" .. tostring(border_id)),
+        name = source and source.name or ("Border #" .. tostring(border_id)),
+        sampleItemId = source and source.sampleItemId or (draft and BorderCommon.primary_item_id(draft) or 0),
+        draft = draft,
+    }
+end
+
+local function same_items(left, right)
+    local left_data = left and left:toXmlGroundData() or nil
+    local right_data = right and right:toXmlGroundData() or nil
+    local left_items = left_data and left_data.items or {}
+    local right_items = right_data and right_data.items or {}
+    if #left_items ~= #right_items then
+        return false
+    end
+    for index = 1, #left_items do
+        if tonumber(left_items[index].itemId or 0) ~= tonumber(right_items[index].itemId or 0) then
+            return false
+        end
+        if tonumber(left_items[index].chance or 0) ~= tonumber(right_items[index].chance or 0) then
+            return false
+        end
+    end
+    return true
+end
+
+local function find_matching_ground(ground_repository, draft)
+    for _, candidate in ipairs((ground_repository and ground_repository.ordered) or {}) do
+        if same_items(candidate, draft)
+            and tonumber(candidate.lookId or 0) == tonumber(draft.lookId or 0)
+            and tonumber(candidate.serverLookId or 0) == tonumber(draft.serverLookId or 0)
+            and tonumber(candidate.zOrder or 0) == tonumber(draft.zOrder or 0)
+            and candidate.randomize == draft.randomize
+            and candidate.soloOptional == draft.soloOptional then
+            return make_ground_reference(candidate.name, candidate, false)
+        end
+    end
+    return nil
+end
+
+function M.read(target_path)
+    local ground_repository = GroundRepository.read(target_path, {})
+    local border_repository = BorderRepository.read({}, app.borders or {})
+    local repository = {
+        target_path = target_path,
+        ground_repository = ground_repository,
+        border_repository = border_repository,
+        composed_ordered = {},
+        composed_by_name = {},
+        warnings = {},
+        api_missing = nil,
+    }
+
+    local content, err = read_file(target_path)
+    if not content then
+        repository.api_missing = err
+        table.insert(repository.warnings, err)
+        return repository
+    end
+
+    for _, block in ipairs(extract_brush_blocks(tostring(content or ""))) do
+        local attrs = block.attributes or {}
+        if string.lower(tostring(attrs.type or "")) == "ground" then
+            local name = GroundCommon.trim(attrs.name or "")
+            if name ~= "" then
+                local items = {}
+                local borders = {}
+                local friends = {}
+
+                for item_attrs in tostring(block.inner or ""):gmatch("<item%s+(.-)%s*/>") do
+                    local parsed = parse_attributes(item_attrs)
+                    local item_id = tonumber(parsed.id or 0) or 0
+                    local chance = tonumber(parsed.chance or 1) or 1
+                    if item_id > 0 then
+                        table.insert(items, { itemId = item_id, chance = chance })
+                    end
+                end
+
+                for border_attrs in tostring(block.inner or ""):gmatch("<border%s+(.-)%s*/>") do
+                    local parsed = parse_attributes(border_attrs)
+                    table.insert(borders, {
+                        id = tonumber(parsed.id or 0) or 0,
+                        align = GroundCommon.trim(parsed.align or ""),
+                        toBrush = GroundCommon.trim(parsed.to or ""),
+                    })
+                end
+
+                for friend_attrs in tostring(block.inner or ""):gmatch("<friend%s+(.-)%s*/>") do
+                    local parsed = parse_attributes(friend_attrs)
+                    local friend_name = GroundCommon.trim(parsed.name or "")
+                    if friend_name ~= "" then
+                        table.insert(friends, friend_name)
+                    end
+                end
+
+                if #borders > 0 or #friends > 0 then
+                    local main_item = items[1]
+                    local variants = {}
+                    for index = 2, #items do
+                        table.insert(variants, items[index])
+                    end
+
+                    local parsed_ground = GroundDraft.new({
+                        name = name,
+                        mainItem = main_item,
+                        mainChance = main_item and main_item.chance or 1,
+                        variants = variants,
+                        lookId = attrs.lookid,
+                        serverLookId = attrs.server_lookid,
+                        zOrder = attrs["z-order"],
+                        randomize = attrs.randomize,
+                        soloOptional = attrs.solo_optional,
+                        isNew = false,
+                    })
+
+                    local border_ref = make_border_reference(border_repository, borders[1] and borders[1].id or 0)
+                    if not border_ref then
+                        table.insert(repository.warnings, string.format("Composer brush '%s' references missing border id %s.", name, tostring(borders[1] and borders[1].id or 0)))
+                    end
+
+                    local ground_ref = find_matching_ground(ground_repository, parsed_ground)
+                    if not ground_ref then
+                        ground_ref = make_ground_reference(name, parsed_ground, true)
+                        table.insert(repository.warnings, string.format("Composer brush '%s' did not match an existing ground source. Loaded as embedded ground data.", name))
+                    end
+
+                    local composer = ComposerDraft.new({
+                        name = name,
+                        selectedGround = ground_ref,
+                        selectedBorder = border_ref,
+                        toBrush = borders[1] and borders[1].toBrush or "",
+                        align = borders[1] and borders[1].align or "outer",
+                        friends = friends,
+                        isNew = false,
+                        sourceName = name,
+                        extraChildrenXml = normalize_extra_children(block.inner),
+                    })
+                    collect_unsupported_child_warnings(block.inner, name, repository.warnings)
+
+                    repository.composed_by_name[name] = composer
+                    table.insert(repository.composed_ordered, composer)
+                end
+            end
+        end
+    end
+
+    table.sort(repository.composed_ordered, function(left, right)
+        return string.lower(left.name or "") < string.lower(right.name or "")
+    end)
+
+    return repository
+end
+
+function M.ground_sources(repository, filter_text)
+    local items = {}
+    local names = {}
+    local needle = string.lower(filter_text or "")
+    for _, draft in ipairs((repository.ground_repository and repository.ground_repository.ordered) or {}) do
+        if not (repository.composed_by_name and repository.composed_by_name[draft.name or ""]) then
+        local main_id = GroundCommon.primary_item_id(draft)
+        local blob = string.lower((draft.name or "") .. " " .. GroundCommon.ground_status(draft))
+        if needle == "" or string.find(blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("%s  |  %s", draft.name or "Unnamed", GroundCommon.ground_status(draft)),
+                tooltip = string.format("%s\nMain item: %d", draft.name or "Unnamed", main_id),
+                image = nil,
+            })
+            table.insert(names, draft.name)
+        end
+        end
+    end
+    return items, names
+end
+
+function M.border_sources(repository, filter_text)
+    local items = {}
+    local ids = {}
+    local needle = string.lower(filter_text or "")
+    for _, source in ipairs(BorderRepository.border_sources(repository.border_repository)) do
+        local blob = string.lower(string.format("%s %s %d", source.name or "", source.status or "", source.borderId or 0))
+        if needle == "" or string.find(blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("#%d  %s  |  %s", source.borderId or 0, source.name or "Border", source.status or "partial"),
+                tooltip = source.tooltip,
+                image = nil,
+            })
+            table.insert(ids, source.borderId)
+        end
+    end
+    return items, ids
+end
+
+function M.composed_sources(repository, filter_text)
+    local items = {}
+    local names = {}
+    local needle = string.lower(filter_text or "")
+    for _, draft in ipairs(repository.composed_ordered or {}) do
+        local border_id = draft.selectedBorder and draft.selectedBorder.borderId or 0
+        local ground_name = draft.selectedGround and draft.selectedGround.name or "?"
+        local blob = string.lower((draft.name or "") .. " " .. ground_name .. " " .. tostring(border_id))
+        if needle == "" or string.find(blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("%s  |  ground: %s  |  border: #%d", draft.name or "Unnamed", ground_name, tonumber(border_id or 0) or 0),
+                tooltip = string.format("%s\nGround: %s\nBorder: #%d", draft.name or "Unnamed", ground_name, tonumber(border_id or 0) or 0),
+                image = nil,
+            })
+            table.insert(names, draft.name)
+        end
+    end
+    return items, names
+end
+
+function M.make_ground_reference(repository, ground_name)
+    local draft = repository.ground_repository and repository.ground_repository.by_name and repository.ground_repository.by_name[ground_name] or nil
+    if not draft then
+        return nil
+    end
+    return make_ground_reference(ground_name, draft, false)
+end
+
+function M.make_border_reference(repository, border_id)
+    return make_border_reference(repository.border_repository, border_id)
+end
+
+function M.find_linked_border_for_ground(repository, ground_name)
+    local target_name = GroundCommon.trim(ground_name or "")
+    if target_name == "" then
+        return nil
+    end
+
+    local exact = repository.composed_by_name and repository.composed_by_name[target_name] or nil
+    if exact and exact.selectedBorder and tonumber(exact.selectedBorder.borderId or 0) > 0 then
+        return GroundCommon.clone(exact.selectedBorder), exact.name
+    end
+
+    for _, draft in ipairs(repository.composed_ordered or {}) do
+        local selected_ground = draft.selectedGround
+        if selected_ground and GroundCommon.trim(selected_ground.name or "") == target_name then
+            if draft.selectedBorder and tonumber(draft.selectedBorder.borderId or 0) > 0 then
+                return GroundCommon.clone(draft.selectedBorder), draft.name
+            end
+        end
+    end
+
+    return nil
+end
+
+function M.load_composer(repository, name)
+    local draft = repository.composed_by_name and repository.composed_by_name[name] or nil
+    return draft and draft:clone() or nil
+end
+
+function M.new_draft()
+    return ComposerDraft.new({
+        align = "outer",
+        isNew = true,
+    })
+end
+
+function M.duplicate_draft(repository, draft)
+    local copy = draft:clone()
+    local base = GroundCommon.trim((copy.name ~= "" and copy.name or "composed brush") .. " copy")
+    local candidate = base
+    local index = 1
+    while repository.composed_by_name and repository.composed_by_name[candidate] do
+        index = index + 1
+        candidate = string.format("%s %d", base, index)
+    end
+    copy.name = candidate
+    copy.sourceName = candidate
+    copy.isNew = true
+    copy.dirty = true
+    return copy
+end
+
+function M.validate_save(repository, draft, mode, target_path)
+    if not target_path or target_path == "" then
+        return false, "Target grounds.xml could not be resolved."
+    end
+    if not GroundCommon.path_starts_with(target_path, app.getDataDirectory()) then
+        return false, "Target grounds.xml must stay inside the RME data directory."
+    end
+    local validation = draft:getValidation()
+    if not validation.isValid then
+        return false, validation.errors[1] or "Composer draft jest niepoprawny."
+    end
+
+    local current_name = GroundCommon.trim(draft.name or "")
+    local source_name = GroundCommon.trim(draft.sourceName or current_name)
+    local exists = repository.composed_by_name and repository.composed_by_name[current_name] ~= nil
+    local source_exists = repository.composed_by_name and repository.composed_by_name[source_name] ~= nil
+
+    if mode == "new" and exists then
+        return false, string.format("Brush '%s' juz istnieje.", current_name)
+    end
+    if mode == "overwrite" and not source_exists then
+        return false, string.format("Brush '%s' nie istnieje do nadpisania.", source_name)
+    end
+
+    return true
+end
+
+function M.backup_xml(target_path)
+    local original, err = read_file(target_path)
+    if not original then
+        return false, nil, nil, "Could not read grounds.xml before backup: " .. tostring(err)
+    end
+
+    local backup_path = string.format("%s.composer.%s.bak", target_path, os.date("%Y%m%d_%H%M%S"))
+    local ok, backup_err = write_file(backup_path, original)
+    if not ok then
+        return false, nil, nil, "Could not write backup file: " .. tostring(backup_err)
+    end
+
+    return true, backup_path, original
+end
+
+local function serialize_composer(draft)
+    local ground_data = draft.selectedGround.draft:toXmlGroundData()
+    local attrs = {
+        string.format('name="%s"', GroundCommon.escape_xml(draft.name)),
+        'type="ground"',
+    }
+
+    if tonumber(ground_data.lookId or 0) > 0 then
+        table.insert(attrs, string.format('lookid="%d"', tonumber(ground_data.lookId or 0) or 0))
+    end
+    if tonumber(ground_data.serverLookId or 0) > 0 then
+        table.insert(attrs, string.format('server_lookid="%d"', tonumber(ground_data.serverLookId or 0) or 0))
+    end
+    if tonumber(ground_data.zOrder or 0) ~= 0 then
+        table.insert(attrs, string.format('z-order="%d"', tonumber(ground_data.zOrder or 0) or 0))
+    end
+    table.insert(attrs, string.format('randomize="%s"', ground_data.randomize and "true" or "false"))
+    if ground_data.soloOptional then
+        table.insert(attrs, 'solo_optional="true"')
+    end
+
+    local lines = {
+        string.format("<brush %s>", table.concat(attrs, " ")),
+    }
+
+    for _, item in ipairs(ground_data.items or {}) do
+        table.insert(lines, string.format('\t<item id="%d" chance="%d" />', tonumber(item.itemId or 0) or 0, tonumber(item.chance or 0) or 0))
+    end
+
+    local border_id = tonumber(draft.selectedBorder.borderId or 0) or 0
+    if border_id > 0 then
+        local target_to = GroundCommon.trim(draft.toBrush or "")
+        local border_attrs = {
+            string.format('align="%s"', GroundCommon.escape_xml(draft.align or "outer")),
+            string.format('id="%d"', border_id),
+        }
+        if target_to ~= "" then
+            table.insert(border_attrs, string.format('to="%s"', GroundCommon.escape_xml(target_to)))
+        end
+        table.insert(lines, string.format("\t<border %s />", table.concat(border_attrs, " ")))
+    end
+
+    for _, friend_name in ipairs(draft.friends or {}) do
+        table.insert(lines, string.format('\t<friend name="%s" />', GroundCommon.escape_xml(friend_name)))
+    end
+
+    local extras = GroundCommon.trim(draft.extraChildrenXml or "")
+    if extras ~= "" then
+        for line in extras:gmatch("[^\r\n]+") do
+            local trimmed = GroundCommon.trim(line)
+            if trimmed ~= "" then
+                table.insert(lines, "\t" .. trimmed)
+            end
+        end
+    end
+
+    table.insert(lines, "</brush>")
+    return table.concat(lines, "\n")
+end
+
+function M.save_draft(repository, draft, mode, target_path)
+    local ok, validation_message = M.validate_save(repository, draft, mode, target_path)
+    if not ok then
+        return false, validation_message
+    end
+
+    local backup_ok, backup_path, original_content, backup_message = M.backup_xml(target_path)
+    if not backup_ok then
+        return false, backup_message
+    end
+
+    local saved_draft = draft:clone()
+    saved_draft.name = GroundCommon.trim(saved_draft.name)
+    saved_draft.isNew = false
+
+    local writer = app.storage(target_path)
+    if not writer or not writer.upsertXml then
+        return false, "The current RME build does not expose XML upsert support."
+    end
+
+    local match_name = mode == "overwrite" and GroundCommon.trim(saved_draft.sourceName or saved_draft.name) or saved_draft.name
+    local xml = serialize_composer(saved_draft)
+    local write_ok, write_mode = writer:upsertXml({
+        root = "materials",
+        parent = "materials",
+        tag = "brush",
+        match_attr = "name",
+        match_value = match_name,
+        xml = xml,
+    })
+
+    if not write_ok then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, write_mode or "Saving failed while updating grounds.xml."
+    end
+
+    saved_draft.sourceName = saved_draft.name
+    return true, {
+        draft = saved_draft,
+        backupPath = backup_path,
+        xmlMode = write_mode or mode,
+        message = string.format("Saved composed brush '%s' successfully.\nBackup: %s", saved_draft.name, backup_path),
+    }
+end
+
+return M

--- a/scripts/brush_studio/logger.lua
+++ b/scripts/brush_studio/logger.lua
@@ -1,0 +1,41 @@
+local M = {}
+
+local STORE = app.storage("brush_studio.log")
+local MAX_LINES = 400
+
+local function lines_buffer()
+    if type(_G.BRUSH_STUDIO_LOG_LINES) ~= "table" then
+        _G.BRUSH_STUDIO_LOG_LINES = {}
+    end
+    return _G.BRUSH_STUDIO_LOG_LINES
+end
+
+local function now_ms()
+    if app and app.getTime then
+        local ok, value = pcall(app.getTime)
+        if ok then
+            return tonumber(value or 0) or 0
+        end
+    end
+    return 0
+end
+
+local function flush(lines)
+    if STORE and STORE.save then
+        STORE:save(table.concat(lines, "\n"))
+    end
+end
+
+function M.log(scope, message)
+    local lines = lines_buffer()
+    local line = string.format("[%06d] [%s] %s", now_ms(), tostring(scope or "log"), tostring(message or ""))
+    table.insert(lines, line)
+    while #lines > MAX_LINES do
+        table.remove(lines, 1)
+    end
+
+    print("[Brush Studio] " .. line)
+    flush(lines)
+end
+
+return M

--- a/scripts/brush_studio/main.lua
+++ b/scripts/brush_studio/main.lua
@@ -1,0 +1,3 @@
+local Shell = dofile("shell.lua")
+
+Shell.open_standalone()

--- a/scripts/brush_studio/manifest.lua
+++ b/scripts/brush_studio/manifest.lua
@@ -1,0 +1,9 @@
+return {
+    name = "Brush Studio",
+    description = "Shared shell for border and ground workflows in RME.",
+    author = "Fr0st",
+    version = "0.1.0",
+    main = "main.lua",
+    shortcut = "Ctrl+Alt+S",
+    autorun = false
+}

--- a/scripts/brush_studio/module_paths.lua
+++ b/scripts/brush_studio/module_paths.lua
@@ -1,0 +1,35 @@
+local M = {}
+
+local function normalize_slashes(path)
+    return tostring(path or ""):gsub("\\", "/")
+end
+
+local brush_studio_dir = normalize_slashes(rawget(_G, "SCRIPT_DIR") or "")
+if brush_studio_dir == "" then
+    error("Brush Studio loader requires SCRIPT_DIR from the script runtime.")
+end
+
+local scripts_dir = brush_studio_dir:gsub("/brush_studio$", "")
+
+function M.resolve(relative_path)
+    relative_path = normalize_slashes(relative_path):gsub("^/*", "")
+    return scripts_dir .. "/" .. relative_path
+end
+
+function M.load(relative_path)
+    relative_path = normalize_slashes(relative_path):gsub("^/*", "")
+
+    local old_script_dir = rawget(_G, "SCRIPT_DIR")
+    _G.SCRIPT_DIR = scripts_dir
+
+    local ok, result = pcall(dofile, relative_path)
+
+    _G.SCRIPT_DIR = old_script_dir
+    if not ok then
+        error(tostring(result))
+    end
+
+    return result
+end
+
+return M

--- a/scripts/brush_studio/page_contract.lua
+++ b/scripts/brush_studio/page_contract.lua
@@ -1,0 +1,21 @@
+local Contract = {}
+
+local REQUIRED_METHODS = {
+    "getTitle",
+    "isDirty",
+    "confirmLeave",
+    "onEnter",
+    "onLeave",
+    "render_into",
+}
+
+function Contract.assert_page(page, label)
+    for _, method_name in ipairs(REQUIRED_METHODS) do
+        if type(page[method_name]) ~= "function" then
+            error(string.format("Brush Studio page '%s' is missing method '%s'.", tostring(label or "?"), method_name))
+        end
+    end
+    return page
+end
+
+return Contract

--- a/scripts/brush_studio/palette_draft.lua
+++ b/scripts/brush_studio/palette_draft.lua
@@ -1,0 +1,124 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+
+local PaletteDraft = {}
+PaletteDraft.__index = PaletteDraft
+
+local function clone_reference(reference)
+    if type(reference) ~= "table" then
+        return nil
+    end
+    return GroundCommon.clone(reference)
+end
+
+function PaletteDraft.new(init)
+    local self = setmetatable({}, PaletteDraft)
+    self.selectedBrush = clone_reference(init and init.selectedBrush)
+    self.targetTileset = GroundCommon.trim(init and init.targetTileset or "")
+    self.targetCategory = GroundCommon.trim(init and init.targetCategory or "")
+    self.displayName = GroundCommon.trim(init and init.displayName or "")
+    self.order = tonumber(init and init.order or 0) or 0
+    self.dirty = GroundCommon.normalize_bool(init and init.dirty, false)
+    return self
+end
+
+function PaletteDraft:clear()
+    self.selectedBrush = nil
+    self.targetTileset = ""
+    self.targetCategory = ""
+    self.displayName = ""
+    self.order = 0
+    self.dirty = false
+end
+
+function PaletteDraft:isEmpty()
+    return not self.selectedBrush and self.targetTileset == "" and self.targetCategory == "" and self.displayName == ""
+end
+
+function PaletteDraft:setBrush(reference)
+    self.selectedBrush = clone_reference(reference)
+    if self.displayName == "" and self.selectedBrush then
+        self.displayName = GroundCommon.trim(self.selectedBrush.title or self.selectedBrush.name or "")
+    end
+    self.dirty = true
+    return self.selectedBrush ~= nil
+end
+
+function PaletteDraft:setTileset(value)
+    self.targetTileset = GroundCommon.trim(value)
+    self.dirty = true
+end
+
+function PaletteDraft:setCategory(value)
+    self.targetCategory = GroundCommon.trim(value)
+    self.dirty = true
+end
+
+function PaletteDraft:setDisplayName(value)
+    self.displayName = GroundCommon.trim(value)
+    self.dirty = true
+end
+
+function PaletteDraft:setOrder(value)
+    local parsed = tonumber(value or 0) or 0
+    parsed = math.floor(parsed)
+    if parsed < 0 then
+        parsed = 0
+    end
+    self.order = parsed
+    self.dirty = true
+end
+
+function PaletteDraft:effectiveDisplayName()
+    if self.displayName ~= "" then
+        return self.displayName
+    end
+    if self.selectedBrush then
+        return GroundCommon.trim(self.selectedBrush.title or self.selectedBrush.name or "")
+    end
+    return ""
+end
+
+function PaletteDraft:hasRequiredDataForSave()
+    if not self.selectedBrush or GroundCommon.trim(self.selectedBrush.name or "") == "" then
+        return false
+    end
+    if self.targetTileset == "" or self.targetCategory == "" then
+        return false
+    end
+    return true
+end
+
+function PaletteDraft:getValidation()
+    local errors = {}
+    local warnings = {}
+
+    if not self.selectedBrush or GroundCommon.trim(self.selectedBrush.name or "") == "" then
+        table.insert(errors, "Najpierw wybierz gotowy brush.")
+    end
+    if self.targetTileset == "" or self.targetCategory == "" then
+        table.insert(errors, "Wybierz miejsce w palecie.")
+    end
+    if self.displayName == "" and self.selectedBrush and GroundCommon.trim(self.selectedBrush.name or "") ~= "" then
+        table.insert(warnings, "Display name jest pusty, wiec paleta uzyje nazwy brusha.")
+    end
+
+    return {
+        isValid = #errors == 0,
+        errors = errors,
+        warnings = warnings,
+    }
+end
+
+function PaletteDraft:clone()
+    return PaletteDraft.new({
+        selectedBrush = self.selectedBrush,
+        targetTileset = self.targetTileset,
+        targetCategory = self.targetCategory,
+        displayName = self.displayName,
+        order = self.order,
+        dirty = self.dirty,
+    })
+end
+
+return PaletteDraft

--- a/scripts/brush_studio/palette_page.lua
+++ b/scripts/brush_studio/palette_page.lua
@@ -2,8 +2,10 @@ local Paths = dofile("module_paths.lua")
 local GroundCommon = Paths.load("ground_studio/common.lua")
 local PaletteDraft = dofile("palette_draft.lua")
 local PaletteRepository = dofile("palette_repository.lua")
+local XmlTarget = dofile("xml_target_helper.lua")
 
 local PalettePage = {}
+local SETTINGS_STORE = app.storage("palette_settings.json")
 
 local palette = {
     header = "#233246",
@@ -29,10 +31,11 @@ local PALETTE_SECTION_OPTIONS = {
 local function create_page(options)
     options = options or {}
     local session = options.session or {}
+    local settings = SETTINGS_STORE:load() or {}
     local dlg
 
     local state = {
-        target_path = PaletteRepository.resolve_target_path(""),
+        target_path = PaletteRepository.resolve_target_path(settings.target_path or ""),
         repository = nil,
         brush_filter = "",
         brush_items = {},
@@ -49,6 +52,12 @@ local function create_page(options)
     }
 
     local actions = {}
+
+    local function persist_settings()
+        SETTINGS_STORE:save({
+            target_path = state.target_path or "",
+        })
+    end
 
     local function sync_session_out()
         session.pageDirty = session.pageDirty or {}
@@ -253,6 +262,60 @@ local function create_page(options)
         return true
     end
 
+    local function refresh_preview_local()
+        if not dlg or not dlg.modify then
+            return false
+        end
+
+        local selected_brush = state.draft.selectedBrush
+        local preview = preview_entries()
+        state.preview_page = clamp_page(state.preview_page, #preview, state.preview_page_size)
+        local preview_first, preview_last, preview_pages = page_bounds(state.preview_page, #preview, state.preview_page_size)
+
+        dlg:modify({
+            id = "palette_preview_prev",
+            bgcolor = state.preview_page > 1 and palette.panel or palette.sidebar,
+        })
+        dlg:modify({
+            id = "palette_preview_page_label",
+            text = string.format(
+                "Pozycje %d-%d / %d  |  Strona %d / %d",
+                #preview > 0 and preview_first or 0,
+                #preview > 0 and preview_last or 0,
+                #preview,
+                state.preview_page,
+                preview_pages
+            ),
+        })
+        dlg:modify({
+            id = "palette_preview_next",
+            bgcolor = state.preview_page < preview_pages and palette.panel or palette.sidebar,
+        })
+
+        for slot = 1, tonumber(state.preview_page_size or 12) or 12 do
+            local index = preview_first + slot - 1
+            local entry = index <= preview_last and preview[index] or nil
+            dlg:modify({
+                id = "palette_preview_slot_" .. slot,
+                bgcolor = entry and (entry.isInserted and palette.accent or (entry.isSelected and palette.success or palette.sidebar)) or palette.sidebar,
+            })
+            dlg:modify({
+                id = "palette_preview_slot_label_" .. slot,
+                text = entry and string.format("%d. %s", index, entry.name) or " ",
+                fgcolor = entry and palette.text or palette.muted,
+            })
+        end
+
+        dlg:modify({
+            id = "palette_preview_empty_hint",
+            text = #preview == 0 and "Wybierz tileset i sekcje, aby zobaczyc podglad publikacji." or " ",
+        })
+
+        dlg:layout()
+        dlg:repaint()
+        return true
+    end
+
     local function use_brush_by_name(name)
         local ref = PaletteRepository.make_brush_reference(state.repository, name)
         if not ref then
@@ -317,12 +380,16 @@ local function create_page(options)
 
     function actions.prev_brush_page()
         state.brush_page = math.max(1, (tonumber(state.brush_page or 1) or 1) - 1)
-        soft_refresh()
+        if not refresh_brush_picker_local() then
+            soft_refresh()
+        end
     end
 
     function actions.next_brush_page()
         state.brush_page = clamp_page((tonumber(state.brush_page or 1) or 1) + 1, #state.brush_names, state.brush_page_size)
-        soft_refresh()
+        if not refresh_brush_picker_local() then
+            soft_refresh()
+        end
     end
 
     function actions.handle_brush_change(index)
@@ -448,12 +515,16 @@ local function create_page(options)
 
     function actions.prev_preview_page()
         state.preview_page = math.max(1, (tonumber(state.preview_page or 1) or 1) - 1)
-        soft_refresh()
+        if not refresh_preview_local() then
+            soft_refresh()
+        end
     end
 
     function actions.next_preview_page(total_entries)
         state.preview_page = clamp_page((tonumber(state.preview_page or 1) or 1) + 1, tonumber(total_entries or 0) or 0, state.preview_page_size)
-        soft_refresh()
+        if not refresh_preview_local() then
+            soft_refresh()
+        end
     end
 
     function actions.save_as_new()
@@ -462,6 +533,39 @@ local function create_page(options)
 
     function actions.update_existing()
         finalize_save("overwrite")
+    end
+
+    function actions.choose_target_path()
+        local chosen, err = XmlTarget.pick_xml_file("tilesets.xml", state.target_path, "Wybierz tilesets.xml")
+        if err then
+            app.alert({
+                title = "Nie mozna ustawic targetu",
+                text = err,
+                buttons = { "OK" },
+            })
+            return
+        end
+        if not chosen then
+            return
+        end
+
+        state.target_path = chosen
+        persist_settings()
+        refresh_repository()
+        sync_brushes()
+        sync_tilesets()
+        state.status_message = "Ustawiono nowy target tilesets.xml."
+        soft_refresh()
+    end
+
+    function actions.use_default_target_path()
+        state.target_path = PaletteRepository.resolve_target_path("")
+        persist_settings()
+        refresh_repository()
+        sync_brushes()
+        sync_tilesets()
+        state.status_message = "Przywrocono domyslny target tilesets.xml."
+        soft_refresh()
     end
 
     refresh_repository()
@@ -499,6 +603,7 @@ local function create_page(options)
     function page.onLeave(shared_session)
         session = shared_session or session
         sync_session_out()
+        persist_settings()
     end
 
     function page.render_into(dialog)
@@ -776,6 +881,7 @@ local function create_page(options)
                         expand = false,
                     })
                         dlg:button({
+                            id = "palette_preview_prev",
                             text = "<",
                             bgcolor = state.preview_page > 1 and palette.panel or palette.sidebar,
                             fgcolor = palette.text,
@@ -786,6 +892,7 @@ local function create_page(options)
                             end,
                         })
                         dlg:label({
+                            id = "palette_preview_page_label",
                             text = string.format(
                                 "Pozycje %d-%d / %d  |  Strona %d / %d",
                                 #preview > 0 and preview_first or 0,
@@ -797,6 +904,7 @@ local function create_page(options)
                             fgcolor = palette.muted,
                         })
                         dlg:button({
+                            id = "palette_preview_next",
                             text = ">",
                             bgcolor = state.preview_page < preview_pages and palette.panel or palette.sidebar,
                             fgcolor = palette.text,
@@ -807,28 +915,30 @@ local function create_page(options)
                             end,
                         })
                     dlg:endbox()
-                    for index = preview_first, preview_last do
-                        local entry = preview[index]
+                    for slot = 1, tonumber(state.preview_page_size or 12) or 12 do
+                        local index = preview_first + slot - 1
+                        local entry = index <= preview_last and preview[index] or nil
                         dlg:newrow()
                         dlg:panel({
-                            bgcolor = entry.isInserted and palette.accent or (entry.isSelected and palette.success or palette.sidebar),
+                            id = "palette_preview_slot_" .. slot,
+                            bgcolor = entry and (entry.isInserted and palette.accent or (entry.isSelected and palette.success or palette.sidebar)) or palette.sidebar,
                             padding = 6,
                             margin = 2,
                             expand = true,
                         })
                             dlg:label({
-                                text = string.format("%d. %s", index, entry.name),
-                                fgcolor = palette.text,
+                                id = "palette_preview_slot_label_" .. slot,
+                                text = entry and string.format("%d. %s", index, entry.name) or " ",
+                                fgcolor = entry and palette.text or palette.muted,
                             })
                         dlg:endpanel()
                     end
-                    if #preview == 0 then
-                        dlg:newrow()
-                        dlg:label({
-                            text = "Wybierz tileset i sekcje, aby zobaczyc podglad publikacji.",
-                            fgcolor = palette.muted,
-                        })
-                    end
+                    dlg:newrow()
+                    dlg:label({
+                        id = "palette_preview_empty_hint",
+                        text = #preview == 0 and "Wybierz tileset i sekcje, aby zobaczyc podglad publikacji." or " ",
+                        fgcolor = palette.muted,
+                    })
                 dlg:endpanel()
             dlg:endbox()
 
@@ -932,6 +1042,28 @@ local function create_page(options)
                         text = save_hint_text(),
                         fgcolor = palette.muted,
                     })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            text = "Zmien XML",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.choose_target_path()
+                            end,
+                        })
+                        dlg:button({
+                            text = "Domyslny XML",
+                            bgcolor = palette.panel,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                actions.use_default_target_path()
+                            end,
+                        })
+                    dlg:endbox()
                 dlg:endpanel()
             dlg:endbox()
         dlg:endbox()

--- a/scripts/brush_studio/palette_page.lua
+++ b/scripts/brush_studio/palette_page.lua
@@ -1,0 +1,982 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+local PaletteDraft = dofile("palette_draft.lua")
+local PaletteRepository = dofile("palette_repository.lua")
+
+local PalettePage = {}
+
+local palette = {
+    header = "#233246",
+    panel = "#243447",
+    panel_alt = "#2C3E50",
+    sidebar = "#26282d",
+    accent = "#2563EB",
+    success = "#2F855A",
+    warning = "#D97706",
+    text = "#F8FAFC",
+    muted = "#CBD5E1",
+    subtle = "#94A3B8",
+}
+
+local PALETTE_SECTION_OPTIONS = {
+    { value = "terrain", title = "Terrain Palette" },
+    { value = "doodad", title = "Doodad Palette" },
+    { value = "items", title = "Item Palette" },
+    { value = "doodad_and_raw", title = "Creature Palette" },
+    { value = "items_and_raw", title = "RAW Palette" },
+}
+
+local function create_page(options)
+    options = options or {}
+    local session = options.session or {}
+    local dlg
+
+    local state = {
+        target_path = PaletteRepository.resolve_target_path(""),
+        repository = nil,
+        brush_filter = "",
+        brush_items = {},
+        brush_names = {},
+        brush_page = 1,
+        brush_page_size = 12,
+        preview_page = 1,
+        preview_page_size = 12,
+        tileset_items = {},
+        tileset_names = {},
+        draft = PaletteDraft.new({}),
+        status_message = "Najpierw wybierz gotowy brush.",
+        dirty = false,
+    }
+
+    local actions = {}
+
+    local function sync_session_out()
+        session.pageDirty = session.pageDirty or {}
+        session.pageDirty.palette = state.dirty
+        if state.draft.selectedBrush then
+            session.lastPaletteBrush = state.draft.selectedBrush.name
+        end
+    end
+
+    local function request_host_render()
+        sync_session_out()
+        if options.onRequestRender then
+            options.onRequestRender()
+            return true
+        end
+        return false
+    end
+
+    local function confirm_discard()
+        if not state.dirty then
+            return true
+        end
+        local choice = app.alert({
+            title = "Discard changes?",
+            text = "The current palette draft has unsaved changes. Continue and discard them?",
+            buttons = { "Yes", "No" },
+        })
+        return choice == 1
+    end
+
+    local function refresh_repository()
+        state.repository = PaletteRepository.read(state.target_path)
+    end
+
+    local function page_count(total, page_size)
+        total = tonumber(total or 0) or 0
+        page_size = tonumber(page_size or 1) or 1
+        if total <= 0 then
+            return 1
+        end
+        return math.max(1, math.ceil(total / page_size))
+    end
+
+    local function clamp_page(page, total, page_size)
+        local max_page = page_count(total, page_size)
+        page = tonumber(page or 1) or 1
+        if page < 1 then
+            return 1
+        end
+        if page > max_page then
+            return max_page
+        end
+        return page
+    end
+
+    local function page_bounds(page, total, page_size)
+        page = clamp_page(page, total, page_size)
+        local first = ((page - 1) * page_size) + 1
+        local last = math.min(total, first + page_size - 1)
+        return first, last, page_count(total, page_size)
+    end
+
+    local function palette_title_from_section(section_name)
+        section_name = tostring(section_name or "")
+        for _, option in ipairs(PALETTE_SECTION_OPTIONS) do
+            if option.value == section_name then
+                return option.title
+            end
+        end
+        return "Terrain Palette"
+    end
+
+    local function palette_section_from_title(title)
+        title = tostring(title or "")
+        for _, option in ipairs(PALETTE_SECTION_OPTIONS) do
+            if option.title == title then
+                return option.value
+            end
+        end
+        return "terrain"
+    end
+
+    local function palette_option_titles()
+        local titles = {}
+        for _, option in ipairs(PALETTE_SECTION_OPTIONS) do
+            table.insert(titles, option.title)
+        end
+        return titles
+    end
+
+    local function tileset_options_for_section(section_name)
+        local options = { "-- wybierz tileset --" }
+        for _, tileset in ipairs(state.repository and state.repository.ordered_tilesets or {}) do
+            if tileset.sections_by_name and tileset.sections_by_name[section_name] then
+                table.insert(options, tileset.name)
+            end
+        end
+        return options
+    end
+
+    local function sync_tilesets()
+        state.tileset_items, state.tileset_names = PaletteRepository.tileset_items(state.repository)
+    end
+
+    local function sync_brushes()
+        state.brush_items, state.brush_names = PaletteRepository.brush_items(state.repository, state.brush_filter)
+        state.brush_page = clamp_page(state.brush_page, #state.brush_names, state.brush_page_size)
+    end
+
+    local function visible_brush_entry(slot)
+        local first, last = page_bounds(state.brush_page, #state.brush_names, state.brush_page_size)
+        local index = first + ((tonumber(slot or 1) or 1) - 1)
+        if index < first or index > last then
+            return nil, nil, nil
+        end
+        return index, state.brush_names[index], state.brush_items[index]
+    end
+
+    local function helper_text()
+        if not state.draft.selectedBrush then
+            return "1. Wybierz gotowy brush. 2. Wybierz tileset i sekcje. 3. Sprawdz preview. 4. Zapisz."
+        end
+        if state.draft.targetTileset == "" or state.draft.targetCategory == "" then
+            return "Wybierz miejsce w palecie, aby opublikowac brush."
+        end
+        return "Palette publikuje gotowy brush do tilesets.xml bez pracy na surowym XML."
+    end
+
+    local function save_hint_text()
+        local validation = state.draft:getValidation()
+        if not validation.isValid then
+            return validation.errors[1] or "Uzupelnij draft."
+        end
+        if state.draft.displayName == "" and state.draft.selectedBrush then
+            return "Paleta uzyje fallbacku z nazwy brusha, bo tilesets.xml nie ma osobnego labela."
+        end
+        return "Zapis utworzy nowy wpis albo zaktualizuje istniejacy wpis palety."
+    end
+
+    local function effective_display_name()
+        return state.draft:effectiveDisplayName()
+    end
+
+    local function preview_entries()
+        return PaletteRepository.preview_entries(state.repository, state.draft)
+    end
+
+    local function soft_refresh()
+        sync_session_out()
+        if request_host_render() then
+            return
+        end
+    end
+
+    local function refresh_brush_picker_local()
+        if not dlg or not dlg.modify then
+            return false
+        end
+
+        local selected_brush = state.draft.selectedBrush
+        local _, _, brush_pages = page_bounds(state.brush_page, #state.brush_names, state.brush_page_size)
+
+        dlg:modify({
+            id = "palette_brush_filter",
+            text = state.brush_filter or "",
+        })
+        dlg:modify({
+            id = "palette_brush_page_label",
+            text = string.format("Strona %d / %d", state.brush_page, brush_pages),
+        })
+        dlg:modify({
+            id = "palette_brush_prev",
+            bgcolor = state.brush_page > 1 and palette.panel or palette.sidebar,
+        })
+        dlg:modify({
+            id = "palette_brush_next",
+            bgcolor = state.brush_page < brush_pages and palette.panel or palette.sidebar,
+        })
+
+        for slot = 1, tonumber(state.brush_page_size or 12) or 12 do
+            local _, name, item = visible_brush_entry(slot)
+            local is_selected = name and selected_brush and selected_brush.name == name or false
+            dlg:modify({
+                id = "palette_brush_icon_" .. slot,
+                image = item and item.image or GroundCommon.safe_image(0),
+            })
+            dlg:modify({
+                id = "palette_brush_label_" .. slot,
+                text = item and item.text or " ",
+                fgcolor = name and palette.text or palette.subtle,
+            })
+            dlg:modify({
+                id = "palette_brush_open_" .. slot,
+                text = name and "Open" or "",
+                bgcolor = name and (is_selected and palette.accent or palette.panel) or palette.sidebar,
+                fgcolor = name and palette.text or palette.subtle,
+            })
+        end
+
+        dlg:layout()
+        dlg:repaint()
+        return true
+    end
+
+    local function use_brush_by_name(name)
+        local ref = PaletteRepository.make_brush_reference(state.repository, name)
+        if not ref then
+            state.status_message = "Wybrany brush nie jest dostepny."
+            soft_refresh()
+            return
+        end
+        state.draft:setBrush(ref)
+        state.preview_page = 1
+        state.dirty = true
+        state.status_message = string.format("Wybrano brush '%s'.", ref.name)
+        sync_brushes()
+        soft_refresh()
+    end
+
+    local function finalize_save(mode)
+        local ok, result = PaletteRepository.save_draft(state.repository, state.draft, mode, state.target_path)
+        if not ok then
+            app.alert({
+                title = "Save failed",
+                text = result,
+                buttons = { "OK" },
+            })
+            return
+        end
+
+        state.dirty = false
+        session.lastSavedPaletteEntry = state.draft.selectedBrush and state.draft.selectedBrush.name or ""
+        state.status_message = result.message
+        refresh_repository()
+        sync_brushes()
+        sync_tilesets()
+        soft_refresh()
+        app.alert({
+            title = "Palette updated",
+            text = result.message,
+            buttons = { "OK" },
+        })
+    end
+
+    function actions.set_brush_filter_text(text)
+        state.brush_filter = tostring(text or "")
+    end
+
+    function actions.set_brush_filter(text)
+        text = tostring(text or "")
+        if text == tostring(state.brush_filter or "") then
+            return
+        end
+        state.brush_filter = text
+        state.brush_page = 1
+        sync_brushes()
+        soft_refresh()
+    end
+
+    function actions.clear_brush_filter()
+        state.brush_filter = ""
+        state.brush_page = 1
+        sync_brushes()
+        soft_refresh()
+    end
+
+    function actions.prev_brush_page()
+        state.brush_page = math.max(1, (tonumber(state.brush_page or 1) or 1) - 1)
+        soft_refresh()
+    end
+
+    function actions.next_brush_page()
+        state.brush_page = clamp_page((tonumber(state.brush_page or 1) or 1) + 1, #state.brush_names, state.brush_page_size)
+        soft_refresh()
+    end
+
+    function actions.handle_brush_change(index)
+        local name = state.brush_names[tonumber(index or 0) or 0]
+        if name then
+            use_brush_by_name(name)
+        end
+    end
+
+    function actions.open_brush_visible_slot(slot)
+        local _, name = visible_brush_entry(slot)
+        if not name then
+            return
+        end
+        use_brush_by_name(name)
+    end
+
+    function actions.use_last_saved_brush()
+        local name = GroundCommon.trim(session.lastSavedComposedBrush or "")
+        if name == "" then
+            state.status_message = "Brak ostatnio zapisanego composed brusha."
+            soft_refresh()
+            return
+        end
+        use_brush_by_name(name)
+    end
+
+    function actions.use_last_saved_ground()
+        local name = GroundCommon.trim(session.lastSavedGround or "")
+        if name == "" then
+            state.status_message = "Brak ostatnio zapisanego grounda."
+            soft_refresh()
+            return
+        end
+        use_brush_by_name(name)
+    end
+
+    function actions.set_tileset(index)
+        local name = state.tileset_names[tonumber(index or 0) or 0]
+        if not name then
+            return
+        end
+        state.draft:setTileset(name)
+        state.draft:setCategory("")
+        state.dirty = true
+        sync_tilesets()
+        state.status_message = string.format("Wybrano tileset '%s'.", name)
+        soft_refresh()
+    end
+
+    function actions.set_tileset_by_name(name)
+        name = tostring(name or "")
+        for index, candidate in ipairs(state.tileset_names or {}) do
+            if candidate == name then
+                actions.set_tileset(index)
+                return
+            end
+        end
+    end
+
+    function actions.set_category(index)
+        local name = state.category_names and state.category_names[tonumber(index or 0) or 0] or nil
+        if name then
+            state.draft:setCategory(name)
+            state.dirty = true
+            state.status_message = string.format("Wybrano sekcje '%s'.", name)
+            soft_refresh()
+        end
+    end
+
+    function actions.set_category_by_name(name)
+        local section_name = tostring(name or "")
+        if section_name == "" then
+            return
+        end
+        state.draft:setCategory(section_name)
+        if state.draft.targetTileset ~= "" then
+            local tileset = state.repository and state.repository.by_tileset and state.repository.by_tileset[state.draft.targetTileset] or nil
+            if not (tileset and tileset.sections_by_name and tileset.sections_by_name[section_name]) then
+                state.draft:setTileset("")
+            end
+        end
+        state.preview_page = 1
+        state.dirty = true
+        state.status_message = string.format("Wybrano palete '%s'.", palette_title_from_section(section_name))
+        soft_refresh()
+    end
+
+    function actions.set_palette_title(title)
+        local section_name = palette_section_from_title(title)
+        actions.set_category_by_name(section_name)
+    end
+
+    function actions.set_tileset_title(title)
+        local name = tostring(title or "")
+        if name == "" or name == "-- wybierz tileset --" then
+            state.draft:setTileset("")
+            state.preview_page = 1
+            state.dirty = true
+            state.status_message = "Wyczyszczono tileset docelowy."
+            soft_refresh()
+            return
+        end
+        state.draft:setTileset(name)
+        state.preview_page = 1
+        state.dirty = true
+        state.status_message = string.format("Wybrano tileset '%s'.", name)
+        soft_refresh()
+    end
+
+    function actions.set_display_name(value)
+        state.draft:setDisplayName(value)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_order(value)
+        state.draft:setOrder(value)
+        state.preview_page = 1
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.prev_preview_page()
+        state.preview_page = math.max(1, (tonumber(state.preview_page or 1) or 1) - 1)
+        soft_refresh()
+    end
+
+    function actions.next_preview_page(total_entries)
+        state.preview_page = clamp_page((tonumber(state.preview_page or 1) or 1) + 1, tonumber(total_entries or 0) or 0, state.preview_page_size)
+        soft_refresh()
+    end
+
+    function actions.save_as_new()
+        finalize_save("new")
+    end
+
+    function actions.update_existing()
+        finalize_save("overwrite")
+    end
+
+    refresh_repository()
+    sync_brushes()
+    sync_tilesets()
+    if state.draft.targetCategory == "" then
+        state.draft:setCategory("terrain")
+        state.draft.dirty = false
+    end
+    if state.repository.api_missing then
+        state.status_message = "Brak API do odczytu tilesets.xml: " .. tostring(state.repository.api_missing)
+    elseif #(state.repository.warnings or {}) > 0 then
+        state.status_message = state.repository.warnings[1]
+    end
+
+    local page = {}
+
+    function page.getTitle()
+        return "Palette"
+    end
+
+    function page.isDirty()
+        return state.dirty
+    end
+
+    function page.confirmLeave()
+        return confirm_discard()
+    end
+
+    function page.onEnter(shared_session)
+        session = shared_session or session
+        sync_session_out()
+    end
+
+    function page.onLeave(shared_session)
+        session = shared_session or session
+        sync_session_out()
+    end
+
+    function page.render_into(dialog)
+        dlg = dialog
+        sync_brushes()
+        sync_tilesets()
+        local selected_brush = state.draft.selectedBrush
+        local preview = preview_entries()
+        local brush_first, brush_last, brush_pages = page_bounds(state.brush_page, #state.brush_names, state.brush_page_size)
+        state.preview_page = clamp_page(state.preview_page, #preview, state.preview_page_size)
+        local preview_first, preview_last, preview_pages = page_bounds(state.preview_page, #preview, state.preview_page_size)
+
+        dlg:panel({
+            bgcolor = palette.header,
+            padding = 10,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "PALETTE",
+                fgcolor = palette.text,
+                font_size = 14,
+                font_weight = "bold",
+                align = "center",
+            })
+            dlg:newrow()
+            dlg:label({
+                text = helper_text(),
+                fgcolor = palette.muted,
+                align = "center",
+            })
+        dlg:endpanel()
+
+        dlg:panel({
+            bgcolor = palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = state.status_message ~= "" and state.status_message or helper_text(),
+                fgcolor = palette.text,
+            })
+        dlg:endpanel()
+
+        dlg:box({
+            orient = "horizontal",
+            expand = true,
+        })
+            dlg:box({
+                label = "1. Wybierz Brush",
+                orient = "vertical",
+                width = 360,
+                min_width = 340,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Selected Brush",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = selected_brush and selected_brush.title or "Brak wybranego brusha",
+                        fgcolor = palette.text,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = selected_brush and ("Source: " .. tostring(selected_brush.sourceType or "brush")) or "Najpierw wybierz gotowy brush",
+                        fgcolor = palette.muted,
+                        font_size = 8,
+                    })
+                    dlg:newrow()
+                    dlg:image({
+                        image = GroundCommon.safe_image(selected_brush and selected_brush.sampleItemId or 0),
+                        width = 72,
+                        height = 72,
+                        smooth = false,
+                    })
+                dlg:endpanel()
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        text = "Use last saved brush",
+                        bgcolor = palette.accent,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.use_last_saved_brush()
+                        end,
+                    })
+                    dlg:button({
+                        text = "Use last saved ground",
+                        bgcolor = palette.panel_alt,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.use_last_saved_ground()
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:input({
+                    id = "palette_brush_filter",
+                    label = "Search",
+                    text = state.brush_filter or "",
+                    expand = true,
+                    onchange = function(d)
+                        actions.set_brush_filter_text(d.data.palette_brush_filter or "")
+                    end,
+                })
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        text = "Search",
+                        bgcolor = palette.panel,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.set_brush_filter(state.brush_filter or "")
+                        end,
+                    })
+                    dlg:button({
+                        text = "Clear",
+                        bgcolor = palette.sidebar,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.clear_brush_filter()
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:box({
+                    orient = "horizontal",
+                    expand = false,
+                })
+                    dlg:button({
+                        id = "palette_brush_prev",
+                        text = "<",
+                        bgcolor = state.brush_page > 1 and palette.panel or palette.sidebar,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            if state.brush_page > 1 then
+                                actions.prev_brush_page()
+                            end
+                        end,
+                    })
+                    dlg:label({
+                        id = "palette_brush_page_label",
+                        text = string.format("Strona %d / %d", state.brush_page, brush_pages),
+                        fgcolor = palette.muted,
+                    })
+                    dlg:button({
+                        id = "palette_brush_next",
+                        text = ">",
+                        bgcolor = state.brush_page < brush_pages and palette.panel or palette.sidebar,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            if state.brush_page < brush_pages then
+                                actions.next_brush_page()
+                            end
+                        end,
+                    })
+                dlg:endbox()
+                dlg:newrow()
+                dlg:panel({
+                    bgcolor = palette.sidebar,
+                    padding = 8,
+                    margin = 2,
+                    expand = true,
+                })
+                    for slot = 1, tonumber(state.brush_page_size or 12) or 12 do
+                        local _, name, item = visible_brush_entry(slot)
+                        local is_selected = name and selected_brush and selected_brush.name == name or false
+                        dlg:box({
+                            orient = "horizontal",
+                            expand = true,
+                        })
+                            dlg:image({
+                                id = "palette_brush_icon_" .. slot,
+                                image = item and item.image or GroundCommon.safe_image(0),
+                                width = 22,
+                                height = 22,
+                                smooth = false,
+                            })
+                            dlg:label({
+                                id = "palette_brush_label_" .. slot,
+                                text = item and item.text or " ",
+                                fgcolor = name and palette.text or palette.subtle,
+                                expand = true,
+                            })
+                            dlg:button({
+                                id = "palette_brush_open_" .. slot,
+                                text = name and "Open" or "",
+                                bgcolor = name and (is_selected and palette.accent or palette.panel) or palette.sidebar,
+                                fgcolor = name and palette.text or palette.subtle,
+                                onclick = function()
+                                    actions.open_brush_visible_slot(slot)
+                                end,
+                            })
+                        dlg:endbox()
+                        dlg:newrow()
+                    end
+                dlg:endpanel()
+            dlg:endbox()
+
+            dlg:box({
+                label = "2-3. Preview Publikacji",
+                orient = "vertical",
+                min_width = 560,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Podglad wpisu palety",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = selected_brush and effective_display_name() or "Najpierw wybierz gotowy brush",
+                        fgcolor = palette.text,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = state.draft.targetTileset ~= "" and (state.draft.targetTileset .. " / " .. (state.draft.targetCategory ~= "" and state.draft.targetCategory or "?")) or "Wybierz miejsce w palecie",
+                        fgcolor = palette.muted,
+                    })
+                dlg:endpanel()
+                dlg:newrow()
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:image({
+                        image = GroundCommon.safe_image(selected_brush and selected_brush.sampleItemId or 0),
+                        width = 96,
+                        height = 96,
+                        smooth = false,
+                    })
+                dlg:endpanel()
+                dlg:newrow()
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = true,
+                })
+                    dlg:label({
+                        text = "Mock widoku palety",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:box({
+                        orient = "horizontal",
+                        expand = false,
+                    })
+                        dlg:button({
+                            text = "<",
+                            bgcolor = state.preview_page > 1 and palette.panel or palette.sidebar,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                if state.preview_page > 1 then
+                                    actions.prev_preview_page()
+                                end
+                            end,
+                        })
+                        dlg:label({
+                            text = string.format(
+                                "Pozycje %d-%d / %d  |  Strona %d / %d",
+                                #preview > 0 and preview_first or 0,
+                                #preview > 0 and preview_last or 0,
+                                #preview,
+                                state.preview_page,
+                                preview_pages
+                            ),
+                            fgcolor = palette.muted,
+                        })
+                        dlg:button({
+                            text = ">",
+                            bgcolor = state.preview_page < preview_pages and palette.panel or palette.sidebar,
+                            fgcolor = palette.text,
+                            onclick = function()
+                                if state.preview_page < preview_pages then
+                                    actions.next_preview_page(#preview)
+                                end
+                            end,
+                        })
+                    dlg:endbox()
+                    for index = preview_first, preview_last do
+                        local entry = preview[index]
+                        dlg:newrow()
+                        dlg:panel({
+                            bgcolor = entry.isInserted and palette.accent or (entry.isSelected and palette.success or palette.sidebar),
+                            padding = 6,
+                            margin = 2,
+                            expand = true,
+                        })
+                            dlg:label({
+                                text = string.format("%d. %s", index, entry.name),
+                                fgcolor = palette.text,
+                            })
+                        dlg:endpanel()
+                    end
+                    if #preview == 0 then
+                        dlg:newrow()
+                        dlg:label({
+                            text = "Wybierz tileset i sekcje, aby zobaczyc podglad publikacji.",
+                            fgcolor = palette.muted,
+                        })
+                    end
+                dlg:endpanel()
+            dlg:endbox()
+
+            dlg:box({
+                label = "4. Ustawienia i Save",
+                orient = "vertical",
+                width = 380,
+                min_width = 360,
+                expand = true,
+                fgcolor = palette.muted,
+            })
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = "Docelowe miejsce",
+                        fgcolor = palette.text,
+                        font_weight = "bold",
+                    })
+                    dlg:newrow()
+                    dlg:combobox({
+                        id = "palette_section_combo",
+                        label = "Palette",
+                        options = palette_option_titles(),
+                        option = palette_title_from_section(state.draft.targetCategory),
+                        onchange = function(d)
+                            actions.set_palette_title(d.data.palette_section_combo or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:combobox({
+                        id = "palette_tileset_combo",
+                        label = "Tileset",
+                        options = tileset_options_for_section(state.draft.targetCategory),
+                        option = (state.draft.targetTileset ~= "" and state.draft.targetTileset) or "-- wybierz tileset --",
+                        onchange = function(d)
+                            actions.set_tileset_title(d.data.palette_tileset_combo or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:input({
+                        id = "palette_display_name",
+                        label = "Display name",
+                        text = state.draft.displayName or "",
+                        expand = true,
+                        onchange = function(d)
+                            actions.set_display_name(d.data.palette_display_name or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:input({
+                        id = "palette_order_input",
+                        label = "Order",
+                        text = tostring(state.draft.order or 0),
+                        expand = true,
+                        onchange = function(d)
+                            actions.set_order(d.data.palette_order_input or "")
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:button({
+                        text = "Save as New Entry",
+                        bgcolor = palette.success,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.save_as_new()
+                        end,
+                    })
+                    dlg:newrow()
+                    dlg:button({
+                        text = "Update Existing Entry",
+                        bgcolor = palette.accent,
+                        fgcolor = palette.text,
+                        onclick = function()
+                            actions.update_existing()
+                        end,
+                    })
+                dlg:endpanel()
+                dlg:newrow()
+                dlg:panel({
+                    bgcolor = palette.panel_alt,
+                    padding = 8,
+                    margin = 4,
+                    expand = false,
+                })
+                    dlg:label({
+                        text = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie",
+                        fgcolor = state.dirty and palette.warning or palette.muted,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = "Target: " .. tostring(state.target_path or ""),
+                        fgcolor = palette.subtle,
+                        font_size = 8,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        text = save_hint_text(),
+                        fgcolor = palette.muted,
+                    })
+                dlg:endpanel()
+            dlg:endbox()
+        dlg:endbox()
+    end
+
+    function page.getTitle()
+        return "Palette"
+    end
+
+    function page.isDirty()
+        return state.dirty
+    end
+
+    function page.confirmLeave()
+        return confirm_discard()
+    end
+
+    function page.onEnter(shared_session)
+        session = shared_session or session
+        sync_session_out()
+    end
+
+    function page.onLeave(shared_session)
+        session = shared_session or session
+        sync_session_out()
+    end
+
+    function page.getSessionState()
+        sync_session_out()
+        return session
+    end
+
+    function page.getStatusText()
+        return state.status_message ~= "" and state.status_message or helper_text()
+    end
+
+    function page.getState()
+        return state
+    end
+
+    return page
+end
+
+function PalettePage.create(options)
+    return create_page(options)
+end
+
+return PalettePage

--- a/scripts/brush_studio/palette_repository.lua
+++ b/scripts/brush_studio/palette_repository.lua
@@ -1,0 +1,499 @@
+local Paths = dofile("module_paths.lua")
+local GroundCommon = Paths.load("ground_studio/common.lua")
+local ComposerRepository = dofile("composer_repository.lua")
+local PaletteDraft = dofile("palette_draft.lua")
+
+local M = {}
+
+local PUBLISHABLE_SECTIONS = {
+    terrain = true,
+    doodad = true,
+    items = true,
+    items_and_raw = true,
+    doodad_and_raw = true,
+}
+
+local function parse_attributes(text)
+    local attrs = {}
+    for key, value in tostring(text or ""):gmatch('([%w_%-]+)%s*=%s*"([^"]-)"') do
+        attrs[key] = GroundCommon.unescape_xml(value)
+    end
+    return attrs
+end
+
+local function extract_blocks(xml, tag_name)
+    local blocks = {}
+    local cursor = 1
+    local open_pattern = "<" .. tag_name .. "%s"
+    local close_tag = "</" .. tag_name .. ">"
+
+    while true do
+        local start_index = xml:find(open_pattern, cursor)
+        if not start_index then
+            break
+        end
+        local tag_end = xml:find(">", start_index, true)
+        if not tag_end then
+            break
+        end
+        local open_tag = xml:sub(start_index, tag_end)
+        local self_closing = open_tag:match("/%s*>$") ~= nil
+        if self_closing then
+            table.insert(blocks, {
+                start_index = start_index,
+                end_index = tag_end,
+                attributes = parse_attributes(open_tag),
+                inner = "",
+                open_tag = open_tag,
+            })
+            cursor = tag_end + 1
+        else
+            local close_start, close_end = xml:find(close_tag, tag_end + 1, true)
+            if not close_start then
+                break
+            end
+            table.insert(blocks, {
+                start_index = start_index,
+                end_index = close_end,
+                attributes = parse_attributes(open_tag),
+                inner = xml:sub(tag_end + 1, close_start - 1),
+                open_tag = open_tag,
+            })
+            cursor = close_end + 1
+        end
+    end
+
+    return blocks
+end
+
+local function read_file(path)
+    local store = app.storage(path)
+    if not store or not store.readText then
+        return nil, "This RME build does not expose raw file reads for tilesets.xml."
+    end
+    local content, err = store:readText()
+    if not content then
+        return nil, err or "Could not open file."
+    end
+    return content
+end
+
+local function write_file(path, content)
+    local store = app.storage(path)
+    if not store or not store.save then
+        return false, "This RME build does not expose safe file writes."
+    end
+    local ok = store:save(content or "")
+    if not ok then
+        return false, "Could not write file."
+    end
+    return true
+end
+
+function M.resolve_target_path(saved_path)
+    if saved_path and saved_path ~= "" then
+        return saved_path
+    end
+    return tostring(app.getDataDirectory() or "") .. "/1310/tilesets.xml"
+end
+
+local function parse_tilesets(xml)
+    local repository = {
+        ordered_tilesets = {},
+        by_tileset = {},
+        warnings = {},
+    }
+
+    for _, tileset_block in ipairs(extract_blocks(tostring(xml or ""), "tileset")) do
+        local tileset_name = GroundCommon.trim((tileset_block.attributes or {}).name or "")
+        if tileset_name ~= "" then
+            local entry = {
+                name = tileset_name,
+                sections = {},
+                sections_by_name = {},
+            }
+
+            for _, section_block in ipairs(extract_blocks(tileset_block.inner or "", "[%w_%-]+")) do
+            end
+
+            local cursor = 1
+            while true do
+                local section_start, section_end, section_name = tostring(tileset_block.inner or ""):find("<([%w_%-]+)>", cursor)
+                if not section_start then
+                    break
+                end
+                local close_tag = "</" .. section_name .. ">"
+                local close_start, close_end = tostring(tileset_block.inner or ""):find(close_tag, section_end + 1, true)
+                if not close_start then
+                    break
+                end
+                local section_inner = tostring(tileset_block.inner or ""):sub(section_end + 1, close_start - 1)
+
+                local section = {
+                    name = section_name,
+                    title = section_name:gsub("_", " "),
+                    brush_entries = {},
+                    other_xml = section_inner:gsub("<brush%s+.-%s*/>", ""),
+                }
+
+                for brush_attrs in tostring(section_inner):gmatch("<brush%s+(.-)%s*/>") do
+                    local parsed = parse_attributes(brush_attrs)
+                    local brush_name = GroundCommon.trim(parsed.name or "")
+                    if brush_name ~= "" then
+                        table.insert(section.brush_entries, {
+                            brushName = brush_name,
+                        })
+                    end
+                end
+
+                entry.sections_by_name[section_name] = section
+                table.insert(entry.sections, section)
+                cursor = close_end + 1
+            end
+
+            repository.by_tileset[tileset_name] = entry
+            table.insert(repository.ordered_tilesets, entry)
+        end
+    end
+
+    return repository
+end
+
+local function composer_brush_sources(composer_repository)
+    local items = {}
+    local seen = {}
+
+    for _, draft in ipairs((composer_repository.composed_ordered) or {}) do
+        local name = GroundCommon.trim(draft.name or "")
+        if name ~= "" and not seen[string.lower(name)] then
+            seen[string.lower(name)] = true
+            local ground_ref = draft.selectedGround
+            table.insert(items, {
+                name = name,
+                title = name,
+                sampleItemId = ground_ref and ground_ref.sampleItemId or 0,
+                sourceType = "composer",
+            })
+        end
+    end
+
+    for _, draft in ipairs((composer_repository.ground_repository and composer_repository.ground_repository.ordered) or {}) do
+        local name = GroundCommon.trim(draft.name or "")
+        if name ~= "" and not seen[string.lower(name)] then
+            seen[string.lower(name)] = true
+            table.insert(items, {
+                name = name,
+                title = name,
+                sampleItemId = GroundCommon.primary_item_id(draft),
+                sourceType = "ground",
+            })
+        end
+    end
+
+    table.sort(items, function(left, right)
+        return string.lower(left.title or "") < string.lower(right.title or "")
+    end)
+
+    return items
+end
+
+function M.read(target_path)
+    local repository = {
+        target_path = target_path,
+        warnings = {},
+        api_missing = nil,
+        ordered_tilesets = {},
+        by_tileset = {},
+        brush_sources = {},
+        brush_sources_by_name = {},
+    }
+
+    local composer_repository = ComposerRepository.read(tostring(app.getDataDirectory() or "") .. "/1310/grounds.xml")
+    repository.composer_repository = composer_repository
+    for _, warning in ipairs(composer_repository.warnings or {}) do
+        table.insert(repository.warnings, warning)
+    end
+
+    local content, err = read_file(target_path)
+    if not content then
+        repository.api_missing = err
+        table.insert(repository.warnings, err)
+        return repository
+    end
+
+    local parsed = parse_tilesets(content)
+    repository.ordered_tilesets = parsed.ordered_tilesets
+    repository.by_tileset = parsed.by_tileset
+    repository.warnings = repository.warnings or {}
+    for _, warning in ipairs(parsed.warnings or {}) do
+        table.insert(repository.warnings, warning)
+    end
+
+    repository.brush_sources = composer_brush_sources(composer_repository)
+    for _, source in ipairs(repository.brush_sources) do
+        repository.brush_sources_by_name[string.lower(source.name)] = source
+    end
+
+    return repository
+end
+
+function M.tileset_items(repository)
+    local items = {}
+    local names = {}
+    for _, tileset in ipairs(repository.ordered_tilesets or {}) do
+        table.insert(items, {
+            text = tileset.name,
+            tooltip = tileset.name,
+        })
+        table.insert(names, tileset.name)
+    end
+    return items, names
+end
+
+function M.category_items(repository, tileset_name)
+    local items = {}
+    local names = {}
+    local tileset = repository.by_tileset and repository.by_tileset[tileset_name] or nil
+    for _, section in ipairs(tileset and tileset.sections or {}) do
+        if PUBLISHABLE_SECTIONS[section.name] then
+            table.insert(items, {
+                text = string.format("%s  |  %d wpisow", section.title, #(section.brush_entries or {})),
+                tooltip = section.name,
+            })
+            table.insert(names, section.name)
+        end
+    end
+    return items, names
+end
+
+function M.brush_items(repository, filter_text)
+    local items = {}
+    local names = {}
+    local needle = string.lower(filter_text or "")
+    for _, source in ipairs(repository.brush_sources or {}) do
+        local blob = string.lower((source.title or "") .. " " .. (source.sourceType or ""))
+        if needle == "" or string.find(blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("%s  |  %s", source.title or source.name, source.sourceType or "brush"),
+                tooltip = string.format("%s\nSource: %s", source.name or "", source.sourceType or "brush"),
+                image = GroundCommon.safe_image(source.sampleItemId or 0),
+            })
+            table.insert(names, source.name)
+        end
+    end
+    return items, names
+end
+
+function M.make_brush_reference(repository, brush_name)
+    return repository.brush_sources_by_name and repository.brush_sources_by_name[string.lower(brush_name or "")] or nil
+end
+
+local function find_entry(repository, brush_name)
+    brush_name = GroundCommon.trim(brush_name or "")
+    if brush_name == "" then
+        return nil
+    end
+    for _, tileset in ipairs(repository.ordered_tilesets or {}) do
+        for _, section in ipairs(tileset.sections or {}) do
+            for index, entry in ipairs(section.brush_entries or {}) do
+                if string.lower(entry.brushName or "") == string.lower(brush_name) then
+                    return {
+                        tileset = tileset.name,
+                        category = section.name,
+                        index = index,
+                    }
+                end
+            end
+        end
+    end
+    return nil
+end
+
+function M.preview_entries(repository, draft)
+    local tileset = repository.by_tileset and repository.by_tileset[draft.targetTileset] or nil
+    local section = tileset and tileset.sections_by_name and tileset.sections_by_name[draft.targetCategory] or nil
+    local preview = {}
+
+    if not section then
+        return preview
+    end
+
+    for _, entry in ipairs(section.brush_entries or {}) do
+        table.insert(preview, {
+            name = entry.brushName,
+            isSelected = draft.selectedBrush and string.lower(entry.brushName or "") == string.lower(draft.selectedBrush.name or ""),
+            isInserted = false,
+        })
+    end
+
+    if draft.selectedBrush and GroundCommon.trim(draft.selectedBrush.name or "") ~= "" then
+        local insert_name = draft.selectedBrush.name
+        local existing_index = nil
+        for index, entry in ipairs(preview) do
+            if string.lower(entry.name or "") == string.lower(insert_name) then
+                existing_index = index
+                break
+            end
+        end
+
+        if not existing_index then
+            local insert_at = tonumber(draft.order or 0) or 0
+            if insert_at <= 0 or insert_at > (#preview + 1) then
+                insert_at = #preview + 1
+            end
+            table.insert(preview, insert_at, {
+                name = insert_name,
+                isSelected = true,
+                isInserted = true,
+            })
+        elseif draft.order > 0 and draft.order ~= existing_index and draft.order <= #preview then
+            local item = table.remove(preview, existing_index)
+            table.insert(preview, draft.order, item)
+            item.isInserted = true
+        end
+    end
+
+    return preview
+end
+
+function M.validate_save(repository, draft, mode, target_path)
+    if not target_path or target_path == "" then
+        return false, "Target tilesets.xml could not be resolved."
+    end
+    if not GroundCommon.path_starts_with(target_path, app.getDataDirectory()) then
+        return false, "Target tilesets.xml must stay inside the RME data directory."
+    end
+
+    local validation = draft:getValidation()
+    if not validation.isValid then
+        return false, validation.errors[1] or "Palette draft jest niepoprawny."
+    end
+
+    local tileset = repository.by_tileset and repository.by_tileset[draft.targetTileset] or nil
+    if not tileset then
+        return false, "Wybrany tileset nie istnieje."
+    end
+    local section = tileset.sections_by_name and tileset.sections_by_name[draft.targetCategory] or nil
+    if not section then
+        return false, "Wybrana sekcja nie istnieje."
+    end
+
+    local existing = find_entry(repository, draft.selectedBrush and draft.selectedBrush.name or "")
+    if mode == "new" and existing then
+        return false, string.format("Brush '%s' jest juz opublikowany w palecie.", draft.selectedBrush.name or "")
+    end
+    if mode == "overwrite" and not existing then
+        return false, string.format("Brush '%s' nie istnieje jeszcze w palecie.", draft.selectedBrush.name or "")
+    end
+
+    return true
+end
+
+function M.backup_xml(target_path)
+    local original, err = read_file(target_path)
+    if not original then
+        return false, nil, nil, "Could not read tilesets.xml before backup: " .. tostring(err)
+    end
+
+    local backup_path = string.format("%s.palette.%s.bak", target_path, os.date("%Y%m%d_%H%M%S"))
+    local ok, backup_err = write_file(backup_path, original)
+    if not ok then
+        return false, nil, nil, "Could not write backup file: " .. tostring(backup_err)
+    end
+
+    return true, backup_path, original
+end
+
+local function serialize_repository(repository)
+    local lines = { "<materials>" }
+    for _, tileset in ipairs(repository.ordered_tilesets or {}) do
+        table.insert(lines, string.format('\t<tileset name="%s">', GroundCommon.escape_xml(tileset.name)))
+        for _, section in ipairs(tileset.sections or {}) do
+            table.insert(lines, string.format("\t\t<%s>", section.name))
+            local other_xml = tostring(section.other_xml or ""):gsub("\r\n", "\n")
+            for line in other_xml:gmatch("[^\r\n]+") do
+                local trimmed = GroundCommon.trim(line)
+                if trimmed ~= "" then
+                    table.insert(lines, "\t\t\t" .. trimmed)
+                end
+            end
+            for _, entry in ipairs(section.brush_entries or {}) do
+                table.insert(lines, string.format('\t\t\t<brush name="%s" />', GroundCommon.escape_xml(entry.brushName)))
+            end
+            table.insert(lines, string.format("\t\t</%s>", section.name))
+        end
+        table.insert(lines, "\t</tileset>")
+    end
+    table.insert(lines, "</materials>")
+    return table.concat(lines, "\n")
+end
+
+local function rebuild_repository_indexes(repository)
+    repository.by_tileset = {}
+    for _, tileset in ipairs(repository.ordered_tilesets or {}) do
+        tileset.sections_by_name = {}
+        for _, section in ipairs(tileset.sections or {}) do
+            tileset.sections_by_name[section.name] = section
+        end
+        repository.by_tileset[tileset.name] = tileset
+    end
+    return repository
+end
+
+function M.save_draft(repository, draft, mode, target_path)
+    local ok, validation_message = M.validate_save(repository, draft, mode, target_path)
+    if not ok then
+        return false, validation_message
+    end
+
+    local backup_ok, backup_path, original_content, backup_message = M.backup_xml(target_path)
+    if not backup_ok then
+        return false, backup_message
+    end
+
+    local working = rebuild_repository_indexes(GroundCommon.clone(repository))
+    local selected_name = draft.selectedBrush.name
+    local existing = find_entry(working, selected_name)
+
+    if existing then
+        local old_tileset = working.by_tileset[existing.tileset]
+        local old_section = old_tileset and old_tileset.sections_by_name and old_tileset.sections_by_name[existing.category] or nil
+        if old_section and old_section.brush_entries then
+            table.remove(old_section.brush_entries, existing.index)
+        end
+    end
+
+    local target_tileset = working.by_tileset[draft.targetTileset]
+    local target_section = target_tileset and target_tileset.sections_by_name and target_tileset.sections_by_name[draft.targetCategory] or nil
+    if not target_section then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, "Wybrana sekcja docelowa nie istnieje."
+    end
+
+    local insert_at = tonumber(draft.order or 0) or 0
+    if insert_at <= 0 or insert_at > (#target_section.brush_entries + 1) then
+        insert_at = #target_section.brush_entries + 1
+    end
+    table.insert(target_section.brush_entries, insert_at, {
+        brushName = selected_name,
+    })
+
+    local xml = serialize_repository(working)
+    local write_ok, write_err = write_file(target_path, xml)
+    if not write_ok then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, write_err or "Saving failed while updating tilesets.xml."
+    end
+
+    return true, {
+        draft = draft:clone(),
+        backupPath = backup_path,
+        message = string.format("Published brush '%s' to %s / %s.\nBackup: %s", selected_name, draft.targetTileset, draft.targetCategory, backup_path),
+    }
+end
+
+return M

--- a/scripts/brush_studio/placeholder_page.lua
+++ b/scripts/brush_studio/placeholder_page.lua
@@ -1,0 +1,48 @@
+local PlaceholderPage = {}
+
+function PlaceholderPage.create(title, message)
+    local page = {}
+
+    function page.getTitle()
+        return title
+    end
+
+    function page.isDirty()
+        return false
+    end
+
+    function page.confirmLeave()
+        return true
+    end
+
+    function page.onEnter()
+    end
+
+    function page.onLeave()
+    end
+
+    function page.render_into(dlg)
+        dlg:panel({
+            padding = 16,
+            margin = 4,
+            expand = true,
+            bgcolor = "#2c2d31",
+        })
+            dlg:label({
+                text = title,
+                font_size = 14,
+                font_weight = "bold",
+                fgcolor = "#f1f1f1",
+            })
+            dlg:newrow()
+            dlg:label({
+                text = message,
+                fgcolor = "#b8bcc7",
+            })
+        dlg:endpanel()
+    end
+
+    return page
+end
+
+return PlaceholderPage

--- a/scripts/brush_studio/session.lua
+++ b/scripts/brush_studio/session.lua
@@ -8,13 +8,16 @@ function Session.new()
         lastSavedGround = "",
         lastSavedComposedBrush = "",
         lastSavedPaletteEntry = "",
+        lastSavedWall = "",
         selectedBorderForComposer = 0,
         selectedGroundForComposer = "",
+        selectedWallCreator = "",
         pageDirty = {
             borders = false,
             grounds = false,
             composer = false,
             palette = false,
+            walls = false,
         },
     }
 end

--- a/scripts/brush_studio/session.lua
+++ b/scripts/brush_studio/session.lua
@@ -1,0 +1,22 @@
+local Session = {}
+
+function Session.new()
+    return {
+        lastSelectedRaw = 0,
+        recentItems = {},
+        lastSavedBorder = 0,
+        lastSavedGround = "",
+        lastSavedComposedBrush = "",
+        lastSavedPaletteEntry = "",
+        selectedBorderForComposer = 0,
+        selectedGroundForComposer = "",
+        pageDirty = {
+            borders = false,
+            grounds = false,
+            composer = false,
+            palette = false,
+        },
+    }
+end
+
+return Session

--- a/scripts/brush_studio/shell.lua
+++ b/scripts/brush_studio/shell.lua
@@ -1,0 +1,237 @@
+local Session = dofile("session.lua")
+local Contract = dofile("page_contract.lua")
+local PlaceholderPage = dofile("placeholder_page.lua")
+local Paths = dofile("module_paths.lua")
+local BorderStudioPage = Paths.load("border_studio/page.lua")
+local GroundStudioPage = Paths.load("ground_studio/page.lua")
+local ComposerPage = dofile("composer_page.lua")
+local PalettePage = dofile("palette_page.lua")
+
+local Shell = {}
+
+local palette = {
+    bg = "#2f2f33",
+    header = "#233246",
+    panel = "#2f2f33",
+    panel_alt = "#31455f",
+    sidebar = "#26282d",
+    accent = "#d68000",
+    text = "#f1f1f1",
+    muted = "#b8bcc7",
+    subtle = "#8e97a6",
+}
+
+local function nav_button(dlg, label, active, onclick)
+    dlg:button({
+        text = label,
+        min_width = 110,
+        bgcolor = active and palette.accent or palette.panel_alt,
+        fgcolor = palette.text,
+        onclick = onclick,
+    })
+end
+
+function Shell.open_standalone()
+    local existing_dialog = _G.BRUSH_STUDIO_DIALOG
+    if existing_dialog then
+        pcall(function()
+            existing_dialog:close()
+        end)
+        _G.BRUSH_STUDIO_DIALOG = nil
+        _G.BRUSH_STUDIO_OPEN = false
+        app.yield()
+    end
+
+    if _G.BORDER_STUDIO_DIALOG then
+        pcall(function()
+            _G.BORDER_STUDIO_DIALOG:close()
+        end)
+        _G.BORDER_STUDIO_DIALOG = nil
+        _G.BORDER_STUDIO_OPEN = false
+    end
+    if _G.GROUND_STUDIO_DIALOG then
+        pcall(function()
+            _G.GROUND_STUDIO_DIALOG:close()
+        end)
+        _G.GROUND_STUDIO_DIALOG = nil
+        _G.GROUND_STUDIO_OPEN = false
+    end
+
+    local dlg
+    local session = Session.new()
+    local state = {
+        active_page_key = "borders",
+        shell_status = "Gotowe.",
+    }
+
+    local pages = {}
+
+    local function rebuild()
+        if not dlg then
+            return
+        end
+
+        local active_page = pages[state.active_page_key]
+        dlg:clear()
+
+        dlg:panel({
+            bgcolor = palette.sidebar,
+            padding = 6,
+            margin = 4,
+            expand = false,
+        })
+            dlg:box({
+                orient = "horizontal",
+                expand = true,
+            })
+                dlg:label({
+                    text = "Brush Studio",
+                    fgcolor = palette.text,
+                    font_weight = "bold",
+                    min_width = 120,
+                })
+                nav_button(dlg, "Borders", state.active_page_key == "borders", function()
+                    if state.active_page_key == "borders" then
+                        return
+                    end
+                    local current_page = pages[state.active_page_key]
+                    if current_page and not current_page.confirmLeave() then
+                        return
+                    end
+                    if current_page then
+                        current_page.onLeave(session)
+                    end
+                    state.active_page_key = "borders"
+                    pages[state.active_page_key].onEnter(session)
+                    state.shell_status = "Przelaczono na workflow borderow."
+                    rebuild()
+                end)
+                nav_button(dlg, "Grounds", state.active_page_key == "grounds", function()
+                    if state.active_page_key == "grounds" then
+                        return
+                    end
+                    local current_page = pages[state.active_page_key]
+                    if current_page and not current_page.confirmLeave() then
+                        return
+                    end
+                    if current_page then
+                        current_page.onLeave(session)
+                    end
+                    state.active_page_key = "grounds"
+                    pages[state.active_page_key].onEnter(session)
+                    state.shell_status = "Przelaczono na workflow groundow."
+                    rebuild()
+                end)
+                nav_button(dlg, "Composer", state.active_page_key == "composer", function()
+                    if state.active_page_key == "composer" then
+                        return
+                    end
+                    local current_page = pages[state.active_page_key]
+                    if current_page and not current_page.confirmLeave() then
+                        return
+                    end
+                    if current_page then
+                        current_page.onLeave(session)
+                    end
+                    state.active_page_key = "composer"
+                    pages[state.active_page_key].onEnter(session)
+                    state.shell_status = "Przelaczono na workflow composera."
+                    rebuild()
+                end)
+                nav_button(dlg, "Palette", state.active_page_key == "palette", function()
+                    if state.active_page_key == "palette" then
+                        return
+                    end
+                    local current_page = pages[state.active_page_key]
+                    if current_page and not current_page.confirmLeave() then
+                        return
+                    end
+                    if current_page then
+                        current_page.onLeave(session)
+                    end
+                    state.active_page_key = "palette"
+                    pages[state.active_page_key].onEnter(session)
+                    state.shell_status = "Przelaczono na workflow publikacji palety."
+                    rebuild()
+                end)
+                dlg:label({
+                    text = string.format(
+                        "RAW %d | B %s | G %s | C %s",
+                        tonumber(session.lastSelectedRaw or 0) or 0,
+                        session.lastSavedBorder and ("#" .. tostring(session.lastSavedBorder)) or "-",
+                        tostring(session.lastSavedGround or "-"),
+                        tostring(session.lastSavedComposedBrush or "-")
+                    ),
+                    fgcolor = palette.muted,
+                    min_width = 260,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+
+        if state.shell_status and state.shell_status ~= "" then
+            dlg:label({
+                text = state.shell_status,
+                fgcolor = palette.subtle,
+            })
+            dlg:newrow()
+        end
+
+        active_page.render_into(dlg)
+
+        dlg:label({
+            text = string.format(
+                "Dirty: B=%s | G=%s | C=%s | P=%s",
+                session.pageDirty and session.pageDirty.borders and "tak" or "nie",
+                session.pageDirty and session.pageDirty.grounds and "tak" or "nie",
+                session.pageDirty and session.pageDirty.composer and "tak" or "nie",
+                session.pageDirty and session.pageDirty.palette and "tak" or "nie"
+            ),
+            fgcolor = palette.subtle,
+        })
+
+        dlg:layout()
+        dlg:repaint()
+    end
+
+    pages.borders = Contract.assert_page(BorderStudioPage.create({
+        session = session,
+        onRequestRender = rebuild,
+    }), "Borders")
+    pages.grounds = Contract.assert_page(GroundStudioPage.create({
+        session = session,
+        onRequestRender = rebuild,
+    }), "Grounds")
+    pages.composer = Contract.assert_page(ComposerPage.create({
+        session = session,
+        onRequestRender = rebuild,
+    }), "Composer")
+    pages.palette = Contract.assert_page(PalettePage.create({
+        session = session,
+        onRequestRender = rebuild,
+    }), "Palette")
+
+    dlg = Dialog({
+        title = "Brush Studio",
+        id = "brush_studio_dock",
+        width = 1700,
+        height = 960,
+        resizable = true,
+        dockable = true,
+        onclose = function()
+            local active_page = pages[state.active_page_key]
+            if active_page then
+                active_page.onLeave(session)
+            end
+            _G.BRUSH_STUDIO_OPEN = false
+            _G.BRUSH_STUDIO_DIALOG = nil
+        end,
+    })
+
+    _G.BRUSH_STUDIO_OPEN = true
+    _G.BRUSH_STUDIO_DIALOG = dlg
+    pages[state.active_page_key].onEnter(session)
+    rebuild()
+    dlg:show({ wait = false, center = "screen" })
+end
+
+return Shell

--- a/scripts/brush_studio/shell.lua
+++ b/scripts/brush_studio/shell.lua
@@ -4,6 +4,7 @@ local PlaceholderPage = dofile("placeholder_page.lua")
 local Paths = dofile("module_paths.lua")
 local BorderStudioPage = Paths.load("border_studio/page.lua")
 local GroundStudioPage = Paths.load("ground_studio/page.lua")
+local WallStudioPage = Paths.load("wall_studio/page.lua")
 local ComposerPage = dofile("composer_page.lua")
 local PalettePage = dofile("palette_page.lua")
 
@@ -138,6 +139,31 @@ function Shell.open_standalone()
                     state.shell_status = "Przelaczono na workflow composera."
                     rebuild()
                 end)
+                dlg:panel({
+                    bgcolor = palette.sidebar,
+                    padding = 0,
+                    margin = 0,
+                    min_width = 44,
+                    max_width = 44,
+                    expand = false,
+                })
+                dlg:endpanel()
+                nav_button(dlg, "Walls", state.active_page_key == "walls", function()
+                    if state.active_page_key == "walls" then
+                        return
+                    end
+                    local current_page = pages[state.active_page_key]
+                    if current_page and not current_page.confirmLeave() then
+                        return
+                    end
+                    if current_page then
+                        current_page.onLeave(session)
+                    end
+                    state.active_page_key = "walls"
+                    pages[state.active_page_key].onEnter(session)
+                    state.shell_status = "Przelaczono na workflow scian."
+                    rebuild()
+                end)
                 nav_button(dlg, "Palette", state.active_page_key == "palette", function()
                     if state.active_page_key == "palette" then
                         return
@@ -156,14 +182,15 @@ function Shell.open_standalone()
                 end)
                 dlg:label({
                     text = string.format(
-                        "RAW %d | B %s | G %s | C %s",
+                        "RAW %d | B %s | G %s | C %s | W %s",
                         tonumber(session.lastSelectedRaw or 0) or 0,
                         session.lastSavedBorder and ("#" .. tostring(session.lastSavedBorder)) or "-",
                         tostring(session.lastSavedGround or "-"),
-                        tostring(session.lastSavedComposedBrush or "-")
+                        tostring(session.lastSavedComposedBrush or "-"),
+                        tostring(session.lastSavedWall or "-")
                     ),
                     fgcolor = palette.muted,
-                    min_width = 260,
+                    min_width = 360,
                 })
             dlg:endbox()
         dlg:endpanel()
@@ -180,11 +207,12 @@ function Shell.open_standalone()
 
         dlg:label({
             text = string.format(
-                "Dirty: B=%s | G=%s | C=%s | P=%s",
+                "Dirty: B=%s | G=%s | C=%s | P=%s | W=%s",
                 session.pageDirty and session.pageDirty.borders and "tak" or "nie",
                 session.pageDirty and session.pageDirty.grounds and "tak" or "nie",
                 session.pageDirty and session.pageDirty.composer and "tak" or "nie",
-                session.pageDirty and session.pageDirty.palette and "tak" or "nie"
+                session.pageDirty and session.pageDirty.palette and "tak" or "nie",
+                session.pageDirty and session.pageDirty.walls and "tak" or "nie"
             ),
             fgcolor = palette.subtle,
         })
@@ -205,6 +233,10 @@ function Shell.open_standalone()
         session = session,
         onRequestRender = rebuild,
     }), "Composer")
+    pages.walls = Contract.assert_page(WallStudioPage.create({
+        session = session,
+        onRequestRender = rebuild,
+    }), "Walls")
     pages.palette = Contract.assert_page(PalettePage.create({
         session = session,
         onRequestRender = rebuild,

--- a/scripts/brush_studio/xml_target_helper.lua
+++ b/scripts/brush_studio/xml_target_helper.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+local function normalize(path)
+    return tostring(path or ""):gsub("\\", "/")
+end
+
+local function lower_path(path)
+    return string.lower(normalize(path))
+end
+
+function M.is_xml_file(path)
+    return lower_path(path):match("%.xml$") ~= nil
+end
+
+function M.matches_expected_filename(path, expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return true
+    end
+    local normalized = lower_path(path)
+    local suffix = "/" .. string.lower(expected_filename)
+    return normalized:sub(-#suffix) == suffix or normalized == string.lower(expected_filename)
+end
+
+function M.is_inside_data_dir(path)
+    local data_dir = lower_path(app.getDataDirectory() or "")
+    local normalized = lower_path(path)
+    if data_dir == "" then
+        return false
+    end
+    if normalized == data_dir then
+        return true
+    end
+    return normalized:sub(1, #data_dir + 1) == (data_dir .. "/")
+end
+
+function M.default_xml_wildcard(expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return "XML files (*.xml)|*.xml|All files (*.*)|*.*"
+    end
+    return string.format("%s (%s)|%s|XML files (*.xml)|*.xml|All files (*.*)|*.*", expected_filename, expected_filename, expected_filename)
+end
+
+function M.pick_xml_file(expected_filename, current_path, title)
+    if not app or not app.chooseFile then
+        return nil, "This RME build does not expose file picker support."
+    end
+
+    local chosen = app.chooseFile({
+        title = title or "Select XML file",
+        path = normalize(current_path),
+        wildcard = M.default_xml_wildcard(expected_filename),
+    })
+
+    if not chosen or chosen == "" then
+        return nil
+    end
+
+    chosen = normalize(chosen)
+    if not M.is_xml_file(chosen) then
+        return nil, "Wybrany plik musi byc plikiem XML."
+    end
+    if not M.matches_expected_filename(chosen, expected_filename) then
+        return nil, string.format("Wybierz plik '%s'.", tostring(expected_filename or ""))
+    end
+    if not M.is_inside_data_dir(chosen) then
+        return nil, "Wybrany plik musi znajdowac sie w aktualnym katalogu data tego RME."
+    end
+
+    return chosen
+end
+
+return M

--- a/scripts/ground_studio/common.lua
+++ b/scripts/ground_studio/common.lua
@@ -1,0 +1,328 @@
+local M = {}
+M._image_cache = M._image_cache or {}
+
+M.palette = {
+    header = "#1F2937",
+    panel = "#243447",
+    panel_alt = "#2C3E50",
+    accent = "#0F766E",
+    accent_soft = "#14B8A6",
+    success = "#2F855A",
+    danger = "#C53030",
+    text = "#F8FAFC",
+    muted = "#CBD5E1",
+    subtle = "#94A3B8",
+    border = "#475569",
+}
+
+function M.clone(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, inner in pairs(value) do
+        copy[key] = M.clone(inner)
+    end
+    return copy
+end
+
+function M.trim(value)
+    return tostring(value or ""):match("^%s*(.-)%s*$")
+end
+
+function M.normalize_path(path)
+    path = tostring(path or ""):gsub("\\", "/")
+    return string.lower(path)
+end
+
+function M.path_starts_with(path, prefix)
+    local lhs = M.normalize_path(path)
+    local rhs = M.normalize_path(prefix)
+    return lhs:sub(1, #rhs) == rhs
+end
+
+function M.normalize_bool(value, default)
+    if value == nil then
+        return default and true or false
+    end
+    if type(value) == "boolean" then
+        return value
+    end
+
+    local text = string.lower(tostring(value))
+    return text == "1" or text == "true" or text == "yes" or text == "on"
+end
+
+function M.safe_item_name(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return ""
+    end
+    return Items.getName(item_id) or ""
+end
+
+function M.safe_item_info(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    return Items.getInfo(item_id)
+end
+
+function M.safe_image(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+    if not M._image_cache[item_id] then
+        M._image_cache[item_id] = Image.fromItemSprite(item_id)
+    end
+    return M._image_cache[item_id]
+end
+
+function M.active_raw_brush_id()
+    local brush = app and app.brush or nil
+    if not brush or brush.type ~= "raw" then
+        return 0
+    end
+
+    local parsed = tonumber(tostring(brush.name or ""):match("^(%d+)"))
+    if parsed and parsed > 0 then
+        return parsed
+    end
+
+    local fallback = tonumber(brush.id or 0) or 0
+    if fallback > 0 and Items and Items.exists and Items.exists(fallback) then
+        return fallback
+    end
+
+    return 0
+end
+
+function M.escape_xml(value)
+    value = tostring(value or "")
+    value = value:gsub("&", "&amp;")
+    value = value:gsub("<", "&lt;")
+    value = value:gsub(">", "&gt;")
+    value = value:gsub('"', "&quot;")
+    value = value:gsub("'", "&apos;")
+    return value
+end
+
+function M.unescape_xml(value)
+    value = tostring(value or "")
+    value = value:gsub("&apos;", "'")
+    value = value:gsub("&quot;", '"')
+    value = value:gsub("&gt;", ">")
+    value = value:gsub("&lt;", "<")
+    value = value:gsub("&amp;", "&")
+    return value
+end
+
+function M.ground_status(draft)
+    if not draft or draft:isEmpty() then
+        return "empty"
+    end
+    if #draft.variants > 0 then
+        return "variants"
+    end
+    return "basic"
+end
+
+function M.format_ground_title(draft)
+    if not draft then
+        return "No ground"
+    end
+    local suffix = draft.isNew and " (new)" or ""
+    return string.format("%s%s", draft.name ~= "" and draft.name or "Untitled ground", suffix)
+end
+
+function M.primary_item_id(draft)
+    if not draft then
+        return 0
+    end
+    if draft.mainGroundItem and draft.mainGroundItem.itemId then
+        return draft.mainGroundItem.itemId
+    end
+    if draft.mainItem and draft.mainItem.itemId then
+        return draft.mainItem.itemId
+    end
+    if draft.variants and draft.variants[1] and draft.variants[1].itemId then
+        return draft.variants[1].itemId
+    end
+    return 0
+end
+
+function M.recent_raw_items(recent_raw_ids)
+    local items = {}
+    for _, item_id in ipairs(recent_raw_ids or {}) do
+        item_id = tonumber(item_id or 0) or 0
+        if item_id > 0 then
+            local name = M.safe_item_name(item_id)
+            table.insert(items, {
+                text = string.format("%d  |  %s", item_id, name ~= "" and name or ("Item " .. tostring(item_id))),
+                tooltip = string.format("Item ID %d", item_id),
+                image = M.safe_image(item_id),
+            })
+        end
+    end
+    return items
+end
+
+function M.variant_list_items(draft)
+    local items = {}
+    for index, variant in ipairs(draft and draft.variants or {}) do
+        local name = variant.name or ("Item " .. tostring(variant.itemId or 0))
+        table.insert(items, {
+            text = string.format("%d. %s  |  chance %d", index, name, tonumber(variant.chance or 0) or 0),
+            tooltip = string.format("Item ID %d\nChance %d", tonumber(variant.itemId or 0) or 0, tonumber(variant.chance or 0) or 0),
+            image = M.safe_image(variant.itemId or 0),
+        })
+    end
+    return items
+end
+
+function M.variant_preview_items(draft)
+    local items = {}
+    local variants = draft and draft.variants or {}
+    local preview_limit = math.min(#variants, 6)
+    for index = 1, preview_limit do
+        local variant = variants[index]
+        local chance = tonumber(variant.chance or 0) or 0
+        table.insert(items, {
+            text = string.format("chance %d", chance),
+            tooltip = string.format("%s\nItem %d\nChance %d", variant.name or "Variant", tonumber(variant.itemId or 0) or 0, chance),
+            image = M.safe_image(variant.itemId or 0),
+        })
+    end
+    if #variants > preview_limit then
+        table.insert(items, {
+            text = string.format("+%d", #variants - preview_limit),
+            tooltip = string.format("Pozostale warianty: %d", #variants - preview_limit),
+            image = nil,
+        })
+    end
+    return items
+end
+
+function M.surface_preview_items(draft)
+    local items = {}
+    local main_id = draft and draft.mainGroundItem and draft.mainGroundItem.itemId or 0
+    if not draft or main_id <= 0 then
+        for _ = 1, 25 do
+            table.insert(items, {
+                text = "",
+                tooltip = "No main ground selected",
+                image = nil,
+            })
+        end
+        return items
+    end
+
+    local weighted_pool = {}
+    for _, entry in ipairs(draft:getAllItems() or {}) do
+        local item_id = tonumber(entry.itemId or 0) or 0
+        if item_id > 0 then
+            table.insert(weighted_pool, {
+                itemId = item_id,
+                chance = math.max(1, tonumber(entry.chance or 0) or 0),
+                name = entry.name or ("Item " .. tostring(item_id)),
+            })
+        end
+    end
+
+    if #weighted_pool == 0 then
+        table.insert(weighted_pool, {
+            itemId = main_id,
+            chance = 1,
+            name = M.safe_item_name(main_id),
+        })
+    end
+
+    local total_weight = 0
+    for _, entry in ipairs(weighted_pool) do
+        total_weight = total_weight + entry.chance
+    end
+
+    for index = 1, 25 do
+        local chosen = weighted_pool[1]
+        if draft.randomize then
+            local pick = (((index - 1) * 137) + (main_id * 17)) % total_weight + 1
+            local acc = 0
+            for _, entry in ipairs(weighted_pool) do
+                acc = acc + entry.chance
+                if pick <= acc then
+                    chosen = entry
+                    break
+                end
+            end
+        end
+
+        if index == 13 then
+            chosen = {
+                itemId = main_id,
+                chance = tonumber(draft.mainChance or 0) or 0,
+                name = (draft.mainGroundItem and draft.mainGroundItem.name) or M.safe_item_name(main_id),
+            }
+        end
+
+        table.insert(items, {
+            text = "",
+            tooltip = string.format("%s\nItem %d\nChance %d", chosen.name or "Ground", chosen.itemId or 0, chosen.chance or 0),
+            image = M.safe_image(chosen.itemId or 0),
+        })
+    end
+
+    return items
+end
+
+function M.ground_set_items(draft)
+    local items = {}
+    if not draft then
+        return items
+    end
+
+    local main = draft.mainGroundItem
+    if main and tonumber(main.itemId or 0) > 0 then
+        table.insert(items, {
+            text = string.format("Main  |  %s  |  chance %d", main.name or ("Item " .. tostring(main.itemId or 0)), tonumber(draft.mainChance or 0) or 0),
+            tooltip = string.format("Main Ground\nItem %d\nChance %d", tonumber(main.itemId or 0) or 0, tonumber(draft.mainChance or 0) or 0),
+            image = M.safe_image(main.itemId or 0),
+        })
+    end
+
+    for index, variant in ipairs(draft.variants or {}) do
+        local chance = tonumber(variant.chance or 0) or 0
+        table.insert(items, {
+            text = string.format("Var %d  |  %s  |  chance %d", index, variant.name or ("Item " .. tostring(variant.itemId or 0)), chance),
+            tooltip = string.format("Variant %d\nItem %d\nChance %d", index, tonumber(variant.itemId or 0) or 0, chance),
+            image = M.safe_image(variant.itemId or 0),
+        })
+    end
+
+    return items
+end
+
+function M.current_step(state)
+    if not state.draft then
+        return 1
+    end
+
+    if not state.draft:hasMainItem() then
+        return 2
+    end
+
+    if #state.draft.variants == 0 then
+        return 4
+    end
+
+    if not state.draft:hasRequiredDataForSave() then
+        return 5
+    end
+
+    return 6
+end
+
+return M

--- a/scripts/ground_studio/ground_draft.lua
+++ b/scripts/ground_studio/ground_draft.lua
@@ -1,0 +1,357 @@
+local Common = dofile("common.lua")
+
+local GroundDraft = {}
+GroundDraft.__index = GroundDraft
+
+local function build_item_reference(raw_item)
+    if type(raw_item) == "table" then
+        local item_id = tonumber(raw_item.itemId or raw_item.item_id or raw_item.id or 0) or 0
+        if item_id <= 0 then
+            return nil
+        end
+        local info = Common.safe_item_info(item_id)
+        return {
+            itemId = item_id,
+            rawId = tonumber(raw_item.rawId or raw_item.raw_id or item_id) or item_id,
+            lookId = tonumber(raw_item.lookId or raw_item.look_id or raw_item.clientId or (info and info.clientId) or 0) or 0,
+            name = raw_item.name or (info and info.name) or ("Item " .. tostring(item_id)),
+        }
+    end
+
+    local item_id = tonumber(raw_item or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+local function normalize_chance(value, default)
+    local chance = tonumber(value or default or 1) or tonumber(default or 1) or 1
+    chance = math.floor(chance)
+    if chance <= 0 then
+        chance = tonumber(default or 1) or 1
+        chance = math.floor(chance)
+        if chance <= 0 then
+            chance = 1
+        end
+    end
+    return chance
+end
+
+local function sync_main_aliases(self, reference)
+    self.mainGroundItem = reference
+    self.mainItem = reference
+end
+
+local function clone_variant(variant)
+    local copy = Common.clone(variant)
+    copy.chance = normalize_chance(copy.chance, 1)
+    return copy
+end
+
+function GroundDraft.new(init)
+    local self = setmetatable({}, GroundDraft)
+    self.groundId = tonumber((init and (init.groundId or init.ground_id or init.id)) or 0) or 0
+    self.name = Common.trim(init and init.name or "")
+    sync_main_aliases(self, build_item_reference(init and (init.mainGroundItem or init.main_ground_item or init.mainItem)))
+    self.mainChance = normalize_chance(init and (init.mainChance or init.main_chance), 1)
+    self.variants = {}
+    self.lookId = tonumber((init and (init.lookId or init.look_id)) or 0) or 0
+    self.serverLookId = tonumber((init and (init.serverLookId or init.server_lookid)) or 0) or 0
+    self.zOrder = tonumber((init and (init.zOrder or init["z-order"] or init.z_order)) or 0) or 0
+    self.randomize = Common.normalize_bool(init and init.randomize, true)
+    self.soloOptional = Common.normalize_bool(init and (init.soloOptional or init.solo_optional), false)
+    self.extraChildrenXml = tostring((init and (init.extraChildrenXml or init.extra_children_xml)) or "")
+    self.isNew = Common.normalize_bool(init and init.isNew, true)
+    self.sourceName = Common.trim(init and (init.sourceName or init.source_name or init.name) or "")
+
+    for _, variant in ipairs((init and init.variants) or {}) do
+        self:addVariant(variant, variant.chance)
+    end
+
+    if self.mainGroundItem then
+        if self.lookId <= 0 then
+            self.lookId = self.mainGroundItem.lookId or 0
+        end
+        if self.serverLookId <= 0 then
+            self.serverLookId = self.mainGroundItem.itemId or 0
+        end
+    end
+
+    return self
+end
+
+function GroundDraft:clear()
+    self.name = ""
+    sync_main_aliases(self, nil)
+    self.mainChance = 1
+    self.variants = {}
+    self.lookId = 0
+    self.serverLookId = 0
+    self.zOrder = 0
+    self.randomize = true
+    self.soloOptional = false
+    self.extraChildrenXml = ""
+end
+
+function GroundDraft:setName(name)
+    self.name = Common.trim(name)
+end
+
+function GroundDraft:setMainGround(raw_item)
+    local reference = build_item_reference(raw_item)
+    if not reference then
+        return false
+    end
+    sync_main_aliases(self, reference)
+    if self.lookId <= 0 then
+        self.lookId = reference.lookId or 0
+    end
+    if self.serverLookId <= 0 then
+        self.serverLookId = reference.itemId or 0
+    end
+    return true
+end
+
+function GroundDraft:setMainItem(raw_item)
+    return self:setMainGround(raw_item)
+end
+
+function GroundDraft:clearMainItem()
+    sync_main_aliases(self, nil)
+end
+
+function GroundDraft:setMainChance(chance)
+    self.mainChance = normalize_chance(chance, self.mainChance)
+end
+
+function GroundDraft:findVariantByItem(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+    for index, variant in ipairs(self.variants) do
+        if tonumber(variant.itemId or 0) == item_id then
+            return index, variant
+        end
+    end
+    return nil
+end
+
+function GroundDraft:addVariant(raw_item, chance)
+    local reference = build_item_reference(raw_item)
+    if not reference then
+        return false, "Invalid ground variant item."
+    end
+    if self.mainGroundItem and self.mainGroundItem.itemId == reference.itemId then
+        return false, "This item is already used as the main ground tile."
+    end
+    if self:findVariantByItem(reference.itemId) then
+        return false, "This variant already exists."
+    end
+
+    reference.chance = normalize_chance(chance, 1)
+    table.insert(self.variants, reference)
+    return true
+end
+
+function GroundDraft:updateVariant(index, raw_item, chance)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #self.variants then
+        return false, "Variant index is out of range."
+    end
+
+    local reference = build_item_reference(raw_item)
+    if not reference then
+        return false, "Invalid ground variant item."
+    end
+    if self.mainGroundItem and self.mainGroundItem.itemId == reference.itemId then
+        return false, "This item is already used as the main ground tile."
+    end
+
+    local existing_index = self:findVariantByItem(reference.itemId)
+    if existing_index and existing_index ~= index then
+        return false, "This variant already exists."
+    end
+
+    reference.chance = normalize_chance(chance, self.variants[index].chance or 1)
+    self.variants[index] = reference
+    return true
+end
+
+function GroundDraft:removeVariant(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #self.variants then
+        return false
+    end
+    table.remove(self.variants, index)
+    return true
+end
+
+function GroundDraft:setVariantChance(index, chance)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #self.variants then
+        return false
+    end
+    self.variants[index].chance = normalize_chance(chance, self.variants[index].chance)
+    return true
+end
+
+function GroundDraft:normalizeChancesIfNeeded()
+    self.mainChance = normalize_chance(self.mainChance, 1)
+    for index, variant in ipairs(self.variants) do
+        self.variants[index].chance = normalize_chance(variant.chance, 1)
+    end
+end
+
+function GroundDraft:setLookId(value)
+    self.lookId = tonumber(value or 0) or 0
+end
+
+function GroundDraft:setServerLookId(value)
+    self.serverLookId = tonumber(value or 0) or 0
+end
+
+function GroundDraft:setZOrder(value)
+    self.zOrder = tonumber(value or 0) or 0
+end
+
+function GroundDraft:setRandomize(value)
+    self.randomize = Common.normalize_bool(value, self.randomize)
+end
+
+function GroundDraft:setSoloOptional(value)
+    self.soloOptional = Common.normalize_bool(value, self.soloOptional)
+end
+
+function GroundDraft:hasMainItem()
+    return self.mainGroundItem ~= nil and tonumber(self.mainGroundItem.itemId or 0) > 0
+end
+
+function GroundDraft:isEmpty()
+    return not self:hasMainItem() and #self.variants == 0
+end
+
+function GroundDraft:getValidation()
+    local errors = {}
+    local warnings = {}
+
+    if self.name == "" then
+        table.insert(errors, "Nazwa grounda nie moze byc pusta.")
+    end
+    if not self:hasMainItem() then
+        table.insert(errors, "Main ground tile nie moze byc pusty.")
+    end
+
+    if self.mainGroundItem and (tonumber(self.mainGroundItem.itemId or 0) or 0) <= 0 then
+        table.insert(errors, "Main ground tile ma niepoprawny item id.")
+    end
+
+    local seen = {}
+    for index, variant in ipairs(self.variants) do
+        local item_id = tonumber(variant.itemId or 0) or 0
+        local chance = tonumber(variant.chance or 0) or 0
+        if item_id <= 0 then
+            table.insert(errors, string.format("Wariant %d ma niepoprawny item id.", index))
+        end
+        if chance <= 0 then
+            table.insert(errors, string.format("Wariant %d ma niepoprawny chance.", index))
+        end
+        if item_id > 0 then
+            if seen[item_id] then
+                table.insert(errors, string.format("Wariant %d duplikuje item %d.", index, item_id))
+            end
+            seen[item_id] = true
+        end
+    end
+
+    if self.mainGroundItem and seen[self.mainGroundItem.itemId] then
+        table.insert(errors, "Wariant nie moze duplikowac glownego ground tile.")
+    end
+
+    return {
+        hasData = not self:isEmpty(),
+        isValid = #errors == 0,
+        errors = errors,
+        warnings = warnings,
+    }
+end
+
+function GroundDraft:hasRequiredDataForSave()
+    return self:getValidation().isValid
+end
+
+function GroundDraft:getAllItems()
+    self:normalizeChancesIfNeeded()
+    local items = {}
+    if self.mainGroundItem then
+        local main = Common.clone(self.mainGroundItem)
+        main.chance = normalize_chance(self.mainChance, 1)
+        table.insert(items, main)
+    end
+    for _, variant in ipairs(self.variants) do
+        table.insert(items, clone_variant(variant))
+    end
+    return items
+end
+
+function GroundDraft:clone()
+    return GroundDraft.new({
+        groundId = self.groundId,
+        name = self.name,
+        mainGroundItem = self.mainGroundItem and Common.clone(self.mainGroundItem) or nil,
+        mainChance = self.mainChance,
+        variants = Common.clone(self.variants),
+        lookId = self.lookId,
+        serverLookId = self.serverLookId,
+        zOrder = self.zOrder,
+        randomize = self.randomize,
+        soloOptional = self.soloOptional,
+        extraChildrenXml = self.extraChildrenXml,
+        isNew = self.isNew,
+        sourceName = self.sourceName,
+    })
+end
+
+function GroundDraft:toSaveData()
+    return {
+        groundId = self.groundId,
+        name = self.name,
+        mainGroundItem = self.mainGroundItem and Common.clone(self.mainGroundItem) or nil,
+        mainChance = self.mainChance,
+        variants = Common.clone(self.variants),
+        lookId = self.lookId,
+        serverLookId = self.serverLookId,
+        zOrder = self.zOrder,
+        randomize = self.randomize,
+        soloOptional = self.soloOptional,
+        extraChildrenXml = self.extraChildrenXml,
+        sourceName = self.sourceName,
+    }
+end
+
+function GroundDraft:toXmlGroundData()
+    self:normalizeChancesIfNeeded()
+    return {
+        groundId = self.groundId,
+        name = self.name,
+        mainGroundItem = self.mainGroundItem and Common.clone(self.mainGroundItem) or nil,
+        variants = Common.clone(self.variants),
+        lookId = self.lookId,
+        serverLookId = self.serverLookId,
+        zOrder = self.zOrder,
+        randomize = self.randomize,
+        soloOptional = self.soloOptional,
+        extraChildrenXml = self.extraChildrenXml,
+        sourceName = self.sourceName,
+        items = self:getAllItems(),
+    }
+end
+
+return GroundDraft

--- a/scripts/ground_studio/library_panel.lua
+++ b/scripts/ground_studio/library_panel.lua
@@ -1,0 +1,139 @@
+local Common = dofile("common.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    dlg:box({
+        label = "1. Wybierz Ground",
+        orient = "vertical",
+        width = 320,
+        min_width = 300,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            text = "Wybierz gotowy ground albo utworz nowy draft.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "ground_library_filter",
+            label = "Search",
+            text = state.filter_text or "",
+            expand = true,
+            onchange = function(d)
+                actions.set_filter(d.data.ground_library_filter or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "<",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.previous_library_page()
+                end,
+            })
+            dlg:label({
+                id = "ground_library_page_label",
+                text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+                fgcolor = Common.palette.subtle,
+                min_width = 120,
+                align = "center",
+            })
+            dlg:button({
+                text = ">",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.next_library_page()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:label({
+            text = "Zaznacz wpis z listy, potem kliknij 'Otworz Zaznaczony'.",
+            fgcolor = Common.palette.subtle,
+            font_size = 8,
+        })
+        dlg:newrow()
+        dlg:list({
+            id = "ground_library",
+            height = 720,
+            expand = true,
+            icon_size = 32,
+            item_height = 40,
+            items = state.library_items,
+            selection = state.library_selection,
+            onchange = function(d)
+                local index = d.data.ground_library or 0
+                Logger.log("library", string.format("onchange index=%s selected_name=%s", tostring(index), tostring(state.library_visible_names[index] or "")))
+                actions.handle_library_change(index)
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Nowy Ground",
+                bgcolor = Common.palette.accent,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.new_ground()
+                end,
+            })
+            dlg:button({
+                text = "Duplikuj Ground",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.duplicate_current()
+                end,
+            })
+            dlg:button({
+                text = "Otworz Zaznaczony",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.open_selected_ground()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Aktualnie edytujesz",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_ground_title",
+                text = Common.format_ground_title(state.draft),
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_ground_status",
+                text = "Status: " .. Common.ground_status(state.draft),
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/ground_studio/logger.lua
+++ b/scripts/ground_studio/logger.lua
@@ -1,0 +1,57 @@
+local M = {}
+
+local STORE = app.storage("ground_studio.log")
+local MAX_LINES = 400
+
+local function lines_buffer()
+    if type(_G.GROUND_STUDIO_LOG_LINES) ~= "table" then
+        _G.GROUND_STUDIO_LOG_LINES = {}
+    end
+    return _G.GROUND_STUDIO_LOG_LINES
+end
+
+local function now_ms()
+    if app and app.getTime then
+        local ok, value = pcall(app.getTime)
+        if ok then
+            return tonumber(value or 0) or 0
+        end
+    end
+    return 0
+end
+
+local function flush(lines)
+    if STORE and STORE.save then
+        STORE:save(table.concat(lines, "\n"))
+    end
+end
+
+function M.reset(reason)
+    local lines = lines_buffer()
+    for index = #lines, 1, -1 do
+        lines[index] = nil
+    end
+    if reason and reason ~= "" then
+        M.log("session", "reset: " .. tostring(reason))
+    else
+        flush(lines)
+    end
+end
+
+function M.log(scope, message)
+    local lines = lines_buffer()
+    local line = string.format("[%06d] [%s] %s", now_ms(), tostring(scope or "log"), tostring(message or ""))
+    table.insert(lines, line)
+    while #lines > MAX_LINES do
+        table.remove(lines, 1)
+    end
+
+    print("[Ground Studio] " .. line)
+    flush(lines)
+end
+
+function M.path()
+    return STORE and STORE.path or "ground_studio.log"
+end
+
+return M

--- a/scripts/ground_studio/main.lua
+++ b/scripts/ground_studio/main.lua
@@ -1,0 +1,3 @@
+local GroundStudioPage = dofile("page.lua")
+
+GroundStudioPage.open_standalone()

--- a/scripts/ground_studio/manifest.lua
+++ b/scripts/ground_studio/manifest.lua
@@ -1,0 +1,9 @@
+return {
+    name = "Ground Studio",
+    description = "A focused step-by-step ground brush editor for RME.",
+    author = "Fr0st",
+    version = "0.1.0",
+    main = "main.lua",
+    shortcut = "Ctrl+Alt+G",
+    autorun = false
+}

--- a/scripts/ground_studio/model.lua
+++ b/scripts/ground_studio/model.lua
@@ -1,0 +1,67 @@
+local Common = dofile("common.lua")
+local Repository = dofile("repository.lua")
+
+local M = {}
+
+local SETTINGS_STORE = app.storage("settings.json")
+
+function M.load_settings()
+    return SETTINGS_STORE:load() or {}
+end
+
+function M.save_settings(state)
+    SETTINGS_STORE:save({
+        target_path = state.target_path or "",
+        last_ground_name = state.draft and state.draft.name or "",
+        recent_raw_ids = state.recent_raw_ids or {},
+    })
+end
+
+function M.resolve_target_path(saved_path)
+    return Repository.resolve_target_path(saved_path)
+end
+
+function M.read_repository(target_path, session_grounds)
+    return Repository.read(target_path, session_grounds)
+end
+
+function M.new_draft(repository, session_grounds)
+    return Repository.new_draft(repository, session_grounds)
+end
+
+function M.load_draft(repository, name)
+    return Repository.load_draft(repository, name)
+end
+
+function M.duplicate_draft(repository, session_grounds, draft)
+    return Repository.duplicate_draft(repository, session_grounds, draft)
+end
+
+function M.library_items(repository, filter_text)
+    return Repository.library_items(repository, filter_text)
+end
+
+function M.save_intent(repository, draft, mode)
+    return Repository.save_intent(repository, draft, mode)
+end
+
+function M.save_draft(repository, session_grounds, draft, mode, target_path)
+    return Repository.save_draft(repository, session_grounds, draft, mode, target_path)
+end
+
+function M.make_raw_reference(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+return M

--- a/scripts/ground_studio/page.lua
+++ b/scripts/ground_studio/page.lua
@@ -1,0 +1,876 @@
+local Common = dofile("common.lua")
+local Model = dofile("model.lua")
+local LibraryPanel = dofile("library_panel.lua")
+local PreviewPanel = dofile("preview_panel.lua")
+local PropertiesPanel = dofile("properties_panel.lua")
+local Logger = dofile("logger.lua")
+
+local GroundStudioPage = {}
+
+local function create_page(options)
+    options = options or {}
+    if options.reset_logger then
+        Logger.reset("startup")
+    end
+    Logger.log("page", "Ground Studio page create")
+
+    local settings = Model.load_settings()
+    local session = options.session or {}
+    local listener_id = nil
+    local dlg
+    local actions = {}
+
+    local state = {
+        filter_text = "",
+        target_path = Model.resolve_target_path(settings.target_path or ""),
+        session_grounds = {},
+        repository = nil,
+        library_filtered_items = {},
+        library_filtered_names = {},
+        library_items = {},
+        library_visible_names = {},
+        library_selection = 0,
+        library_selected_name = "",
+        library_page = 1,
+        library_page_size = 18,
+        library_page_count = 1,
+        draft = nil,
+        variant_selection = 0,
+        selected_variant_chance = "",
+        placement_chance = tostring(settings.main_chance or 1),
+        selected_raw_id = Common.active_raw_brush_id(),
+        recent_raw_ids = Common.clone(settings.recent_raw_ids or {}),
+        status_message = "",
+        dirty = false,
+        rebuilding = false,
+        library_skip_changes = 0,
+    }
+
+local function refresh_repository()
+    Logger.log("main", "refresh_repository")
+    state.repository = Model.read_repository(state.target_path, state.session_grounds)
+end
+
+local function sync_library(preferred_name, allow_draft_fallback)
+    local filtered_items, filtered_names = Model.library_items(state.repository, state.filter_text)
+    state.library_filtered_items = filtered_items
+    state.library_filtered_names = filtered_names
+    local explicit_preferred = preferred_name ~= nil
+    if type(preferred_name) ~= "string" then
+        preferred_name = ""
+    end
+    preferred_name = Common.trim(preferred_name)
+    if preferred_name == "" and not explicit_preferred then
+        preferred_name = Common.trim(state.library_selected_name or "")
+    end
+    if allow_draft_fallback ~= false and preferred_name == "" and state.draft and not state.draft.isNew then
+        preferred_name = state.draft.name
+    end
+
+    local filtered_count = #state.library_filtered_names
+    local page_size = math.max(1, tonumber(state.library_page_size or 18) or 18)
+    state.library_page_count = math.max(1, math.ceil(filtered_count / page_size))
+
+    if preferred_name ~= "" then
+        for absolute_index, name in ipairs(state.library_filtered_names) do
+            if name == preferred_name then
+                state.library_page = math.ceil(absolute_index / page_size)
+                break
+            end
+        end
+    end
+
+    if state.library_page < 1 then
+        state.library_page = 1
+    end
+    if state.library_page > state.library_page_count then
+        state.library_page = state.library_page_count
+    end
+
+    local page_start = ((state.library_page - 1) * page_size) + 1
+    local page_end = math.min(filtered_count, page_start + page_size - 1)
+
+    state.library_items = {}
+    state.library_visible_names = {}
+    for absolute_index = page_start, page_end do
+        table.insert(state.library_items, state.library_filtered_items[absolute_index])
+        table.insert(state.library_visible_names, state.library_filtered_names[absolute_index])
+    end
+
+    state.library_selection = 0
+    if preferred_name ~= "" then
+        for index, name in ipairs(state.library_visible_names) do
+            if name == preferred_name then
+                state.library_selection = index
+                break
+            end
+        end
+    end
+    Logger.log("main", string.format("sync_library filter='%s' filtered=%d page=%d/%d visible=%d selection=%d selected='%s'", tostring(state.filter_text or ""), filtered_count, tonumber(state.library_page or 1), tonumber(state.library_page_count or 1), #state.library_visible_names, tonumber(state.library_selection or 0), tostring(state.library_selected_name or "")))
+end
+
+local function soft_refresh_library()
+    if not dlg then
+        return
+    end
+
+    state.library_skip_changes = 12
+    dlg:modify({
+        ground_library = {
+            items = state.library_items,
+            selection = state.library_selection,
+        },
+        ground_library_page_label = {
+            text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+        },
+    })
+    dlg:layout()
+    dlg:repaint()
+end
+
+local function persist_settings()
+    Model.save_settings(state)
+end
+
+local function sync_session_out()
+    session.lastSelectedRaw = tonumber(state.selected_raw_id or 0) or 0
+    session.recentItems = session.recentItems or {}
+    session.recentItems.groundRawIds = state.recent_raw_ids
+    session.pageDirty = session.pageDirty or {}
+    session.pageDirty.grounds = state.dirty
+    if state.draft and not state.draft.isNew and Common.trim(state.draft.name or "") ~= "" then
+        session.selectedGroundForComposer = state.draft.name
+    end
+end
+
+local function sync_session_in()
+    local shared_raw = tonumber(session.lastSelectedRaw or 0) or 0
+    if shared_raw > 0 then
+        state.selected_raw_id = shared_raw
+    end
+end
+
+local function request_host_render()
+    sync_session_out()
+    if options.onRequestRender then
+        options.onRequestRender()
+        return true
+    end
+    return false
+end
+
+local function confirm_discard()
+    if not state.dirty then
+        return true
+    end
+
+    local choice = app.alert({
+        title = "Discard changes?",
+        text = "The current ground draft has unsaved changes. Continue and discard them?",
+        buttons = { "Yes", "No" },
+    })
+    return choice == 1
+end
+
+local function helper_text()
+    local step = Common.current_step(state)
+    local labels = {
+        "Krok 1: wybierz gotowy ground albo utworz nowy.",
+        "Krok 2: wybierz RAW tile z glownej palety RME.",
+        "Krok 3: ustaw glowny ground tile.",
+        "Krok 4: opcjonalnie dodaj warianty z chance.",
+        "Krok 5: ustaw wlasciwosci i sprawdz preview.",
+        "Krok 6: zapisz ground.",
+    }
+    return labels[step] or labels[1]
+end
+
+local function current_raw_id()
+    return Common.active_raw_brush_id()
+end
+
+local function sync_selected_raw_from_brush(reason)
+    local active = current_raw_id()
+    local current = tonumber(state.selected_raw_id or 0) or 0
+    if active == current then
+        return false
+    end
+    state.selected_raw_id = active
+    Logger.log("main", string.format("sync_selected_raw_from_brush reason=%s raw=%d previous=%d", tostring(reason or "unknown"), active, current))
+    return true
+end
+
+local function selected_variant()
+    local index = tonumber(state.variant_selection or 0) or 0
+    if index <= 0 or not state.draft or index > #state.draft.variants then
+        return nil
+    end
+    return state.draft.variants[index]
+end
+
+local function remember_recent_raw(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return
+    end
+
+    local next_items = { item_id }
+    for _, existing in ipairs(state.recent_raw_ids or {}) do
+        existing = tonumber(existing or 0) or 0
+        if existing > 0 and existing ~= item_id then
+            table.insert(next_items, existing)
+        end
+        if #next_items >= 8 then
+            break
+        end
+    end
+    state.recent_raw_ids = next_items
+end
+
+local function preview_status_text()
+    if not state.draft or not state.draft:hasMainItem() then
+        return "Wybierz glowny ground tile, aby zobaczyc preview."
+    end
+    if #state.draft.variants == 0 then
+        return "Preview pokazuje glowny tile. Warianty sa opcjonalne."
+    end
+    return string.format("Preview pokazuje glowny tile i %d wariant(y).", #state.draft.variants)
+end
+
+local function save_hint_text()
+    if not state.draft or Common.trim(state.draft.name or "") == "" then
+        return "Podaj nazwe grounda, aby zapisac."
+    end
+    if not state.draft:hasMainItem() then
+        return "Wybierz glowny ground tile przed zapisem."
+    end
+    return "Zapis utworzy nowy wpis albo nadpisze istniejacy ground."
+end
+
+local function soft_refresh()
+    if not dlg or not state.draft then
+        return
+    end
+
+    sync_session_out()
+    sync_selected_raw_from_brush("soft_refresh")
+    state.rebuilding = true
+
+    local raw_info = Common.safe_item_info(state.selected_raw_id)
+    local main_item_id = state.draft.mainGroundItem and state.draft.mainGroundItem.itemId or 0
+    local selected_variant = selected_variant()
+
+    state.library_skip_changes = 12
+    dlg:modify({
+        ground_library_page_label = {
+            text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+        },
+        current_ground_title = {
+            text = Common.format_ground_title(state.draft),
+        },
+        current_ground_status = {
+            text = "Status: " .. Common.ground_status(state.draft),
+        },
+        ground_preview_help = {
+            text = helper_text(),
+        },
+        ground_main_preview = {
+            image = Common.safe_image(main_item_id),
+            width = 80,
+            height = 80,
+            smooth = false,
+        },
+        ground_main_label = {
+            text = main_item_id > 0 and string.format("Item ID %d  |  chance %d", main_item_id, tonumber(state.draft.mainChance or 0) or 0) or "Brak glownego tile",
+        },
+        ground_surface_preview = {
+            items = Common.surface_preview_items(state.draft),
+        },
+        ground_preview_status = {
+            text = preview_status_text(),
+        },
+        ground_variant_preview = {
+            items = Common.variant_preview_items(state.draft),
+        },
+        active_raw_preview = {
+            image = Common.safe_image(state.selected_raw_id),
+            width = 48,
+            height = 48,
+            smooth = false,
+        },
+        active_raw_title = {
+            text = raw_info and (raw_info.name or ("Item " .. tostring(state.selected_raw_id))) or "Najpierw wybierz RAW tile",
+        },
+        active_raw_meta = {
+            text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW.",
+        },
+        active_raw_hint = {
+            text = raw_info and "Ten RAW mozesz ustawic jako Main Ground albo dodac jako wariant." or "Najpierw wybierz RAW tile w glownej palecie RME.",
+        },
+        main_ground_preview_side = {
+            image = Common.safe_image(main_item_id),
+            width = 56,
+            height = 56,
+            smooth = false,
+        },
+        main_ground_title = {
+            text = main_item_id > 0 and ((state.draft.mainGroundItem and state.draft.mainGroundItem.name) or ("Item " .. tostring(main_item_id))) or "Brak Main Ground",
+        },
+        main_ground_meta = {
+            text = main_item_id > 0 and string.format("Item ID %d  |  chance %d", main_item_id, tonumber(state.draft.mainChance or 0) or 0) or "Wybierz RAW i kliknij 'Ustaw jako Main Ground'.",
+        },
+        ground_name_input = {
+            text = state.draft.name or "",
+        },
+        ground_variant_list = {
+            items = Common.variant_list_items(state.draft),
+            selection = tonumber(state.variant_selection or 0) or 0,
+        },
+        ground_variant_chance = {
+            text = selected_variant and tostring(selected_variant.chance or "") or "",
+        },
+        placement_chance = {
+            text = tostring(state.placement_chance or state.draft.mainChance or 1),
+        },
+        selected_variant_preview = {
+            image = Common.safe_image(selected_variant and selected_variant.itemId or 0),
+            width = 40,
+            height = 40,
+            smooth = false,
+        },
+        selected_variant_title = {
+            text = selected_variant and (selected_variant.name or ("Item " .. tostring(selected_variant.itemId or 0))) or "Nie wybrano wariantu",
+        },
+        selected_variant_meta = {
+            text = selected_variant and string.format("Item ID %d  |  chance %d", tonumber(selected_variant.itemId or 0) or 0, tonumber(selected_variant.chance or 0) or 0) or "Wybierz wariant z listy, aby edytowac chance.",
+        },
+        variant_hint_label = {
+            text = #state.draft.variants > 0 and "Warianty sa oddzielone od Main Ground. Wybierz wariant z listy, aby edytowac chance." or "Brak wariantow. Wybierz RAW i kliknij 'Dodaj Wariant'.",
+        },
+        recent_raw_list = {
+            items = Common.recent_raw_items(state.recent_raw_ids),
+        },
+        ground_set_list = {
+            items = Common.ground_set_items(state.draft),
+        },
+        ground_lookid_input = {
+            text = tostring(state.draft.lookId or 0),
+        },
+        ground_server_lookid_input = {
+            text = tostring(state.draft.serverLookId or 0),
+        },
+        ground_z_order_input = {
+            text = tostring(state.draft.zOrder or 0),
+        },
+        toggle_randomize_button = {
+            text = state.draft.randomize and "Randomize: ON" or "Randomize: OFF",
+        },
+        toggle_solo_optional_button = {
+            text = state.draft.soloOptional and "Solo Optional: ON" or "Solo Optional: OFF",
+        },
+    })
+    dlg:repaint()
+    state.rebuilding = false
+end
+
+local function soft_refresh_active_raw()
+    if not dlg then
+        return
+    end
+
+    sync_session_out()
+    sync_selected_raw_from_brush("soft_refresh_raw")
+
+    local raw_info = Common.safe_item_info(state.selected_raw_id)
+    dlg:modify({
+        active_raw_preview = {
+            image = Common.safe_image(state.selected_raw_id),
+            width = 48,
+            height = 48,
+            smooth = false,
+        },
+        active_raw_title = {
+            text = raw_info and (raw_info.name or ("Item " .. tostring(state.selected_raw_id))) or "Najpierw wybierz RAW tile",
+        },
+        active_raw_meta = {
+            text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW.",
+        },
+        active_raw_hint = {
+            text = raw_info and "Ten RAW mozesz ustawic jako Main Ground albo dodac jako wariant." or "Najpierw wybierz RAW tile w glownej palecie RME.",
+        },
+    })
+    dlg:repaint()
+end
+
+local function render_page_content()
+    state.rebuilding = true
+    Logger.log("main", string.format("rebuild start ground='%s' dirty=%s", state.draft and state.draft.name or "nil", tostring(state.dirty)))
+    refresh_repository()
+    sync_library()
+    sync_selected_raw_from_brush("rebuild")
+    dlg:panel({
+        bgcolor = Common.palette.header,
+        padding = 10,
+        margin = 4,
+        expand = false,
+    })
+        dlg:label({
+            text = "GROUND STUDIO",
+            fgcolor = Common.palette.text,
+            font_size = 14,
+            font_weight = "bold",
+            align = "center",
+        })
+    dlg:endpanel()
+
+    dlg:box({
+        orient = "horizontal",
+        expand = true,
+    })
+        LibraryPanel.render(dlg, state, actions)
+        PreviewPanel.render(dlg, state)
+        PropertiesPanel.render(dlg, state, actions)
+    dlg:endbox()
+    state.library_skip_changes = 8
+    state.rebuilding = false
+    Logger.log("main", "rebuild done")
+end
+
+local function rebuild()
+    if not dlg then
+        return
+    end
+    if request_host_render() then
+        return
+    end
+
+    dlg:clear()
+    render_page_content()
+    dlg:layout()
+    dlg:repaint()
+end
+
+function actions.set_filter(text)
+    state.filter_text = text or ""
+    state.library_page = 1
+    sync_library("", false)
+    soft_refresh_library()
+end
+
+function actions.previous_library_page()
+    if state.library_page <= 1 then
+        return
+    end
+    state.library_page = state.library_page - 1
+    sync_library("", false)
+    soft_refresh_library()
+end
+
+function actions.next_library_page()
+    if state.library_page >= state.library_page_count then
+        return
+    end
+    state.library_page = state.library_page + 1
+    sync_library("", false)
+    soft_refresh_library()
+end
+
+function actions.set_library_selection(index)
+    index = tonumber(index or 0) or 0
+    state.library_selection = index
+    state.library_selected_name = state.library_visible_names[index] or ""
+end
+
+function actions.handle_library_change(index)
+    index = tonumber(index or 0) or 0
+    if index <= 0 then
+        Logger.log("library", "handle_library_change ignored empty index")
+        return
+    end
+    if state.library_skip_changes > 0 then
+        state.library_skip_changes = state.library_skip_changes - 1
+        Logger.log("library", string.format("handle_library_change skipped programmatic index=%d remaining=%d", index, state.library_skip_changes))
+        return
+    end
+
+    local previous_index = tonumber(state.library_selection or 0) or 0
+    local previous_name = tostring(state.library_selected_name or "")
+    actions.set_library_selection(index)
+
+    if previous_index == index and previous_name == tostring(state.library_selected_name or "") then
+        Logger.log("library", string.format("handle_library_change ignored duplicate index=%d selected_name=%s", index, tostring(state.library_selected_name or "")))
+        return
+    end
+
+    Logger.log("library", string.format("handle_library_change open index=%d selected_name=%s", index, tostring(state.library_selected_name or "")))
+    if state.library_selected_name ~= "" then
+        actions.open_ground(state.library_selected_name)
+    end
+end
+
+function actions.open_selected_ground()
+    if state.library_selected_name == "" then
+        Logger.log("library", "open_selected_ground ignored empty selection")
+        return
+    end
+    Logger.log("library", string.format("open_selected_ground name=%s", tostring(state.library_selected_name or "")))
+    actions.open_ground(state.library_selected_name)
+end
+
+function actions.open_ground(name)
+    name = Common.trim(name)
+    Logger.log("main", string.format("open_ground request name='%s'", tostring(name)))
+    if name == "" then
+        Logger.log("main", "open_ground ignored empty name")
+        return
+    end
+    if state.draft and state.draft.name == name and not state.dirty then
+        Logger.log("main", string.format("open_ground skipped same name='%s'", tostring(name)))
+        return
+    end
+    if not confirm_discard() then
+        Logger.log("main", string.format("open_ground cancelled by discard dialog name='%s'", tostring(name)))
+        return
+    end
+
+    local loaded = Model.load_draft(state.repository, name)
+    if not loaded then
+        Logger.log("main", string.format("open_ground failed missing name='%s'", tostring(name)))
+        app.alert("This ground could not be loaded from grounds.xml.")
+        return
+    end
+
+    Logger.log("main", string.format("open_ground loaded name='%s' variants=%d", tostring(loaded.name or ""), #(loaded.variants or {})))
+    state.draft = loaded
+    state.library_selected_name = loaded.name
+    state.variant_selection = 0
+    state.selected_variant_chance = ""
+    state.placement_chance = tostring(loaded.mainChance or state.placement_chance or 1)
+    state.status_message = string.format("Zaladowano ground '%s' do edycji.", loaded.name)
+    state.dirty = false
+    Logger.log("main", string.format("open_ground before rebuild name='%s'", tostring(loaded.name or "")))
+    rebuild()
+end
+
+function actions.new_ground()
+    if not confirm_discard() then
+        return
+    end
+    state.draft = Model.new_draft(state.repository, state.session_grounds)
+    state.library_selected_name = ""
+    state.variant_selection = 0
+    state.selected_variant_chance = ""
+    state.placement_chance = tostring(state.draft.mainChance or 1)
+    state.status_message = string.format("Utworzono nowy draft '%s'.", state.draft.name)
+    state.dirty = false
+    rebuild()
+end
+
+function actions.duplicate_current()
+    state.draft = Model.duplicate_draft(state.repository, state.session_grounds, state.draft)
+    state.library_selected_name = ""
+    state.variant_selection = 0
+    state.selected_variant_chance = ""
+    state.placement_chance = tostring(state.draft.mainChance or 1)
+    state.status_message = string.format("Zduplikowano ground do nowego draftu '%s'.", state.draft.name)
+    state.dirty = true
+    rebuild()
+end
+
+function actions.use_active_raw_as_main()
+    local raw_id = current_raw_id()
+    local placement_chance = tonumber(state.placement_chance or state.draft.mainChance or 1) or 1
+    if raw_id <= 0 then
+        state.status_message = "Najpierw wybierz RAW tile."
+        soft_refresh()
+        return
+    end
+    if state.draft.mainGroundItem and tonumber(state.draft.mainGroundItem.itemId or 0) == raw_id then
+        state.status_message = string.format("Tile %d jest juz ustawiony jako Main Ground.", raw_id)
+        soft_refresh()
+        return
+    end
+    state.draft:setMainGround(Model.make_raw_reference(raw_id))
+    state.draft:setMainChance(placement_chance)
+    remember_recent_raw(raw_id)
+    state.status_message = string.format("Ustawiono glowny tile %d z chance %d.", raw_id, placement_chance)
+    state.dirty = true
+    soft_refresh()
+end
+
+function actions.add_variant_from_active_raw()
+    local raw_id = current_raw_id()
+    local placement_chance = tonumber(state.placement_chance or 1) or 1
+    if raw_id <= 0 then
+        state.status_message = "Najpierw wybierz RAW tile."
+        soft_refresh()
+        return
+    end
+
+    local ok, message = state.draft:addVariant(Model.make_raw_reference(raw_id), placement_chance)
+    if not ok then
+        state.status_message = message
+        soft_refresh()
+        return
+    end
+
+    remember_recent_raw(raw_id)
+    state.variant_selection = #state.draft.variants
+    state.selected_variant_chance = tostring(state.draft.variants[state.variant_selection].chance or "")
+    state.status_message = string.format("Dodano wariant %d z chance %d.", raw_id, placement_chance)
+    state.dirty = true
+    soft_refresh()
+end
+
+function actions.set_name(name)
+    if not state.draft then
+        return
+    end
+    state.draft:setName(name)
+    state.dirty = true
+    sync_session_out()
+end
+
+function actions.set_placement_chance(text)
+    state.placement_chance = tostring(text or "")
+    sync_session_out()
+end
+
+function actions.set_variant_selection(index)
+    state.variant_selection = tonumber(index or 0) or 0
+    local variant = selected_variant()
+    state.selected_variant_chance = variant and tostring(variant.chance or "") or ""
+    soft_refresh()
+end
+
+function actions.set_variant_chance(text)
+    local variant = selected_variant()
+    if not variant then
+        return
+    end
+    state.selected_variant_chance = tostring(text or "")
+    state.draft:setVariantChance(state.variant_selection, tonumber(text or variant.chance or 1) or 1)
+    state.dirty = true
+    sync_session_out()
+end
+
+function actions.remove_selected_variant()
+    if state.variant_selection <= 0 then
+        state.status_message = "Najpierw wybierz wariant do usuniecia."
+        soft_refresh()
+        return
+    end
+    if state.draft:removeVariant(state.variant_selection) then
+        state.variant_selection = 0
+        state.selected_variant_chance = ""
+        state.status_message = "Usunieto wybrany wariant."
+        state.dirty = true
+        soft_refresh()
+    end
+end
+
+function actions.set_look_id(value)
+    state.draft:setLookId(tonumber(value or 0) or 0)
+    state.dirty = true
+    sync_session_out()
+end
+
+function actions.set_server_lookid(value)
+    state.draft:setServerLookId(tonumber(value or 0) or 0)
+    state.dirty = true
+    sync_session_out()
+end
+
+function actions.set_z_order(value)
+    state.draft:setZOrder(tonumber(value or 0) or 0)
+    state.dirty = true
+    sync_session_out()
+end
+
+function actions.toggle_randomize()
+    state.draft:setRandomize(not state.draft.randomize)
+    state.dirty = true
+    soft_refresh()
+end
+
+function actions.toggle_solo_optional()
+    state.draft:setSoloOptional(not state.draft.soloOptional)
+    state.dirty = true
+    soft_refresh()
+end
+
+local function finalize_save(mode)
+    local ok, result = Model.save_draft(state.repository, state.session_grounds, state.draft, mode, state.target_path)
+    if not ok then
+        app.alert({
+            title = "Save failed",
+            text = result,
+            buttons = { "OK" },
+        })
+        return
+    end
+
+    state.draft = result.draft
+    state.library_selected_name = result.draft.name
+    state.status_message = result.message
+    state.dirty = false
+    session.lastSavedGround = result.draft.name
+    sync_session_out()
+    rebuild()
+    app.alert({
+        title = "Ground saved",
+        text = result.message,
+        buttons = { "OK" },
+    })
+end
+
+function actions.save_as_new()
+    finalize_save("new")
+end
+
+function actions.overwrite_existing()
+    finalize_save("overwrite")
+end
+
+local function attach_brush_listener()
+    if listener_id or not app.events or not app.events.on then
+        return
+    end
+
+    listener_id = app.events:on("brushChange", function(brush_name)
+        Logger.log("main", string.format("brushChange event brush=%s", tostring(brush_name)))
+        if sync_selected_raw_from_brush("brushChange") and dlg then
+            sync_session_out()
+            soft_refresh_active_raw()
+        end
+    end)
+end
+
+local function detach_brush_listener()
+    if listener_id and app.events and app.events.off then
+        pcall(function()
+            app.events:off(listener_id)
+        end)
+    end
+    listener_id = nil
+end
+
+local function initialize()
+    refresh_repository()
+    state.draft = settings.last_ground_name and Model.load_draft(state.repository, settings.last_ground_name) or nil
+    if not state.draft then
+        state.draft = Model.new_draft(state.repository, state.session_grounds)
+        Logger.log("main", "initial draft missing, creating new")
+    end
+
+    if state.repository.api_missing then
+        state.status_message = "Brak API do odczytu grounds.xml: " .. tostring(state.repository.api_missing)
+    elseif #state.repository.warnings > 0 then
+        state.status_message = state.repository.warnings[1]
+    else
+        state.status_message = "Wybierz gotowy ground albo utworz nowy draft."
+    end
+
+    sync_session_in()
+    sync_selected_raw_from_brush("startup")
+    sync_session_out()
+end
+
+initialize()
+
+local page = {}
+
+function page.getTitle()
+    return "Grounds"
+end
+
+function page.isDirty()
+    return state.dirty
+end
+
+function page.confirmLeave()
+    return confirm_discard()
+end
+
+function page.onEnter(shared_session)
+    session = shared_session or session
+    sync_session_in()
+    sync_session_out()
+    attach_brush_listener()
+end
+
+function page.onLeave(shared_session)
+    session = shared_session or session
+    sync_session_out()
+    persist_settings()
+    detach_brush_listener()
+end
+
+function page.render_into(dialog)
+    dlg = dialog
+    render_page_content()
+end
+
+function page.getSessionState()
+    sync_session_out()
+    return session
+end
+
+function page.getStatusText()
+    return state.status_message ~= "" and state.status_message or helper_text()
+end
+
+function page.getState()
+    return state
+end
+
+return page
+end
+
+function GroundStudioPage.create(options)
+    return create_page(options)
+end
+
+function GroundStudioPage.open_standalone()
+    local existing_dialog = _G.GROUND_STUDIO_DIALOG
+    if existing_dialog then
+        pcall(function()
+            existing_dialog:close()
+        end)
+        _G.GROUND_STUDIO_DIALOG = nil
+        _G.GROUND_STUDIO_OPEN = false
+        app.yield()
+    end
+
+    local page = create_page({
+        reset_logger = true,
+    })
+
+    local dlg = Dialog({
+        title = "Ground Studio",
+        id = "ground_studio_dock",
+        width = 1540,
+        height = 900,
+        resizable = true,
+        dockable = true,
+        onclose = function()
+            Logger.log("main", "dialog onclose")
+            page.onLeave({})
+            _G.GROUND_STUDIO_OPEN = false
+            _G.GROUND_STUDIO_DIALOG = nil
+        end,
+    })
+
+    _G.GROUND_STUDIO_OPEN = true
+    _G.GROUND_STUDIO_DIALOG = dlg
+    page.onEnter({})
+    dlg:clear()
+    page.render_into(dlg)
+    dlg:layout()
+    dlg:repaint()
+    Logger.log("main", "show dialog")
+    dlg:show({ wait = false, center = "screen" })
+    return page
+end
+
+return GroundStudioPage

--- a/scripts/ground_studio/page.lua
+++ b/scripts/ground_studio/page.lua
@@ -3,7 +3,9 @@ local Model = dofile("model.lua")
 local LibraryPanel = dofile("library_panel.lua")
 local PreviewPanel = dofile("preview_panel.lua")
 local PropertiesPanel = dofile("properties_panel.lua")
+local SavePanel = dofile("save_panel.lua")
 local Logger = dofile("logger.lua")
+local XmlTarget = dofile("xml_target_helper.lua")
 
 local GroundStudioPage = {}
 
@@ -247,6 +249,18 @@ local function save_hint_text()
     return "Zapis utworzy nowy wpis albo nadpisze istniejacy ground."
 end
 
+local function save_panel_state()
+    local is_existing = state.draft and not state.draft.isNew
+    return {
+        mode_label = state.draft and (state.draft.isNew and "Tryb: nowy ground" or "Tryb: edycja istniejacego grounda") or "Tryb: nowy ground",
+        dirty_label = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie",
+        target_label = "Target: " .. tostring(state.target_path or ""),
+        hint_label = save_hint_text(),
+        intent_new = Model.save_intent(state.repository, state.draft, "new"),
+        intent_overwrite = is_existing and Model.save_intent(state.repository, state.draft, "overwrite") or Model.save_intent(state.repository, state.draft, "overwrite"),
+    }
+end
+
 local function soft_refresh()
     if not dlg or not state.draft then
         return
@@ -259,6 +273,7 @@ local function soft_refresh()
     local raw_info = Common.safe_item_info(state.selected_raw_id)
     local main_item_id = state.draft.mainGroundItem and state.draft.mainGroundItem.itemId or 0
     local selected_variant = selected_variant()
+    local save_state = save_panel_state()
 
     state.library_skip_changes = 12
     dlg:modify({
@@ -368,6 +383,24 @@ local function soft_refresh()
         toggle_solo_optional_button = {
             text = state.draft.soloOptional and "Solo Optional: ON" or "Solo Optional: OFF",
         },
+        save_mode_label = {
+            text = save_state.mode_label,
+        },
+        save_dirty_label = {
+            text = save_state.dirty_label,
+        },
+        save_target_label = {
+            text = save_state.target_label,
+        },
+        save_hint_label = {
+            text = save_state.hint_label,
+        },
+        save_intent_new = {
+            text = save_state.intent_new,
+        },
+        save_intent_overwrite = {
+            text = save_state.intent_overwrite,
+        },
     })
     dlg:repaint()
     state.rebuilding = false
@@ -429,7 +462,16 @@ local function render_page_content()
     })
         LibraryPanel.render(dlg, state, actions)
         PreviewPanel.render(dlg, state)
-        PropertiesPanel.render(dlg, state, actions)
+        dlg:box({
+            orient = "vertical",
+            width = 380,
+            min_width = 360,
+            expand = true,
+        })
+            PropertiesPanel.render(dlg, state, actions)
+            dlg:newrow()
+            SavePanel.render(dlg, state, actions)
+        dlg:endbox()
     dlg:endbox()
     state.library_skip_changes = 8
     state.rebuilding = false
@@ -730,6 +772,31 @@ end
 
 function actions.overwrite_existing()
     finalize_save("overwrite")
+end
+
+function actions.choose_target_path()
+    local chosen, err = XmlTarget.pick_xml_file("grounds.xml", state.target_path, "Wybierz grounds.xml")
+    if err then
+        app.alert({
+            title = "Nie mozna ustawic targetu",
+            text = err,
+            buttons = { "OK" },
+        })
+        return
+    end
+    if not chosen then
+        return
+    end
+
+    state.target_path = chosen
+    persist_settings()
+    rebuild()
+end
+
+function actions.use_default_target_path()
+    state.target_path = Model.resolve_target_path("")
+    persist_settings()
+    rebuild()
 end
 
 local function attach_brush_listener()

--- a/scripts/ground_studio/preview_panel.lua
+++ b/scripts/ground_studio/preview_panel.lua
@@ -1,0 +1,122 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state)
+    local main_item_id = state.draft and state.draft.mainItem and state.draft.mainItem.itemId or 0
+
+    dlg:box({
+        label = "2-5. Preview Grounda",
+        orient = "vertical",
+        expand = true,
+        min_width = 420,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            id = "ground_preview_help",
+            text = "Krok 2: wybierz RAW. Krok 3: ustaw glowny tile i warianty. Krok 4: sprawdz preview.",
+            fgcolor = Common.palette.text,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = true,
+        })
+            dlg:panel({
+                bgcolor = Common.palette.panel_alt,
+                padding = 10,
+                margin = 4,
+                expand = false,
+                min_width = 130,
+            })
+                dlg:label({
+                    text = "Main Ground",
+                    fgcolor = Common.palette.text,
+                    font_weight = "bold",
+                })
+                dlg:newrow()
+                dlg:image({
+                    id = "ground_main_preview",
+                    image = Common.safe_image(main_item_id),
+                    width = 80,
+                    height = 80,
+                    smooth = false,
+                })
+                dlg:newrow()
+                dlg:label({
+                    id = "ground_main_label",
+                    text = main_item_id > 0 and ("Item ID " .. tostring(main_item_id)) or "Brak glownego tile",
+                    fgcolor = Common.palette.muted,
+                })
+            dlg:endpanel()
+
+            dlg:panel({
+                bgcolor = Common.palette.panel_alt,
+                padding = 10,
+                margin = 4,
+                expand = true,
+            })
+                dlg:label({
+                    text = "Podglad Powierzchni",
+                    fgcolor = Common.palette.text,
+                    font_weight = "bold",
+                })
+                dlg:newrow()
+                dlg:grid({
+                    id = "ground_surface_preview",
+                    width = 280,
+                    height = 280,
+                    cell_width = 54,
+                    cell_height = 54,
+                    item_width = 48,
+                    item_height = 48,
+                    icon_width = 48,
+                    icon_height = 48,
+                    show_text = false,
+                    items = Common.surface_preview_items(state.draft),
+                })
+                dlg:newrow()
+                dlg:label({
+                    id = "ground_preview_status",
+                    text = "Podglad powierzchni pokazuje glowny tile i warianty.",
+                    fgcolor = Common.palette.muted,
+                })
+            dlg:endpanel()
+        dlg:endbox()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 10,
+            margin = 4,
+            expand = true,
+        })
+            dlg:label({
+                text = "Warianty Preview",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                text = #((state.draft and state.draft.variants) or {}) > 0 and "To sa tylko dodatkowe warianty. Main Ground pozostaje osobny." or "Brak wariantow. Dodaj je z prawej kolumny, jesli chcesz losowosc.",
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:grid({
+                id = "ground_variant_preview",
+                height = 170,
+                expand = true,
+                cell_width = 96,
+                cell_height = 120,
+                item_width = 72,
+                item_height = 72,
+                icon_width = 72,
+                icon_height = 72,
+                show_text = true,
+                items = Common.variant_preview_items(state.draft),
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/ground_studio/properties_panel.lua
+++ b/scripts/ground_studio/properties_panel.lua
@@ -92,28 +92,6 @@ function M.render(dlg, state, actions)
                     end,
                 })
             dlg:endbox()
-            dlg:newrow()
-            dlg:box({
-                orient = "horizontal",
-                expand = false,
-            })
-                dlg:button({
-                    text = "Save as New",
-                    bgcolor = Common.palette.success,
-                    fgcolor = Common.palette.text,
-                    onclick = function()
-                        actions.save_as_new()
-                    end,
-                })
-                dlg:button({
-                    text = "Overwrite Existing",
-                    bgcolor = Common.palette.accent,
-                    fgcolor = Common.palette.text,
-                    onclick = function()
-                        actions.overwrite_existing()
-                    end,
-                })
-            dlg:endbox()
         dlg:endpanel()
         dlg:newrow()
         dlg:panel({

--- a/scripts/ground_studio/properties_panel.lua
+++ b/scripts/ground_studio/properties_panel.lua
@@ -1,0 +1,358 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    local active_raw_id = state.selected_raw_id or 0
+    local raw_info = Common.safe_item_info(active_raw_id)
+    local main_item_id = state.draft and state.draft.mainGroundItem and state.draft.mainGroundItem.itemId or 0
+    local selected_variant = state.draft and state.draft.variants and state.draft.variants[tonumber(state.variant_selection or 0) or 0] or nil
+
+    dlg:box({
+        label = "3-4. Wlasciwosci",
+        orient = "vertical",
+        width = 360,
+        min_width = 340,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            text = "Aktualny RAW z glownej palety sluzy jako zrodlo main tile i wariantow.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Aktualny RAW",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:image({
+                id = "active_raw_preview",
+                image = Common.safe_image(active_raw_id),
+                width = 48,
+                height = 48,
+                smooth = false,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "active_raw_title",
+                text = raw_info and (raw_info.name or ("Item " .. tostring(active_raw_id))) or "Najpierw wybierz RAW tile",
+                fgcolor = Common.palette.text,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "active_raw_meta",
+                text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW.",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "active_raw_hint",
+                text = raw_info and "Ten RAW mozesz ustawic jako Main Ground albo dodac jako wariant." or "Najpierw wybierz RAW tile w glownej palecie RME.",
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "placement_chance",
+                label = "Set chance",
+                text = tostring(state.placement_chance or (state.draft and state.draft.mainChance) or 1),
+                expand = true,
+                onchange = function(d)
+                    actions.set_placement_chance(d.data.placement_chance or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Ustaw jako Main Ground",
+                    bgcolor = Common.palette.accent,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.use_active_raw_as_main()
+                    end,
+                })
+                dlg:button({
+                    text = "Dodaj jako Wariant",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.add_variant_from_active_raw()
+                    end,
+                })
+            dlg:endbox()
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Save as New",
+                    bgcolor = Common.palette.success,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.save_as_new()
+                    end,
+                })
+                dlg:button({
+                    text = "Overwrite Existing",
+                    bgcolor = Common.palette.accent,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.overwrite_existing()
+                    end,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Main Ground",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:image({
+                id = "main_ground_preview_side",
+                image = Common.safe_image(main_item_id),
+                width = 56,
+                height = 56,
+                smooth = false,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "main_ground_title",
+                text = main_item_id > 0 and (state.draft.mainGroundItem.name or ("Item " .. tostring(main_item_id))) or "Brak Main Ground",
+                fgcolor = Common.palette.text,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "main_ground_meta",
+                text = main_item_id > 0 and string.format("Item ID %d  |  chance %d", main_item_id, tonumber(state.draft.mainChance or 0) or 0) or "Wybierz RAW i kliknij 'Ustaw jako Main Ground'.",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = true,
+        })
+            dlg:label({
+                text = "Warianty Grounda",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "variant_hint_label",
+                text = #state.draft.variants > 0 and "Warianty sa oddzielone od Main Ground. Wybierz wariant z listy, aby edytowac chance." or "Brak wariantow. Wybierz RAW i kliknij 'Dodaj Wariant'.",
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "ground_variant_list",
+                label = "Lista wariantow",
+                height = 180,
+                expand = true,
+                icon_size = 24,
+                item_height = 34,
+                items = Common.variant_list_items(state.draft),
+                selection = tonumber(state.variant_selection or 0) or 0,
+                onchange = function(d)
+                    actions.set_variant_selection(d.data.ground_variant_list or 0)
+                end,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:image({
+                    id = "selected_variant_preview",
+                    image = Common.safe_image(selected_variant and selected_variant.itemId or 0),
+                    width = 40,
+                    height = 40,
+                    smooth = false,
+                })
+                dlg:box({
+                    orient = "vertical",
+                    expand = true,
+                })
+                    dlg:label({
+                        id = "selected_variant_title",
+                        text = selected_variant and (selected_variant.name or ("Item " .. tostring(selected_variant.itemId or 0))) or "Nie wybrano wariantu",
+                        fgcolor = Common.palette.text,
+                    })
+                    dlg:newrow()
+                    dlg:label({
+                        id = "selected_variant_meta",
+                        text = selected_variant and string.format("Item ID %d  |  chance %d", tonumber(selected_variant.itemId or 0) or 0, tonumber(selected_variant.chance or 0) or 0) or "Wybierz wariant z listy, aby edytowac chance.",
+                        fgcolor = Common.palette.subtle,
+                        font_size = 8,
+                    })
+                dlg:endbox()
+            dlg:endbox()
+            dlg:newrow()
+            dlg:input({
+                id = "ground_variant_chance",
+                label = "Chance wariantu",
+                text = state.selected_variant_chance or "",
+                expand = true,
+                onchange = function(d)
+                    actions.set_variant_chance(d.data.ground_variant_chance or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Dodaj Wariant",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.add_variant_from_active_raw()
+                    end,
+                })
+                dlg:button({
+                    text = "Usun Wybrany Wariant",
+                    bgcolor = Common.palette.panel_alt,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.remove_selected_variant()
+                    end,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Tile w Tym Groundzie",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "ground_set_list",
+                height = 130,
+                expand = true,
+                icon_size = 28,
+                item_height = 34,
+                items = Common.ground_set_items(state.draft),
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Ostatnio Uzyte",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "recent_raw_list",
+                height = 120,
+                expand = true,
+                icon_size = 24,
+                item_height = 30,
+                items = Common.recent_raw_items(state.recent_raw_ids),
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:input({
+            id = "ground_name_input",
+            label = "Nazwa",
+            text = state.draft and state.draft.name or "",
+            expand = true,
+            onchange = function(d)
+                actions.set_name(d.data.ground_name_input or "")
+            end,
+        })
+        dlg:input({
+            id = "ground_lookid_input",
+            label = "lookid",
+            text = tostring(state.draft and state.draft.lookId or 0),
+            expand = true,
+            onchange = function(d)
+                actions.set_look_id(d.data.ground_lookid_input or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "ground_server_lookid_input",
+            label = "server_lookid",
+            text = tostring(state.draft and state.draft.serverLookId or 0),
+            expand = true,
+            onchange = function(d)
+                actions.set_server_lookid(d.data.ground_server_lookid_input or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "ground_z_order_input",
+            label = "z-order",
+            text = tostring(state.draft and state.draft.zOrder or 0),
+            expand = true,
+            onchange = function(d)
+                actions.set_z_order(d.data.ground_z_order_input or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                id = "toggle_randomize_button",
+                text = state.draft and (state.draft.randomize and "Randomize: ON" or "Randomize: OFF") or "Randomize: ON",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.toggle_randomize()
+                end,
+            })
+            dlg:button({
+                id = "toggle_solo_optional_button",
+                text = state.draft and (state.draft.soloOptional and "Solo Optional: ON" or "Solo Optional: OFF") or "Solo Optional: OFF",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.toggle_solo_optional()
+                end,
+            })
+        dlg:endbox()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/ground_studio/repository.lua
+++ b/scripts/ground_studio/repository.lua
@@ -1,0 +1,370 @@
+local Common = dofile("common.lua")
+local GroundDraft = dofile("ground_draft.lua")
+local XmlCodec = dofile("xml_codec.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+local function file_exists(path)
+    if not path or path == "" then
+        return false
+    end
+
+    local store = app.storage(path)
+    if store and store.exists then
+        return store:exists()
+    end
+
+    return false
+end
+
+local function read_file(path)
+    local store = app.storage(path)
+    if not store or not store.readText then
+        return nil, "This RME build does not expose raw file reads for grounds.xml."
+    end
+
+    local content, err = store:readText()
+    if not content then
+        return nil, err or "Could not open file."
+    end
+
+    return content
+end
+
+local function build_repository_from_app_grounds(app_grounds, session_grounds)
+    local repository = {
+        ordered = {},
+        by_name = {},
+        warnings = {},
+        target_path = "",
+        api_missing = nil,
+    }
+
+    for _, ground_data in pairs(app_grounds or {}) do
+        local name = Common.trim(ground_data.name or "")
+        if name ~= "" then
+            local items = {}
+            for _, item_data in ipairs(ground_data.items or {}) do
+                local item_id = tonumber(item_data.id or item_data.itemId or 0) or 0
+                local chance = tonumber(item_data.chance or 1) or 1
+                if item_id > 0 then
+                    table.insert(items, {
+                        itemId = item_id,
+                        chance = chance,
+                    })
+                end
+            end
+
+            local main_item = items[1]
+            local variants = {}
+            for index = 2, #items do
+                table.insert(variants, items[index])
+            end
+
+            repository.by_name[name] = GroundDraft.new({
+                groundId = tonumber(ground_data.id or 0) or 0,
+                name = name,
+                mainItem = main_item,
+                mainChance = main_item and main_item.chance or 1,
+                variants = variants,
+                lookId = tonumber(ground_data.lookid or 0) or 0,
+                serverLookId = tonumber(ground_data.server_lookid or 0) or 0,
+                zOrder = tonumber(ground_data.z_order or ground_data["z-order"] or 0) or 0,
+                randomize = ground_data.randomize,
+                soloOptional = ground_data.solo_optional,
+                isNew = false,
+                sourceName = name,
+            })
+        end
+    end
+
+    for name, overlay in pairs(session_grounds or {}) do
+        repository.by_name[name] = overlay:clone()
+        repository.by_name[name].isNew = false
+    end
+
+    for _, ground in pairs(repository.by_name) do
+        table.insert(repository.ordered, ground)
+    end
+
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+
+    return repository
+end
+
+local function write_file(path, content)
+    local store = app.storage(path)
+    if not store or not store.save then
+        return false, "This RME build does not expose safe file writes."
+    end
+
+    local ok = store:save(content or "")
+    if not ok then
+        return false, "Could not write file."
+    end
+
+    return true
+end
+
+function M.resolve_target_path(saved_path)
+    if saved_path and saved_path ~= "" and file_exists(saved_path) then
+        return saved_path
+    end
+
+    local data_dir = app.getDataDirectory()
+    local preferred = tostring(data_dir or "") .. "/1310/grounds.xml"
+    if file_exists(preferred) then
+        return preferred
+    end
+
+    return preferred
+end
+
+function M.read(target_path, session_grounds)
+    local repository
+
+    if app and app.grounds then
+        repository = build_repository_from_app_grounds(app.grounds, session_grounds)
+        repository.target_path = target_path or ""
+        Logger.log("repository", string.format("read done from app.grounds count=%d warnings=%d", #repository.ordered, #repository.warnings))
+        return repository
+    end
+
+    repository = {
+        ordered = {},
+        by_name = {},
+        warnings = {},
+        target_path = target_path or "",
+        api_missing = nil,
+    }
+
+    Logger.log("repository", "read start")
+    local content, err = read_file(target_path)
+    if not content then
+        repository.api_missing = err
+        table.insert(repository.warnings, err)
+        Logger.log("repository", "read failed: " .. tostring(err))
+        return repository
+    end
+
+    local parsed = XmlCodec.parse_grounds(content)
+    repository.ordered = parsed.ordered
+    repository.by_name = parsed.by_name
+    repository.warnings = parsed.warnings or {}
+
+    for name, overlay in pairs(session_grounds or {}) do
+        repository.by_name[name] = overlay:clone()
+        repository.by_name[name].isNew = false
+    end
+
+    repository.ordered = {}
+    for _, ground in pairs(repository.by_name) do
+        table.insert(repository.ordered, ground)
+    end
+
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+
+    for _, warning in ipairs(repository.warnings) do
+        Logger.log("repository", "warning: " .. tostring(warning))
+    end
+
+    Logger.log("repository", string.format("read done count=%d warnings=%d", #repository.ordered, #repository.warnings))
+    return repository
+end
+
+function M.next_name(repository, session_grounds, preferred_base)
+    local base = Common.trim(preferred_base or "new ground")
+    if base == "" then
+        base = "new ground"
+    end
+
+    local candidate = base
+    local index = 1
+    while (repository.by_name and repository.by_name[candidate]) or (session_grounds and session_grounds[candidate]) do
+        index = index + 1
+        candidate = string.format("%s %d", base, index)
+    end
+    return candidate
+end
+
+function M.new_draft(repository, session_grounds)
+    return GroundDraft.new({
+        name = M.next_name(repository, session_grounds, "new ground"),
+        randomize = true,
+        isNew = true,
+    })
+end
+
+function M.load_draft(repository, name)
+    local ground = repository.by_name[name]
+    if not ground then
+        return nil
+    end
+    return ground:clone()
+end
+
+function M.duplicate_draft(repository, session_grounds, draft)
+    local copy = draft:clone()
+    copy.name = M.next_name(repository, session_grounds, Common.trim((draft.name ~= "" and draft.name or "ground") .. " copy"))
+    copy.sourceName = copy.name
+    copy.isNew = true
+    return copy
+end
+
+function M.library_items(repository, filter_text)
+    local items = {}
+    local visible_names = {}
+    local needle = string.lower(filter_text or "")
+
+    for _, ground in ipairs(repository.ordered or {}) do
+        local status = Common.ground_status(ground)
+        local item_count = #ground:getAllItems()
+        local main_item_id = Common.primary_item_id(ground)
+        local main_item_name = Common.safe_item_name(main_item_id)
+        local blob = string.lower((ground.name or "") .. " " .. status .. " " .. main_item_name)
+        if needle == "" or string.find(blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("%s  |  %s  |  %s", ground.name or "Unnamed", status, main_item_name ~= "" and main_item_name or ("Item " .. tostring(main_item_id or 0))),
+                tooltip = string.format("%s\nStatus: %s\nMain: %s (%d)\nItems: %d", ground.name or "Unnamed", status, main_item_name ~= "" and main_item_name or "Unknown", tonumber(main_item_id or 0) or 0, item_count),
+                image = Common.safe_image(main_item_id),
+            })
+            table.insert(visible_names, ground.name)
+        end
+    end
+
+    return items, visible_names
+end
+
+function M.save_intent(repository, draft, mode)
+    local name = Common.trim(draft and draft.name or "")
+    local source_name = Common.trim(draft and draft.sourceName or "")
+    local exists = name ~= "" and repository.by_name and repository.by_name[name] ~= nil
+    local source_exists = source_name ~= "" and repository.by_name and repository.by_name[source_name] ~= nil
+
+    if mode == "new" then
+        if name == "" then
+            return "Podaj nazwe grounda, aby zapisac nowy wpis."
+        end
+        if exists then
+            return string.format("Save as New zablokowany: ground '%s' juz istnieje.", name)
+        end
+        return string.format("Utworzy nowy ground '%s'.", name)
+    end
+
+    if not source_exists then
+        return "Overwrite wymaga istniejacego grounda w bibliotece."
+    end
+    return string.format("Nadpisze ground '%s'.", source_name)
+end
+
+function M.validate_save(repository, draft, mode, target_path)
+    if not target_path or target_path == "" then
+        return false, "Target grounds.xml could not be resolved."
+    end
+    if not Common.path_starts_with(target_path, app.getDataDirectory()) then
+        return false, "Target grounds.xml must stay inside the RME data directory."
+    end
+    if not tostring(target_path):lower():match("%.xml$") then
+        return false, "Target file must be an XML file."
+    end
+    if not file_exists(target_path) then
+        return false, "Target grounds.xml does not exist."
+    end
+    if not draft then
+        return false, "Brak draftu do zapisu."
+    end
+
+    local validation = draft:getValidation()
+    if not validation.isValid then
+        return false, validation.errors[1] or "Ground draft jest niepoprawny."
+    end
+
+    local current_name = Common.trim(draft.name or "")
+    local source_name = Common.trim(draft.sourceName or current_name)
+    local exists = repository.by_name and repository.by_name[current_name] ~= nil
+    local source_exists = repository.by_name and repository.by_name[source_name] ~= nil
+
+    if mode == "new" and exists then
+        return false, string.format("Ground '%s' juz istnieje.", current_name)
+    end
+    if mode == "overwrite" and not source_exists then
+        return false, string.format("Ground '%s' nie istnieje do nadpisania.", source_name)
+    end
+
+    return true
+end
+
+function M.backup_xml(target_path)
+    local original, err = read_file(target_path)
+    if not original then
+        return false, nil, nil, "Could not read grounds.xml before backup: " .. tostring(err)
+    end
+
+    local backup_path = string.format("%s.groundstudio.%s.bak", target_path, os.date("%Y%m%d_%H%M%S"))
+    local ok, backup_err = write_file(backup_path, original)
+    if not ok then
+        return false, nil, nil, "Could not write backup file: " .. tostring(backup_err)
+    end
+
+    return true, backup_path, original
+end
+
+function M.save_draft(repository, session_grounds, draft, mode, target_path)
+    local ok, validation_message = M.validate_save(repository, draft, mode, target_path)
+    if not ok then
+        return false, validation_message
+    end
+
+    local backup_ok, backup_path, original_content, backup_message = M.backup_xml(target_path)
+    if not backup_ok then
+        return false, backup_message
+    end
+
+    local saved_draft = draft:clone()
+    saved_draft.name = Common.trim(saved_draft.name)
+    saved_draft.isNew = false
+
+    local writer = app.storage(target_path)
+    if not writer or not writer.upsertXml then
+        return false, "The current RME build does not expose XML upsert support."
+    end
+
+    local match_name = mode == "overwrite" and Common.trim(saved_draft.sourceName or saved_draft.name) or saved_draft.name
+    local xml = XmlCodec.serialize_ground(saved_draft)
+    local write_ok, write_mode = writer:upsertXml({
+        root = "materials",
+        parent = "materials",
+        tag = "brush",
+        match_attr = "name",
+        match_value = match_name,
+        xml = xml,
+    })
+
+    if not write_ok then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, write_mode or "Saving failed while updating grounds.xml."
+    end
+
+    if match_name ~= saved_draft.name then
+        session_grounds[match_name] = nil
+    end
+
+    saved_draft.sourceName = saved_draft.name
+    session_grounds[saved_draft.name] = saved_draft:clone()
+
+    return true, {
+        draft = saved_draft,
+        backupPath = backup_path,
+        xmlMode = write_mode or mode,
+        message = string.format("Saved ground '%s' successfully.\nBackup: %s", saved_draft.name, backup_path),
+    }
+end
+
+return M

--- a/scripts/ground_studio/save_panel.lua
+++ b/scripts/ground_studio/save_panel.lua
@@ -1,0 +1,83 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    dlg:box({
+        label = "6. Zapis",
+        orient = "vertical",
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = true,
+        })
+            dlg:label({
+                id = "save_mode_label",
+                text = state.draft and (state.draft.isNew and "Tryb: nowy ground" or "Tryb: edycja istniejacego grounda"),
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "save_dirty_label",
+                text = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie",
+                fgcolor = Common.palette.subtle,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "save_target_label",
+                text = "Target: " .. tostring(state.target_path or ""),
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "save_hint_label",
+                text = "Podaj nazwe i glowny tile, aby zapisac ground.",
+                fgcolor = Common.palette.muted,
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Save as New",
+                bgcolor = Common.palette.success,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.save_as_new()
+                end,
+            })
+            dlg:button({
+                text = "Overwrite Existing",
+                bgcolor = Common.palette.accent,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.overwrite_existing()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:label({
+            id = "save_intent_new",
+            text = "",
+            fgcolor = Common.palette.muted,
+            font_size = 8,
+        })
+        dlg:newrow()
+        dlg:label({
+            id = "save_intent_overwrite",
+            text = "",
+            fgcolor = Common.palette.muted,
+            font_size = 8,
+        })
+    dlg:endbox()
+end
+
+return M

--- a/scripts/ground_studio/settings.json
+++ b/scripts/ground_studio/settings.json
@@ -1,0 +1,14 @@
+{
+    "last_ground_name": "test",
+    "recent_raw_ids": [
+        21447,
+        21446,
+        21445,
+        21444,
+        21442,
+        21441,
+        21440,
+        21439
+    ],
+    "target_path": "D:\\remeres-map-editor-redux-master\\data\\/1310/grounds.xml"
+}

--- a/scripts/ground_studio/xml_codec.lua
+++ b/scripts/ground_studio/xml_codec.lua
@@ -1,0 +1,178 @@
+local Common = dofile("common.lua")
+local GroundDraft = dofile("ground_draft.lua")
+
+local M = {}
+
+local function parse_attributes(text)
+    local attrs = {}
+    for key, value in tostring(text or ""):gmatch('([%w_%-]+)%s*=%s*"([^"]-)"') do
+        attrs[key] = Common.unescape_xml(value)
+    end
+    return attrs
+end
+
+local function extract_brush_blocks(xml)
+    local blocks = {}
+    local cursor = 1
+
+    while true do
+        local start_index = xml:find("<brush%s", cursor)
+        if not start_index then
+            break
+        end
+
+        local tag_end = xml:find(">", start_index, true)
+        if not tag_end then
+            break
+        end
+
+        local open_tag = xml:sub(start_index, tag_end)
+        local self_closing = open_tag:match("/%s*>$") ~= nil
+        if self_closing then
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = "",
+            })
+            cursor = tag_end + 1
+        else
+            local close_start, close_end = xml:find("</brush>", tag_end + 1, true)
+            if not close_start then
+                break
+            end
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = xml:sub(tag_end + 1, close_start - 1),
+            })
+            cursor = close_end + 1
+        end
+    end
+
+    return blocks
+end
+
+local function normalize_extra_children(inner)
+    local extras = tostring(inner or "")
+    extras = extras:gsub("<item%s+.-%s*/>", "")
+    extras = extras:gsub("\r\n", "\n")
+    extras = extras:gsub("^\n+", "")
+    extras = extras:gsub("\n+$", "")
+    return extras
+end
+
+local function collect_unsupported_child_warnings(inner, name, warnings)
+    local seen = {}
+    for tag in tostring(inner or ""):gmatch("<%s*([%w_%-]+)") do
+        local lower = string.lower(tag)
+        if lower ~= "item" and lower ~= "!--" and not seen[lower] then
+            seen[lower] = true
+            table.insert(warnings, string.format("Ground '%s' contains unsupported child <%s>. It was preserved but not edited by Ground Studio.", name, tag))
+        end
+    end
+end
+
+function M.parse_grounds(xml)
+    local repository = {
+        ordered = {},
+        by_name = {},
+        warnings = {},
+    }
+
+    for _, block in ipairs(extract_brush_blocks(tostring(xml or ""))) do
+        local attrs = block.attributes or {}
+        if string.lower(tostring(attrs.type or "")) == "ground" then
+            local name = Common.trim(attrs.name or "")
+            if name == "" then
+                table.insert(repository.warnings, "Skipped ground brush without name.")
+            else
+                local items = {}
+                for item_attrs in tostring(block.inner or ""):gmatch("<item%s+(.-)%s*/>") do
+                    local parsed = parse_attributes(item_attrs)
+                    local item_id = tonumber(parsed.id or 0) or 0
+                    local chance = tonumber(parsed.chance or 1) or 1
+                    if item_id > 0 then
+                        table.insert(items, { itemId = item_id, chance = chance })
+                    else
+                        table.insert(repository.warnings, "Skipped ground item with invalid id in " .. name)
+                    end
+                end
+
+                local main_item = items[1]
+                local variants = {}
+                for index = 2, #items do
+                    table.insert(variants, items[index])
+                end
+
+                local draft = GroundDraft.new({
+                    name = name,
+                    mainItem = main_item,
+                    mainChance = main_item and main_item.chance or 1,
+                    variants = variants,
+                    lookId = attrs.lookid,
+                    serverLookId = attrs.server_lookid,
+                    zOrder = attrs["z-order"],
+                    randomize = attrs.randomize,
+                    soloOptional = attrs.solo_optional,
+                    extraChildrenXml = normalize_extra_children(block.inner),
+                    isNew = false,
+                    sourceName = name,
+                })
+
+                collect_unsupported_child_warnings(block.inner, name, repository.warnings)
+
+                repository.by_name[name] = draft
+                table.insert(repository.ordered, draft)
+            end
+        end
+    end
+
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+
+    return repository
+end
+
+function M.serialize_ground(draft)
+    local data = draft:toXmlGroundData()
+    local attrs = {
+        string.format('name="%s"', Common.escape_xml(data.name)),
+        'type="ground"',
+    }
+
+    if tonumber(data.lookId or 0) > 0 then
+        table.insert(attrs, string.format('lookid="%d"', tonumber(data.lookId or 0) or 0))
+    end
+    if tonumber(data.serverLookId or 0) > 0 then
+        table.insert(attrs, string.format('server_lookid="%d"', tonumber(data.serverLookId or 0) or 0))
+    end
+    if tonumber(data.zOrder or 0) ~= 0 then
+        table.insert(attrs, string.format('z-order="%d"', tonumber(data.zOrder or 0) or 0))
+    end
+    table.insert(attrs, string.format('randomize="%s"', data.randomize and "true" or "false"))
+    if data.soloOptional then
+        table.insert(attrs, 'solo_optional="true"')
+    end
+
+    local lines = {
+        string.format("<brush %s>", table.concat(attrs, " ")),
+    }
+
+    for _, item in ipairs(data.items or {}) do
+        table.insert(lines, string.format('\t<item id="%d" chance="%d"/>', tonumber(item.itemId or 0) or 0, tonumber(item.chance or 0) or 0))
+    end
+
+    local extras = Common.trim(data.extraChildrenXml or "")
+    if extras ~= "" then
+        for line in extras:gmatch("[^\r\n]+") do
+            local trimmed = Common.trim(line)
+            if trimmed ~= "" then
+                table.insert(lines, "\t" .. trimmed)
+            end
+        end
+    end
+
+    table.insert(lines, "</brush>")
+    return table.concat(lines, "\n")
+end
+
+return M

--- a/scripts/ground_studio/xml_target_helper.lua
+++ b/scripts/ground_studio/xml_target_helper.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+local function normalize(path)
+    return tostring(path or ""):gsub("\\", "/")
+end
+
+local function lower_path(path)
+    return string.lower(normalize(path))
+end
+
+function M.is_xml_file(path)
+    return lower_path(path):match("%.xml$") ~= nil
+end
+
+function M.matches_expected_filename(path, expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return true
+    end
+    local normalized = lower_path(path)
+    local suffix = "/" .. string.lower(expected_filename)
+    return normalized:sub(-#suffix) == suffix or normalized == string.lower(expected_filename)
+end
+
+function M.is_inside_data_dir(path)
+    local data_dir = lower_path(app.getDataDirectory() or "")
+    local normalized = lower_path(path)
+    if data_dir == "" then
+        return false
+    end
+    if normalized == data_dir then
+        return true
+    end
+    return normalized:sub(1, #data_dir + 1) == (data_dir .. "/")
+end
+
+function M.default_xml_wildcard(expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return "XML files (*.xml)|*.xml|All files (*.*)|*.*"
+    end
+    return string.format("%s (%s)|%s|XML files (*.xml)|*.xml|All files (*.*)|*.*", expected_filename, expected_filename, expected_filename)
+end
+
+function M.pick_xml_file(expected_filename, current_path, title)
+    if not app or not app.chooseFile then
+        return nil, "This RME build does not expose file picker support."
+    end
+
+    local chosen = app.chooseFile({
+        title = title or "Select XML file",
+        path = normalize(current_path),
+        wildcard = M.default_xml_wildcard(expected_filename),
+    })
+
+    if not chosen or chosen == "" then
+        return nil
+    end
+
+    chosen = normalize(chosen)
+    if not M.is_xml_file(chosen) then
+        return nil, "Wybrany plik musi byc plikiem XML."
+    end
+    if not M.matches_expected_filename(chosen, expected_filename) then
+        return nil, string.format("Wybierz plik '%s'.", tostring(expected_filename or ""))
+    end
+    if not M.is_inside_data_dir(chosen) then
+        return nil, "Wybrany plik musi znajdowac sie w aktualnym katalogu data tego RME."
+    end
+
+    return chosen
+end
+
+return M

--- a/scripts/wall_studio/common.lua
+++ b/scripts/wall_studio/common.lua
@@ -1,0 +1,308 @@
+local M = {}
+M._image_cache = M._image_cache or {}
+
+M.palette = {
+    header = "#1F2937",
+    panel = "#243447",
+    panel_alt = "#2C3E50",
+    accent = "#0F766E",
+    accent_soft = "#14B8A6",
+    success = "#2F855A",
+    danger = "#C53030",
+    text = "#F8FAFC",
+    muted = "#CBD5E1",
+    subtle = "#94A3B8",
+    border = "#475569",
+}
+
+M.alignment_order = {
+    { token = "vertical", label = "Vertical" },
+    { token = "horizontal", label = "Horizontal" },
+    { token = "corner", label = "Corner" },
+    { token = "pole", label = "Pole" },
+    { token = "south end", label = "South End" },
+    { token = "east end", label = "East End" },
+    { token = "north end", label = "North End" },
+    { token = "west end", label = "West End" },
+    { token = "south T", label = "South T" },
+    { token = "east T", label = "East T" },
+    { token = "west T", label = "West T" },
+    { token = "north T", label = "North T" },
+    { token = "northeast diagonal", label = "NE Diagonal" },
+    { token = "northwest diagonal", label = "NW Diagonal" },
+    { token = "southeast diagonal", label = "SE Diagonal" },
+    { token = "southwest diagonal", label = "SW Diagonal" },
+    { token = "intersection", label = "Intersection" },
+    { token = "untouchable", label = "Untouchable" },
+}
+
+M.alignment_lookup = {}
+for _, alignment in ipairs(M.alignment_order) do
+    M.alignment_lookup[alignment.token] = alignment
+end
+
+M.door_type_options = {
+    "normal",
+    "normal_alt",
+    "locked",
+    "quest",
+    "magic",
+    "archway",
+    "window",
+    "hatch_window",
+}
+
+function M.clone(value)
+    if type(value) ~= "table" then
+        return value
+    end
+
+    local copy = {}
+    for key, inner in pairs(value) do
+        copy[key] = M.clone(inner)
+    end
+    return copy
+end
+
+function M.trim(value)
+    return tostring(value or ""):match("^%s*(.-)%s*$")
+end
+
+function M.normalize_bool(value, default)
+    if value == nil then
+        return default and true or false
+    end
+    if type(value) == "boolean" then
+        return value
+    end
+
+    local text = string.lower(tostring(value))
+    return text == "1" or text == "true" or text == "yes" or text == "on"
+end
+
+function M.normalize_path(path)
+    path = tostring(path or ""):gsub("\\", "/")
+    return string.lower(path)
+end
+
+function M.path_starts_with(path, prefix)
+    local lhs = M.normalize_path(path)
+    local rhs = M.normalize_path(prefix)
+    return lhs:sub(1, #rhs) == rhs
+end
+
+function M.safe_item_name(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return ""
+    end
+    return Items.getName(item_id) or ""
+end
+
+function M.safe_item_info(item_id)
+    if not item_id or item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    return Items.getInfo(item_id)
+end
+
+function M.safe_image(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 or not Items or not Items.exists(item_id) then
+        return nil
+    end
+    if not M._image_cache[item_id] then
+        M._image_cache[item_id] = Image.fromItemSprite(item_id)
+    end
+    return M._image_cache[item_id]
+end
+
+function M.active_raw_brush_id()
+    local brush = app and app.brush or nil
+    if not brush or brush.type ~= "raw" then
+        return 0
+    end
+
+    local parsed = tonumber(tostring(brush.name or ""):match("^(%d+)"))
+    if parsed and parsed > 0 then
+        return parsed
+    end
+
+    local fallback = tonumber(brush.id or 0) or 0
+    if fallback > 0 and Items and Items.exists and Items.exists(fallback) then
+        return fallback
+    end
+
+    return 0
+end
+
+function M.escape_xml(value)
+    value = tostring(value or "")
+    value = value:gsub("&", "&amp;")
+    value = value:gsub("<", "&lt;")
+    value = value:gsub(">", "&gt;")
+    value = value:gsub('"', "&quot;")
+    value = value:gsub("'", "&apos;")
+    return value
+end
+
+function M.unescape_xml(value)
+    value = tostring(value or "")
+    value = value:gsub("&apos;", "'")
+    value = value:gsub("&quot;", '"')
+    value = value:gsub("&gt;", ">")
+    value = value:gsub("&lt;", "<")
+    value = value:gsub("&amp;", "&")
+    return value
+end
+
+function M.alignment_label(token)
+    local alignment = M.alignment_lookup[token]
+    return alignment and alignment.label or token
+end
+
+function M.make_bucket(token)
+    return {
+        token = token,
+        wallItems = {},
+        doorItems = {},
+    }
+end
+
+function M.representative_item_id(bucket)
+    if not bucket then
+        return 0
+    end
+    if bucket.wallItems and bucket.wallItems[1] then
+        return tonumber(bucket.wallItems[1].itemId or 0) or 0
+    end
+    if bucket.doorItems and bucket.doorItems[1] then
+        return tonumber(bucket.doorItems[1].itemId or 0) or 0
+    end
+    return 0
+end
+
+function M.wall_status(draft)
+    if not draft then
+        return "empty"
+    end
+    local filled = 0
+    local door_count = 0
+    for _, alignment in ipairs(M.alignment_order) do
+        local bucket = draft.alignments and draft.alignments[alignment.token] or nil
+        if bucket and (#(bucket.wallItems or {}) > 0 or #(bucket.doorItems or {}) > 0) then
+            filled = filled + 1
+            door_count = door_count + #(bucket.doorItems or {})
+        end
+    end
+    if filled == 0 then
+        return "empty"
+    end
+    if door_count > 0 then
+        return string.format("%d buckets | doors", filled)
+    end
+    return string.format("%d buckets", filled)
+end
+
+function M.format_wall_title(draft)
+    if not draft then
+        return "No wall"
+    end
+    local suffix = draft.isNew and " (new)" or ""
+    return string.format("%s%s", draft.name ~= "" and draft.name or "Untitled wall", suffix)
+end
+
+function M.library_items(repository, filter_text)
+    local items = {}
+    local visible_names = {}
+    local needle = string.lower(filter_text or "")
+
+    for _, draft in ipairs(repository.ordered or {}) do
+        local preview_id = draft:getPreviewItemId()
+        local label_blob = string.lower((draft.name or "") .. " " .. M.wall_status(draft))
+        if needle == "" or string.find(label_blob, needle, 1, true) then
+            table.insert(items, {
+                text = string.format("%s  |  %s", draft.name or "Unnamed", M.wall_status(draft)),
+                tooltip = string.format("%s\nStatus: %s\nPreview item: %d", draft.name or "Unnamed", M.wall_status(draft), preview_id),
+                image = M.safe_image(preview_id),
+            })
+            table.insert(visible_names, draft.name)
+        end
+    end
+
+    return items, visible_names
+end
+
+function M.recent_raw_items(recent_raw_ids)
+    local items = {}
+    for _, item_id in ipairs(recent_raw_ids or {}) do
+        item_id = tonumber(item_id or 0) or 0
+        if item_id > 0 then
+            local name = M.safe_item_name(item_id)
+            table.insert(items, {
+                text = string.format("%d  |  %s", item_id, name ~= "" and name or ("Item " .. tostring(item_id))),
+                tooltip = string.format("Item ID %d", item_id),
+                image = M.safe_image(item_id),
+            })
+        end
+    end
+    return items
+end
+
+function M.alignment_grid_items(draft)
+    local items = {}
+    for _, alignment in ipairs(M.alignment_order) do
+        local bucket = draft and draft.alignments and draft.alignments[alignment.token] or nil
+        local item_count = bucket and #(bucket.wallItems or {}) or 0
+        local door_count = bucket and #(bucket.doorItems or {}) or 0
+        table.insert(items, {
+            text = alignment.label,
+            tooltip = string.format("%s\nWall items: %d\nDoors: %d", alignment.label, item_count, door_count),
+            image = M.safe_image(M.representative_item_id(bucket)),
+        })
+    end
+    return items
+end
+
+function M.bucket_wall_list_items(bucket)
+    local items = {}
+    for index, item in ipairs(bucket and bucket.wallItems or {}) do
+        table.insert(items, {
+            text = string.format("%d. Item %d  |  chance %d", index, tonumber(item.itemId or 0) or 0, tonumber(item.chance or 0) or 0),
+            tooltip = string.format("Item ID %d\nChance %d", tonumber(item.itemId or 0) or 0, tonumber(item.chance or 0) or 0),
+            image = M.safe_image(item.itemId or 0),
+        })
+    end
+    return items
+end
+
+function M.bucket_door_list_items(bucket)
+    local items = {}
+    for index, door in ipairs(bucket and bucket.doorItems or {}) do
+        local bits = {
+            door.doorType or "normal",
+            door.isOpen and "open" or "closed",
+        }
+        if door.isLocked then
+            table.insert(bits, "locked")
+        end
+        if door.hate then
+            table.insert(bits, "hate")
+        end
+        table.insert(items, {
+            text = string.format("%d. Item %d  |  %s", index, tonumber(door.itemId or 0) or 0, table.concat(bits, " / ")),
+            tooltip = string.format("Item ID %d\nType %s", tonumber(door.itemId or 0) or 0, door.doorType or "normal"),
+            image = M.safe_image(door.itemId or 0),
+        })
+    end
+    return items
+end
+
+function M.friend_summary(draft)
+    local friends = draft and draft.friends or {}
+    if #friends == 0 then
+        return "Brak friend links."
+    end
+    return "Friends: " .. table.concat(friends, ", ")
+end
+
+return M

--- a/scripts/wall_studio/library_panel.lua
+++ b/scripts/wall_studio/library_panel.lua
@@ -1,0 +1,130 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    dlg:box({
+        label = "1. Wybierz Wall Brush",
+        orient = "vertical",
+        width = 320,
+        min_width = 300,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            text = "Wybierz istniejacy wall brush albo utworz nowy draft.",
+            fgcolor = Common.palette.muted,
+        })
+        dlg:newrow()
+        dlg:input({
+            id = "wall_library_filter",
+            label = "Search",
+            text = state.filter_text or "",
+            expand = true,
+            onchange = function(d)
+                actions.set_filter(d.data.wall_library_filter or "")
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "<",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.previous_library_page()
+                end,
+            })
+            dlg:label({
+                id = "wall_library_page_label",
+                text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+                fgcolor = Common.palette.subtle,
+                min_width = 120,
+                align = "center",
+            })
+            dlg:button({
+                text = ">",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.next_library_page()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:list({
+            id = "wall_library",
+            height = 720,
+            expand = true,
+            icon_size = 32,
+            item_height = 40,
+            items = state.library_items,
+            selection = state.library_selection,
+            onchange = function(d)
+                actions.handle_library_change(d.data.wall_library or 0)
+            end,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = false,
+        })
+            dlg:button({
+                text = "Nowy Wall",
+                bgcolor = Common.palette.accent,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.new_wall()
+                end,
+            })
+            dlg:button({
+                text = "Duplikuj",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.duplicate_current()
+                end,
+            })
+            dlg:button({
+                text = "Otworz",
+                bgcolor = Common.palette.panel_alt,
+                fgcolor = Common.palette.text,
+                onclick = function()
+                    actions.open_selected_wall()
+                end,
+            })
+        dlg:endbox()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Aktualnie edytujesz",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_wall_title",
+                text = Common.format_wall_title(state.draft),
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "current_wall_status",
+                text = "Status: " .. Common.wall_status(state.draft),
+                fgcolor = Common.palette.muted,
+                font_size = 8,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/wall_studio/logger.lua
+++ b/scripts/wall_studio/logger.lua
@@ -1,0 +1,34 @@
+local STORE = app.storage("wall_studio.log")
+
+local Logger = {}
+
+local function append_line(line)
+    if not STORE or not STORE.save or not STORE.readText then
+        return
+    end
+
+    local previous = ""
+    local content = STORE:readText()
+    if type(content) == "string" then
+        previous = content
+    elseif type(content) == "table" then
+        previous = content[1] or ""
+    end
+
+    local next_content = previous ~= "" and (previous .. "\n" .. line) or line
+    STORE:save(next_content)
+end
+
+function Logger.reset(reason)
+    if STORE and STORE.save then
+        STORE:save(string.format("[reset] %s", tostring(reason or "")))
+    end
+end
+
+function Logger.log(scope, message)
+    local line = string.format("[%s] %s", tostring(scope or "main"), tostring(message or ""))
+    print("[Wall Studio] " .. line)
+    append_line(line)
+end
+
+return Logger

--- a/scripts/wall_studio/main.lua
+++ b/scripts/wall_studio/main.lua
@@ -1,0 +1,3 @@
+local WallStudioPage = dofile("page.lua")
+
+WallStudioPage.open_standalone()

--- a/scripts/wall_studio/manifest.lua
+++ b/scripts/wall_studio/manifest.lua
@@ -1,0 +1,9 @@
+return {
+    name = "Wall Creator Addon",
+    description = "Addon module used by Brush Creator for wall workflows.",
+    author = "Fr0st",
+    version = "0.1.0",
+    main = "main.lua",
+    shortcut = "Ctrl+Alt+W",
+    autorun = false
+}

--- a/scripts/wall_studio/model.lua
+++ b/scripts/wall_studio/model.lua
@@ -1,0 +1,67 @@
+local Common = dofile("common.lua")
+local Repository = dofile("repository.lua")
+
+local M = {}
+
+local SETTINGS_STORE = app.storage("settings.json")
+
+function M.load_settings()
+    return SETTINGS_STORE:load() or {}
+end
+
+function M.save_settings(state)
+    SETTINGS_STORE:save({
+        target_path = state.target_path or "",
+        last_wall_name = state.draft and state.draft.name or "",
+        recent_raw_ids = state.recent_raw_ids or {},
+    })
+end
+
+function M.resolve_target_path(saved_path)
+    return Repository.resolve_target_path(saved_path)
+end
+
+function M.read_repository(target_path, session_walls)
+    return Repository.read(target_path, session_walls)
+end
+
+function M.new_draft(repository, session_walls)
+    return Repository.new_draft(repository, session_walls)
+end
+
+function M.load_draft(repository, name)
+    return Repository.load_draft(repository, name)
+end
+
+function M.duplicate_draft(repository, session_walls, draft)
+    return Repository.duplicate_draft(repository, session_walls, draft)
+end
+
+function M.library_items(repository, filter_text)
+    return Repository.library_items(repository, filter_text)
+end
+
+function M.save_intent(repository, draft, mode)
+    return Repository.save_intent(repository, draft, mode)
+end
+
+function M.save_draft(repository, session_walls, draft, mode, target_path)
+    return Repository.save_draft(repository, session_walls, draft, mode, target_path)
+end
+
+function M.make_raw_reference(item_id)
+    item_id = tonumber(item_id or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+return M

--- a/scripts/wall_studio/page.lua
+++ b/scripts/wall_studio/page.lua
@@ -1,0 +1,872 @@
+local Common = dofile("common.lua")
+local Model = dofile("model.lua")
+local LibraryPanel = dofile("library_panel.lua")
+local PreviewPanel = dofile("preview_panel.lua")
+local PropertiesPanel = dofile("properties_panel.lua")
+local Logger = dofile("logger.lua")
+local XmlTarget = dofile("xml_target_helper.lua")
+
+local WallStudioPage = {}
+
+local function create_page(options)
+    options = options or {}
+    local settings = Model.load_settings()
+    local session = options.session or {}
+    local listener_id = nil
+    local dlg
+    local actions = {}
+
+    local state = {
+        filter_text = "",
+        target_path = Model.resolve_target_path(settings.target_path or ""),
+        session_walls = {},
+        repository = nil,
+        library_filtered_items = {},
+        library_filtered_names = {},
+        library_items = {},
+        library_visible_names = {},
+        library_selection = 0,
+        library_selected_name = "",
+        library_page = 1,
+        library_page_size = 18,
+        library_page_count = 1,
+        draft = nil,
+        selected_alignment = Common.alignment_order[1].token,
+        selected_wall_item_index = 0,
+        selected_door_index = 0,
+        selected_raw_id = Common.active_raw_brush_id(),
+        recent_raw_ids = Common.clone(settings.recent_raw_ids or {}),
+        wall_item_chance = "1",
+        door_form = {
+            type = "normal",
+            open = false,
+            locked = false,
+            hate = false,
+        },
+        status_message = "",
+        dirty = false,
+        rebuilding = false,
+        library_ignore_index = 0,
+        library_ignore_budget = 0,
+        library_skip_changes = 0,
+    }
+
+    local function refresh_repository()
+        state.repository = Model.read_repository(state.target_path, state.session_walls)
+    end
+
+    local function selected_bucket()
+        return state.draft and state.draft:getBucket(state.selected_alignment) or Common.make_bucket(state.selected_alignment)
+    end
+
+    local function sync_library(preferred_name)
+        local filtered_items, filtered_names = Model.library_items(state.repository, state.filter_text)
+        state.library_filtered_items = filtered_items
+        state.library_filtered_names = filtered_names
+
+        local page_size = math.max(1, tonumber(state.library_page_size or 18) or 18)
+        state.library_page_count = math.max(1, math.ceil(#filtered_names / page_size))
+        local desired = Common.trim(preferred_name or state.library_selected_name)
+
+        if desired ~= "" then
+            for absolute_index, name in ipairs(filtered_names) do
+                if name == desired then
+                    state.library_page = math.ceil(absolute_index / page_size)
+                    break
+                end
+            end
+        end
+
+        if state.library_page < 1 then
+            state.library_page = 1
+        end
+        if state.library_page > state.library_page_count then
+            state.library_page = state.library_page_count
+        end
+
+        local page_start = ((state.library_page - 1) * page_size) + 1
+        local page_end = math.min(#filtered_names, page_start + page_size - 1)
+        state.library_items = {}
+        state.library_visible_names = {}
+        for absolute_index = page_start, page_end do
+            table.insert(state.library_items, filtered_items[absolute_index])
+            table.insert(state.library_visible_names, filtered_names[absolute_index])
+        end
+
+        state.library_selection = 0
+        if desired ~= "" then
+            for index, name in ipairs(state.library_visible_names) do
+                if name == desired then
+                    state.library_selection = index
+                    break
+                end
+            end
+        end
+    end
+
+    local function soft_refresh_library()
+        if not dlg then
+            return
+        end
+
+        state.rebuilding = true
+        state.library_skip_changes = 1
+        state.library_ignore_index = tonumber(state.library_selection or 0) or 0
+        state.library_ignore_budget = state.library_ignore_index > 0 and 2 or 0
+        dlg:modify({
+            wall_library_page_label = {
+                text = string.format("Strona %d / %d", tonumber(state.library_page or 1), tonumber(state.library_page_count or 1)),
+            },
+            wall_library = {
+                items = state.library_items,
+                selection = tonumber(state.library_selection or 0) or 0,
+            },
+        })
+        state.rebuilding = false
+        dlg:repaint()
+    end
+
+    local function persist_settings()
+        Model.save_settings(state)
+    end
+
+    local function sync_session_out()
+        session.lastSelectedRaw = tonumber(state.selected_raw_id or 0) or 0
+        session.recentItems = session.recentItems or {}
+        session.recentItems.wallRawIds = state.recent_raw_ids
+        session.pageDirty = session.pageDirty or {}
+        session.pageDirty.walls = state.dirty
+        if state.draft and not state.draft.isNew and Common.trim(state.draft.name or "") ~= "" then
+            session.selectedWallCreator = state.draft.name
+        end
+    end
+
+    local function sync_session_in()
+        local shared_raw = tonumber(session.lastSelectedRaw or 0) or 0
+        if shared_raw > 0 then
+            state.selected_raw_id = shared_raw
+        end
+    end
+
+    local function request_host_render()
+        sync_session_out()
+        if options.onRequestRender then
+            options.onRequestRender()
+            return true
+        end
+        return false
+    end
+
+    local function confirm_discard()
+        if not state.dirty then
+            return true
+        end
+        local choice = app.alert({
+            title = "Discard changes?",
+            text = "The current wall draft has unsaved changes. Continue and discard them?",
+            buttons = { "Yes", "No" },
+        })
+        return choice == 1
+    end
+
+    local function current_raw_id()
+        return Common.active_raw_brush_id()
+    end
+
+    local function sync_selected_raw_from_brush()
+        local active = current_raw_id()
+        if active > 0 then
+            state.selected_raw_id = active
+        end
+    end
+
+    local function remember_recent_raw(item_id)
+        item_id = tonumber(item_id or 0) or 0
+        if item_id <= 0 then
+            return
+        end
+
+        local next_items = { item_id }
+        for _, existing in ipairs(state.recent_raw_ids or {}) do
+            existing = tonumber(existing or 0) or 0
+            if existing > 0 and existing ~= item_id then
+                table.insert(next_items, existing)
+            end
+            if #next_items >= 8 then
+                break
+            end
+        end
+        state.recent_raw_ids = next_items
+    end
+
+    local function reset_bucket_selection()
+        state.selected_wall_item_index = 0
+        state.selected_door_index = 0
+        state.wall_item_chance = "1"
+        state.door_form = {
+            type = "normal",
+            open = false,
+            locked = false,
+            hate = false,
+        }
+    end
+
+    local function sync_forms_from_selection()
+        local bucket = selected_bucket()
+        local wall_item = bucket.wallItems[tonumber(state.selected_wall_item_index or 0) or 0]
+        if wall_item then
+            state.wall_item_chance = tostring(wall_item.chance or 0)
+        end
+        local door = bucket.doorItems[tonumber(state.selected_door_index or 0) or 0]
+        if door then
+            state.door_form = {
+                type = door.doorType or "normal",
+                open = door.isOpen and true or false,
+                locked = door.isLocked and true or false,
+                hate = door.hate and true or false,
+            }
+        end
+    end
+
+    local function soft_refresh()
+        if not dlg or not state.draft then
+            return
+        end
+
+        sync_selected_raw_from_brush()
+        sync_session_out()
+        sync_forms_from_selection()
+        state.rebuilding = true
+
+        local bucket = selected_bucket()
+        local raw_info = Common.safe_item_info(state.selected_raw_id)
+        local selected_wall_item = bucket.wallItems[tonumber(state.selected_wall_item_index or 0) or 0]
+        local selected_door = bucket.doorItems[tonumber(state.selected_door_index or 0) or 0]
+
+        dlg:modify({
+            current_wall_title = { text = Common.format_wall_title(state.draft) },
+            current_wall_status = { text = "Status: " .. Common.wall_status(state.draft) },
+            wall_alignment_combo = { option = Common.alignment_label(state.selected_alignment) },
+            wall_alignment_grid = { items = Common.alignment_grid_items(state.draft) },
+            selected_alignment_preview = { image = Common.safe_image(Common.representative_item_id(bucket)), width = 80, height = 80, smooth = false },
+            selected_alignment_title = { text = Common.alignment_label(state.selected_alignment) },
+            selected_alignment_meta = { text = string.format("Wall items: %d  |  Doors: %d", #(bucket.wallItems or {}), #(bucket.doorItems or {})) },
+            wall_friend_summary = { text = Common.friend_summary(state.draft) },
+            wall_redirect_summary = { text = state.draft.redirectName ~= "" and ("Redirect: " .. state.draft.redirectName) or "Redirect: brak" },
+            wall_active_raw_preview = { image = Common.safe_image(state.selected_raw_id), width = 48, height = 48, smooth = false },
+            wall_active_raw_title = { text = raw_info and (raw_info.name or ("Item " .. tostring(state.selected_raw_id))) or "Najpierw wybierz RAW tile" },
+            wall_active_raw_meta = { text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW." },
+            wall_name_input = { text = state.draft.name or "" },
+            wall_lookid_input = { text = tostring(state.draft.lookId or 0) },
+            wall_server_lookid_input = { text = tostring(state.draft.serverLookId or 0) },
+            wall_friends_input = { text = table.concat(state.draft.friends or {}, ", ") },
+            wall_redirect_input = { text = state.draft.redirectName or "" },
+            wall_bucket_item_list = { items = Common.bucket_wall_list_items(bucket), selection = tonumber(state.selected_wall_item_index or 0) or 0 },
+            wall_bucket_door_list = { items = Common.bucket_door_list_items(bucket), selection = tonumber(state.selected_door_index or 0) or 0 },
+            wall_item_chance_input = { text = selected_wall_item and tostring(selected_wall_item.chance or 0) or tostring(state.wall_item_chance or 1) },
+            wall_door_type_combo = { option = state.door_form.type or "normal" },
+            wall_door_open_check = { selected = state.door_form.open and true or false },
+            wall_door_locked_check = { selected = state.door_form.locked and true or false },
+            wall_door_hate_check = { selected = state.door_form.hate and true or false },
+            wall_recent_raw_list = { items = Common.recent_raw_items(state.recent_raw_ids) },
+            wall_save_mode_label = { text = state.draft.isNew and "Tryb: nowy wall brush" or "Tryb: edycja istniejacego wall brusha" },
+            wall_save_dirty_label = { text = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie" },
+            wall_save_target_label = { text = "Target: " .. tostring(state.target_path or "") },
+            wall_save_hint_label = { text = "Podaj nazwe i co najmniej jeden wall item, aby zapisac wall brush." },
+            wall_save_intent_new = { text = Model.save_intent(state.repository, state.draft, "new") },
+            wall_save_intent_overwrite = { text = Model.save_intent(state.repository, state.draft, "overwrite") },
+        })
+        state.rebuilding = false
+        dlg:repaint()
+    end
+
+    local function soft_refresh_active_raw()
+        if not dlg then
+            return
+        end
+
+        sync_selected_raw_from_brush()
+        sync_session_out()
+        state.rebuilding = true
+
+        local raw_info = Common.safe_item_info(state.selected_raw_id)
+        dlg:modify({
+            wall_active_raw_preview = { image = Common.safe_image(state.selected_raw_id), width = 48, height = 48, smooth = false },
+            wall_active_raw_title = { text = raw_info and (raw_info.name or ("Item " .. tostring(state.selected_raw_id))) or "Najpierw wybierz RAW tile" },
+            wall_active_raw_meta = { text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW." },
+            wall_recent_raw_list = { items = Common.recent_raw_items(state.recent_raw_ids) },
+        })
+        state.rebuilding = false
+        dlg:repaint()
+    end
+
+    local function render_page_content()
+        state.rebuilding = true
+        refresh_repository()
+        sync_library()
+        sync_selected_raw_from_brush()
+
+        dlg:panel({
+            bgcolor = Common.palette.header,
+            padding = 10,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "WALL STUDIO",
+                fgcolor = Common.palette.text,
+                font_size = 14,
+                font_weight = "bold",
+                align = "center",
+            })
+        dlg:endpanel()
+
+        dlg:box({
+            orient = "horizontal",
+            expand = true,
+        })
+            LibraryPanel.render(dlg, state, actions)
+            PreviewPanel.render(dlg, state)
+            PropertiesPanel.render(dlg, state, actions)
+        dlg:endbox()
+        state.library_skip_changes = 1
+        state.library_ignore_index = tonumber(state.library_selection or 0) or 0
+        state.library_ignore_budget = state.library_ignore_index > 0 and 2 or 0
+        state.rebuilding = false
+    end
+
+    local function rebuild()
+        if not dlg then
+            return
+        end
+        if request_host_render() then
+            return
+        end
+        dlg:clear()
+        render_page_content()
+        dlg:layout()
+        dlg:repaint()
+    end
+
+    function actions.set_filter(text)
+        if state.rebuilding then
+            return
+        end
+        state.filter_text = text or ""
+        state.library_page = 1
+        sync_library("")
+        soft_refresh_library()
+    end
+
+    function actions.previous_library_page()
+        if state.rebuilding then
+            return
+        end
+        if state.library_page > 1 then
+            state.library_page = state.library_page - 1
+            sync_library("")
+            soft_refresh_library()
+        end
+    end
+
+    function actions.next_library_page()
+        if state.rebuilding then
+            return
+        end
+        if state.library_page < state.library_page_count then
+            state.library_page = state.library_page + 1
+            sync_library("")
+            soft_refresh_library()
+        end
+    end
+
+    function actions.handle_library_change(index)
+        if state.rebuilding then
+            return
+        end
+        index = tonumber(index or 0) or 0
+        if index <= 0 then
+            return
+        end
+        if state.library_skip_changes > 0 then
+            state.library_skip_changes = state.library_skip_changes - 1
+            return
+        end
+        if state.library_ignore_budget > 0 and index == state.library_ignore_index then
+            state.library_ignore_budget = state.library_ignore_budget - 1
+            return
+        end
+
+        local previous_index = tonumber(state.library_selection or 0) or 0
+        local previous_name = tostring(state.library_selected_name or "")
+        state.library_selection = index
+        state.library_selected_name = state.library_visible_names[index] or ""
+
+        if previous_index == index and previous_name == tostring(state.library_selected_name or "") then
+            return
+        end
+
+        if state.library_selected_name ~= "" then
+            actions.open_wall(state.library_selected_name)
+        end
+    end
+
+    function actions.open_selected_wall()
+        if state.library_selected_name ~= "" then
+            actions.open_wall(state.library_selected_name)
+        end
+    end
+
+    function actions.open_wall(name)
+        name = Common.trim(name)
+        if name == "" then
+            return
+        end
+        if state.draft and state.draft.name == name and not state.dirty then
+            return
+        end
+        if not confirm_discard() then
+            return
+        end
+        local loaded = Model.load_draft(state.repository, name)
+        if not loaded then
+            app.alert("This wall brush could not be loaded from walls.xml.")
+            return
+        end
+        state.draft = loaded
+        state.library_selected_name = loaded.name
+        state.selected_alignment = Common.alignment_order[1].token
+        reset_bucket_selection()
+        state.status_message = string.format("Zaladowano wall brush '%s'.", loaded.name)
+        state.dirty = false
+        sync_library(loaded.name)
+        soft_refresh_library()
+        soft_refresh()
+    end
+
+    function actions.new_wall()
+        if not confirm_discard() then
+            return
+        end
+        state.draft = Model.new_draft(state.repository, state.session_walls)
+        state.library_selected_name = ""
+        state.selected_alignment = Common.alignment_order[1].token
+        reset_bucket_selection()
+        state.status_message = string.format("Utworzono nowy draft '%s'.", state.draft.name)
+        state.dirty = false
+        sync_library("")
+        soft_refresh_library()
+        soft_refresh()
+    end
+
+    function actions.duplicate_current()
+        state.draft = Model.duplicate_draft(state.repository, state.session_walls, state.draft)
+        state.library_selected_name = ""
+        reset_bucket_selection()
+        state.status_message = string.format("Zduplikowano wall brush do '%s'.", state.draft.name)
+        state.dirty = true
+        sync_library("")
+        soft_refresh_library()
+        soft_refresh()
+    end
+
+    function actions.set_alignment_title(title)
+        if state.rebuilding then
+            return
+        end
+        for _, alignment in ipairs(Common.alignment_order) do
+            if alignment.label == title then
+                state.selected_alignment = alignment.token
+                reset_bucket_selection()
+                soft_refresh()
+                return
+            end
+        end
+    end
+
+    function actions.set_name(name)
+        if state.rebuilding then
+            return
+        end
+        state.draft:setName(name)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_lookid(value)
+        if state.rebuilding then
+            return
+        end
+        state.draft:setLookId(tonumber(value or 0) or 0)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_server_lookid(value)
+        if state.rebuilding then
+            return
+        end
+        state.draft:setServerLookId(tonumber(value or 0) or 0)
+        state.dirty = true
+        sync_session_out()
+    end
+
+    function actions.set_friends_text(text)
+        if state.rebuilding then
+            return
+        end
+        state.draft:setFriendsFromText(text)
+        state.dirty = true
+        soft_refresh()
+    end
+
+    function actions.set_redirect_name(text)
+        if state.rebuilding then
+            return
+        end
+        state.draft:setRedirectName(text)
+        state.dirty = true
+        soft_refresh()
+    end
+
+    function actions.set_wall_item_selection(index)
+        if state.rebuilding then
+            return
+        end
+        state.selected_wall_item_index = tonumber(index or 0) or 0
+        state.selected_door_index = 0
+        sync_forms_from_selection()
+        soft_refresh()
+    end
+
+    function actions.set_wall_item_chance_text(text)
+        if state.rebuilding then
+            return
+        end
+        state.wall_item_chance = tostring(text or "")
+    end
+
+    function actions.add_wall_item_from_active_raw()
+        local raw_id = current_raw_id()
+        if raw_id <= 0 then
+            state.status_message = "Najpierw wybierz RAW tile."
+            soft_refresh()
+            return
+        end
+        local ok, message = state.draft:addWallItem(state.selected_alignment, Model.make_raw_reference(raw_id), tonumber(state.wall_item_chance or 1) or 1)
+        if not ok then
+            state.status_message = message
+            soft_refresh()
+            return
+        end
+        remember_recent_raw(raw_id)
+        state.selected_wall_item_index = #selected_bucket().wallItems
+        state.selected_door_index = 0
+        state.dirty = true
+        state.status_message = string.format("Dodano wall item %d do %s.", raw_id, Common.alignment_label(state.selected_alignment))
+        soft_refresh()
+    end
+
+    function actions.apply_selected_wall_item_chance()
+        if state.selected_wall_item_index <= 0 then
+            return
+        end
+        state.draft:setWallItemChance(state.selected_alignment, state.selected_wall_item_index, tonumber(state.wall_item_chance or 0) or 0)
+        state.dirty = true
+        soft_refresh()
+    end
+
+    function actions.remove_selected_wall_item()
+        if state.draft:removeWallItem(state.selected_alignment, state.selected_wall_item_index) then
+            state.selected_wall_item_index = 0
+            state.dirty = true
+            soft_refresh()
+        end
+    end
+
+    function actions.set_door_selection(index)
+        if state.rebuilding then
+            return
+        end
+        state.selected_door_index = tonumber(index or 0) or 0
+        state.selected_wall_item_index = 0
+        sync_forms_from_selection()
+        soft_refresh()
+    end
+
+    function actions.set_door_form_type(value)
+        if state.rebuilding then
+            return
+        end
+        state.door_form.type = value or "normal"
+    end
+
+    function actions.set_door_form_open(value)
+        if state.rebuilding then
+            return
+        end
+        state.door_form.open = value and true or false
+    end
+
+    function actions.set_door_form_locked(value)
+        if state.rebuilding then
+            return
+        end
+        state.door_form.locked = value and true or false
+    end
+
+    function actions.set_door_form_hate(value)
+        if state.rebuilding then
+            return
+        end
+        state.door_form.hate = value and true or false
+    end
+
+    function actions.add_door_from_active_raw()
+        local raw_id = current_raw_id()
+        if raw_id <= 0 then
+            state.status_message = "Najpierw wybierz RAW tile."
+            soft_refresh()
+            return
+        end
+        local ok, message = state.draft:addDoorItem(state.selected_alignment, Model.make_raw_reference(raw_id), {
+            doorType = state.door_form.type,
+            isOpen = state.door_form.open,
+            isLocked = state.door_form.locked,
+            hate = state.door_form.hate,
+        })
+        if not ok then
+            state.status_message = message
+            soft_refresh()
+            return
+        end
+        remember_recent_raw(raw_id)
+        state.selected_door_index = #selected_bucket().doorItems
+        state.selected_wall_item_index = 0
+        state.dirty = true
+        state.status_message = string.format("Dodano door entry %d do %s.", raw_id, Common.alignment_label(state.selected_alignment))
+        soft_refresh()
+    end
+
+    function actions.apply_selected_door()
+        if state.selected_door_index <= 0 then
+            return
+        end
+        state.draft:updateDoorItem(state.selected_alignment, state.selected_door_index, {
+            doorType = state.door_form.type,
+            isOpen = state.door_form.open,
+            isLocked = state.door_form.locked,
+            hate = state.door_form.hate,
+        })
+        state.dirty = true
+        soft_refresh()
+    end
+
+    function actions.remove_selected_door()
+        if state.draft:removeDoorItem(state.selected_alignment, state.selected_door_index) then
+            state.selected_door_index = 0
+            state.dirty = true
+            soft_refresh()
+        end
+    end
+
+    local function finalize_save(mode)
+        local ok, result = Model.save_draft(state.repository, state.session_walls, state.draft, mode, state.target_path)
+        if not ok then
+            app.alert({
+                title = "Save failed",
+                text = result,
+                buttons = { "OK" },
+            })
+            return
+        end
+
+        state.draft = result.draft
+        refresh_repository()
+        sync_library(result.draft.name)
+        state.library_selected_name = result.draft.name
+        state.status_message = result.message
+        state.dirty = false
+        session.lastSavedWall = result.draft.name
+        sync_session_out()
+        soft_refresh_library()
+        soft_refresh()
+        app.alert({
+            title = "Wall saved",
+            text = result.message,
+            buttons = { "OK" },
+        })
+    end
+
+    function actions.save_as_new()
+        finalize_save("new")
+    end
+
+    function actions.overwrite_existing()
+        finalize_save("overwrite")
+    end
+
+    function actions.get_save_intent(mode)
+        return Model.save_intent(state.repository, state.draft, mode)
+    end
+
+    function actions.choose_target_path()
+        local chosen, err = XmlTarget.pick_xml_file("walls.xml", state.target_path, "Wybierz walls.xml")
+        if err then
+            app.alert({
+                title = "Nie mozna ustawic targetu",
+                text = err,
+                buttons = { "OK" },
+            })
+            return
+        end
+        if not chosen then
+            return
+        end
+
+        state.target_path = chosen
+        persist_settings()
+        refresh_repository()
+        sync_library(nil)
+        state.status_message = "Ustawiono nowy target walls.xml."
+        soft_refresh_library()
+        soft_refresh()
+    end
+
+    function actions.use_default_target_path()
+        state.target_path = Model.resolve_target_path("")
+        persist_settings()
+        refresh_repository()
+        sync_library(nil)
+        state.status_message = "Przywrocono domyslny target walls.xml."
+        soft_refresh_library()
+        soft_refresh()
+    end
+
+    local function attach_brush_listener()
+        if listener_id or not app.events or not app.events.on then
+            return
+        end
+        listener_id = app.events:on("brushChange", function()
+            sync_selected_raw_from_brush()
+            if dlg then
+                soft_refresh_active_raw()
+            end
+        end)
+    end
+
+    local function detach_brush_listener()
+        if listener_id and app.events and app.events.off then
+            pcall(function()
+                app.events:off(listener_id)
+            end)
+        end
+        listener_id = nil
+    end
+
+    local function initialize()
+        refresh_repository()
+        state.draft = settings.last_wall_name and Model.load_draft(state.repository, settings.last_wall_name) or nil
+        if not state.draft then
+            state.draft = Model.new_draft(state.repository, state.session_walls)
+        end
+        if #state.repository.warnings > 0 then
+            state.status_message = state.repository.warnings[1]
+        else
+            state.status_message = "Wybierz gotowy wall brush albo utworz nowy draft."
+        end
+        sync_session_in()
+        sync_selected_raw_from_brush()
+        sync_session_out()
+    end
+
+    initialize()
+
+    local page = {}
+
+    function page.getTitle()
+        return "Walls"
+    end
+
+    function page.isDirty()
+        return state.dirty
+    end
+
+    function page.confirmLeave()
+        return confirm_discard()
+    end
+
+    function page.onEnter(shared_session)
+        session = shared_session or session
+        sync_session_in()
+        sync_session_out()
+        attach_brush_listener()
+    end
+
+    function page.onLeave(shared_session)
+        session = shared_session or session
+        sync_session_out()
+        persist_settings()
+        detach_brush_listener()
+    end
+
+    function page.render_into(dialog)
+        dlg = dialog
+        render_page_content()
+    end
+
+    function page.getSessionState()
+        sync_session_out()
+        return session
+    end
+
+    function page.getStatusText()
+        return state.status_message
+    end
+
+    return page
+end
+
+function WallStudioPage.create(options)
+    return create_page(options)
+end
+
+function WallStudioPage.open_standalone()
+    local existing_dialog = _G.WALL_STUDIO_DIALOG
+    if existing_dialog then
+        pcall(function()
+            existing_dialog:close()
+        end)
+        _G.WALL_STUDIO_DIALOG = nil
+        _G.WALL_STUDIO_OPEN = false
+        app.yield()
+    end
+
+    local page = create_page({})
+
+    local dlg = Dialog({
+        title = "Wall Studio",
+        id = "wall_studio_dock",
+        width = 1560,
+        height = 920,
+        resizable = true,
+        dockable = true,
+        onclose = function()
+            page.onLeave({})
+            _G.WALL_STUDIO_OPEN = false
+            _G.WALL_STUDIO_DIALOG = nil
+        end,
+    })
+
+    _G.WALL_STUDIO_OPEN = true
+    _G.WALL_STUDIO_DIALOG = dlg
+    page.onEnter({})
+    dlg:clear()
+    page.render_into(dlg)
+    dlg:layout()
+    dlg:repaint()
+    dlg:show({ wait = false, center = "screen" })
+    return page
+end
+
+return WallStudioPage

--- a/scripts/wall_studio/preview_panel.lua
+++ b/scripts/wall_studio/preview_panel.lua
@@ -1,0 +1,121 @@
+local Common = dofile("common.lua")
+
+local M = {}
+
+function M.render(dlg, state)
+    local current_bucket = state.draft and state.draft:getBucket(state.selected_alignment) or nil
+    local preview_id = current_bucket and Common.representative_item_id(current_bucket) or 0
+
+    dlg:box({
+        label = "2-5. Preview Walla",
+        orient = "vertical",
+        expand = true,
+        min_width = 430,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:label({
+            id = "wall_preview_help",
+            text = "Wybierz alignment i buduj bucket itemow oraz door entries.",
+            fgcolor = Common.palette.text,
+        })
+        dlg:newrow()
+        dlg:box({
+            orient = "horizontal",
+            expand = true,
+        })
+            dlg:panel({
+                bgcolor = Common.palette.panel_alt,
+                padding = 10,
+                margin = 4,
+                expand = false,
+                min_width = 150,
+            })
+                dlg:label({
+                    text = "Wybrany Alignment",
+                    fgcolor = Common.palette.text,
+                    font_weight = "bold",
+                })
+                dlg:newrow()
+                dlg:image({
+                    id = "selected_alignment_preview",
+                    image = Common.safe_image(preview_id),
+                    width = 80,
+                    height = 80,
+                    smooth = false,
+                })
+                dlg:newrow()
+                dlg:label({
+                    id = "selected_alignment_title",
+                    text = Common.alignment_label(state.selected_alignment),
+                    fgcolor = Common.palette.text,
+                })
+                dlg:newrow()
+                dlg:label({
+                    id = "selected_alignment_meta",
+                    text = string.format("Wall items: %d  |  Doors: %d", current_bucket and #(current_bucket.wallItems or {}) or 0, current_bucket and #(current_bucket.doorItems or {}) or 0),
+                    fgcolor = Common.palette.muted,
+                    font_size = 8,
+                })
+            dlg:endpanel()
+            dlg:panel({
+                bgcolor = Common.palette.panel_alt,
+                padding = 10,
+                margin = 4,
+                expand = true,
+            })
+                dlg:label({
+                    text = "Pokrycie Alignmentow",
+                    fgcolor = Common.palette.text,
+                    font_weight = "bold",
+                })
+                dlg:newrow()
+                dlg:grid({
+                    id = "wall_alignment_grid",
+                    width = 300,
+                    height = 380,
+                    cell_width = 96,
+                    cell_height = 96,
+                    item_width = 56,
+                    item_height = 56,
+                    icon_width = 56,
+                    icon_height = 56,
+                    show_text = true,
+                    items = Common.alignment_grid_items(state.draft),
+                })
+                dlg:newrow()
+                dlg:label({
+                    id = "wall_preview_status",
+                    text = "Grid pokazuje representative item dla kazdego alignmentu.",
+                    fgcolor = Common.palette.muted,
+                })
+            dlg:endpanel()
+        dlg:endbox()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 10,
+            margin = 4,
+            expand = true,
+        })
+            dlg:label({
+                text = "Relacje",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "wall_friend_summary",
+                text = Common.friend_summary(state.draft),
+                fgcolor = Common.palette.muted,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "wall_redirect_summary",
+                text = state.draft and state.draft.redirectName ~= "" and ("Redirect: " .. state.draft.redirectName) or "Redirect: brak",
+                fgcolor = Common.palette.subtle,
+            })
+        dlg:endpanel()
+    dlg:endbox()
+end
+
+return M

--- a/scripts/wall_studio/properties_panel.lua
+++ b/scripts/wall_studio/properties_panel.lua
@@ -1,0 +1,316 @@
+local Common = dofile("common.lua")
+local SavePanel = dofile("save_panel.lua")
+
+local M = {}
+
+function M.render(dlg, state, actions)
+    local active_raw_id = state.selected_raw_id or 0
+    local raw_info = Common.safe_item_info(active_raw_id)
+    local bucket = state.draft and state.draft:getBucket(state.selected_alignment) or Common.make_bucket(Common.alignment_order[1].token)
+    local selected_wall_item = bucket.wallItems[tonumber(state.selected_wall_item_index or 0) or 0]
+    local selected_door = bucket.doorItems[tonumber(state.selected_door_index or 0) or 0]
+
+    dlg:box({
+        label = "3-5. Wlasciwosci",
+        orient = "vertical",
+        width = 390,
+        min_width = 360,
+        expand = true,
+        fgcolor = Common.palette.muted,
+    })
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Aktualny RAW",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:image({
+                id = "wall_active_raw_preview",
+                image = Common.safe_image(active_raw_id),
+                width = 48,
+                height = 48,
+                smooth = false,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "wall_active_raw_title",
+                text = raw_info and (raw_info.name or ("Item " .. tostring(active_raw_id))) or "Najpierw wybierz RAW tile",
+                fgcolor = Common.palette.text,
+            })
+            dlg:newrow()
+            dlg:label({
+                id = "wall_active_raw_meta",
+                text = raw_info and string.format("Item ID %d  |  Look ID %d", raw_info.id or 0, raw_info.clientId or 0) or "Brak aktywnego RAW.",
+                fgcolor = Common.palette.subtle,
+                font_size = 8,
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:combobox({
+                id = "wall_alignment_combo",
+                label = "Alignment",
+                options = (function()
+                    local options = {}
+                    for _, alignment in ipairs(Common.alignment_order) do
+                        table.insert(options, alignment.label)
+                    end
+                    return options
+                end)(),
+                option = Common.alignment_label(state.selected_alignment),
+                onchange = function(d)
+                    actions.set_alignment_title(d.data.wall_alignment_combo or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_name_input",
+                label = "Nazwa",
+                text = state.draft and state.draft.name or "",
+                expand = true,
+                onchange = function(d)
+                    actions.set_name(d.data.wall_name_input or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_lookid_input",
+                label = "lookid",
+                text = tostring(state.draft and state.draft.lookId or 0),
+                expand = true,
+                onchange = function(d)
+                    actions.set_lookid(d.data.wall_lookid_input or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_server_lookid_input",
+                label = "server_lookid",
+                text = tostring(state.draft and state.draft.serverLookId or 0),
+                expand = true,
+                onchange = function(d)
+                    actions.set_server_lookid(d.data.wall_server_lookid_input or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_friends_input",
+                label = "Friends (comma)",
+                text = table.concat(state.draft and state.draft.friends or {}, ", "),
+                expand = true,
+                onchange = function(d)
+                    actions.set_friends_text(d.data.wall_friends_input or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_redirect_input",
+                label = "Redirect",
+                text = state.draft and state.draft.redirectName or "",
+                expand = true,
+                onchange = function(d)
+                    actions.set_redirect_name(d.data.wall_redirect_input or "")
+                end,
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Wall Items w Buckecie",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "wall_bucket_item_list",
+                height = 130,
+                expand = true,
+                icon_size = 24,
+                item_height = 30,
+                items = Common.bucket_wall_list_items(bucket),
+                selection = tonumber(state.selected_wall_item_index or 0) or 0,
+                onchange = function(d)
+                    actions.set_wall_item_selection(d.data.wall_bucket_item_list or 0)
+                end,
+            })
+            dlg:newrow()
+            dlg:input({
+                id = "wall_item_chance_input",
+                label = "Chance",
+                text = selected_wall_item and tostring(selected_wall_item.chance or 0) or tostring(state.wall_item_chance or 1),
+                expand = true,
+                onchange = function(d)
+                    actions.set_wall_item_chance_text(d.data.wall_item_chance_input or "")
+                end,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Dodaj RAW jako Wall",
+                    bgcolor = Common.palette.accent,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.add_wall_item_from_active_raw()
+                    end,
+                })
+                dlg:button({
+                    text = "Aktualizuj Chance",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.apply_selected_wall_item_chance()
+                    end,
+                })
+                dlg:button({
+                    text = "Usun",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.remove_selected_wall_item()
+                    end,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Door / Window Entries",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "wall_bucket_door_list",
+                height = 130,
+                expand = true,
+                icon_size = 24,
+                item_height = 30,
+                items = Common.bucket_door_list_items(bucket),
+                selection = tonumber(state.selected_door_index or 0) or 0,
+                onchange = function(d)
+                    actions.set_door_selection(d.data.wall_bucket_door_list or 0)
+                end,
+            })
+            dlg:newrow()
+            dlg:combobox({
+                id = "wall_door_type_combo",
+                label = "Door type",
+                options = Common.door_type_options,
+                option = state.door_form.type or "normal",
+                onchange = function(d)
+                    actions.set_door_form_type(d.data.wall_door_type_combo or "normal")
+                end,
+            })
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:check({
+                    id = "wall_door_open_check",
+                    text = "Open",
+                    selected = state.door_form.open and true or false,
+                    onclick = function(d)
+                        actions.set_door_form_open(d.data.wall_door_open_check)
+                    end,
+                })
+                dlg:check({
+                    id = "wall_door_locked_check",
+                    text = "Locked",
+                    selected = state.door_form.locked and true or false,
+                    onclick = function(d)
+                        actions.set_door_form_locked(d.data.wall_door_locked_check)
+                    end,
+                })
+                dlg:check({
+                    id = "wall_door_hate_check",
+                    text = "Hate",
+                    selected = state.door_form.hate and true or false,
+                    onclick = function(d)
+                        actions.set_door_form_hate(d.data.wall_door_hate_check)
+                    end,
+                })
+            dlg:endbox()
+            dlg:newrow()
+            dlg:box({
+                orient = "horizontal",
+                expand = false,
+            })
+                dlg:button({
+                    text = "Dodaj RAW jako Door",
+                    bgcolor = Common.palette.accent_soft,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.add_door_from_active_raw()
+                    end,
+                })
+                dlg:button({
+                    text = "Aktualizuj Door",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.apply_selected_door()
+                    end,
+                })
+                dlg:button({
+                    text = "Usun Door",
+                    bgcolor = Common.palette.panel,
+                    fgcolor = Common.palette.text,
+                    onclick = function()
+                        actions.remove_selected_door()
+                    end,
+                })
+            dlg:endbox()
+        dlg:endpanel()
+        dlg:newrow()
+        dlg:panel({
+            bgcolor = Common.palette.panel_alt,
+            padding = 8,
+            margin = 4,
+            expand = false,
+        })
+            dlg:label({
+                text = "Ostatnio Uzyte RAW",
+                fgcolor = Common.palette.text,
+                font_weight = "bold",
+            })
+            dlg:newrow()
+            dlg:list({
+                id = "wall_recent_raw_list",
+                height = 110,
+                expand = true,
+                icon_size = 24,
+                item_height = 30,
+                items = Common.recent_raw_items(state.recent_raw_ids),
+            })
+        dlg:endpanel()
+        dlg:newrow()
+        SavePanel.render(dlg, state, actions)
+    dlg:endbox()
+end
+
+return M

--- a/scripts/wall_studio/repository.lua
+++ b/scripts/wall_studio/repository.lua
@@ -1,0 +1,345 @@
+local Common = dofile("common.lua")
+local WallDraft = dofile("wall_draft.lua")
+local XmlCodec = dofile("xml_codec.lua")
+local Logger = dofile("logger.lua")
+
+local M = {}
+
+local function file_exists(path)
+    if not path or path == "" then
+        return false
+    end
+    local store = app.storage(path)
+    return store and store.exists and store:exists() or false
+end
+
+local function read_file(path)
+    local store = app.storage(path)
+    if not store or not store.readText then
+        return nil, "This RME build does not expose raw file reads for walls.xml."
+    end
+    local content, err = store:readText()
+    if not content then
+        return nil, err or "Could not open file."
+    end
+    return content
+end
+
+local function write_file(path, content)
+    local store = app.storage(path)
+    if not store or not store.save then
+        return false, "This RME build does not expose safe file writes."
+    end
+    local ok = store:save(content or "")
+    if not ok then
+        return false, "Could not write file."
+    end
+    return true
+end
+
+local function build_repository_from_app_walls(app_walls, session_walls)
+    local repository = {
+        ordered = {},
+        by_name = {},
+        warnings = {},
+        target_path = "",
+        api_missing = nil,
+    }
+
+    for _, wall_data in pairs(app_walls or {}) do
+        local name = Common.trim(wall_data.name or "")
+        if name ~= "" then
+            local alignments = {}
+            for _, alignment in ipairs(Common.alignment_order) do
+                local bucket_data = wall_data.alignments and wall_data.alignments[alignment.token] or {}
+                local bucket = Common.make_bucket(alignment.token)
+                for _, item in ipairs(bucket_data.items or {}) do
+                    local item_id = tonumber(item.id or item.itemId or 0) or 0
+                    if item_id > 0 then
+                        table.insert(bucket.wallItems, {
+                            itemId = item_id,
+                            chance = tonumber(item.chance or 1) or 1,
+                            name = Common.safe_item_name(item_id),
+                            lookId = (Common.safe_item_info(item_id) or {}).clientId or 0,
+                        })
+                    end
+                end
+                for _, door in ipairs(bucket_data.doors or {}) do
+                    local item_id = tonumber(door.id or door.itemId or 0) or 0
+                    if item_id > 0 then
+                        table.insert(bucket.doorItems, {
+                            itemId = item_id,
+                            doorType = Common.trim(door.type or door.doorType or "normal"),
+                            isOpen = Common.normalize_bool(door.open, false),
+                            isLocked = Common.normalize_bool(door.locked, false),
+                            hate = Common.normalize_bool(door.hate, false),
+                            name = Common.safe_item_name(item_id),
+                            lookId = (Common.safe_item_info(item_id) or {}).clientId or 0,
+                        })
+                    end
+                end
+                alignments[alignment.token] = bucket
+            end
+
+            local draft = WallDraft.new({
+                name = name,
+                lookId = tonumber(wall_data.lookid or 0) or 0,
+                serverLookId = tonumber(wall_data.server_lookid or 0) or 0,
+                isNew = false,
+                sourceName = name,
+                friends = Common.clone(wall_data.friends or {}),
+                redirectName = Common.trim(wall_data.redirect_to or ""),
+                alignments = alignments,
+            })
+
+            if draft.serverLookId <= 0 then
+                draft.serverLookId = draft:getPreviewItemId()
+            end
+
+            repository.by_name[name] = draft
+        end
+    end
+
+    for name, overlay in pairs(session_walls or {}) do
+        repository.by_name[name] = overlay:clone()
+        repository.by_name[name].isNew = false
+    end
+
+    for _, draft in pairs(repository.by_name) do
+        table.insert(repository.ordered, draft)
+    end
+
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+
+    return repository
+end
+
+function M.resolve_target_path(saved_path)
+    if saved_path and saved_path ~= "" and file_exists(saved_path) then
+        return saved_path
+    end
+
+    local preferred = tostring(app.getDataDirectory() or "") .. "/1310/walls.xml"
+    return preferred
+end
+
+function M.read(target_path, session_walls)
+    local repository = nil
+    if app and app.walls then
+        repository = build_repository_from_app_walls(app.walls, session_walls)
+        repository.target_path = target_path or ""
+    end
+
+    local content, err = read_file(target_path)
+    if not content then
+        repository = repository or {
+            ordered = {},
+            by_name = {},
+            warnings = {},
+            target_path = target_path or "",
+            api_missing = err,
+        }
+        table.insert(repository.warnings, err)
+        return repository
+    end
+
+    local parsed = XmlCodec.parse_walls(content)
+    if not repository then
+        repository = parsed
+    else
+        for name, draft in pairs(parsed.by_name or {}) do
+            if not repository.by_name[name] then
+                repository.by_name[name] = draft
+            else
+                repository.by_name[name].serverLookId = tonumber(draft.serverLookId or repository.by_name[name].serverLookId or 0) or 0
+                repository.by_name[name].lookId = tonumber(repository.by_name[name].lookId or draft.lookId or 0) or 0
+            end
+        end
+        repository.warnings = repository.warnings or {}
+        for _, warning in ipairs(parsed.warnings or {}) do
+            table.insert(repository.warnings, warning)
+        end
+    end
+
+    for name, overlay in pairs(session_walls or {}) do
+        repository.by_name[name] = overlay:clone()
+        repository.by_name[name].isNew = false
+    end
+
+    repository.ordered = {}
+    for _, draft in pairs(repository.by_name) do
+        table.insert(repository.ordered, draft)
+    end
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+    repository.target_path = target_path or ""
+    return repository
+end
+
+function M.new_draft(repository, session_walls)
+    local base = "new wall"
+    local index = 1
+    local candidate = base
+    while (repository.by_name and repository.by_name[candidate]) or (session_walls and session_walls[candidate]) do
+        index = index + 1
+        candidate = string.format("%s %d", base, index)
+    end
+    return WallDraft.new({
+        name = candidate,
+        isNew = true,
+    })
+end
+
+function M.load_draft(repository, name)
+    local draft = repository.by_name[name]
+    return draft and draft:clone() or nil
+end
+
+function M.duplicate_draft(repository, session_walls, draft)
+    local copy = draft:clone()
+    local base = Common.trim((draft.name ~= "" and draft.name or "wall") .. " copy")
+    local index = 1
+    local candidate = base
+    while (repository.by_name and repository.by_name[candidate]) or (session_walls and session_walls[candidate]) do
+        index = index + 1
+        candidate = string.format("%s %d", base, index)
+    end
+    copy.name = candidate
+    copy.sourceName = candidate
+    copy.isNew = true
+    return copy
+end
+
+function M.library_items(repository, filter_text)
+    return Common.library_items(repository, filter_text)
+end
+
+function M.save_intent(repository, draft, mode)
+    local name = Common.trim(draft and draft.name or "")
+    local source_name = Common.trim(draft and draft.sourceName or "")
+    local exists = name ~= "" and repository.by_name and repository.by_name[name] ~= nil
+    local source_exists = source_name ~= "" and repository.by_name and repository.by_name[source_name] ~= nil
+
+    if mode == "new" then
+        if name == "" then
+            return "Podaj nazwe wall brusha, aby zapisac nowy wpis."
+        end
+        if exists then
+            return string.format("Save as New zablokowany: wall '%s' juz istnieje.", name)
+        end
+        return string.format("Utworzy nowy wall brush '%s'.", name)
+    end
+
+    if not source_exists then
+        return "Overwrite wymaga istniejacego wall brusha w bibliotece."
+    end
+    return string.format("Nadpisze wall brush '%s'.", source_name)
+end
+
+function M.validate_save(repository, draft, mode, target_path)
+    if not target_path or target_path == "" then
+        return false, "Target walls.xml could not be resolved."
+    end
+    if not Common.path_starts_with(target_path, app.getDataDirectory()) then
+        return false, "Target walls.xml must stay inside the RME data directory."
+    end
+    if not tostring(target_path):lower():match("%.xml$") then
+        return false, "Target file must be an XML file."
+    end
+    if not file_exists(target_path) then
+        return false, "Target walls.xml does not exist."
+    end
+
+    local validation = draft:getValidation()
+    if not validation.isValid then
+        return false, validation.errors[1] or "Wall draft jest niepoprawny."
+    end
+
+    local current_name = Common.trim(draft.name or "")
+    local source_name = Common.trim(draft.sourceName or current_name)
+    local exists = repository.by_name and repository.by_name[current_name] ~= nil
+    local source_exists = repository.by_name and repository.by_name[source_name] ~= nil
+
+    if mode == "new" and exists then
+        return false, string.format("Wall '%s' juz istnieje.", current_name)
+    end
+    if mode == "overwrite" and not source_exists then
+        return false, string.format("Wall '%s' nie istnieje do nadpisania.", source_name)
+    end
+
+    return true
+end
+
+function M.backup_xml(target_path)
+    local original, err = read_file(target_path)
+    if not original then
+        return false, nil, nil, "Could not read walls.xml before backup: " .. tostring(err)
+    end
+
+    local backup_path = string.format("%s.wallstudio.%s.bak", target_path, os.date("%Y%m%d_%H%M%S"))
+    local ok, backup_err = write_file(backup_path, original)
+    if not ok then
+        return false, nil, nil, "Could not write backup file: " .. tostring(backup_err)
+    end
+
+    return true, backup_path, original
+end
+
+function M.save_draft(repository, session_walls, draft, mode, target_path)
+    local ok, validation_message = M.validate_save(repository, draft, mode, target_path)
+    if not ok then
+        return false, validation_message
+    end
+
+    local backup_ok, backup_path, original_content, backup_message = M.backup_xml(target_path)
+    if not backup_ok then
+        return false, backup_message
+    end
+
+    local saved_draft = draft:clone()
+    saved_draft.name = Common.trim(saved_draft.name)
+    saved_draft.isNew = false
+
+    local writer = app.storage(target_path)
+    if not writer or not writer.upsertXml then
+        return false, "The current RME build does not expose XML upsert support."
+    end
+
+    local match_name = mode == "overwrite" and Common.trim(saved_draft.sourceName or saved_draft.name) or saved_draft.name
+    local xml = XmlCodec.serialize_wall(saved_draft)
+    local write_ok, write_mode = writer:upsertXml({
+        root = "materials",
+        parent = "materials",
+        tag = "brush",
+        match_attr = "name",
+        match_value = match_name,
+        xml = xml,
+    })
+
+    if not write_ok then
+        if original_content then
+            write_file(target_path, original_content)
+        end
+        return false, write_mode or "Saving failed while updating walls.xml."
+    end
+
+    if match_name ~= saved_draft.name then
+        session_walls[match_name] = nil
+    end
+
+    saved_draft.sourceName = saved_draft.name
+    session_walls[saved_draft.name] = saved_draft:clone()
+    Logger.log("repository", string.format("saved wall '%s'", saved_draft.name))
+
+    return true, {
+        draft = saved_draft,
+        backupPath = backup_path,
+        xmlMode = write_mode or mode,
+        message = string.format("Saved wall brush '%s' successfully.\nBackup: %s", saved_draft.name, backup_path),
+    }
+end
+
+return M

--- a/scripts/wall_studio/save_panel.lua
+++ b/scripts/wall_studio/save_panel.lua
@@ -16,28 +16,28 @@ function M.render(dlg, state, actions)
             expand = true,
         })
             dlg:label({
-                id = "save_mode_label",
-                text = state.draft and (state.draft.isNew and "Tryb: nowy ground" or "Tryb: edycja istniejacego grounda"),
+                id = "wall_save_mode_label",
+                text = state.draft and (state.draft.isNew and "Tryb: nowy wall brush" or "Tryb: edycja istniejacego wall brusha"),
                 fgcolor = Common.palette.text,
                 font_weight = "bold",
             })
             dlg:newrow()
             dlg:label({
-                id = "save_dirty_label",
+                id = "wall_save_dirty_label",
                 text = state.dirty and "Niezapisane zmiany: tak" or "Niezapisane zmiany: nie",
                 fgcolor = Common.palette.subtle,
             })
             dlg:newrow()
             dlg:label({
-                id = "save_target_label",
+                id = "wall_save_target_label",
                 text = "Target: " .. tostring(state.target_path or ""),
                 fgcolor = Common.palette.subtle,
                 font_size = 8,
             })
             dlg:newrow()
             dlg:label({
-                id = "save_hint_label",
-                text = "Podaj nazwe i glowny tile, aby zapisac ground.",
+                id = "wall_save_hint_label",
+                text = "Podaj nazwe i co najmniej jeden wall item, aby zapisac wall brush.",
                 fgcolor = Common.palette.muted,
             })
         dlg:endpanel()
@@ -87,15 +87,15 @@ function M.render(dlg, state, actions)
         dlg:endbox()
         dlg:newrow()
         dlg:label({
-            id = "save_intent_new",
-            text = "",
+            id = "wall_save_intent_new",
+            text = state.draft and actions and actions.get_save_intent and actions.get_save_intent("new") or "",
             fgcolor = Common.palette.muted,
             font_size = 8,
         })
         dlg:newrow()
         dlg:label({
-            id = "save_intent_overwrite",
-            text = "",
+            id = "wall_save_intent_overwrite",
+            text = state.draft and actions and actions.get_save_intent and actions.get_save_intent("overwrite") or "",
             fgcolor = Common.palette.muted,
             font_size = 8,
         })

--- a/scripts/wall_studio/wall_draft.lua
+++ b/scripts/wall_studio/wall_draft.lua
@@ -1,0 +1,341 @@
+local Common = dofile("common.lua")
+
+local WallDraft = {}
+WallDraft.__index = WallDraft
+
+local function build_item_reference(raw_item)
+    if type(raw_item) == "table" then
+        local item_id = tonumber(raw_item.itemId or raw_item.item_id or raw_item.id or 0) or 0
+        if item_id <= 0 then
+            return nil
+        end
+        local info = Common.safe_item_info(item_id)
+        return {
+            itemId = item_id,
+            rawId = tonumber(raw_item.rawId or raw_item.raw_id or item_id) or item_id,
+            lookId = tonumber(raw_item.lookId or raw_item.look_id or raw_item.clientId or (info and info.clientId) or 0) or 0,
+            name = raw_item.name or (info and info.name) or ("Item " .. tostring(item_id)),
+        }
+    end
+
+    local item_id = tonumber(raw_item or 0) or 0
+    if item_id <= 0 then
+        return nil
+    end
+    local info = Common.safe_item_info(item_id)
+    return {
+        itemId = item_id,
+        rawId = item_id,
+        lookId = info and info.clientId or 0,
+        name = info and info.name or ("Item " .. tostring(item_id)),
+    }
+end
+
+local function normalize_chance(value, default)
+    local chance = tonumber(value or default or 1) or tonumber(default or 1) or 1
+    chance = math.floor(chance)
+    if chance < 0 then
+        chance = 0
+    end
+    return chance
+end
+
+local function normalize_door_type(value)
+    local text = Common.trim(value or "normal")
+    for _, option in ipairs(Common.door_type_options) do
+        if option == text then
+            return option
+        end
+    end
+    return "normal"
+end
+
+local function clone_bucket(source, token)
+    local bucket = Common.make_bucket(token)
+    for _, item in ipairs(source and source.wallItems or {}) do
+        table.insert(bucket.wallItems, Common.clone(item))
+    end
+    for _, door in ipairs(source and source.doorItems or {}) do
+        table.insert(bucket.doorItems, Common.clone(door))
+    end
+    return bucket
+end
+
+function WallDraft.new(init)
+    local self = setmetatable({}, WallDraft)
+    self.name = Common.trim(init and init.name or "")
+    self.lookId = tonumber((init and (init.lookId or init.look_id)) or 0) or 0
+    self.serverLookId = tonumber((init and (init.serverLookId or init.server_lookid)) or 0) or 0
+    self.isNew = Common.normalize_bool(init and init.isNew, true)
+    self.sourceName = Common.trim(init and (init.sourceName or init.source_name or init.name) or "")
+    self.friends = Common.clone(init and init.friends or {})
+    self.redirectName = Common.trim(init and (init.redirectName or init.redirect_to) or "")
+    self.extraChildrenXml = tostring((init and (init.extraChildrenXml or init.extra_children_xml)) or "")
+    self.alignments = {}
+
+    for _, alignment in ipairs(Common.alignment_order) do
+        self.alignments[alignment.token] = clone_bucket(init and init.alignments and init.alignments[alignment.token], alignment.token)
+    end
+
+    if self.lookId <= 0 then
+        self.lookId = self:getPreviewLookId()
+    end
+    if self.serverLookId <= 0 then
+        self.serverLookId = self:getPreviewItemId()
+    end
+
+    return self
+end
+
+function WallDraft:getBucket(token)
+    token = Common.trim(token)
+    if token == "" or not self.alignments[token] then
+        token = Common.alignment_order[1].token
+    end
+    return self.alignments[token]
+end
+
+function WallDraft:getPreviewItemId()
+    for _, alignment in ipairs(Common.alignment_order) do
+        local item_id = Common.representative_item_id(self.alignments[alignment.token])
+        if item_id > 0 then
+            return item_id
+        end
+    end
+    return 0
+end
+
+function WallDraft:getPreviewLookId()
+    for _, alignment in ipairs(Common.alignment_order) do
+        local bucket = self.alignments[alignment.token]
+        for _, item in ipairs(bucket.wallItems or {}) do
+            if tonumber(item.lookId or 0) > 0 then
+                return tonumber(item.lookId or 0) or 0
+            end
+        end
+        for _, door in ipairs(bucket.doorItems or {}) do
+            if tonumber(door.lookId or 0) > 0 then
+                return tonumber(door.lookId or 0) or 0
+            end
+        end
+    end
+    return 0
+end
+
+function WallDraft:setName(name)
+    self.name = Common.trim(name)
+end
+
+function WallDraft:setLookId(value)
+    self.lookId = tonumber(value or 0) or 0
+end
+
+function WallDraft:setServerLookId(value)
+    self.serverLookId = tonumber(value or 0) or 0
+end
+
+function WallDraft:setFriendsFromText(text)
+    local names = {}
+    local seen = {}
+    for raw in tostring(text or ""):gmatch("[^,]+") do
+        local name = Common.trim(raw)
+        local key = string.lower(name)
+        if name ~= "" and not seen[key] then
+            seen[key] = true
+            table.insert(names, name)
+        end
+    end
+    self.friends = names
+end
+
+function WallDraft:setRedirectName(name)
+    self.redirectName = Common.trim(name)
+end
+
+function WallDraft:addWallItem(token, raw_item, chance)
+    local bucket = self:getBucket(token)
+    local reference = build_item_reference(raw_item)
+    if not reference then
+        return false, "Invalid wall item."
+    end
+    for _, item in ipairs(bucket.wallItems) do
+        if tonumber(item.itemId or 0) == reference.itemId then
+            return false, "This wall item already exists in the selected alignment."
+        end
+    end
+
+    reference.chance = normalize_chance(chance, 1)
+    table.insert(bucket.wallItems, reference)
+    if self.lookId <= 0 then
+        self.lookId = reference.lookId or 0
+    end
+    if self.serverLookId <= 0 then
+        self.serverLookId = reference.itemId or 0
+    end
+    return true
+end
+
+function WallDraft:removeWallItem(token, index)
+    local bucket = self:getBucket(token)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #bucket.wallItems then
+        return false
+    end
+    table.remove(bucket.wallItems, index)
+    return true
+end
+
+function WallDraft:setWallItemChance(token, index, chance)
+    local bucket = self:getBucket(token)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #bucket.wallItems then
+        return false
+    end
+    bucket.wallItems[index].chance = normalize_chance(chance, bucket.wallItems[index].chance)
+    return true
+end
+
+function WallDraft:addDoorItem(token, raw_item, config)
+    local bucket = self:getBucket(token)
+    local reference = build_item_reference(raw_item)
+    if not reference then
+        return false, "Invalid door item."
+    end
+    for _, door in ipairs(bucket.doorItems) do
+        if tonumber(door.itemId or 0) == reference.itemId then
+            return false, "This door item already exists in the selected alignment."
+        end
+    end
+
+    reference.doorType = normalize_door_type(config and config.doorType or "normal")
+    reference.isOpen = Common.normalize_bool(config and config.isOpen, false)
+    reference.isLocked = Common.normalize_bool(config and config.isLocked, false)
+    reference.hate = Common.normalize_bool(config and config.hate, false)
+    table.insert(bucket.doorItems, reference)
+    if self.lookId <= 0 then
+        self.lookId = reference.lookId or 0
+    end
+    if self.serverLookId <= 0 then
+        self.serverLookId = reference.itemId or 0
+    end
+    return true
+end
+
+function WallDraft:removeDoorItem(token, index)
+    local bucket = self:getBucket(token)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #bucket.doorItems then
+        return false
+    end
+    table.remove(bucket.doorItems, index)
+    return true
+end
+
+function WallDraft:updateDoorItem(token, index, config)
+    local bucket = self:getBucket(token)
+    index = tonumber(index or 0) or 0
+    if index <= 0 or index > #bucket.doorItems then
+        return false
+    end
+    local door = bucket.doorItems[index]
+    door.doorType = normalize_door_type(config and config.doorType or door.doorType)
+    door.isOpen = Common.normalize_bool(config and config.isOpen, door.isOpen)
+    door.isLocked = Common.normalize_bool(config and config.isLocked, door.isLocked)
+    door.hate = Common.normalize_bool(config and config.hate, door.hate)
+    return true
+end
+
+function WallDraft:getValidation()
+    local errors = {}
+    local warnings = {}
+    local has_any_items = false
+    local has_base_wall = false
+
+    if self.name == "" then
+        table.insert(errors, "Nazwa wall brusha nie moze byc pusta.")
+    end
+    if self.redirectName ~= "" and self.redirectName == self.name then
+        table.insert(errors, "Redirect nie moze wskazywac na ten sam wall brush.")
+    end
+
+    local friend_seen = {}
+    for index, friend_name in ipairs(self.friends or {}) do
+        local key = string.lower(friend_name or "")
+        if key == "" then
+            table.insert(errors, string.format("Friend link %d ma pusta nazwe.", index))
+        elseif friend_seen[key] then
+            table.insert(errors, string.format("Friend link '%s' wystepuje wiecej niz raz.", friend_name))
+        else
+            friend_seen[key] = true
+        end
+    end
+    if self.redirectName ~= "" and not friend_seen[string.lower(self.redirectName)] then
+        table.insert(warnings, "Redirect brush nie jest na liscie friends. Zostanie dopisany przy eksporcie.")
+    end
+
+    for _, alignment in ipairs(Common.alignment_order) do
+        local bucket = self.alignments[alignment.token]
+        if bucket then
+            local seen_items = {}
+            for index, item in ipairs(bucket.wallItems or {}) do
+                has_any_items = true
+                has_base_wall = true
+                local item_id = tonumber(item.itemId or 0) or 0
+                local chance = tonumber(item.chance or 0) or 0
+                if item_id <= 0 then
+                    table.insert(errors, string.format("%s wall item %d ma niepoprawny item id.", alignment.label, index))
+                end
+                if chance < 0 then
+                    table.insert(errors, string.format("%s wall item %d ma ujemny chance.", alignment.label, index))
+                end
+                if item_id > 0 then
+                    if seen_items[item_id] then
+                        table.insert(errors, string.format("%s duplikuje wall item %d.", alignment.label, item_id))
+                    end
+                    seen_items[item_id] = true
+                end
+            end
+
+            for index, door in ipairs(bucket.doorItems or {}) do
+                has_any_items = true
+                local item_id = tonumber(door.itemId or 0) or 0
+                if item_id <= 0 then
+                    table.insert(errors, string.format("%s door %d ma niepoprawny item id.", alignment.label, index))
+                end
+                if door.doorType == "undefined" then
+                    table.insert(errors, string.format("%s door %d ma niepoprawny type.", alignment.label, index))
+                end
+            end
+        end
+    end
+
+    if not has_any_items then
+        table.insert(errors, "Wall brush jest pusty.")
+    end
+    if not has_base_wall then
+        table.insert(errors, "Wall brush musi miec przynajmniej jeden zwykly wall item.")
+    end
+
+    return {
+        hasData = has_any_items,
+        isValid = #errors == 0,
+        errors = errors,
+        warnings = warnings,
+    }
+end
+
+function WallDraft:clone()
+    return WallDraft.new({
+        name = self.name,
+        lookId = self.lookId,
+        serverLookId = self.serverLookId,
+        isNew = self.isNew,
+        sourceName = self.sourceName,
+        friends = Common.clone(self.friends),
+        redirectName = self.redirectName,
+        extraChildrenXml = self.extraChildrenXml,
+        alignments = Common.clone(self.alignments),
+    })
+end
+
+return WallDraft

--- a/scripts/wall_studio/xml_codec.lua
+++ b/scripts/wall_studio/xml_codec.lua
@@ -1,0 +1,255 @@
+local Common = dofile("common.lua")
+local WallDraft = dofile("wall_draft.lua")
+
+local M = {}
+
+local function parse_attributes(text)
+    local attrs = {}
+    for key, value in tostring(text or ""):gmatch('([%w_%-]+)%s*=%s*"([^"]-)"') do
+        attrs[key] = Common.unescape_xml(value)
+    end
+    return attrs
+end
+
+local function extract_brush_blocks(xml)
+    local blocks = {}
+    local cursor = 1
+
+    while true do
+        local start_index = xml:find("<brush%s", cursor)
+        if not start_index then
+            break
+        end
+
+        local tag_end = xml:find(">", start_index, true)
+        if not tag_end then
+            break
+        end
+
+        local open_tag = xml:sub(start_index, tag_end)
+        local self_closing = open_tag:match("/%s*>$") ~= nil
+        if self_closing then
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = "",
+            })
+            cursor = tag_end + 1
+        else
+            local close_start, close_end = xml:find("</brush>", tag_end + 1, true)
+            if not close_start then
+                break
+            end
+            table.insert(blocks, {
+                attributes = parse_attributes(open_tag),
+                inner = xml:sub(tag_end + 1, close_start - 1),
+            })
+            cursor = close_end + 1
+        end
+    end
+
+    return blocks
+end
+
+local function extract_wall_blocks(inner)
+    local blocks = {}
+    local cursor = 1
+    while true do
+        local start_index = tostring(inner or ""):find("<wall%s", cursor)
+        if not start_index then
+            break
+        end
+        local tag_end = tostring(inner or ""):find(">", start_index, true)
+        if not tag_end then
+            break
+        end
+        local open_tag = tostring(inner or ""):sub(start_index, tag_end)
+        local close_start, close_end = tostring(inner or ""):find("</wall>", tag_end + 1, true)
+        if not close_start then
+            break
+        end
+        table.insert(blocks, {
+            attributes = parse_attributes(open_tag),
+            inner = tostring(inner or ""):sub(tag_end + 1, close_start - 1),
+        })
+        cursor = close_end + 1
+    end
+    return blocks
+end
+
+function M.parse_walls(xml)
+    local repository = {
+        ordered = {},
+        by_name = {},
+        warnings = {},
+    }
+
+    for _, block in ipairs(extract_brush_blocks(tostring(xml or ""))) do
+        local attrs = block.attributes or {}
+        if string.lower(tostring(attrs.type or "")) == "wall" then
+            local name = Common.trim(attrs.name or "")
+            if name == "" then
+                table.insert(repository.warnings, "Skipped wall brush without name.")
+            else
+                local alignments = {}
+                local has_supported_wall = false
+
+                for _, alignment in ipairs(Common.alignment_order) do
+                    alignments[alignment.token] = Common.make_bucket(alignment.token)
+                end
+
+                local found_unsupported = false
+                for tag in tostring(block.inner or ""):gmatch("<%s*([%w_%-]+)") do
+                    local lower = string.lower(tag)
+                    if lower ~= "wall" and lower ~= "friend" and lower ~= "!--" then
+                        found_unsupported = true
+                    end
+                end
+
+                for _, wall_block in ipairs(extract_wall_blocks(block.inner)) do
+                    local token = Common.trim((wall_block.attributes or {}).type or "")
+                    if token ~= "" then
+                        local normalized = token == "corner" and "corner" or token
+                        local bucket = alignments[normalized]
+                        if bucket then
+                            has_supported_wall = true
+                            for item_attrs in tostring(wall_block.inner or ""):gmatch("<item%s+(.-)%s*/>") do
+                                local parsed = parse_attributes(item_attrs)
+                                local item_id = tonumber(parsed.id or 0) or 0
+                                if item_id > 0 then
+                                    table.insert(bucket.wallItems, {
+                                        itemId = item_id,
+                                        chance = tonumber(parsed.chance or 1) or 1,
+                                        name = Common.safe_item_name(item_id),
+                                        lookId = (Common.safe_item_info(item_id) or {}).clientId or 0,
+                                    })
+                                end
+                            end
+
+                            for door_attrs in tostring(wall_block.inner or ""):gmatch("<door%s+(.-)%s*/>") do
+                                local parsed = parse_attributes(door_attrs)
+                                local item_id = tonumber(parsed.id or 0) or 0
+                                if item_id > 0 then
+                                    table.insert(bucket.doorItems, {
+                                        itemId = item_id,
+                                        doorType = Common.trim(parsed.type or "normal"),
+                                        isOpen = Common.normalize_bool(parsed.open, parsed.type == "window" or parsed.type == "hatch_window"),
+                                        isLocked = Common.normalize_bool(parsed.locked, false),
+                                        hate = Common.normalize_bool(parsed.hate, false),
+                                        name = Common.safe_item_name(item_id),
+                                        lookId = (Common.safe_item_info(item_id) or {}).clientId or 0,
+                                    })
+                                end
+                            end
+                        else
+                            table.insert(repository.warnings, string.format("Wall '%s' uses unsupported alignment '%s'.", name, token))
+                        end
+                    end
+                end
+
+                if found_unsupported and not has_supported_wall then
+                    table.insert(repository.warnings, string.format("Skipped wall brush '%s' because it does not use <wall> buckets.", name))
+                elseif has_supported_wall then
+                    local friends = {}
+                    local redirect_name = ""
+                    for friend_attrs in tostring(block.inner or ""):gmatch("<friend%s+(.-)%s*/>") do
+                        local parsed = parse_attributes(friend_attrs)
+                        local friend_name = Common.trim(parsed.name or "")
+                        if friend_name ~= "" then
+                            table.insert(friends, friend_name)
+                            if Common.normalize_bool(parsed.redirect, false) and redirect_name == "" then
+                                redirect_name = friend_name
+                            end
+                        elseif parsed.id then
+                            table.insert(repository.warnings, string.format("Wall '%s' uses <friend id=...>, but loader expects name=...", name))
+                        end
+                    end
+
+                    local draft = WallDraft.new({
+                        name = name,
+                        lookId = attrs.lookid,
+                        serverLookId = attrs.server_lookid,
+                        isNew = false,
+                        sourceName = name,
+                        friends = friends,
+                        redirectName = redirect_name,
+                        alignments = alignments,
+                    })
+                    repository.by_name[name] = draft
+                    table.insert(repository.ordered, draft)
+                end
+            end
+        end
+    end
+
+    table.sort(repository.ordered, function(a, b)
+        return string.lower(a.name or "") < string.lower(b.name or "")
+    end)
+
+    return repository
+end
+
+function M.serialize_wall(draft)
+    local attrs = {
+        string.format('name="%s"', Common.escape_xml(draft.name or "")),
+        'type="wall"',
+    }
+    if tonumber(draft.lookId or 0) > 0 then
+        table.insert(attrs, string.format('lookid="%d"', tonumber(draft.lookId or 0) or 0))
+    end
+    if tonumber(draft.serverLookId or 0) > 0 then
+        table.insert(attrs, string.format('server_lookid="%d"', tonumber(draft.serverLookId or 0) or 0))
+    end
+
+    local lines = {
+        string.format("<brush %s>", table.concat(attrs, " ")),
+    }
+
+    for _, alignment in ipairs(Common.alignment_order) do
+        local bucket = draft.alignments[alignment.token]
+        if bucket and (#(bucket.wallItems or {}) > 0 or #(bucket.doorItems or {}) > 0) then
+            table.insert(lines, string.format('\t<wall type="%s">', Common.escape_xml(alignment.token)))
+            for _, item in ipairs(bucket.wallItems or {}) do
+                table.insert(lines, string.format('\t\t<item id="%d" chance="%d"/>', tonumber(item.itemId or 0) or 0, tonumber(item.chance or 0) or 0))
+            end
+            for _, door in ipairs(bucket.doorItems or {}) do
+                local door_attrs = {
+                    string.format('id="%d"', tonumber(door.itemId or 0) or 0),
+                    string.format('type="%s"', Common.escape_xml(door.doorType or "normal")),
+                    string.format('open="%s"', door.isOpen and "true" or "false"),
+                }
+                if door.isLocked then
+                    table.insert(door_attrs, 'locked="true"')
+                end
+                if door.hate then
+                    table.insert(door_attrs, 'hate="true"')
+                end
+                table.insert(lines, string.format('\t\t<door %s/>', table.concat(door_attrs, " ")))
+            end
+            table.insert(lines, "\t</wall>")
+        end
+    end
+
+    local emitted_redirect = false
+    local seen = {}
+    for _, friend_name in ipairs(draft.friends or {}) do
+        local trimmed = Common.trim(friend_name)
+        if trimmed ~= "" and not seen[string.lower(trimmed)] then
+            seen[string.lower(trimmed)] = true
+            local attrs_line = string.format('name="%s"', Common.escape_xml(trimmed))
+            if draft.redirectName ~= "" and trimmed == draft.redirectName then
+                attrs_line = attrs_line .. ' redirect="true"'
+                emitted_redirect = true
+            end
+            table.insert(lines, string.format('\t<friend %s/>', attrs_line))
+        end
+    end
+
+    if draft.redirectName ~= "" and not emitted_redirect then
+        table.insert(lines, string.format('\t<friend name="%s" redirect="true"/>', Common.escape_xml(draft.redirectName)))
+    end
+
+    table.insert(lines, "</brush>")
+    return table.concat(lines, "\n")
+end
+
+return M

--- a/scripts/wall_studio/xml_target_helper.lua
+++ b/scripts/wall_studio/xml_target_helper.lua
@@ -1,0 +1,74 @@
+local M = {}
+
+local function normalize(path)
+    return tostring(path or ""):gsub("\\", "/")
+end
+
+local function lower_path(path)
+    return string.lower(normalize(path))
+end
+
+function M.is_xml_file(path)
+    return lower_path(path):match("%.xml$") ~= nil
+end
+
+function M.matches_expected_filename(path, expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return true
+    end
+    local normalized = lower_path(path)
+    local suffix = "/" .. string.lower(expected_filename)
+    return normalized:sub(-#suffix) == suffix or normalized == string.lower(expected_filename)
+end
+
+function M.is_inside_data_dir(path)
+    local data_dir = lower_path(app.getDataDirectory() or "")
+    local normalized = lower_path(path)
+    if data_dir == "" then
+        return false
+    end
+    if normalized == data_dir then
+        return true
+    end
+    return normalized:sub(1, #data_dir + 1) == (data_dir .. "/")
+end
+
+function M.default_xml_wildcard(expected_filename)
+    expected_filename = tostring(expected_filename or "")
+    if expected_filename == "" then
+        return "XML files (*.xml)|*.xml|All files (*.*)|*.*"
+    end
+    return string.format("%s (%s)|%s|XML files (*.xml)|*.xml|All files (*.*)|*.*", expected_filename, expected_filename, expected_filename)
+end
+
+function M.pick_xml_file(expected_filename, current_path, title)
+    if not app or not app.chooseFile then
+        return nil, "This RME build does not expose file picker support."
+    end
+
+    local chosen = app.chooseFile({
+        title = title or "Select XML file",
+        path = normalize(current_path),
+        wildcard = M.default_xml_wildcard(expected_filename),
+    })
+
+    if not chosen or chosen == "" then
+        return nil
+    end
+
+    chosen = normalize(chosen)
+    if not M.is_xml_file(chosen) then
+        return nil, "Wybrany plik musi byc plikiem XML."
+    end
+    if not M.matches_expected_filename(chosen, expected_filename) then
+        return nil, string.format("Wybierz plik '%s'.", tostring(expected_filename or ""))
+    end
+    if not M.is_inside_data_dir(chosen) then
+        return nil, "Wybrany plik musi znajdowac sie w aktualnym katalogu data tego RME."
+    end
+
+    return chosen
+end
+
+return M

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -158,6 +158,9 @@ set(rme_H
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_grid.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_palette_panel.h
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_panel.h
+    ${CMAKE_CURRENT_LIST_DIR}/palette/panels/tileset_move_queue_panel.h
+    ${CMAKE_CURRENT_LIST_DIR}/tileset_move_queue/tileset_move_queue.h
+    ${CMAKE_CURRENT_LIST_DIR}/tileset_move_queue/tileset_xml_rewriter.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/animator.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/atlas_manager.h
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/coordinate_mapper.h
@@ -534,6 +537,9 @@ set(rme_SRC
     ${CMAKE_CURRENT_LIST_DIR}/palette/controls/virtual_brush_grid.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_palette_panel.cpp
     ${CMAKE_CURRENT_LIST_DIR}/palette/panels/brush_panel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/palette/panels/tileset_move_queue_panel.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tileset_move_queue/tileset_move_queue.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/tileset_move_queue/tileset_xml_rewriter.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/animator.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/atlas_manager.cpp
     ${CMAKE_CURRENT_LIST_DIR}/rendering/core/coordinate_mapper.cpp

--- a/source/brushes/brush.h
+++ b/source/brushes/brush.h
@@ -227,6 +227,10 @@ public:
 
 	bool friendOf(TerrainBrush* other);
 
+	const std::vector<uint32_t>& getFriendIds() const {
+		return friends;
+	}
+
 protected:
 	std::vector<uint32_t> friends;
 	std::string name;

--- a/source/brushes/ground/ground_brush.cpp
+++ b/source/brushes/ground/ground_brush.cpp
@@ -22,7 +22,6 @@
 #include "brushes/ground/auto_border.h"
 #include "brushes/ground/ground_brush_loader.h"
 #include "brushes/ground/ground_border_calculator.h"
-#include "brushes/ground/terrain_placement.h"
 #include "map/basemap.h"
 
 uint32_t GroundBrush::border_types[256];
@@ -83,7 +82,7 @@ void GroundBrush::draw(BaseMap* map, Tile* tile, void* parameter) {
 		id = border_items.front().id;
 	}
 
-	TerrainPlacement::placeBrushItem(*tile, id);
+	tile->addItem(Item::Create(id));
 }
 
 const GroundBrush::BorderBlock* GroundBrush::getBrushTo(GroundBrush* first, GroundBrush* second) {
@@ -170,6 +169,16 @@ void GroundBrush::getRelatedItems(std::vector<uint16_t>& items) {
 			if (sc->with_id != 0) {
 				items.push_back(sc->with_id);
 			}
+		}
+	}
+}
+
+void GroundBrush::getItemChanceEntries(std::vector<std::pair<uint16_t, int>>& items) const {
+	items.clear();
+	items.reserve(border_items.size());
+	for (const auto& item_block : border_items) {
+		if (item_block.id != 0) {
+			items.emplace_back(item_block.id, item_block.chance);
 		}
 	}
 }

--- a/source/brushes/ground/ground_brush.h
+++ b/source/brushes/ground/ground_brush.h
@@ -41,6 +41,7 @@ public:
 	void draw(BaseMap* map, Tile* tile, void* parameter) override;
 	void undraw(BaseMap* map, Tile* tile) override;
 	void getRelatedItems(std::vector<uint16_t>& items) override;
+	void getItemChanceEntries(std::vector<std::pair<uint16_t, int>>& items) const;
 
 	static void doBorders(BaseMap* map, Tile* tile);
 	static const BorderBlock* getBrushTo(GroundBrush* first, GroundBrush* second);

--- a/source/brushes/wall/wall_brush.h
+++ b/source/brushes/wall/wall_brush.h
@@ -46,6 +46,10 @@ public:
 		return true;
 	}
 
+	WallBrush* getRedirectTo() const {
+		return redirect_to;
+	}
+
 	static uint32_t full_border_types[16];
 	static uint32_t half_border_types[16];
 

--- a/source/editor/hotkey_manager.cpp
+++ b/source/editor/hotkey_manager.cpp
@@ -60,22 +60,24 @@ std::istream& operator>>(std::istream& os, Hotkey& hotkey) {
 }
 
 HotkeyManager::HotkeyManager() :
-	hotkeys_enabled(true) {
+	hotkeys_disable_depth(0) {
 }
 
 HotkeyManager::~HotkeyManager() {
 }
 
 void HotkeyManager::EnableHotkeys() {
-	hotkeys_enabled = true;
+	if (hotkeys_disable_depth > 0) {
+		--hotkeys_disable_depth;
+	}
 }
 
 void HotkeyManager::DisableHotkeys() {
-	hotkeys_enabled = false;
+	++hotkeys_disable_depth;
 }
 
 bool HotkeyManager::AreHotkeysEnabled() const {
-	return hotkeys_enabled;
+	return hotkeys_disable_depth == 0;
 }
 
 void HotkeyManager::SetHotkey(int index, Hotkey& hotkey) {

--- a/source/editor/hotkey_manager.h
+++ b/source/editor/hotkey_manager.h
@@ -65,7 +65,7 @@ public:
 
 private:
 	Hotkey hotkeys[10];
-	bool hotkeys_enabled;
+	int hotkeys_disable_depth;
 };
 
 extern HotkeyManager g_hotkeys;

--- a/source/lua/lua_api_app.cpp
+++ b/source/lua/lua_api_app.cpp
@@ -30,12 +30,15 @@
 #include "brushes/raw/raw_brush.h"
 #include "brushes/ground/auto_border.h"
 #include "brushes/ground/ground_brush.h"
+#include "brushes/wall/wall_brush.h"
 #include "util/file_system.h"
 #include "ext/pugixml.hpp"
 
 #include <wx/msgdlg.h>
 #include <wx/app.h>
 #include <wx/clipbrd.h>
+#include <wx/filedlg.h>
+#include <wx/filename.h>
 #include <fstream>
 #include <filesystem>
 #include <unordered_set>
@@ -342,6 +345,46 @@ namespace LuaAPI {
 		}
 	}
 
+	static sol::object chooseFile(sol::this_state ts, sol::object arg) {
+		sol::state_view lua(ts);
+
+		std::string title = "Select file";
+		std::string path;
+		std::string wildcard = "XML files (*.xml)|*.xml|All files (*.*)|*.*";
+
+		if (arg.is<sol::table>()) {
+			sol::table options = arg.as<sol::table>();
+			title = options.get_or(std::string("title"), title);
+			path = options.get_or(std::string("path"), std::string(""));
+			wildcard = options.get_or(std::string("wildcard"), wildcard);
+		} else if (arg.is<std::string>()) {
+			path = arg.as<std::string>();
+		}
+
+		wxFileName fileName{wxString(path)};
+		wxString defaultDir = fileName.GetPath();
+		wxString defaultFile = fileName.GetFullName();
+		if (defaultDir.IsEmpty()) {
+			defaultDir = wxString(FileSystem::GetDataDirectory().ToStdString());
+		}
+
+		wxWindow* parent = g_gui.root;
+		wxFileDialog dlg(
+			parent,
+			wxString(title),
+			defaultDir,
+			defaultFile,
+			wxString(wildcard),
+			wxFD_OPEN | wxFD_FILE_MUST_EXIST
+		);
+
+		if (dlg.ShowModal() != wxID_OK) {
+			return sol::make_object(lua, sol::nil);
+		}
+
+		return sol::make_object(lua, dlg.GetPath().ToStdString());
+	}
+
 	// Check if a map is currently open
 	static bool hasMap() {
 		Editor* editor = g_gui.GetCurrentEditor();
@@ -483,6 +526,193 @@ namespace LuaAPI {
 		}
 
 		return groundsTable;
+	}
+
+	static std::string doorTypeToString(DoorType type) {
+		switch (type) {
+			case WALL_ARCHWAY:
+				return "archway";
+			case WALL_DOOR_NORMAL:
+				return "normal";
+			case WALL_DOOR_LOCKED:
+				return "locked";
+			case WALL_DOOR_QUEST:
+				return "quest";
+			case WALL_DOOR_MAGIC:
+				return "magic";
+			case WALL_DOOR_NORMAL_ALT:
+				return "normal_alt";
+			case WALL_WINDOW:
+				return "window";
+			case WALL_HATCH_WINDOW:
+				return "hatch_window";
+			default:
+				return "undefined";
+		}
+	}
+
+	static sol::object chooseFile(sol::this_state ts, sol::object arg) {
+		sol::state_view lua(ts);
+
+		std::string title = "Select file";
+		std::string path;
+		std::string wildcard = "XML files (*.xml)|*.xml|All files (*.*)|*.*";
+
+		if (arg.is<sol::table>()) {
+			sol::table options = arg.as<sol::table>();
+			title = options.get_or(std::string("title"), title);
+			path = options.get_or(std::string("path"), std::string(""));
+			wildcard = options.get_or(std::string("wildcard"), wildcard);
+		} else if (arg.is<std::string>()) {
+			path = arg.as<std::string>();
+		}
+
+		wxFileName fileName{wxString(path)};
+		wxString defaultDir = fileName.GetPath();
+		wxString defaultFile = fileName.GetFullName();
+		if (defaultDir.IsEmpty()) {
+			defaultDir = wxString(FileSystem::GetDataDirectory().ToStdString());
+		}
+
+		wxWindow* parent = g_gui.root;
+		wxFileDialog dlg(
+			parent,
+			wxString(title),
+			defaultDir,
+			defaultFile,
+			wxString(wildcard),
+			wxFD_OPEN | wxFD_FILE_MUST_EXIST
+		);
+
+		if (dlg.ShowModal() != wxID_OK) {
+			return sol::make_object(lua, sol::nil);
+		}
+
+		return sol::make_object(lua, dlg.GetPath().ToStdString());
+	}
+
+	static std::string wallAlignmentToString(int alignment) {
+		switch (alignment) {
+			case WALL_VERTICAL:
+				return "vertical";
+			case WALL_HORIZONTAL:
+				return "horizontal";
+			case WALL_NORTHWEST_DIAGONAL:
+				return "corner";
+			case WALL_POLE:
+				return "pole";
+			case WALL_SOUTH_END:
+				return "south end";
+			case WALL_EAST_END:
+				return "east end";
+			case WALL_NORTH_END:
+				return "north end";
+			case WALL_WEST_END:
+				return "west end";
+			case WALL_SOUTH_T:
+				return "south T";
+			case WALL_EAST_T:
+				return "east T";
+			case WALL_WEST_T:
+				return "west T";
+			case WALL_NORTH_T:
+				return "north T";
+			case WALL_NORTHEAST_DIAGONAL:
+				return "northeast diagonal";
+			case WALL_SOUTHWEST_DIAGONAL:
+				return "southwest diagonal";
+			case WALL_SOUTHEAST_DIAGONAL:
+				return "southeast diagonal";
+			case WALL_INTERSECTION:
+				return "intersection";
+			case WALL_UNTOUCHABLE:
+				return "untouchable";
+			default:
+				return "unknown";
+		}
+	}
+
+	static sol::object getWalls(sol::this_state ts) {
+		sol::state_view lua(ts);
+
+		sol::table wallsTable = lua.create_table();
+
+		for (const auto& pair : g_brushes.getMap()) {
+			const Brush* brush = pair.second.get();
+			const WallBrush* wall = brush ? brush->as<WallBrush>() : nullptr;
+			if (!wall || wall->is<WallDecorationBrush>()) {
+				continue;
+			}
+
+			sol::table wallTable = lua.create_table();
+			wallTable["id"] = wall->getID();
+			wallTable["name"] = wall->getName();
+			wallTable["lookid"] = wall->getLookID();
+			wallTable["kind"] = "wall";
+			uint16_t serverLookId = 0;
+
+			sol::table alignments = lua.create_table();
+			for (int alignment = 0; alignment < WallBrushItems::WALL_ALIGNMENT_COUNT; ++alignment) {
+				sol::table bucket = lua.create_table();
+				bucket["token"] = wallAlignmentToString(alignment);
+
+				sol::table items = lua.create_table();
+				const auto& wallNode = wall->items.getWallNode(alignment);
+				for (size_t itemIndex = 0; itemIndex < wallNode.items.size(); ++itemIndex) {
+					sol::table item = lua.create_table();
+					item["id"] = wallNode.items[itemIndex].id;
+					int previousChance = itemIndex == 0 ? 0 : wallNode.items[itemIndex - 1].chance;
+					item["chance"] = wallNode.items[itemIndex].chance - previousChance;
+					items[static_cast<int>(itemIndex + 1)] = item;
+				}
+				bucket["items"] = items;
+
+				sol::table doors = lua.create_table();
+				const auto& doorItems = wall->items.getDoorItems(alignment);
+				for (size_t doorIndex = 0; doorIndex < doorItems.size(); ++doorIndex) {
+					const auto& doorItem = doorItems[doorIndex];
+					const auto definition = g_item_definitions.get(doorItem.id);
+
+					sol::table door = lua.create_table();
+					door["id"] = doorItem.id;
+					door["type"] = doorTypeToString(doorItem.type);
+					door["locked"] = doorItem.locked;
+					door["open"] = definition.hasFlag(ItemFlag::IsOpen);
+					door["hate"] = definition.hasFlag(ItemFlag::WallHateMe);
+					doors[static_cast<int>(doorIndex + 1)] = door;
+				}
+				bucket["doors"] = doors;
+				if (serverLookId == 0) {
+					if (wallNode.items.size() > 0) {
+						serverLookId = wallNode.items.front().id;
+					} else if (doorItems.size() > 0) {
+						serverLookId = doorItems.front().id;
+					}
+				}
+
+				alignments[wallAlignmentToString(alignment)] = bucket;
+			}
+			wallTable["alignments"] = alignments;
+			wallTable["server_lookid"] = serverLookId;
+
+			sol::table friends = lua.create_table();
+			int friendIndex = 1;
+			for (uint32_t friendId : wall->getFriendIds()) {
+				for (const auto& candidatePair : g_brushes.getMap()) {
+					const Brush* candidate = candidatePair.second.get();
+					if (candidate && candidate->getID() == friendId) {
+						friends[friendIndex++] = candidate->getName();
+						break;
+					}
+				}
+			}
+			wallTable["friends"] = friends;
+			wallTable["redirect_to"] = wall->getRedirectTo() ? wall->getRedirectTo()->getName() : "";
+
+			wallsTable[wall->getName()] = wallTable;
+		}
+
+		return wallsTable;
 	}
 
 	static std::string getDataDirectory() {
@@ -803,6 +1033,7 @@ namespace LuaAPI {
 
 		// Functions
 		app["alert"] = showAlert;
+		app["chooseFile"] = chooseFile;
 		app["hasMap"] = hasMap;
 		app["refresh"] = refresh;
 		app["setBrush"] = [](const std::string& name) {
@@ -881,6 +1112,8 @@ namespace LuaAPI {
 				return getBorders(ts);
 			} else if (key == "grounds") {
 				return getGrounds(ts);
+			} else if (key == "walls") {
+				return getWalls(ts);
 			} else if (key == "editor") {
 				Editor* editor = g_gui.GetCurrentEditor();
 				if (editor) {

--- a/source/lua/lua_api_app.cpp
+++ b/source/lua/lua_api_app.cpp
@@ -29,7 +29,9 @@
 #include "game/items.h"
 #include "brushes/raw/raw_brush.h"
 #include "brushes/ground/auto_border.h"
+#include "brushes/ground/ground_brush.h"
 #include "util/file_system.h"
+#include "ext/pugixml.hpp"
 
 #include <wx/msgdlg.h>
 #include <wx/app.h>
@@ -435,8 +437,171 @@ namespace LuaAPI {
 		return bordersTable;
 	}
 
+	static sol::object getGrounds(sol::this_state ts) {
+		sol::state_view lua(ts);
+
+		sol::table groundsTable = lua.create_table();
+
+		for (const auto& pair : g_brushes.getMap()) {
+			const Brush* brush = pair.second.get();
+			const GroundBrush* ground = brush ? brush->as<GroundBrush>() : nullptr;
+			if (!ground) {
+				continue;
+			}
+
+			sol::table g = lua.create_table();
+			g["id"] = ground->getID();
+			g["name"] = ground->getName();
+			g["lookid"] = ground->getLookID();
+			g["server_lookid"] = 0;
+			g["z_order"] = ground->getZ();
+			g["randomize"] = ground->isReRandomizable();
+			g["solo_optional"] = ground->useSoloOptionalBorder();
+
+			std::vector<std::pair<uint16_t, int>> itemEntries;
+			ground->getItemChanceEntries(itemEntries);
+
+			sol::table items = lua.create_table();
+			for (size_t i = 0; i < itemEntries.size(); ++i) {
+				sol::table item = lua.create_table();
+				item["id"] = itemEntries[i].first;
+				item["chance"] = itemEntries[i].second;
+				items[static_cast<int>(i + 1)] = item;
+			}
+			g["items"] = items;
+
+			if (!itemEntries.empty()) {
+				sol::table mainItem = lua.create_table();
+				mainItem["id"] = itemEntries.front().first;
+				mainItem["chance"] = itemEntries.front().second;
+				g["main_item"] = mainItem;
+			} else {
+				g["main_item"] = sol::nil;
+			}
+
+			groundsTable[ground->getName()] = g;
+		}
+
+		return groundsTable;
+	}
+
 	static std::string getDataDirectory() {
 		return FileSystem::GetDataDirectory().ToStdString();
+	}
+
+	static std::vector<std::string> splitPath(std::string_view path) {
+		std::vector<std::string> parts;
+		size_t start = 0;
+		while (start < path.size()) {
+			size_t slash = path.find('/', start);
+			size_t count = slash == std::string_view::npos ? path.size() - start : slash - start;
+			if (count > 0) {
+				parts.emplace_back(path.substr(start, count));
+			}
+			if (slash == std::string_view::npos) {
+				break;
+			}
+			start = slash + 1;
+		}
+		return parts;
+	}
+
+	static pugi::xml_node findNodeByPath(pugi::xml_node root, const std::string& path) {
+		if (!root) {
+			return pugi::xml_node();
+		}
+
+		if (path.empty()) {
+			return root;
+		}
+
+		pugi::xml_node current = root;
+		const auto parts = splitPath(path);
+		for (size_t index = 0; index < parts.size(); ++index) {
+			const std::string& part = parts[index];
+			if (index == 0 && current.type() == pugi::node_element && current.name() == part) {
+				continue;
+			}
+			current = current.child(part.c_str());
+			if (!current) {
+				return pugi::xml_node();
+			}
+		}
+
+		return current;
+	}
+
+	static std::tuple<bool, std::string> upsertXmlNodeFile(const std::string& path, const sol::table& options) {
+		const std::string rootName = options.get_or(std::string("root"), std::string("root"));
+		const std::string parentPath = options.get_or(std::string("parent"), rootName);
+		const std::string fragment = options.get_or(std::string("xml"), std::string(""));
+		const std::string matchTag = options.get_or(std::string("tag"), std::string(""));
+		const std::string matchAttr = options.get_or(std::string("match_attr"), std::string(""));
+		const std::string matchValue = options.get_or(std::string("match_value"), std::string(""));
+
+		if (fragment.empty()) {
+			return { false, "Missing XML fragment." };
+		}
+
+		pugi::xml_document document;
+		bool fileExists = std::filesystem::exists(path);
+		if (fileExists) {
+			const pugi::xml_parse_result loaded = document.load_file(path.c_str(), pugi::parse_default);
+			if (!loaded) {
+				return { false, "Failed to parse XML file: " + std::string(loaded.description()) };
+			}
+		}
+
+		pugi::xml_node root = document.document_element();
+		if (!root) {
+			document.reset();
+			document.append_child(pugi::node_declaration).append_attribute("version") = "1.0";
+			document.first_child().append_attribute("encoding") = "utf-8";
+			root = document.append_child(rootName.c_str());
+		}
+
+		if (!root || std::string(root.name()) != rootName) {
+			return { false, "Root node does not match expected <" + rootName + ">." };
+		}
+
+		pugi::xml_node parent = findNodeByPath(root, parentPath);
+		if (!parent) {
+			return { false, "Parent node path not found: " + parentPath };
+		}
+
+		pugi::xml_document fragmentDocument;
+		const pugi::xml_parse_result fragmentLoaded = fragmentDocument.load_buffer(fragment.data(), fragment.size(), pugi::parse_default);
+		if (!fragmentLoaded) {
+			return { false, "Failed to parse XML fragment: " + std::string(fragmentLoaded.description()) };
+		}
+
+		pugi::xml_node fragmentNode = fragmentDocument.document_element();
+		if (!fragmentNode) {
+			return { false, "XML fragment does not contain an element node." };
+		}
+
+		pugi::xml_node existing;
+		if (!matchTag.empty() && !matchAttr.empty()) {
+			for (pugi::xml_node child = parent.child(matchTag.c_str()); child; child = child.next_sibling(matchTag.c_str())) {
+				if (child.attribute(matchAttr.c_str()).as_string() == matchValue) {
+					existing = child;
+					break;
+				}
+			}
+		}
+
+		if (existing) {
+			parent.insert_copy_before(fragmentNode, existing);
+			parent.remove_child(existing);
+		} else {
+			parent.append_copy(fragmentNode);
+		}
+
+		if (!document.save_file(path.c_str(), "\t", pugi::format_default, pugi::encoding_utf8)) {
+			return { false, "Failed to save XML file." };
+		}
+
+		return { true, existing ? "updated" : "appended" };
 	}
 
 	static sol::table storageForScript(sol::this_state ts, const std::string& name) {
@@ -538,6 +703,44 @@ namespace LuaAPI {
 			}
 		};
 
+		storage["exists"] = [path](sol::object) -> bool {
+			return std::filesystem::exists(path);
+		};
+
+		storage["readText"] = [path](sol::this_state ts2, sol::object) -> std::tuple<sol::object, sol::object> {
+			sol::state_view lua(ts2);
+
+			std::ifstream file(path, std::ios::binary | std::ios::ate);
+			if (!file.is_open()) {
+				return {
+					sol::make_object(lua, sol::nil),
+					sol::make_object(lua, std::string("Could not open file."))
+				};
+			}
+
+			const std::streamsize fileSize = file.tellg();
+			if (fileSize < 0 || fileSize > static_cast<std::streamsize>(4 * 1024 * 1024)) {
+				return {
+					sol::make_object(lua, sol::nil),
+					sol::make_object(lua, std::string("File is too large to read safely."))
+				};
+			}
+
+			std::string content(static_cast<size_t>(fileSize), '\0');
+			file.seekg(0, std::ios::beg);
+			if (fileSize > 0 && !file.read(content.data(), fileSize)) {
+				return {
+					sol::make_object(lua, sol::nil),
+					sol::make_object(lua, std::string("Could not read file contents."))
+				};
+			}
+
+			return {
+				sol::make_object(lua, content),
+				sol::make_object(lua, sol::nil)
+			};
+		};
+
 		storage["save"] = [path](sol::this_state ts2, sol::object first, sol::object second) -> bool {
 			sol::state_view lua(ts2);
 			std::string content;
@@ -577,6 +780,10 @@ namespace LuaAPI {
 
 		storage["clear"] = [path](sol::object) -> bool {
 			return std::remove(path.c_str()) == 0;
+		};
+
+		storage["upsertXml"] = [path](sol::object, sol::table options) -> std::tuple<bool, std::string> {
+			return upsertXmlNodeFile(path, options);
 		};
 
 		return storage;
@@ -672,6 +879,8 @@ namespace LuaAPI {
 				return sol::nil;
 			} else if (key == "borders") {
 				return getBorders(ts);
+			} else if (key == "grounds") {
+				return getGrounds(ts);
 			} else if (key == "editor") {
 				Editor* editor = g_gui.GetCurrentEditor();
 				if (editor) {

--- a/source/palette/controls/virtual_brush_grid.cpp
+++ b/source/palette/controls/virtual_brush_grid.cpp
@@ -2,6 +2,7 @@
 #include "palette/controls/virtual_brush_grid.h"
 #include "ui/gui.h"
 #include "rendering/core/graphics.h"
+#include "brushes/raw/raw_brush.h"
 
 #include <glad/glad.h>
 
@@ -13,6 +14,8 @@
 
 #include <spdlog/spdlog.h>
 
+wxDEFINE_EVENT(EVT_VIRTUAL_BRUSH_GRID_SELECTED, wxCommandEvent);
+
 namespace {
 	static constexpr float GROW_FACTOR = 2.0f;
 	static constexpr float SHADOW_ALPHA_BASE = 20.0f;
@@ -22,11 +25,12 @@ namespace {
 	static constexpr int TIMER_INTERVAL = 16;
 	static constexpr float INTER_THRESHOLD = 0.01f;
 	static constexpr float INTER_FACTOR = 0.2f;
+	static constexpr int RAW_GRID_LABEL_HEIGHT = 14;
+	static constexpr float QUEUED_DIM_ALPHA = 0.38f;
 }
 
 VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz) :
 	NanoVGCanvas(parent, wxID_ANY, wxVSCROLL | wxWANTS_CHARS),
-	BrushBoxInterface(_tileset),
 	icon_size(rsz),
 	selected_index(-1),
 	hover_index(-1),
@@ -35,6 +39,9 @@ VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _til
 	padding(4),
 	m_animTimer(this) {
 
+	tileset = _tileset;
+	palette_type = _tileset ? _tileset->getType() : TILESET_UNKNOWN;
+
 	if (icon_size == RENDER_SIZE_16x16) {
 		item_size = 18;
 	} else {
@@ -42,6 +49,35 @@ VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _til
 	}
 
 	Bind(wxEVT_LEFT_DOWN, &VirtualBrushGrid::OnMouseDown, this);
+	Bind(wxEVT_RIGHT_DOWN, &VirtualBrushGrid::OnMouseRightDown, this);
+	Bind(wxEVT_MOTION, &VirtualBrushGrid::OnMotion, this);
+	Bind(wxEVT_SIZE, &VirtualBrushGrid::OnSize, this);
+	Bind(wxEVT_TIMER, &VirtualBrushGrid::OnTimer, this);
+
+	UpdateLayout();
+}
+
+VirtualBrushGrid::VirtualBrushGrid(wxWindow* parent, const EntryList* _entries, TilesetCategoryType _palette_type, RenderSize rsz) :
+	NanoVGCanvas(parent, wxID_ANY, wxVSCROLL | wxWANTS_CHARS),
+	icon_size(rsz),
+	selected_index(-1),
+	hover_index(-1),
+	columns(1),
+	item_size(0),
+	padding(4),
+	m_animTimer(this) {
+
+	entries = _entries;
+	palette_type = _palette_type;
+
+	if (icon_size == RENDER_SIZE_16x16) {
+		item_size = 18;
+	} else {
+		item_size = GRID_ITEM_SIZE_BASE + 2; // + borders
+	}
+
+	Bind(wxEVT_LEFT_DOWN, &VirtualBrushGrid::OnMouseDown, this);
+	Bind(wxEVT_RIGHT_DOWN, &VirtualBrushGrid::OnMouseRightDown, this);
 	Bind(wxEVT_MOTION, &VirtualBrushGrid::OnMotion, this);
 	Bind(wxEVT_SIZE, &VirtualBrushGrid::OnSize, this);
 	Bind(wxEVT_TIMER, &VirtualBrushGrid::OnTimer, this);
@@ -59,6 +95,87 @@ void VirtualBrushGrid::SetDisplayMode(DisplayMode mode) {
 	}
 }
 
+void VirtualBrushGrid::SetEntryList(const EntryList* next_entries, TilesetCategoryType next_palette_type) {
+	entries = next_entries;
+	tileset = nullptr;
+	palette_type = next_palette_type;
+	ClearSelection();
+	hover_index = -1;
+	m_utf8NameCache.clear();
+	UpdateLayout();
+	Refresh();
+}
+
+void VirtualBrushGrid::SetIconSize(RenderSize size) {
+	if (icon_size == size) {
+		return;
+	}
+
+	icon_size = size;
+	if (icon_size == RENDER_SIZE_16x16) {
+		item_size = 18;
+	} else {
+		item_size = GRID_ITEM_SIZE_BASE + 2; // + borders
+	}
+
+	UpdateLayout();
+	Refresh();
+}
+
+int VirtualBrushGrid::ItemCount() const {
+	if (entries) {
+		return static_cast<int>(entries->size());
+	}
+	return tileset ? static_cast<int>(tileset->size()) : 0;
+}
+
+Brush* VirtualBrushGrid::ItemBrush(int index) const {
+	if (index < 0 || index >= ItemCount()) {
+		return nullptr;
+	}
+	if (entries) {
+		return (*entries)[static_cast<size_t>(index)].brush;
+	}
+	return tileset ? tileset->brushlist[static_cast<size_t>(index)] : nullptr;
+}
+
+TilesetCategoryType VirtualBrushGrid::ItemPaletteType(int index) const {
+	if (entries && index >= 0 && index < ItemCount()) {
+		const auto entry_palette = (*entries)[static_cast<size_t>(index)].palette_type;
+		if (entry_palette != TILESET_UNKNOWN) {
+			return entry_palette;
+		}
+	}
+	if (palette_type != TILESET_UNKNOWN) {
+		return palette_type;
+	}
+	return tileset ? tileset->getType() : TILESET_UNKNOWN;
+}
+
+int VirtualBrushGrid::ItemTilesetIndex(int index) const {
+	if (!entries || index < 0 || index >= ItemCount()) {
+		return -1;
+	}
+	return (*entries)[static_cast<size_t>(index)].tileset_index;
+}
+
+bool VirtualBrushGrid::ShowRawIdLabel(int index) const {
+	return display_mode == DisplayMode::Grid && ItemPaletteType(index) == TILESET_RAW;
+}
+
+int VirtualBrushGrid::GridCellHeight() const {
+	if (!entries) {
+		return item_size + (palette_type == TILESET_RAW ? RAW_GRID_LABEL_HEIGHT : 0);
+	}
+
+	for (int index = 0; index < ItemCount(); ++index) {
+		if (ShowRawIdLabel(index)) {
+			return item_size + RAW_GRID_LABEL_HEIGHT;
+		}
+	}
+	return item_size;
+}
+
 void VirtualBrushGrid::UpdateLayout() {
 	int width = GetClientSize().x;
 	if (width <= 0) {
@@ -67,13 +184,13 @@ void VirtualBrushGrid::UpdateLayout() {
 
 	if (display_mode == DisplayMode::List) {
 		columns = 1;
-		int rows = static_cast<int>(tileset->size());
+		int rows = ItemCount();
 		int contentHeight = rows * LIST_ROW_HEIGHT + padding;
 		UpdateScrollbar(contentHeight);
 	} else {
 		columns = std::max(1, (width - padding) / (item_size + padding));
-		int rows = (static_cast<int>(tileset->size()) + columns - 1) / columns;
-		int contentHeight = rows * (item_size + padding) + padding;
+		int rows = (ItemCount() + columns - 1) / columns;
+		int contentHeight = rows * (GridCellHeight() + padding) + padding;
 		UpdateScrollbar(contentHeight);
 	}
 }
@@ -85,12 +202,12 @@ wxSize VirtualBrushGrid::DoGetBestClientSize() const {
 void VirtualBrushGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 	// Calculate visible range
 	int scrollPos = GetScrollPosition();
-	int rowHeight = (display_mode == DisplayMode::List) ? LIST_ROW_HEIGHT : (item_size + padding);
+	int rowHeight = (display_mode == DisplayMode::List) ? LIST_ROW_HEIGHT : (GridCellHeight() + padding);
 	int startRow = scrollPos / rowHeight;
 	int endRow = (scrollPos + height + rowHeight - 1) / rowHeight + 1;
 
 	int startIdx = startRow * columns;
-	int endIdx = std::min(static_cast<int>(tileset->size()), endRow * columns);
+	int endIdx = std::min(ItemCount(), endRow * columns);
 
 	// Draw visible items
 	for (int i = startIdx; i < endIdx; ++i) {
@@ -99,10 +216,16 @@ void VirtualBrushGrid::OnNanoVGPaint(NVGcontext* vg, int width, int height) {
 }
 
 void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) {
-	float x = static_cast<float>(rect.x);
-	float y = static_cast<float>(rect.y);
-	float w = static_cast<float>(rect.width);
-	float h = static_cast<float>(rect.height);
+	const bool showRawIdLabel = ShowRawIdLabel(i) && ItemBrush(i) && ItemBrush(i)->is<RAWBrush>();
+	const int cardHeight = (display_mode == DisplayMode::Grid && showRawIdLabel) ? item_size : rect.height;
+	const wxRect cardRect(rect.x, rect.y, rect.width, cardHeight);
+	const bool isSelected = IsIndexSelected(i);
+	const bool isQueued = IsQueuedBrush(ItemBrush(i));
+
+	float x = static_cast<float>(cardRect.x);
+	float y = static_cast<float>(cardRect.y);
+	float w = static_cast<float>(cardRect.width);
+	float h = static_cast<float>(cardRect.height);
 
 	// Animation scaling
 	if (i == hover_index) {
@@ -114,7 +237,7 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 	}
 
 	// Shadow / Glow
-	if (i == selected_index) {
+	if (isSelected) {
 		// Glow for selected
 		NVGpaint shadowPaint = nvgBoxGradient(vg, x, y, w, h, 4.0f, 10.0f, nvgRGBA(100, 150, 255, 128), nvgRGBA(0, 0, 0, 0));
 		nvgBeginPath(vg);
@@ -140,7 +263,7 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 	nvgBeginPath(vg);
 	nvgRoundedRect(vg, x, y, w, h, 4.0f);
 
-	if (i == selected_index) {
+	if (isSelected) {
 		NVGcolor selCol = NvgUtils::ToNvColor(Theme::Get(Theme::Role::Accent));
 		selCol.a = 1.0f; // Force opaque for background
 		nvgFillColor(vg, selCol);
@@ -153,7 +276,7 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 	nvgFill(vg);
 
 	// Selection border
-	if (i == selected_index) {
+	if (isSelected) {
 		nvgBeginPath(vg);
 		nvgRoundedRect(vg, x + 0.5f, y + 0.5f, w - 1.0f, h - 1.0f, 4.0f);
 		nvgStrokeColor(vg, NvgUtils::ToNvColor(Theme::Get(Theme::Role::Accent)));
@@ -162,7 +285,7 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 	}
 
 	// Draw brush sprite
-	Brush* brush = (i < static_cast<int>(tileset->size())) ? tileset->brushlist[i] : nullptr;
+	Brush* brush = ItemBrush(i);
 	if (brush) {
 		Sprite* spr = brush->getSprite();
 		if (!spr) {
@@ -170,21 +293,27 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 		}
 
 		if (!spr) {
-			return; // Safety check
+			// Keep drawing name/id even if sprite is missing.
+			spr = nullptr;
 		}
 
-		int tex = GetOrCreateSpriteTexture(vg, spr);
-		if (tex > 0) {
-			int iconSize = (display_mode == DisplayMode::List) ? GRID_ITEM_SIZE_BASE : (item_size - 2 * ICON_OFFSET);
-			int iconX = rect.x + ICON_OFFSET;
-			int iconY = rect.y + ICON_OFFSET;
+		const int baseIconSize = (icon_size == RENDER_SIZE_16x16) ? 16 : GRID_ITEM_SIZE_BASE;
+		const int iconSize = (display_mode == DisplayMode::List) ? baseIconSize : (item_size - 2 * ICON_OFFSET);
+		const int iconX = cardRect.x + ICON_OFFSET;
+		const int iconY = (display_mode == DisplayMode::List)
+			? cardRect.y + std::max(0, (cardRect.height - iconSize) / 2)
+			: cardRect.y + ICON_OFFSET;
 
-			NVGpaint imgPaint = nvgImagePattern(vg, static_cast<float>(iconX), static_cast<float>(iconY), static_cast<float>(iconSize), static_cast<float>(iconSize), 0.0f, tex, 1.0f);
+		if (spr) {
+			int tex = GetOrCreateSpriteTexture(vg, spr);
+			if (tex > 0) {
+				NVGpaint imgPaint = nvgImagePattern(vg, static_cast<float>(iconX), static_cast<float>(iconY), static_cast<float>(iconSize), static_cast<float>(iconSize), 0.0f, tex, 1.0f);
 
-			nvgBeginPath(vg);
-			nvgRoundedRect(vg, static_cast<float>(iconX), static_cast<float>(iconY), static_cast<float>(iconSize), static_cast<float>(iconSize), 3.0f);
-			nvgFillPaint(vg, imgPaint);
-			nvgFill(vg);
+				nvgBeginPath(vg);
+				nvgRoundedRect(vg, static_cast<float>(iconX), static_cast<float>(iconY), static_cast<float>(iconSize), static_cast<float>(iconSize), 3.0f);
+				nvgFillPaint(vg, imgPaint);
+				nvgFill(vg);
+			}
 		}
 
 		if (display_mode == DisplayMode::List) {
@@ -198,8 +327,32 @@ void VirtualBrushGrid::DrawBrushItem(NVGcontext* vg, int i, const wxRect& rect) 
 				m_utf8NameCache[brush] = std::string(wxstr(brush->getName()).ToUTF8());
 				it = m_utf8NameCache.find(brush);
 			}
-			nvgText(vg, rect.x + 40, rect.y + rect.height / 2.0f, it->second.c_str(), nullptr);
+			const float textX = static_cast<float>(cardRect.x + iconSize + ICON_OFFSET + 8);
+			nvgText(vg, textX, cardRect.y + cardRect.height / 2.0f, it->second.c_str(), nullptr);
+		} else {
+			if (showRawIdLabel) {
+				const uint16_t id = brush->as<RAWBrush>()->getItemID();
+				const std::string label = std::to_string(id);
+				nvgFontSize(vg, 11.0f);
+				nvgFontFace(vg, "sans");
+				nvgTextAlign(vg, NVG_ALIGN_CENTER | NVG_ALIGN_MIDDLE);
+				const auto role = isSelected ? Theme::Role::Text : Theme::Role::TextSubtle;
+				nvgFillColor(vg, NvgUtils::ToNvColor(Theme::Get(role)));
+				nvgText(vg, rect.x + rect.width / 2.0f, rect.y + item_size + RAW_GRID_LABEL_HEIGHT / 2.0f, label.c_str(), nullptr);
+			}
 		}
+	}
+
+	if (isQueued) {
+		nvgBeginPath(vg);
+		nvgRoundedRect(vg, x, y, w, h, 4.0f);
+		nvgFillColor(vg, nvgRGBA(12, 12, 14, static_cast<unsigned char>(255.0f * QUEUED_DIM_ALPHA)));
+		nvgFill(vg);
+
+		nvgBeginPath(vg);
+		nvgCircle(vg, x + w - 9.0f, y + 9.0f, 4.0f);
+		nvgFillColor(vg, nvgRGBA(255, 196, 64, 255));
+		nvgFill(vg);
 	}
 }
 
@@ -213,9 +366,9 @@ wxRect VirtualBrushGrid::GetItemRect(int index) const {
 
 		return wxRect(
 			padding + col * (item_size + padding),
-			padding + row * (item_size + padding),
+			padding + row * (GridCellHeight() + padding),
 			item_size,
-			item_size
+			GridCellHeight()
 		);
 	}
 }
@@ -228,7 +381,7 @@ int VirtualBrushGrid::HitTest(int x, int y) const {
 	if (display_mode == DisplayMode::List) {
 		int row = (realY - padding) / LIST_ROW_HEIGHT;
 
-		if (row < 0 || row >= static_cast<int>(tileset->size())) {
+		if (row < 0 || row >= ItemCount()) {
 			return -1;
 		}
 
@@ -241,14 +394,14 @@ int VirtualBrushGrid::HitTest(int x, int y) const {
 		return -1;
 	} else {
 		int col = (realX - padding) / (item_size + padding);
-		int row = (realY - padding) / (item_size + padding);
+		int row = (realY - padding) / (GridCellHeight() + padding);
 
 		if (col < 0 || col >= columns || row < 0) {
 			return -1;
 		}
 
 		int index = row * columns + col;
-		if (index >= 0 && index < static_cast<int>(tileset->size())) {
+		if (index >= 0 && index < ItemCount()) {
 			wxRect rect = GetItemRect(index);
 			// Adjust rect to scroll position for contains check
 			rect.y -= scrollPos;
@@ -262,23 +415,40 @@ int VirtualBrushGrid::HitTest(int x, int y) const {
 
 void VirtualBrushGrid::OnMouseDown(wxMouseEvent& event) {
 	int index = HitTest(event.GetX(), event.GetY());
-	if (index != -1 && index != selected_index) {
-		selected_index = index;
-
-		// Notify GUI - find PaletteWindow parent
-		wxWindow* w = GetParent();
-		while (w) {
-			PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
-			if (pw) {
-				g_gui.ActivatePalette(pw);
-				break;
-			}
-			w = w->GetParent();
+	if (index == -1) {
+		if (HasSelection()) {
+			ClearSelection();
+			g_gui.SetPaletteMultiSelectionCount(0);
+			g_gui.SelectBrush();
+			Refresh();
 		}
+		return;
+	}
 
-		g_gui.SelectBrush(tileset->brushlist[selected_index], tileset->getType());
+	if (event.ShiftDown() && selection_anchor != -1) {
+		SelectRangeTo(index);
+	} else if (event.ControlDown()) {
+		ToggleIndexSelection(index);
+	} else {
+		SelectSingleIndex(index);
+	}
+
+	NotifySelectionChanged();
+	Refresh();
+}
+
+void VirtualBrushGrid::OnMouseRightDown(wxMouseEvent& event) {
+	const int index = HitTest(event.GetX(), event.GetY());
+	if (index != -1 && !IsIndexSelected(index)) {
+		SelectSingleIndex(index);
+		NotifySelectionChanged();
 		Refresh();
 	}
+
+	wxContextMenuEvent menu_event(wxEVT_CONTEXT_MENU);
+	menu_event.SetEventObject(this);
+	menu_event.SetPosition(ClientToScreen(event.GetPosition()));
+	ProcessWindowEvent(menu_event);
 }
 
 void VirtualBrushGrid::OnMotion(wxMouseEvent& event) {
@@ -299,7 +469,7 @@ void VirtualBrushGrid::OnMotion(wxMouseEvent& event) {
 
 	// Tooltip
 	if (index != -1) {
-		Brush* brush = tileset->brushlist[index];
+		Brush* brush = ItemBrush(index);
 		if (brush) {
 			wxString tip = wxstr(brush->getName());
 			if (GetToolTipText() != tip) {
@@ -333,40 +503,214 @@ void VirtualBrushGrid::OnSize(wxSizeEvent& event) {
 }
 
 void VirtualBrushGrid::SelectFirstBrush() {
-	if (tileset->size() > 0) {
-		selected_index = 0;
+	if (ItemCount() > 0) {
+		SelectSingleIndex(0);
+		g_gui.SetPaletteMultiSelectionCount(1);
 		Refresh();
 	}
 }
 
 Brush* VirtualBrushGrid::GetSelectedBrush() const {
-	if (selected_index >= 0 && selected_index < static_cast<int>(tileset->size())) {
-		return tileset->brushlist[selected_index];
-	}
-	return nullptr;
+	return ItemBrush(selected_index);
 }
 
 bool VirtualBrushGrid::SelectBrush(const Brush* brush) {
-	for (size_t i = 0; i < tileset->size(); ++i) {
-		if (tileset->brushlist[i] == brush) {
-			selected_index = static_cast<int>(i);
+	return SelectBrush(brush, SelectionScrollBehavior::EnsureVisible);
+}
 
-			// Ensure visible
+bool VirtualBrushGrid::SelectBrush(const Brush* brush, SelectionScrollBehavior scroll_behavior) {
+	const int count = ItemCount();
+	for (int i = 0; i < count; ++i) {
+		if (ItemBrush(i) == brush) {
+			SelectSingleIndex(i);
+			g_gui.SetPaletteMultiSelectionCount(1);
+
 			wxRect rect = GetItemRect(selected_index);
-			int scrollPos = GetScrollPosition();
-			int clientHeight = GetClientSize().y;
+			if (scroll_behavior == SelectionScrollBehavior::AlignToTop) {
+				SetScrollPosition(std::max(0, rect.y - padding));
+			} else if (scroll_behavior == SelectionScrollBehavior::EnsureVisible) {
+				int scrollPos = GetScrollPosition();
+				int clientHeight = GetClientSize().y;
 
-			if (rect.y < scrollPos) {
-				SetScrollPosition(rect.y - padding);
-			} else if (rect.y + rect.height > scrollPos + clientHeight) {
-				SetScrollPosition(rect.y + rect.height - clientHeight + padding);
+				if (rect.y < scrollPos) {
+					SetScrollPosition(std::max(0, rect.y - padding));
+				} else if (rect.y + rect.height > scrollPos + clientHeight) {
+					SetScrollPosition(rect.y + rect.height - clientHeight + padding);
+				}
 			}
 
 			Refresh();
 			return true;
 		}
 	}
-	selected_index = -1;
+	ClearSelection();
+	g_gui.SetPaletteMultiSelectionCount(0);
 	Refresh();
 	return false;
+}
+
+std::vector<VirtualBrushGrid::Entry> VirtualBrushGrid::GetSelectedEntries() const {
+	std::vector<int> sorted_indices(selected_indices.begin(), selected_indices.end());
+	std::ranges::sort(sorted_indices);
+
+	std::vector<Entry> result;
+	result.reserve(sorted_indices.size());
+	for (const int index : sorted_indices) {
+		if (Brush* brush = ItemBrush(index)) {
+			result.push_back(Entry {
+				.brush = brush,
+				.palette_type = ItemPaletteType(index),
+				.tileset_index = ItemTilesetIndex(index),
+			});
+		}
+	}
+	return result;
+}
+
+std::optional<VirtualBrushGrid::Entry> VirtualBrushGrid::GetSelectedEntry() const {
+	if (selected_index < 0 || selected_index >= ItemCount()) {
+		return std::nullopt;
+	}
+
+	Brush* brush = ItemBrush(selected_index);
+	if (!brush) {
+		return std::nullopt;
+	}
+
+	return Entry {
+		.brush = brush,
+		.palette_type = ItemPaletteType(selected_index),
+		.tileset_index = ItemTilesetIndex(selected_index),
+	};
+}
+
+std::vector<Brush*> VirtualBrushGrid::GetSelectedBrushes() const {
+	std::vector<int> sorted_indices(selected_indices.begin(), selected_indices.end());
+	std::ranges::sort(sorted_indices);
+
+	std::vector<Brush*> brushes;
+	brushes.reserve(sorted_indices.size());
+	for (const int index : sorted_indices) {
+		if (Brush* brush = ItemBrush(index)) {
+			brushes.push_back(brush);
+		}
+	}
+	return brushes;
+}
+
+std::vector<ServerItemId> VirtualBrushGrid::GetSelectedItemIds() const {
+	std::vector<ServerItemId> item_ids;
+	item_ids.reserve(selected_indices.size());
+
+	for (Brush* brush : GetSelectedBrushes()) {
+		if (!brush || !brush->is<RAWBrush>()) {
+			continue;
+		}
+		item_ids.push_back(brush->as<RAWBrush>()->getItemID());
+	}
+	return item_ids;
+}
+
+bool VirtualBrushGrid::HasSelection() const {
+	return !selected_indices.empty();
+}
+
+size_t VirtualBrushGrid::GetSelectionCount() const {
+	return selected_indices.size();
+}
+
+bool VirtualBrushGrid::IsIndexSelected(int index) const {
+	return selected_indices.contains(index);
+}
+
+bool VirtualBrushGrid::IsQueuedBrush(const Brush* brush) const {
+	if (!brush || !brush->is<RAWBrush>()) {
+		return false;
+	}
+
+	return g_gui.GetTilesetMoveQueue().IsQueued(brush->as<RAWBrush>()->getItemID());
+}
+
+void VirtualBrushGrid::ClearSelection() {
+	selected_indices.clear();
+	selected_index = -1;
+	selection_anchor = -1;
+}
+
+void VirtualBrushGrid::SelectSingleIndex(int index) {
+	ClearSelection();
+	if (index < 0 || index >= ItemCount()) {
+		return;
+	}
+
+	selected_indices.insert(index);
+	selected_index = index;
+	selection_anchor = index;
+}
+
+void VirtualBrushGrid::ToggleIndexSelection(int index) {
+	if (index < 0 || index >= ItemCount()) {
+		return;
+	}
+
+	if (selected_indices.contains(index)) {
+		selected_indices.erase(index);
+		if (selected_index == index) {
+			selected_index = selected_indices.empty() ? -1 : *selected_indices.begin();
+		}
+		if (selection_anchor == index) {
+			selection_anchor = selected_index;
+		}
+		return;
+	}
+
+	selected_indices.insert(index);
+	selected_index = index;
+	selection_anchor = index;
+}
+
+void VirtualBrushGrid::SelectRangeTo(int index) {
+	if (index < 0 || index >= ItemCount()) {
+		return;
+	}
+	if (selection_anchor == -1) {
+		SelectSingleIndex(index);
+		return;
+	}
+
+	selected_indices.clear();
+	const int begin = std::min(selection_anchor, index);
+	const int end = std::max(selection_anchor, index);
+	for (int current = begin; current <= end; ++current) {
+		selected_indices.insert(current);
+	}
+	selected_index = index;
+}
+
+void VirtualBrushGrid::NotifySelectionChanged() {
+	wxWindow* w = GetParent();
+	while (w) {
+		PaletteWindow* pw = dynamic_cast<PaletteWindow*>(w);
+		if (pw) {
+			g_gui.ActivatePalette(pw);
+			break;
+		}
+		w = w->GetParent();
+	}
+
+	g_gui.SetPaletteMultiSelectionCount(GetSelectionCount());
+
+	if (GetSelectionCount() == 1) {
+		if (Brush* brush = GetSelectedBrush()) {
+			g_gui.SelectBrush(brush, ItemPaletteType(selected_index));
+		}
+	} else {
+		g_gui.SelectBrush();
+	}
+
+	wxCommandEvent selected_event(EVT_VIRTUAL_BRUSH_GRID_SELECTED, GetId());
+	selected_event.SetEventObject(this);
+	selected_event.SetInt(selected_index);
+	selected_event.SetExtraLong(selected_index >= 0 ? ItemTilesetIndex(selected_index) : -1);
+	ProcessWindowEvent(selected_event);
 }

--- a/source/palette/controls/virtual_brush_grid.h
+++ b/source/palette/controls/virtual_brush_grid.h
@@ -5,6 +5,12 @@
 #include "util/nanovg_canvas.h"
 #include "palette/panels/brush_panel.h"
 #include "ui/dcbutton.h" // For RenderSize
+#include "item_definitions/core/item_definition_types.h"
+
+#include <unordered_set>
+#include <vector>
+
+wxDECLARE_EVENT(EVT_VIRTUAL_BRUSH_GRID_SELECTED, wxCommandEvent);
 
 /**
  * @class VirtualBrushGrid
@@ -16,6 +22,13 @@
  */
 class VirtualBrushGrid : public NanoVGCanvas, public BrushBoxInterface {
 public:
+	struct Entry {
+		Brush* brush = nullptr;
+		PaletteType palette_type = TILESET_UNKNOWN;
+		int tileset_index = -1; // Used by global-search to restore tileset selection.
+	};
+	using EntryList = std::vector<Entry>;
+
 	/**
 	 * @brief Constructs a VirtualBrushGrid.
 	 * @param parent Parent window
@@ -23,6 +36,7 @@ public:
 	 * @param rsz Icon render size (16x16 or 32x32)
 	 */
 	VirtualBrushGrid(wxWindow* parent, const TilesetCategory* _tileset, RenderSize rsz);
+	VirtualBrushGrid(wxWindow* parent, const EntryList* entries, TilesetCategoryType palette_type, RenderSize rsz);
 	~VirtualBrushGrid() override;
 
 	wxWindow* GetSelfWindow() override {
@@ -32,7 +46,18 @@ public:
 	// BrushBoxInterface
 	void SelectFirstBrush() override;
 	Brush* GetSelectedBrush() const override;
+	enum class SelectionScrollBehavior {
+		EnsureVisible,
+		AlignToTop,
+	};
 	bool SelectBrush(const Brush* brush) override;
+	bool SelectBrush(const Brush* brush, SelectionScrollBehavior scroll_behavior);
+	std::optional<Entry> GetSelectedEntry() const;
+	std::vector<Entry> GetSelectedEntries() const;
+	std::vector<Brush*> GetSelectedBrushes() const;
+	std::vector<ServerItemId> GetSelectedItemIds() const;
+	bool HasSelection() const;
+	size_t GetSelectionCount() const;
 
 	enum class DisplayMode {
 		Grid,
@@ -45,6 +70,8 @@ public:
 	static constexpr int ICON_OFFSET = 2;
 
 	void SetDisplayMode(DisplayMode mode);
+	void SetEntryList(const EntryList* entries, TilesetCategoryType palette_type);
+	void SetIconSize(RenderSize size);
 
 protected:
 	/**
@@ -59,6 +86,7 @@ protected:
 
 	// Event Handlers
 	void OnMouseDown(wxMouseEvent& event);
+	void OnMouseRightDown(wxMouseEvent& event);
 	void OnMotion(wxMouseEvent& event);
 	void OnSize(wxSizeEvent& event);
 
@@ -68,13 +96,33 @@ protected:
 	wxRect GetItemRect(int index) const;
 	void DrawBrushItem(NVGcontext* vg, int index, const wxRect& rect);
 
+	int ItemCount() const;
+	Brush* ItemBrush(int index) const;
+	TilesetCategoryType ItemPaletteType(int index) const;
+	int ItemTilesetIndex(int index) const;
+	bool ShowRawIdLabel(int index) const;
+	int GridCellHeight() const;
+	bool IsIndexSelected(int index) const;
+	bool IsQueuedBrush(const Brush* brush) const;
+	void ClearSelection();
+	void SelectSingleIndex(int index);
+	void ToggleIndexSelection(int index);
+	void SelectRangeTo(int index);
+	void NotifySelectionChanged();
+
 	DisplayMode display_mode = DisplayMode::Grid;
 	RenderSize icon_size;
 	int selected_index;
+	int selection_anchor = -1;
 	int hover_index;
 	int columns;
 	int item_size;
 	int padding;
+	std::unordered_set<int> selected_indices;
+
+	const TilesetCategory* tileset = nullptr;
+	const EntryList* entries = nullptr;
+	TilesetCategoryType palette_type = TILESET_UNKNOWN;
 
 	// Optimization: UTF8 name cache
 	mutable std::unordered_map<const Brush*, std::string> m_utf8NameCache;

--- a/source/palette/palette_window.cpp
+++ b/source/palette/palette_window.cpp
@@ -206,6 +206,44 @@ void PaletteWindow::InvalidateContents() {
 	}
 }
 
+void PaletteWindow::InvalidatePage(PaletteType palette) {
+	PalettePanel* page = nullptr;
+	switch (palette) {
+		case TILESET_TERRAIN:
+			page = terrain_palette;
+			break;
+		case TILESET_DOODAD:
+			page = doodad_palette;
+			break;
+		case TILESET_COLLECTION:
+			page = collection_palette;
+			break;
+		case TILESET_ITEM:
+			page = item_palette;
+			break;
+		case TILESET_CREATURE:
+			page = creature_palette;
+			break;
+		case TILESET_WAYPOINT:
+			page = waypoint_palette;
+			break;
+		case TILESET_RAW:
+			page = raw_palette;
+			break;
+		default:
+			break;
+	}
+
+	if (!page) {
+		return;
+	}
+
+	page->InvalidateContents();
+	if (page->GetType() == GetSelectedPage()) {
+		page->LoadCurrentContents();
+	}
+}
+
 void PaletteWindow::SelectPage(PaletteType id) {
 	if (!choicebook) {
 		return;
@@ -255,32 +293,42 @@ PaletteType PaletteWindow::GetSelectedPage() const {
 	return panel->GetType();
 }
 
-bool PaletteWindow::OnSelectBrush(const Brush* whatbrush, PaletteType primary) {
+bool PaletteWindow::OnSelectBrush(const Brush* whatbrush, PaletteType primary, int tileset_index, bool align_to_top) {
 	if (!choicebook || !whatbrush) {
 		return false;
 	}
 
+	const auto select_brush_panel = [whatbrush, tileset_index, align_to_top](BrushPalettePanel* panel) {
+		if (!panel) {
+			return false;
+		}
+		return tileset_index >= 0 ? panel->SelectBrushInTileset(whatbrush, tileset_index, align_to_top) : panel->SelectBrushWithOptions(whatbrush, align_to_top);
+	};
+
 	switch (primary) {
 		case TILESET_TERRAIN: {
-			// This is already searched first
+			if (select_brush_panel(terrain_palette)) {
+				SelectPage(TILESET_TERRAIN);
+				return true;
+			}
 			break;
 		}
 		case TILESET_DOODAD: {
-			// Ok, search doodad before terrain
-			if (doodad_palette && doodad_palette->SelectBrush(whatbrush)) {
+			if (select_brush_panel(doodad_palette)) {
 				SelectPage(TILESET_DOODAD);
 				return true;
 			}
 			break;
 		}
 		case TILESET_COLLECTION: {
-			if (collection_palette && collection_palette->SelectBrush(whatbrush)) {
+			if (select_brush_panel(collection_palette)) {
 				SelectPage(TILESET_COLLECTION);
 				return true;
 			}
+			break;
 		}
 		case TILESET_ITEM: {
-			if (item_palette && item_palette->SelectBrush(whatbrush)) {
+			if (select_brush_panel(item_palette)) {
 				SelectPage(TILESET_ITEM);
 				return true;
 			}
@@ -294,7 +342,7 @@ bool PaletteWindow::OnSelectBrush(const Brush* whatbrush, PaletteType primary) {
 			break;
 		}
 		case TILESET_RAW: {
-			if (raw_palette && raw_palette->SelectBrush(whatbrush)) {
+			if (select_brush_panel(raw_palette)) {
 				SelectPage(TILESET_RAW);
 				return true;
 			}

--- a/source/palette/palette_window.h
+++ b/source/palette/palette_window.h
@@ -35,6 +35,7 @@ public:
 	void ReloadSettings(Map* from);
 	// Flushes all pages and forces them to be reloaded from the palette data again
 	void InvalidateContents();
+	void InvalidatePage(PaletteType palette);
 	// (Re)Loads all currently displayed data, called from InvalidateContents implicitly
 	void LoadCurrentContents();
 	// Goes to the selected page and selects any brush there
@@ -50,7 +51,7 @@ public:
 	// Custom Event handlers (something has changed?)
 	// Finds the brush pointed to by whatbrush and selects it as the current brush (also changes page)
 	// Returns if the brush was found in this palette
-	virtual bool OnSelectBrush(const Brush* whatbrush, PaletteType primary = TILESET_UNKNOWN);
+	virtual bool OnSelectBrush(const Brush* whatbrush, PaletteType primary = TILESET_UNKNOWN, int tileset_index = -1, bool align_to_top = false);
 	// Updates the palette window to use the current brush size
 	virtual void OnUpdateBrushSize(BrushShape shape, int size);
 	// Updates the content of the palette (eg. houses, creatures)

--- a/source/palette/panels/brush_palette_panel.cpp
+++ b/source/palette/panels/brush_palette_panel.cpp
@@ -1,91 +1,317 @@
 #include "palette/panels/brush_palette_panel.h"
-#include "ui/gui.h"
-#include "ui/add_tileset_window.h"
-#include "ui/add_item_window.h"
-#include "game/materials.h"
-#include "palette/palette_window.h"
-#include "util/image_manager.h"
-#include <spdlog/spdlog.h>
 
-// ============================================================================
-// Brush Palette Panel
-// A common class for terrain/doodad/item/raw palette
+#include "app/settings.h"
+#include "game/materials.h"
+#include "brushes/raw/raw_brush.h"
+#include "item_definitions/core/item_definition_store.h"
+#include "palette/controls/virtual_brush_grid.h"
+#include "palette/palette_window.h"
+#include "tileset_move_queue/tileset_xml_rewriter.h"
+#include "ui/add_item_window.h"
+#include "ui/add_tileset_window.h"
+#include "ui/gui.h"
+#include "util/image_manager.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string_view>
+#include <unordered_set>
+
+#include <wx/bmpbuttn.h>
+#include <wx/checkbox.h>
+#include <wx/choice.h>
+#include <wx/menu.h>
+#include <wx/sizer.h>
+#include <wx/statbox.h>
+#include <wx/textctrl.h>
+#include <wx/tglbtn.h>
+#include <wx/timer.h>
+
+namespace {
+	constexpr int TOOL_ICON_SIZE = 16;
+	bool g_globalBrushSearchById = false;
+	bool g_globalBrushViewModeOverride = false;
+	bool g_globalBrushViewModeIsGrid = false;
+
+	void ConfigureToggleIcon(wxBitmapToggleButton* button, const wxBitmap& bitmap) {
+		if (!button) {
+			return;
+		}
+		button->SetBitmap(bitmap);
+		button->SetBitmapCurrent(bitmap);
+		button->SetBitmapFocus(bitmap);
+		button->SetBitmapPressed(bitmap);
+	}
+
+	[[nodiscard]] std::string lowerCopy(std::string value) {
+		for (char& ch : value) {
+			ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+		}
+		return value;
+	}
+
+	[[nodiscard]] std::vector<std::string_view> tokenizeWords(std::string_view text) {
+		std::vector<std::string_view> tokens;
+
+		size_t index = 0;
+		while (index < text.size()) {
+			while (index < text.size() && !std::isalnum(static_cast<unsigned char>(text[index]))) {
+				++index;
+			}
+
+			const size_t start = index;
+			while (index < text.size() && std::isalnum(static_cast<unsigned char>(text[index]))) {
+				++index;
+			}
+
+			if (start < index) {
+				tokens.push_back(text.substr(start, index - start));
+			}
+		}
+
+		return tokens;
+	}
+
+	[[nodiscard]] bool matchesWholeWordSequence(const std::string& name_lower, const std::string& query_lower) {
+		const auto query_tokens = tokenizeWords(query_lower);
+		if (query_tokens.empty()) {
+			return false;
+		}
+
+		const auto name_tokens = tokenizeWords(name_lower);
+		if (name_tokens.size() < query_tokens.size()) {
+			return false;
+		}
+
+		for (size_t start = 0; start + query_tokens.size() <= name_tokens.size(); ++start) {
+			bool matched = true;
+			for (size_t offset = 0; offset < query_tokens.size(); ++offset) {
+				if (name_tokens[start + offset] != query_tokens[offset]) {
+					matched = false;
+					break;
+				}
+			}
+
+			if (matched) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	[[nodiscard]] bool matchesExactWordSequence(const std::string& name_lower, const std::string& query_lower) {
+		const auto query_tokens = tokenizeWords(query_lower);
+		if (query_tokens.empty()) {
+			return false;
+		}
+
+		const auto name_tokens = tokenizeWords(name_lower);
+		if (name_tokens.size() != query_tokens.size()) {
+			return false;
+		}
+
+		for (size_t index = 0; index < query_tokens.size(); ++index) {
+			if (name_tokens[index] != query_tokens[index]) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	[[nodiscard]] bool isXmlBackedMoveTarget(
+		const TilesetMoveQueue::Target& target,
+		const std::unordered_set<std::string>& xml_tileset_names
+	) {
+		if (!target.isValid()) {
+			return false;
+		}
+
+		if (TilesetXmlRewriter::IsVirtualRuntimeTilesetName(target.tileset_name)) {
+			return false;
+		}
+
+		return xml_tileset_names.contains(target.tileset_name);
+	}
+
+	[[nodiscard]] bool supportsMoveQueue(PaletteType paletteType) {
+		return paletteType == TILESET_RAW || paletteType == TILESET_ITEM;
+	}
+
+	[[nodiscard]] wxString paletteLabel(PaletteType paletteType) {
+		return paletteType == TILESET_RAW ? "RAW" : "Items";
+	}
+
+	[[nodiscard]] constexpr auto globalSearchPalettes() {
+		return std::array<PaletteType, 5> {
+			TILESET_TERRAIN,
+			TILESET_DOODAD,
+			TILESET_COLLECTION,
+			TILESET_ITEM,
+			TILESET_RAW,
+		};
+	}
+}
 
 BrushPalettePanel::BrushPalettePanel(wxWindow* parent, const TilesetContainer& tilesets, TilesetCategoryType category, wxWindowID id) :
 	PalettePanel(parent, id),
-	palette_type(category),
-	choicebook(nullptr) {
-	Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddItemToTileset, this, wxID_ADD);
-	Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddTileset, this, wxID_NEW);
-	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGING, &BrushPalettePanel::OnSwitchingPage, this);
-	Bind(wxEVT_CHOICEBOOK_PAGE_CHANGED, &BrushPalettePanel::OnPageChanged, this);
+	palette_type(category) {
+	search_mode = g_globalBrushSearchById ? SearchMode::Id : SearchMode::Name;
 
-	wxSizer* topsizer = newd wxBoxSizer(wxVERTICAL);
+	BuildTilesetPages(tilesets);
 
-	// Create the tileset panel
-	wxSizer* ts_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tileset");
-	wxChoicebook* tmp_choicebook = newd wxChoicebook(static_cast<wxStaticBoxSizer*>(ts_sizer)->GetStaticBox(), wxID_ANY, wxDefaultPosition, wxSize(180, 250));
-	ts_sizer->Add(tmp_choicebook, 1, wxEXPAND);
-	topsizer->Add(ts_sizer, 1, wxEXPAND);
+	auto* topsizer = newd wxBoxSizer(wxVERTICAL);
+
+	// Tileset selector
+	auto* ts_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tileset");
+	tileset_choice = newd wxChoice(ts_sizer->GetStaticBox(), wxID_ANY);
+	for (const auto& page : tileset_pages) {
+		tileset_choice->Append(wxstr(page.name));
+	}
+	tileset_choice->SetSelection(tileset_pages.empty() ? wxNOT_FOUND : 0);
+	tileset_choice->Enable(!tileset_pages.empty());
+	ts_sizer->Add(tileset_choice, 0, wxEXPAND | wxALL, FromDIP(4));
 
 	if (g_settings.getBoolean(Config::SHOW_TILESET_EDITOR)) {
-		wxSizer* tmpsizer = newd wxBoxSizer(wxHORIZONTAL);
-		wxButton* buttonAddTileset = newd wxButton(this, wxID_NEW, "Add new Tileset");
-		buttonAddTileset->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+		auto* row = newd wxBoxSizer(wxHORIZONTAL);
+
+		auto* buttonAddTileset = newd wxButton(ts_sizer->GetStaticBox(), wxID_NEW, "Add new Tileset");
+		buttonAddTileset->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
 		buttonAddTileset->SetToolTip("Create a new custom tileset");
-		tmpsizer->Add(buttonAddTileset, wxSizerFlags(0).Center());
+		row->Add(buttonAddTileset, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(6));
 
-		wxButton* buttonAddItemToTileset = newd wxButton(this, wxID_ADD, "Add new Item");
-		buttonAddItemToTileset->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(16, 16)));
+		auto* buttonAddItemToTileset = newd wxButton(ts_sizer->GetStaticBox(), wxID_ADD, "Add new Item");
+		buttonAddItemToTileset->SetBitmap(IMAGE_MANAGER.GetBitmap(ICON_PLUS, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
 		buttonAddItemToTileset->SetToolTip("Add a new item to the current tileset");
-		tmpsizer->Add(buttonAddItemToTileset, wxSizerFlags(0).Center());
+		row->Add(buttonAddItemToTileset, 0, wxALIGN_CENTER_VERTICAL);
 
-		topsizer->Add(tmpsizer, 0, wxCENTER, 10);
+		ts_sizer->Add(row, 0, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(4));
+
+		Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddItemToTileset, this, wxID_ADD);
+		Bind(wxEVT_BUTTON, &BrushPalettePanel::OnClickAddTileset, this, wxID_NEW);
 	}
 
-	for (const auto& tileset : GetSortedTilesets(tilesets)) {
-		const TilesetCategory* tcg = tileset->getCategory(category);
-		if (tcg && tcg->size() > 0) {
-			BrushPanel* panel = newd BrushPanel(tmp_choicebook);
-			panel->AssignTileset(tcg);
-			tmp_choicebook->AddPage(panel, wxstr(tileset->name));
-		}
+	topsizer->Add(ts_sizer, 0, wxEXPAND);
+
+	// Fixed toolbar row
+	toolbar_panel = newd wxPanel(this, wxID_ANY);
+	auto* toolbar_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	search_text = newd wxTextCtrl(toolbar_panel, wxID_ANY, "", wxDefaultPosition, wxDefaultSize, wxTE_PROCESS_ENTER);
+	search_text->SetMinSize(FromDIP(wxSize(150, -1)));
+	search_mode_button = newd wxBitmapButton(
+		toolbar_panel,
+		wxID_ANY,
+		IMAGE_MANAGER.GetBitmap(ICON_ANGLE_DOWN, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)),
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxBU_EXACTFIT
+	);
+	search_mode_button->SetToolTip("Search mode");
+
+	auto* search_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	search_sizer->Add(search_text, 1, wxEXPAND);
+	search_sizer->Add(search_mode_button, 0, wxLEFT, FromDIP(4));
+	toolbar_sizer->Add(search_sizer, 0, wxEXPAND);
+
+	list_toggle = newd wxBitmapToggleButton(toolbar_panel, wxID_ANY, wxBitmap(), wxDefaultPosition, FromDIP(wxSize(28, 28)), wxBU_EXACTFIT | wxBORDER_NONE);
+	grid_toggle = newd wxBitmapToggleButton(toolbar_panel, wxID_ANY, wxBitmap(), wxDefaultPosition, FromDIP(wxSize(28, 28)), wxBU_EXACTFIT | wxBORDER_NONE);
+	ConfigureToggleIcon(list_toggle, IMAGE_MANAGER.GetBitmap(ICON_RECTANGLE_LIST, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
+	ConfigureToggleIcon(grid_toggle, IMAGE_MANAGER.GetBitmap(ICON_TABLE_CELLS, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
+	list_toggle->SetToolTip("List view");
+	grid_toggle->SetToolTip("Grid view");
+
+	auto* controls_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	controls_sizer->Add(list_toggle, 0, wxALIGN_CENTER_VERTICAL | wxRIGHT, FromDIP(2));
+	controls_sizer->Add(grid_toggle, 0, wxALIGN_CENTER_VERTICAL);
+
+	if (palette_type == TILESET_RAW) {
+		raw_unused_checkbox = newd wxCheckBox(toolbar_panel, wxID_ANY, "Only unused");
+		raw_unused_checkbox->SetToolTip("Hide RAW items already used by other brush systems.");
+		controls_sizer->AddStretchSpacer(1);
+		controls_sizer->Add(raw_unused_checkbox, 0, wxALIGN_CENTER_VERTICAL | wxLEFT, FromDIP(8));
 	}
+
+	toolbar_sizer->Add(controls_sizer, 0, wxEXPAND | wxTOP, FromDIP(4));
+
+	toolbar_panel->SetSizer(toolbar_sizer);
+	topsizer->Add(toolbar_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(4));
+
+	// Results (scrollable)
+	results_grid = newd VirtualBrushGrid(this, &tileset_entries, palette_type, RENDER_SIZE_32x32);
+	topsizer->Add(results_grid, 1, wxEXPAND | wxLEFT | wxRIGHT | wxBOTTOM, FromDIP(4));
 
 	SetSizerAndFit(topsizer);
 
-	choicebook = tmp_choicebook;
+	// Bind events
+	tileset_choice->Bind(wxEVT_CHOICE, &BrushPalettePanel::OnTilesetChoice, this);
+	search_text->Bind(wxEVT_TEXT, &BrushPalettePanel::OnSearchText, this);
+	search_text->Bind(wxEVT_TEXT_ENTER, &BrushPalettePanel::OnSearchEnter, this);
+	search_text->Bind(wxEVT_CHAR_HOOK, &BrushPalettePanel::OnSearchCharHook, this);
+	search_text->Bind(wxEVT_SET_FOCUS, &BrushPalettePanel::OnSearchFocus, this);
+	search_text->Bind(wxEVT_KILL_FOCUS, &BrushPalettePanel::OnSearchBlur, this);
+	search_mode_button->Bind(wxEVT_BUTTON, &BrushPalettePanel::OnSearchModeButton, this);
+	list_toggle->Bind(wxEVT_TOGGLEBUTTON, &BrushPalettePanel::OnViewToggle, this);
+	grid_toggle->Bind(wxEVT_TOGGLEBUTTON, &BrushPalettePanel::OnViewToggle, this);
+	if (raw_unused_checkbox) {
+		raw_unused_checkbox->Bind(wxEVT_CHECKBOX, &BrushPalettePanel::OnRawUnusedToggle, this);
+	}
+	results_grid->Bind(EVT_VIRTUAL_BRUSH_GRID_SELECTED, &BrushPalettePanel::OnSearchGridSelected, this);
+	results_grid->Bind(wxEVT_CONTEXT_MENU, &BrushPalettePanel::OnResultsGridContextMenu, this);
+
+	UpdateSearchHint();
+
+	// Apply initial state
+	ApplyViewModeToViews();
+	ApplySearchNow();
 }
 
 BrushPalettePanel::~BrushPalettePanel() {
-	////
+	if (search_hotkeys_suspended) {
+		g_hotkeys.EnableHotkeys();
+		search_hotkeys_suspended = false;
+	}
+}
+
+void BrushPalettePanel::BuildTilesetPages(const TilesetContainer& tilesets) {
+	tileset_pages.clear();
+	for (const auto& tileset : GetSortedTilesets(tilesets)) {
+		const TilesetCategory* tcg = tileset->getCategory(palette_type);
+		if (tcg && tcg->size() > 0) {
+			tileset_pages.push_back(TilesetPage { .name = tileset->name, .category = tcg });
+		}
+	}
 }
 
 void BrushPalettePanel::InvalidateContents() {
-	for (size_t iz = 0; iz < choicebook->GetPageCount(); ++iz) {
-		BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetPage(iz));
-		panel->InvalidateContents();
-	}
+	raw_used_built = false;
+	raw_used_flags.clear();
+	all_entries.clear();
+	tileset_entries.clear();
+	filtered_entries.clear();
+	last_search_selected_brush = nullptr;
+	last_search_selected_tileset_index = -1;
+	last_search_selected_palette = TILESET_UNKNOWN;
+	pending_switch_selection = nullptr;
+	pending_switch_align_to_top = false;
+
+	ApplySearchNow();
 	PalettePanel::InvalidateContents();
 }
 
 void BrushPalettePanel::LoadCurrentContents() {
-	if (!choicebook) {
-		return;
-	}
-	wxWindow* page = choicebook->GetCurrentPage();
-	BrushPanel* panel = dynamic_cast<BrushPanel*>(page);
-	if (panel) {
-		panel->OnSwitchIn();
-	}
+	SyncSearchModeFromGlobal();
+	SyncViewModeFromGlobal();
+	ApplySearchNow();
 	PalettePanel::LoadCurrentContents();
 }
 
 void BrushPalettePanel::LoadAllContents() {
-	for (size_t iz = 0; iz < choicebook->GetPageCount(); ++iz) {
-		BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetPage(iz));
-		panel->LoadContents();
-	}
+	SyncSearchModeFromGlobal();
+	SyncViewModeFromGlobal();
+	ApplySearchNow();
 	PalettePanel::LoadAllContents();
 }
 
@@ -94,138 +320,750 @@ PaletteType BrushPalettePanel::GetType() const {
 }
 
 void BrushPalettePanel::SetListType(BrushListType ltype) {
-	if (!choicebook) {
-		return;
+	style_list_type = ltype;
+
+	if (!view_mode_user_override) {
+		view_mode = (ltype == BRUSHLIST_LISTBOX || ltype == BRUSHLIST_TEXT_LISTBOX) ? ViewMode::List : ViewMode::Grid;
 	}
-	for (size_t iz = 0; iz < choicebook->GetPageCount(); ++iz) {
-		BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetPage(iz));
-		panel->SetListType(ltype);
-	}
+
+	ApplyViewModeToViews();
+	ApplySearchNow();
 }
 
 void BrushPalettePanel::SetListType(wxString ltype) {
-	if (!choicebook) {
-		return;
-	}
-	for (size_t iz = 0; iz < choicebook->GetPageCount(); ++iz) {
-		BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetPage(iz));
-		panel->SetListType(ltype);
+	if (ltype == "small icons") {
+		SetListType(BRUSHLIST_SMALL_ICONS);
+	} else if (ltype == "large icons") {
+		SetListType(BRUSHLIST_LARGE_ICONS);
+	} else if (ltype == "listbox") {
+		SetListType(BRUSHLIST_LISTBOX);
+	} else if (ltype == "textlistbox") {
+		SetListType(BRUSHLIST_TEXT_LISTBOX);
 	}
 }
 
 Brush* BrushPalettePanel::GetSelectedBrush() const {
-	if (!choicebook) {
-		return nullptr;
-	}
-	wxWindow* page = choicebook->GetCurrentPage();
-	BrushPanel* panel = dynamic_cast<BrushPanel*>(page);
-	Brush* res = nullptr;
-	if (panel) {
-		for (const auto& toolBar : tool_bars) {
-			res = toolBar->GetSelectedBrush();
-			if (res) {
-				return res;
-			}
+	for (const auto& toolBar : tool_bars) {
+		if (Brush* res = toolBar->GetSelectedBrush()) {
+			return res;
 		}
-		res = panel->GetSelectedBrush();
 	}
-	return res;
+
+	return results_grid ? results_grid->GetSelectedBrush() : nullptr;
 }
 
 void BrushPalettePanel::SelectFirstBrush() {
-	if (!choicebook) {
-		return;
-	}
-	wxWindow* page = choicebook->GetCurrentPage();
-	if (!page) {
-		return;
-	}
-	BrushPanel* panel = dynamic_cast<BrushPanel*>(page);
-	if (panel) {
-		panel->SelectFirstBrush();
+	if (results_grid) {
+		results_grid->SelectFirstBrush();
 	}
 }
 
 bool BrushPalettePanel::SelectBrush(const Brush* whatbrush) {
-	if (!choicebook) {
+	return SelectBrushWithOptions(whatbrush, false);
+}
+
+bool BrushPalettePanel::SelectBrushWithOptions(const Brush* whatbrush, bool align_to_top) {
+	if (!results_grid) {
 		return false;
 	}
 
-	BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetCurrentPage());
-	if (!panel) {
-		return false;
-	}
+	pending_switch_selection = const_cast<Brush*>(whatbrush);
+	pending_switch_align_to_top = align_to_top;
 
+	// If a toolbar selects something, clear the main selection.
 	for (PalettePanel* toolBar : tool_bars) {
 		if (toolBar->SelectBrush(whatbrush)) {
-			panel->SelectBrush(nullptr);
+			results_grid->SelectBrush(nullptr);
 			return true;
 		}
 	}
 
-	if (panel->SelectBrush(whatbrush)) {
+	// If search is active, clear it so selection can jump tilesets.
+	if (search_text && (!search_text->GetValue().IsEmpty() || !applied_search_query.IsEmpty())) {
+		search_text->ChangeValue("");
+		applied_search_query.Clear();
+		ApplySearchNow();
+	}
+
+	if (results_grid->SelectBrush(whatbrush)) {
+		if (tileset_choice) {
+			const int sel = tileset_choice->GetSelection();
+			if (sel != wxNOT_FOUND && sel >= 0 && static_cast<size_t>(sel) < tileset_pages.size()) {
+				remembered_brushes[tileset_pages[static_cast<size_t>(sel)].name] = const_cast<Brush*>(whatbrush);
+			}
+		}
 		for (PalettePanel* toolBar : tool_bars) {
 			toolBar->SelectBrush(nullptr);
 		}
 		return true;
 	}
 
-	for (size_t iz = 0; iz < choicebook->GetPageCount(); ++iz) {
-		if ((int)iz == choicebook->GetSelection()) {
+	// Try other tilesets.
+	for (size_t idx = 0; idx < tileset_pages.size(); ++idx) {
+		const auto* category = tileset_pages[idx].category;
+		if (!category) {
 			continue;
 		}
-
-		panel = dynamic_cast<BrushPanel*>(choicebook->GetPage(iz));
-		if (panel && panel->SelectBrush(whatbrush)) {
-			choicebook->ChangeSelection(iz);
-			for (PalettePanel* toolBar : tool_bars) {
-				toolBar->SelectBrush(nullptr);
+		for (const auto* b : category->brushlist) {
+			if (b == whatbrush) {
+				tileset_choice->SetSelection(static_cast<int>(idx));
+				last_tileset_selection = static_cast<int>(idx);
+				remembered_brushes[tileset_pages[idx].name] = const_cast<Brush*>(whatbrush);
+				ApplySearchNow();
+				return results_grid->SelectBrush(whatbrush);
 			}
-			return true;
 		}
 	}
+
 	return false;
 }
 
-void BrushPalettePanel::OnSwitchingPage(wxChoicebookEvent& event) {
-	event.Skip();
+bool BrushPalettePanel::SelectBrushInTileset(const Brush* whatbrush, int tileset_index) {
+	return SelectBrushInTileset(whatbrush, tileset_index, false);
 }
 
-void BrushPalettePanel::OnPageChanged(wxChoicebookEvent& event) {
-	if (!choicebook) {
-		return;
+bool BrushPalettePanel::SelectBrushInTileset(const Brush* whatbrush, int tileset_index, bool align_to_top) {
+	if (!whatbrush) {
+		return false;
 	}
 
-	BrushPanel* panel = dynamic_cast<BrushPanel*>(choicebook->GetCurrentPage());
-	Brush* new_brush = nullptr;
+	pending_switch_selection = const_cast<Brush*>(whatbrush);
+	pending_switch_align_to_top = align_to_top;
 
-	if (panel) {
-		panel->OnSwitchIn();
-		new_brush = panel->GetSelectedBrush();
+	if (search_text && (!search_text->GetValue().IsEmpty() || !applied_search_query.IsEmpty())) {
+		search_text->ChangeValue("");
+		applied_search_query.Clear();
 	}
 
-	g_gui.ActivatePalette(GetParentPalette());
-	if (new_brush) {
-		g_gui.SelectBrush(new_brush, palette_type);
-	} else {
-		g_gui.SelectBrush();
+	if (tileset_index >= 0 && static_cast<size_t>(tileset_index) < tileset_pages.size() && tileset_choice) {
+		tileset_choice->SetSelection(tileset_index);
+		last_tileset_selection = tileset_index;
+		remembered_brushes[tileset_pages[static_cast<size_t>(tileset_index)].name] = const_cast<Brush*>(whatbrush);
 	}
-	Layout();
+
+	ApplySearchNow();
+	return results_grid ? results_grid->SelectBrush(whatbrush) : false;
 }
 
 void BrushPalettePanel::OnSwitchIn() {
 	g_palettes.ActivatePalette(GetParentPalette());
 	g_gui.RestoreBrushSizeState(last_brush_size_state);
+	SyncSearchModeFromGlobal();
+	SyncViewModeFromGlobal();
 	LoadCurrentContents();
+	if (pending_switch_selection && results_grid) {
+		results_grid->SelectBrush(
+			pending_switch_selection,
+			pending_switch_align_to_top ? VirtualBrushGrid::SelectionScrollBehavior::AlignToTop : VirtualBrushGrid::SelectionScrollBehavior::EnsureVisible
+		);
+		pending_switch_selection = nullptr;
+		pending_switch_align_to_top = false;
+	}
+	SyncSelectedBrushToGui();
 }
 
-void BrushPalettePanel::OnClickAddTileset(wxCommandEvent& WXUNUSED(event)) {
-	if (!choicebook) {
+void BrushPalettePanel::UpdateSearchHint() {
+	if (!search_text) {
+		return;
+	}
+	if (search_mode == SearchMode::Id) {
+		search_text->SetHint("Search ID...");
+	} else {
+		search_text->SetHint("Search name...");
+	}
+}
+
+void BrushPalettePanel::ApplyViewModeToViews() {
+	// Icon size follows the style; list/grid follows runtime toggle.
+	const RenderSize iconSize = (style_list_type == BRUSHLIST_SMALL_ICONS) ? RENDER_SIZE_16x16 : RENDER_SIZE_32x32;
+	if (results_grid) {
+		results_grid->SetIconSize(iconSize);
+		results_grid->SetDisplayMode(view_mode == ViewMode::List ? VirtualBrushGrid::DisplayMode::List : VirtualBrushGrid::DisplayMode::Grid);
+	}
+
+	if (list_toggle && grid_toggle) {
+		list_toggle->SetValue(view_mode == ViewMode::List);
+		grid_toggle->SetValue(view_mode == ViewMode::Grid);
+	}
+}
+
+void BrushPalettePanel::SyncSearchModeFromGlobal() {
+	const SearchMode global_mode = g_globalBrushSearchById ? SearchMode::Id : SearchMode::Name;
+	if (search_mode == global_mode) {
 		return;
 	}
 
+	search_mode = global_mode;
+	UpdateSearchHint();
+
+	if (!applied_search_query.IsEmpty()) {
+		ApplySearchNow();
+	}
+}
+
+void BrushPalettePanel::SyncViewModeFromGlobal() {
+	if (!g_globalBrushViewModeOverride) {
+		return;
+	}
+
+	const ViewMode global_mode = g_globalBrushViewModeIsGrid ? ViewMode::Grid : ViewMode::List;
+	if (view_mode == global_mode && view_mode_user_override) {
+		return;
+	}
+
+	view_mode = global_mode;
+	view_mode_user_override = true;
+	ApplyViewModeToViews();
+}
+
+bool BrushPalettePanel::IsActivePalettePage() const {
+	const auto* palette = GetParentPalette();
+	return palette && palette->GetSelectedPage() == palette_type;
+}
+
+void BrushPalettePanel::SyncSelectedBrushToGui() {
+	if (!IsActivePalettePage()) {
+		return;
+	}
+
+	Brush* current = results_grid ? results_grid->GetSelectedBrush() : nullptr;
+	if (current) {
+		g_gui.SelectBrush(current, palette_type);
+	} else {
+		g_gui.SelectBrush();
+	}
+}
+
+void BrushPalettePanel::EnsureRawUsedFlags() {
+	if (raw_used_built) {
+		return;
+	}
+	raw_used_built = true;
+	raw_used_flags.assign(65536, 0);
+
+	for (ServerItemId id : g_item_definitions.allIds()) {
+		const auto definition = g_item_definitions.get(id);
+		if (!definition) {
+			continue;
+		}
+
+		const ItemEditorData& data = definition.editorData();
+		if (data.brush != nullptr || data.doodad_brush != nullptr || data.collection_brush != nullptr) {
+			raw_used_flags[id] = 1;
+		}
+	}
+}
+
+bool BrushPalettePanel::IsRawBrushUnused(const Brush* brush) const {
+	if (palette_type != TILESET_RAW) {
+		return true;
+	}
+	if (!raw_unused_checkbox || !raw_unused_checkbox->GetValue()) {
+		return true;
+	}
+	if (!brush || !brush->is<RAWBrush>()) {
+		return true;
+	}
+	const uint16_t id = brush->as<RAWBrush>()->getItemID();
+	if (id >= raw_used_flags.size()) {
+		return true;
+	}
+	return raw_used_flags[id] == 0;
+}
+
+bool BrushPalettePanel::SupportsMoveQueue() const {
+	return supportsMoveQueue(palette_type);
+}
+
+std::vector<TilesetMoveQueue::Target> BrushPalettePanel::CollectMoveTargets(PaletteType palette) const {
+	std::vector<TilesetMoveQueue::Target> targets;
+	const auto xml_tileset_names = TilesetXmlRewriter::LoadXmlTilesetNames();
+	for (Tileset* tileset : GetSortedTilesets(g_materials.tilesets)) {
+		if (!tileset) {
+			continue;
+		}
+
+		const TilesetCategory* category = tileset->getCategory(palette);
+		if (!category || category->size() == 0) {
+			continue;
+		}
+
+		TilesetMoveQueue::Target target {
+			.palette = palette,
+			.tileset_name = tileset->name,
+		};
+		if (!isXmlBackedMoveTarget(target, xml_tileset_names)) {
+			continue;
+		}
+
+		targets.push_back(std::move(target));
+	}
+	return targets;
+}
+
+std::optional<TilesetMoveQueue::Target> BrushPalettePanel::ResolveSourceTarget(int tileset_index) const {
+	if (tileset_index < 0 || static_cast<size_t>(tileset_index) >= tileset_pages.size()) {
+		return std::nullopt;
+	}
+
+	return TilesetMoveQueue::Target {
+		.palette = palette_type,
+		.tileset_name = tileset_pages[static_cast<size_t>(tileset_index)].name,
+	};
+}
+
+void BrushPalettePanel::QueueSelectedItemsTo(const TilesetMoveQueue::Target& target) {
+	if (!results_grid || !target.isValid()) {
+		return;
+	}
+
+	auto selected_entries = results_grid->GetSelectedEntries();
+	if (selected_entries.empty()) {
+		return;
+	}
+
+	auto& move_queue = g_gui.GetTilesetMoveQueue();
+	for (const auto& entry : selected_entries) {
+		if (!entry.brush || !entry.brush->is<RAWBrush>()) {
+			continue;
+		}
+
+		int source_tileset_index = entry.tileset_index;
+		if (source_tileset_index < 0 && tileset_choice) {
+			source_tileset_index = tileset_choice->GetSelection();
+		}
+
+		const auto source = ResolveSourceTarget(source_tileset_index);
+		if (!source.has_value()) {
+			continue;
+		}
+
+		const ServerItemId item_id = entry.brush->as<RAWBrush>()->getItemID();
+		if (*source == target) {
+			move_queue.Remove(item_id);
+			continue;
+		}
+
+		move_queue.QueueMove(item_id, *source, target);
+	}
+
+	RefreshQueueVisuals();
+}
+
+void BrushPalettePanel::RefreshQueueVisuals() {
+	if (results_grid) {
+		results_grid->Refresh();
+	}
+
+	for (PaletteWindow* palette : g_gui.GetPalettes()) {
+		if (!palette) {
+			continue;
+		}
+		palette->Refresh();
+	}
+
+	g_gui.RefreshTilesetMoveQueuePanel(true);
+}
+
+void BrushPalettePanel::RebuildAllEntries() {
+	all_entries.clear();
+
+	for (const PaletteType search_palette : globalSearchPalettes()) {
+		int tileset_index = 0;
+		for (Tileset* tileset : GetSortedTilesets(g_materials.tilesets)) {
+			if (!tileset) {
+				continue;
+			}
+
+			const auto* category = tileset->getCategory(search_palette);
+			if (!category || category->size() == 0) {
+				continue;
+			}
+
+			for (Brush* brush : category->brushlist) {
+				if (!brush) {
+					continue;
+				}
+
+				SearchEntry entry;
+				entry.brush = brush;
+				entry.palette_type = search_palette;
+				entry.tileset_index = tileset_index;
+				if (brush->is<RAWBrush>()) {
+					entry.id = brush->as<RAWBrush>()->getItemID();
+				}
+				entry.name_lower = lowerCopy(brush->getName());
+				all_entries.push_back(std::move(entry));
+			}
+
+			++tileset_index;
+		}
+	}
+}
+
+void BrushPalettePanel::ApplySearchNow() {
+	if (!results_grid || !tileset_choice || !search_text) {
+		return;
+	}
+
+	wxString query = applied_search_query;
+	query.Trim(true).Trim(false);
+	const bool searching = !query.IsEmpty();
+
+	if (palette_type == TILESET_RAW && raw_unused_checkbox && raw_unused_checkbox->GetValue()) {
+		EnsureRawUsedFlags();
+	}
+
+	if (!searching) {
+		tileset_choice->Enable(!tileset_pages.empty());
+
+		int sel = tileset_choice->GetSelection();
+		const int restore_tileset_index = (last_search_selected_palette == palette_type) ? last_search_selected_tileset_index : -1;
+		if (restore_tileset_index != -1) {
+			sel = restore_tileset_index;
+			tileset_choice->SetSelection(sel);
+		}
+
+		if (sel == wxNOT_FOUND && !tileset_pages.empty()) {
+			sel = 0;
+			tileset_choice->SetSelection(0);
+		}
+
+		last_tileset_selection = sel == wxNOT_FOUND ? 0 : sel;
+		tileset_entries.clear();
+
+		if (sel != wxNOT_FOUND && sel >= 0 && static_cast<size_t>(sel) < tileset_pages.size()) {
+			const auto* category = tileset_pages[static_cast<size_t>(sel)].category;
+			if (category) {
+				tileset_entries.reserve(category->brushlist.size());
+				for (Brush* brush : category->brushlist) {
+					if (!brush) {
+						continue;
+					}
+					if (!IsRawBrushUnused(brush)) {
+						continue;
+					}
+					tileset_entries.push_back(VirtualBrushGrid::Entry {
+						.brush = brush,
+						.palette_type = palette_type,
+						.tileset_index = sel,
+					});
+				}
+			}
+		}
+
+		results_grid->SetEntryList(&tileset_entries, palette_type);
+
+		// If user selected something while searching, keep that selection when returning.
+		if (last_search_selected_brush && last_search_selected_palette == palette_type && restore_tileset_index == sel) {
+			results_grid->SelectBrush(last_search_selected_brush);
+			remembered_brushes[tileset_pages[static_cast<size_t>(sel)].name] = last_search_selected_brush;
+		}
+
+		if (restore_tileset_index != -1) {
+			last_search_selected_tileset_index = -1;
+		}
+
+		// Restore remembered selection for this tileset if possible.
+		if (sel != wxNOT_FOUND && sel >= 0 && static_cast<size_t>(sel) < tileset_pages.size()) {
+			const std::string& name = tileset_pages[static_cast<size_t>(sel)].name;
+			auto it = remembered_brushes.find(name);
+			if (it != remembered_brushes.end()) {
+				results_grid->SelectBrush(it->second);
+			} else {
+				results_grid->SelectFirstBrush();
+			}
+		}
+
+		return;
+	}
+
+	tileset_choice->Enable(false);
+
+	if (all_entries.empty()) {
+		RebuildAllEntries();
+	}
+
+	filtered_entries.clear();
+
+	if (search_mode == SearchMode::Id) {
+		long id_val = -1;
+		if (query.ToLong(&id_val) && id_val >= 0 && id_val <= 65535) {
+			for (const auto& entry : all_entries) {
+				if (!entry.id.has_value()) {
+					continue;
+				}
+				if (static_cast<long>(*entry.id) != id_val) {
+					continue;
+				}
+				if (!IsRawBrushUnused(entry.brush)) {
+					continue;
+				}
+				filtered_entries.push_back(VirtualBrushGrid::Entry {
+					.brush = entry.brush,
+					.palette_type = entry.palette_type,
+					.tileset_index = entry.tileset_index,
+				});
+			}
+		}
+	} else {
+		const std::string q = lowerCopy(nstr(query));
+		if (!q.empty()) {
+			bool found_exact_name_match = false;
+			for (const auto& entry : all_entries) {
+				if (!matchesExactWordSequence(entry.name_lower, q)) {
+					continue;
+				}
+				if (!IsRawBrushUnused(entry.brush)) {
+					continue;
+				}
+				filtered_entries.push_back(VirtualBrushGrid::Entry {
+					.brush = entry.brush,
+					.palette_type = entry.palette_type,
+					.tileset_index = entry.tileset_index,
+				});
+				found_exact_name_match = true;
+			}
+
+			if (!found_exact_name_match) {
+			for (const auto& entry : all_entries) {
+				if (!matchesWholeWordSequence(entry.name_lower, q)) {
+					continue;
+				}
+				if (!IsRawBrushUnused(entry.brush)) {
+					continue;
+				}
+				filtered_entries.push_back(VirtualBrushGrid::Entry {
+					.brush = entry.brush,
+					.palette_type = entry.palette_type,
+					.tileset_index = entry.tileset_index,
+				});
+			}
+			}
+		}
+	}
+
+	results_grid->SetEntryList(&filtered_entries, TILESET_UNKNOWN);
+	if (last_search_selected_brush) {
+		results_grid->SelectBrush(last_search_selected_brush);
+	} else {
+		results_grid->SelectFirstBrush();
+	}
+}
+
+void BrushPalettePanel::OnTilesetChoice(wxCommandEvent&) {
+	// Remember selection for previous tileset.
+	const int old_sel = last_tileset_selection;
+	if (old_sel != wxNOT_FOUND && old_sel >= 0 && static_cast<size_t>(old_sel) < tileset_pages.size()) {
+		if (Brush* b = results_grid->GetSelectedBrush()) {
+			remembered_brushes[tileset_pages[static_cast<size_t>(old_sel)].name] = b;
+		}
+	}
+
+	last_tileset_selection = tileset_choice->GetSelection();
+	ApplySearchNow();
+	SyncSelectedBrushToGui();
+}
+
+void BrushPalettePanel::OnSearchText(wxCommandEvent&) {
+	// Search is committed explicitly with Enter so typing doesn't reshuffle results mid-input.
+}
+
+void BrushPalettePanel::OnSearchEnter(wxCommandEvent&) {
+	if (!search_text) {
+		return;
+	}
+
+	wxString next_query = search_text->GetValue();
+	next_query.Trim(true).Trim(false);
+	if (next_query != applied_search_query) {
+		last_search_selected_brush = nullptr;
+		last_search_selected_tileset_index = -1;
+		last_search_selected_palette = TILESET_UNKNOWN;
+	}
+
+	applied_search_query = next_query;
+	ApplySearchNow();
+	SyncSelectedBrushToGui();
+}
+
+void BrushPalettePanel::OnSearchCharHook(wxKeyEvent& event) {
+	// Keep palette/menu hotkeys from firing while the user is typing in the filter.
+	event.StopPropagation();
+	event.Skip();
+}
+
+void BrushPalettePanel::OnSearchFocus(wxFocusEvent& event) {
+	if (!search_hotkeys_suspended) {
+		g_hotkeys.DisableHotkeys();
+		search_hotkeys_suspended = true;
+	}
+	event.Skip();
+}
+
+void BrushPalettePanel::OnSearchBlur(wxFocusEvent& event) {
+	if (search_hotkeys_suspended) {
+		g_hotkeys.EnableHotkeys();
+		search_hotkeys_suspended = false;
+	}
+	event.Skip();
+}
+
+void BrushPalettePanel::OnSearchModeButton(wxCommandEvent&) {
+	wxMenu menu;
+	const int id_name = wxNewId();
+	const int id_id = wxNewId();
+
+	menu.AppendRadioItem(id_name, "Name");
+	menu.AppendRadioItem(id_id, "ID");
+	menu.Check(search_mode == SearchMode::Name ? id_name : id_id, true);
+
+	menu.Bind(wxEVT_MENU, [this, id_name, id_id](wxCommandEvent& evt) {
+		search_mode = (evt.GetId() == id_id) ? SearchMode::Id : SearchMode::Name;
+		g_globalBrushSearchById = (search_mode == SearchMode::Id);
+		UpdateSearchHint();
+		ApplySearchNow();
+		SyncSelectedBrushToGui();
+	}, id_name);
+	menu.Bind(wxEVT_MENU, [this, id_name, id_id](wxCommandEvent& evt) {
+		search_mode = (evt.GetId() == id_id) ? SearchMode::Id : SearchMode::Name;
+		g_globalBrushSearchById = (search_mode == SearchMode::Id);
+		UpdateSearchHint();
+		ApplySearchNow();
+		SyncSelectedBrushToGui();
+	}, id_id);
+
+	search_mode_button->PopupMenu(&menu, 0, search_mode_button->GetSize().y);
+}
+
+void BrushPalettePanel::OnViewToggle(wxCommandEvent& event) {
+	Brush* selected_brush = results_grid ? results_grid->GetSelectedBrush() : nullptr;
+
+	if (event.GetEventObject() == list_toggle) {
+		view_mode = ViewMode::List;
+	} else if (event.GetEventObject() == grid_toggle) {
+		view_mode = ViewMode::Grid;
+	} else {
+		return;
+	}
+
+	view_mode_user_override = true;
+	g_globalBrushViewModeOverride = true;
+	g_globalBrushViewModeIsGrid = (view_mode == ViewMode::Grid);
+	ApplyViewModeToViews();
+	if (selected_brush && results_grid) {
+		results_grid->SelectBrush(selected_brush, VirtualBrushGrid::SelectionScrollBehavior::EnsureVisible);
+	}
+}
+
+void BrushPalettePanel::OnRawUnusedToggle(wxCommandEvent&) {
+	// RAW-only toggle affects both tileset browsing and search results.
+	raw_used_built = false;
+	ApplySearchNow();
+	SyncSelectedBrushToGui();
+}
+
+void BrushPalettePanel::OnSearchGridSelected(wxCommandEvent& event) {
+	if (!results_grid || !tileset_choice) {
+		return;
+	}
+
+	const bool searching = !applied_search_query.IsEmpty();
+
+	if (searching) {
+		const auto selected_entry = results_grid->GetSelectedEntry();
+		if (!selected_entry.has_value() || !selected_entry->brush) {
+			return;
+		}
+
+		last_search_selected_brush = selected_entry->brush;
+		last_search_selected_tileset_index = selected_entry->tileset_index;
+		last_search_selected_palette = selected_entry->palette_type;
+
+		if (auto* palette = GetParentPalette()) {
+			palette->OnSelectBrush(selected_entry->brush, selected_entry->palette_type, selected_entry->tileset_index, true);
+		}
+	} else {
+		const int sel = tileset_choice->GetSelection();
+		if (sel != wxNOT_FOUND && sel >= 0 && static_cast<size_t>(sel) < tileset_pages.size()) {
+			if (Brush* b = results_grid->GetSelectedBrush()) {
+				remembered_brushes[tileset_pages[static_cast<size_t>(sel)].name] = b;
+			}
+		}
+	}
+}
+
+void BrushPalettePanel::OnResultsGridContextMenu(wxContextMenuEvent& event) {
+	if (!SupportsMoveQueue() || !results_grid || !results_grid->HasSelection()) {
+		return;
+	}
+
+	wxMenu menu;
+	auto* move_menu = newd wxMenu();
+
+	const auto appendTargetItem = [this](wxMenu* target_menu, const TilesetMoveQueue::Target& target, const wxString& label) {
+		const int menu_id = wxWindow::NewControlId();
+		target_menu->Append(menu_id, label);
+		target_menu->Bind(wxEVT_MENU, [this, target](wxCommandEvent&) {
+			QueueSelectedItemsTo(target);
+		}, menu_id);
+	};
+
+	const auto xml_tileset_names = TilesetXmlRewriter::LoadXmlTilesetNames();
+	const auto& recent_targets = g_gui.GetTilesetMoveQueue().RecentTargets();
+	size_t recent_target_count = 0;
+	for (const auto& target : recent_targets) {
+		if (!isXmlBackedMoveTarget(target, xml_tileset_names)) {
+			continue;
+		}
+		appendTargetItem(move_menu, target, wxString::Format("(Last used) %s -> %s", paletteLabel(target.palette), wxstr(target.tileset_name)));
+		++recent_target_count;
+	}
+
+	if (recent_target_count > 0) {
+		move_menu->AppendSeparator();
+	}
+
+	auto* raw_targets_menu = newd wxMenu();
+	for (const auto& target : CollectMoveTargets(TILESET_RAW)) {
+		appendTargetItem(raw_targets_menu, target, wxstr(target.tileset_name));
+	}
+	if (raw_targets_menu->GetMenuItemCount() > 0) {
+		move_menu->AppendSubMenu(raw_targets_menu, "RAW");
+	} else {
+		delete raw_targets_menu;
+	}
+
+	auto* item_targets_menu = newd wxMenu();
+	for (const auto& target : CollectMoveTargets(TILESET_ITEM)) {
+		appendTargetItem(item_targets_menu, target, wxstr(target.tileset_name));
+	}
+	if (item_targets_menu->GetMenuItemCount() > 0) {
+		move_menu->AppendSubMenu(item_targets_menu, "Items");
+	} else {
+		delete item_targets_menu;
+	}
+
+	if (move_menu->GetMenuItemCount() == 0) {
+		delete move_menu;
+		return;
+	}
+
+	menu.AppendSubMenu(move_menu, "Move to");
+
+	wxPoint menu_position = event.GetPosition();
+	if (menu_position == wxDefaultPosition) {
+		menu_position = wxPoint(8, 8);
+	} else {
+		menu_position = results_grid->ScreenToClient(menu_position);
+	}
+
+	results_grid->PopupMenu(&menu, menu_position);
+}
+
+void BrushPalettePanel::OnClickAddTileset(wxCommandEvent& WXUNUSED(event)) {
 	wxDialog* w = newd AddTilesetWindow(g_gui.root, palette_type);
-	int ret = w->ShowModal();
+	const int ret = w->ShowModal();
 	w->Destroy();
 
 	if (ret != 0) {
@@ -235,23 +1073,22 @@ void BrushPalettePanel::OnClickAddTileset(wxCommandEvent& WXUNUSED(event)) {
 }
 
 void BrushPalettePanel::OnClickAddItemToTileset(wxCommandEvent& WXUNUSED(event)) {
-	if (!choicebook) {
+	const int selection = tileset_choice ? tileset_choice->GetSelection() : wxNOT_FOUND;
+	if (selection == wxNOT_FOUND || selection < 0 || static_cast<size_t>(selection) >= tileset_pages.size()) {
 		return;
 	}
-	int selection = choicebook->GetSelection();
-	if (selection == wxNOT_FOUND) {
+
+	const std::string tilesetName = tileset_pages[static_cast<size_t>(selection)].name;
+	auto it = g_materials.tilesets.find(tilesetName);
+	if (it == g_materials.tilesets.end()) {
 		return;
 	}
-	std::string tilesetName = choicebook->GetPageText(selection).ToStdString();
 
-	auto _it = g_materials.tilesets.find(tilesetName);
-	if (_it != g_materials.tilesets.end()) {
-		wxDialog* w = newd AddItemWindow(g_gui.root, palette_type, _it->second);
-		int ret = w->ShowModal();
-		w->Destroy();
+	wxDialog* w = newd AddItemWindow(g_gui.root, palette_type, it->second);
+	const int ret = w->ShowModal();
+	w->Destroy();
 
-		if (ret != 0) {
-			g_gui.RebuildPalettes();
-		}
+	if (ret != 0) {
+		g_gui.RebuildPalettes();
 	}
 }

--- a/source/palette/panels/brush_palette_panel.h
+++ b/source/palette/panels/brush_palette_panel.h
@@ -3,9 +3,24 @@
 
 #include "palette/palette_common.h"
 #include "palette/panels/brush_panel.h"
+#include "palette/controls/virtual_brush_grid.h"
 #include "app/settings.h"
+#include "tileset_move_queue/tileset_move_queue.h"
 
+#include <cstdint>
+#include <optional>
+#include <string>
 #include <unordered_map>
+#include <vector>
+
+class wxBitmapButton;
+class wxBitmapToggleButton;
+class wxCheckBox;
+class wxChoice;
+class wxPanel;
+class wxSimplebook;
+class wxTextCtrl;
+class wxTimer;
 
 class BrushPalettePanel : public PalettePanel {
 public:
@@ -32,23 +47,105 @@ public:
 	Brush* GetSelectedBrush() const override;
 	// Select the brush in the parameter, this only changes the look of the panel
 	bool SelectBrush(const Brush* whatbrush) override;
+	bool SelectBrushInTileset(const Brush* whatbrush, int tileset_index);
+	bool SelectBrushWithOptions(const Brush* whatbrush, bool align_to_top);
+	bool SelectBrushInTileset(const Brush* whatbrush, int tileset_index, bool align_to_top);
 
 	// Called when this page is displayed
 	void OnSwitchIn() override;
 
-	// Event handler for child window
-	void OnSwitchingPage(wxChoicebookEvent& event);
-	void OnPageChanged(wxChoicebookEvent& event);
 	void OnClickAddTileset(wxCommandEvent& WXUNUSED(event));
 	void OnClickAddItemToTileset(wxCommandEvent& WXUNUSED(event));
 
 protected:
+	enum class SearchMode {
+		Id,
+		Name,
+	};
+
+	enum class ViewMode {
+		List,
+		Grid,
+	};
+
+	struct TilesetPage {
+		std::string name;
+		const TilesetCategory* category = nullptr;
+	};
+
+	struct SearchEntry {
+		Brush* brush = nullptr;
+		PaletteType palette_type = TILESET_UNKNOWN;
+		int tileset_index = -1;
+		std::optional<uint16_t> id;
+		std::string name_lower;
+	};
+
 	PaletteType palette_type;
-	wxChoicebook* choicebook;
 
-	// No size_panel, it was unused
+	wxChoice* tileset_choice = nullptr;
 
-	std::unordered_map<wxWindow*, Brush*> remembered_brushes;
+	wxPanel* toolbar_panel = nullptr;
+	wxTextCtrl* search_text = nullptr;
+	wxBitmapButton* search_mode_button = nullptr;
+	wxBitmapToggleButton* list_toggle = nullptr;
+	wxBitmapToggleButton* grid_toggle = nullptr;
+	wxCheckBox* raw_unused_checkbox = nullptr; // RAW palette only
+
+	VirtualBrushGrid* results_grid = nullptr;
+
+	SearchMode search_mode = SearchMode::Name;
+	ViewMode view_mode = ViewMode::List;
+	bool view_mode_user_override = false;
+	BrushListType style_list_type = BRUSHLIST_LISTBOX;
+	bool search_hotkeys_suspended = false;
+	wxString applied_search_query;
+
+	std::vector<TilesetPage> tileset_pages;
+	std::unordered_map<std::string, Brush*> remembered_brushes;
+	int last_tileset_selection = 0;
+
+	std::vector<SearchEntry> all_entries;
+	std::vector<VirtualBrushGrid::Entry> tileset_entries;
+	std::vector<VirtualBrushGrid::Entry> filtered_entries;
+	Brush* last_search_selected_brush = nullptr;
+	int last_search_selected_tileset_index = -1;
+	PaletteType last_search_selected_palette = TILESET_UNKNOWN;
+	Brush* pending_switch_selection = nullptr;
+	bool pending_switch_align_to_top = false;
+
+	bool raw_used_built = false;
+	std::vector<uint8_t> raw_used_flags;
+
+	void BuildTilesetPages(const TilesetContainer& tilesets);
+	void RebuildAllEntries();
+	void ApplySearchNow();
+	void SyncSearchModeFromGlobal();
+	void SyncViewModeFromGlobal();
+
+	void UpdateSearchHint();
+	void ApplyViewModeToViews();
+	void EnsureRawUsedFlags();
+	bool IsRawBrushUnused(const Brush* brush) const;
+	bool SupportsMoveQueue() const;
+	bool IsActivePalettePage() const;
+	void SyncSelectedBrushToGui();
+	std::vector<TilesetMoveQueue::Target> CollectMoveTargets(PaletteType palette) const;
+	std::optional<TilesetMoveQueue::Target> ResolveSourceTarget(int tileset_index) const;
+	void QueueSelectedItemsTo(const TilesetMoveQueue::Target& target);
+	void RefreshQueueVisuals();
+
+	void OnTilesetChoice(wxCommandEvent& event);
+	void OnSearchText(wxCommandEvent& event);
+	void OnSearchEnter(wxCommandEvent& event);
+	void OnSearchCharHook(wxKeyEvent& event);
+	void OnSearchFocus(wxFocusEvent& event);
+	void OnSearchBlur(wxFocusEvent& event);
+	void OnSearchModeButton(wxCommandEvent& event);
+	void OnViewToggle(wxCommandEvent& event);
+	void OnRawUnusedToggle(wxCommandEvent& event);
+	void OnSearchGridSelected(wxCommandEvent& event);
+	void OnResultsGridContextMenu(wxContextMenuEvent& event);
 };
 
 #endif

--- a/source/palette/panels/brush_panel.cpp
+++ b/source/palette/panels/brush_panel.cpp
@@ -18,7 +18,8 @@ BrushPanel::BrushPanel(wxWindow* parent) :
 	tileset(nullptr),
 	brushbox(nullptr),
 	loaded(false),
-	list_type(BRUSHLIST_LISTBOX) {
+	list_type(BRUSHLIST_LISTBOX),
+	force_list_mode(std::nullopt) {
 	sizer = newd wxBoxSizer(wxVERTICAL);
 	SetSizerAndFit(sizer);
 }
@@ -50,6 +51,22 @@ void BrushPanel::SetListType(wxString ltype) {
 		SetListType(BRUSHLIST_LISTBOX);
 	} else if (ltype == "textlistbox") {
 		SetListType(BRUSHLIST_TEXT_LISTBOX);
+	}
+}
+
+void BrushPanel::SetForceListMode(std::optional<bool> next_force_list_mode) {
+	if (force_list_mode == next_force_list_mode) {
+		return;
+	}
+	force_list_mode = next_force_list_mode;
+
+	if (!loaded || !brushbox) {
+		return;
+	}
+
+	if (auto* vbg = dynamic_cast<VirtualBrushGrid*>(brushbox->GetSelfWindow())) {
+		const bool list_mode = force_list_mode.value_or(list_type == BRUSHLIST_LISTBOX || list_type == BRUSHLIST_TEXT_LISTBOX);
+		vbg->SetDisplayMode(list_mode ? VirtualBrushGrid::DisplayMode::List : VirtualBrushGrid::DisplayMode::Grid);
 	}
 }
 
@@ -86,6 +103,11 @@ void BrushPanel::LoadContents() {
 
 	if (!brushbox) {
 		return;
+	}
+
+	if (auto* vbg = dynamic_cast<VirtualBrushGrid*>(brushbox->GetSelfWindow())) {
+		const bool list_mode = force_list_mode.value_or(list_type == BRUSHLIST_LISTBOX || list_type == BRUSHLIST_TEXT_LISTBOX);
+		vbg->SetDisplayMode(list_mode ? VirtualBrushGrid::DisplayMode::List : VirtualBrushGrid::DisplayMode::Grid);
 	}
 
 	loaded = true;

--- a/source/palette/panels/brush_panel.h
+++ b/source/palette/panels/brush_panel.h
@@ -5,6 +5,8 @@
 #include "map/tileset.h"
 #include "brushes/brush.h"
 
+#include <optional>
+
 enum BrushListType {
 	BRUSHLIST_LARGE_ICONS,
 	BRUSHLIST_SMALL_ICONS,
@@ -14,11 +16,7 @@ enum BrushListType {
 
 class BrushBoxInterface {
 public:
-	BrushBoxInterface(const TilesetCategory* _tileset) :
-		tileset(_tileset), loaded(false) {
-		ASSERT(tileset);
-	}
-	virtual ~BrushBoxInterface() { }
+	virtual ~BrushBoxInterface() = default;
 
 	virtual wxWindow* GetSelfWindow() = 0;
 
@@ -28,10 +26,6 @@ public:
 	virtual Brush* GetSelectedBrush() const = 0;
 	// Select the brush in the parameter, this only changes the look of the panel
 	virtual bool SelectBrush(const Brush* brush) = 0;
-
-protected:
-	const TilesetCategory* const tileset;
-	bool loaded;
 };
 
 class BrushPanel : public wxPanel {
@@ -48,6 +42,10 @@ public:
 	// Sets the display type (list or icons)
 	void SetListType(BrushListType ltype);
 	void SetListType(wxString ltype);
+
+	// Overrides list/grid display mode without changing the underlying style.
+	// std::nullopt means "follow style default".
+	void SetForceListMode(std::optional<bool> force_list_mode);
 	// Assigns a tileset to this list
 	void AssignTileset(const TilesetCategory* tileset);
 
@@ -69,6 +67,7 @@ protected:
 	BrushBoxInterface* brushbox;
 	bool loaded;
 	BrushListType list_type;
+	std::optional<bool> force_list_mode;
 };
 
 #endif

--- a/source/palette/panels/tileset_move_queue_panel.cpp
+++ b/source/palette/panels/tileset_move_queue_panel.cpp
@@ -1,0 +1,356 @@
+#include "palette/panels/tileset_move_queue_panel.h"
+
+#include "brushes/raw/raw_brush.h"
+#include "game/materials.h"
+#include "item_definitions/core/item_definition_store.h"
+#include "palette/palette_window.h"
+#include "ui/gui.h"
+#include "util/image_manager.h"
+
+#include <algorithm>
+#include <cctype>
+#include <unordered_set>
+
+#include <wx/bmpbuttn.h>
+#include <wx/button.h>
+#include <wx/choice.h>
+#include <wx/menu.h>
+#include <wx/sizer.h>
+#include <wx/statbox.h>
+#include <wx/textctrl.h>
+#include <wx/tglbtn.h>
+#include <wx/msgdlg.h>
+
+namespace {
+	constexpr int TOOL_ICON_SIZE = 16;
+
+	void ConfigureToggleIcon(wxBitmapToggleButton* button, const wxBitmap& bitmap) {
+		if (!button) {
+			return;
+		}
+		button->SetBitmap(bitmap);
+		button->SetBitmapCurrent(bitmap);
+		button->SetBitmapFocus(bitmap);
+		button->SetBitmapPressed(bitmap);
+	}
+
+	[[nodiscard]] std::string lowerCopy(std::string value) {
+		for (char& ch : value) {
+			ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+		}
+		return value;
+	}
+
+	[[nodiscard]] wxString paletteLabel(PaletteType palette) {
+		return palette == TILESET_RAW ? "RAW" : "Items";
+	}
+}
+
+TilesetMoveQueuePanel::TilesetMoveQueuePanel(wxWindow* parent, wxWindowID id) :
+	wxPanel(parent, id, wxDefaultPosition, wxSize(225, 250)) {
+	SetMinSize(wxSize(225, 250));
+
+	auto* top_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	auto* palette_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Palette");
+	palette_choice = newd wxChoice(palette_sizer->GetStaticBox(), wxID_ANY);
+	palette_choice->Append("RAW");
+	palette_choice->Append("Items");
+	palette_choice->SetSelection(0);
+	palette_sizer->Add(palette_choice, 0, wxEXPAND | wxALL, FromDIP(4));
+	top_sizer->Add(palette_sizer, 0, wxEXPAND);
+
+	auto* tileset_sizer = newd wxStaticBoxSizer(wxVERTICAL, this, "Tileset");
+	tileset_choice = newd wxChoice(tileset_sizer->GetStaticBox(), wxID_ANY);
+	tileset_sizer->Add(tileset_choice, 0, wxEXPAND | wxALL, FromDIP(4));
+	top_sizer->Add(tileset_sizer, 0, wxEXPAND);
+
+	auto* toolbar_panel = newd wxPanel(this, wxID_ANY);
+	auto* toolbar_sizer = newd wxBoxSizer(wxVERTICAL);
+
+	search_text = newd wxTextCtrl(toolbar_panel, wxID_ANY);
+	search_mode_button = newd wxBitmapButton(
+		toolbar_panel,
+		wxID_ANY,
+		IMAGE_MANAGER.GetBitmap(ICON_ANGLE_DOWN, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)),
+		wxDefaultPosition,
+		wxDefaultSize,
+		wxBU_EXACTFIT
+	);
+
+	auto* search_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	search_sizer->Add(search_text, 1, wxEXPAND);
+	search_sizer->Add(search_mode_button, 0, wxLEFT, FromDIP(4));
+	toolbar_sizer->Add(search_sizer, 0, wxEXPAND);
+
+	list_toggle = newd wxBitmapToggleButton(toolbar_panel, wxID_ANY, wxBitmap(), wxDefaultPosition, FromDIP(wxSize(28, 28)), wxBU_EXACTFIT | wxBORDER_NONE);
+	grid_toggle = newd wxBitmapToggleButton(toolbar_panel, wxID_ANY, wxBitmap(), wxDefaultPosition, FromDIP(wxSize(28, 28)), wxBU_EXACTFIT | wxBORDER_NONE);
+	ConfigureToggleIcon(list_toggle, IMAGE_MANAGER.GetBitmap(ICON_RECTANGLE_LIST, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
+	ConfigureToggleIcon(grid_toggle, IMAGE_MANAGER.GetBitmap(ICON_TABLE_CELLS, wxSize(TOOL_ICON_SIZE, TOOL_ICON_SIZE)));
+
+	auto* view_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	view_sizer->Add(list_toggle, 0, wxRIGHT, FromDIP(2));
+	view_sizer->Add(grid_toggle, 0);
+	toolbar_sizer->Add(view_sizer, 0, wxTOP, FromDIP(4));
+
+	toolbar_panel->SetSizer(toolbar_sizer);
+	top_sizer->Add(toolbar_panel, 0, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(4));
+
+	results_grid = newd VirtualBrushGrid(this, &visible_entries, TILESET_RAW, RENDER_SIZE_32x32);
+	top_sizer->Add(results_grid, 1, wxEXPAND | wxLEFT | wxRIGHT | wxTOP, FromDIP(4));
+
+	auto* action_sizer = newd wxBoxSizer(wxHORIZONTAL);
+	discard_button = newd wxButton(this, wxID_ANY, "Discard");
+	apply_button = newd wxButton(this, wxID_ANY, "Apply");
+	action_sizer->Add(discard_button, 1, wxRIGHT, FromDIP(4));
+	action_sizer->Add(apply_button, 1);
+	top_sizer->Add(action_sizer, 0, wxEXPAND | wxALL, FromDIP(4));
+
+	SetSizer(top_sizer);
+
+	palette_choice->Bind(wxEVT_CHOICE, &TilesetMoveQueuePanel::OnPaletteChoice, this);
+	tileset_choice->Bind(wxEVT_CHOICE, &TilesetMoveQueuePanel::OnTilesetChoice, this);
+	search_text->Bind(wxEVT_TEXT, &TilesetMoveQueuePanel::OnSearchText, this);
+	search_text->Bind(wxEVT_CHAR_HOOK, &TilesetMoveQueuePanel::OnSearchCharHook, this);
+	search_text->Bind(wxEVT_SET_FOCUS, &TilesetMoveQueuePanel::OnSearchFocus, this);
+	search_text->Bind(wxEVT_KILL_FOCUS, &TilesetMoveQueuePanel::OnSearchBlur, this);
+	search_mode_button->Bind(wxEVT_BUTTON, &TilesetMoveQueuePanel::OnSearchModeButton, this);
+	list_toggle->Bind(wxEVT_TOGGLEBUTTON, &TilesetMoveQueuePanel::OnViewToggle, this);
+	grid_toggle->Bind(wxEVT_TOGGLEBUTTON, &TilesetMoveQueuePanel::OnViewToggle, this);
+	apply_button->Bind(wxEVT_BUTTON, &TilesetMoveQueuePanel::OnApply, this);
+	discard_button->Bind(wxEVT_BUTTON, &TilesetMoveQueuePanel::OnDiscard, this);
+
+	UpdateSearchHint();
+	UpdateViewMode();
+	ReloadFromQueue();
+}
+
+TilesetMoveQueuePanel::~TilesetMoveQueuePanel() {
+	if (search_hotkeys_suspended) {
+		g_hotkeys.EnableHotkeys();
+		search_hotkeys_suspended = false;
+	}
+}
+
+void TilesetMoveQueuePanel::ReloadFromQueue() {
+	RebuildTilesetChoices();
+	ApplyFilter();
+}
+
+void TilesetMoveQueuePanel::RebuildTilesetChoices() {
+	const PaletteType palette = SelectedPalette();
+	const auto queue_entries = g_gui.GetTilesetMoveQueue().Entries();
+
+	std::unordered_set<std::string> seen_tilesets;
+	std::vector<std::string> names;
+	for (const auto& entry : queue_entries) {
+		if (entry.target.palette != palette) {
+			continue;
+		}
+
+		if (seen_tilesets.insert(entry.target.tileset_name).second) {
+			names.push_back(entry.target.tileset_name);
+		}
+	}
+
+	std::ranges::sort(names);
+	const std::string current = SelectedTilesetName();
+
+	tileset_options.clear();
+	tileset_choice->Clear();
+	for (const auto& name : names) {
+		tileset_options.push_back(TilesetOption { .tileset_name = name });
+		tileset_choice->Append(wxstr(name));
+	}
+
+	if (tileset_options.empty()) {
+		tileset_choice->SetSelection(wxNOT_FOUND);
+		tileset_choice->Enable(false);
+		return;
+	}
+
+	tileset_choice->Enable(true);
+	int selection = 0;
+	for (size_t index = 0; index < tileset_options.size(); ++index) {
+		if (tileset_options[index].tileset_name == current) {
+			selection = static_cast<int>(index);
+			break;
+		}
+	}
+	tileset_choice->SetSelection(selection);
+}
+
+void TilesetMoveQueuePanel::ApplyFilter() {
+	const PaletteType palette = SelectedPalette();
+	const std::string tileset_name = SelectedTilesetName();
+	const std::string query = lowerCopy(nstr(search_text ? search_text->GetValue() : wxString()));
+
+	visible_entries.clear();
+	if (tileset_name.empty()) {
+		results_grid->SetEntryList(&visible_entries, palette);
+		apply_button->Enable(false);
+		discard_button->Enable(!g_gui.GetTilesetMoveQueue().Empty());
+		return;
+	}
+
+	auto queued_entries = g_gui.GetTilesetMoveQueue().EntriesForTarget(palette, tileset_name);
+	for (const auto& entry : queued_entries) {
+		const auto definition = g_item_definitions.get(entry.item_id);
+		RAWBrush* brush = definition ? definition.editorData().raw_brush : nullptr;
+		if (!brush) {
+			continue;
+		}
+
+		bool matches = true;
+		if (!query.empty()) {
+			if (search_mode == SearchMode::Id) {
+				matches = std::to_string(entry.item_id) == query;
+			} else {
+				matches = lowerCopy(brush->getName()).find(query) != std::string::npos;
+			}
+		}
+
+		if (matches) {
+			visible_entries.push_back(VirtualBrushGrid::Entry { .brush = brush, .tileset_index = -1 });
+		}
+	}
+
+	results_grid->SetEntryList(&visible_entries, palette);
+	apply_button->Enable(!g_gui.GetTilesetMoveQueue().Empty());
+	discard_button->Enable(!g_gui.GetTilesetMoveQueue().Empty());
+}
+
+PaletteType TilesetMoveQueuePanel::SelectedPalette() const {
+	return (palette_choice && palette_choice->GetSelection() == 1) ? TILESET_ITEM : TILESET_RAW;
+}
+
+std::string TilesetMoveQueuePanel::SelectedTilesetName() const {
+	const int selection = tileset_choice ? tileset_choice->GetSelection() : wxNOT_FOUND;
+	if (selection == wxNOT_FOUND || selection < 0 || static_cast<size_t>(selection) >= tileset_options.size()) {
+		return {};
+	}
+	return tileset_options[static_cast<size_t>(selection)].tileset_name;
+}
+
+void TilesetMoveQueuePanel::UpdateSearchHint() {
+	if (!search_text) {
+		return;
+	}
+
+	search_text->SetHint(search_mode == SearchMode::Id ? "Search ID..." : "Search name...");
+}
+
+void TilesetMoveQueuePanel::UpdateViewMode() {
+	results_grid->SetDisplayMode(view_mode == ViewMode::List ? VirtualBrushGrid::DisplayMode::List : VirtualBrushGrid::DisplayMode::Grid);
+	list_toggle->SetValue(view_mode == ViewMode::List);
+	grid_toggle->SetValue(view_mode == ViewMode::Grid);
+}
+
+void TilesetMoveQueuePanel::OnPaletteChoice(wxCommandEvent&) {
+	RebuildTilesetChoices();
+	ApplyFilter();
+}
+
+void TilesetMoveQueuePanel::OnTilesetChoice(wxCommandEvent&) {
+	ApplyFilter();
+}
+
+void TilesetMoveQueuePanel::OnSearchText(wxCommandEvent&) {
+	ApplyFilter();
+}
+
+void TilesetMoveQueuePanel::OnSearchCharHook(wxKeyEvent& event) {
+	event.StopPropagation();
+	event.Skip();
+}
+
+void TilesetMoveQueuePanel::OnSearchFocus(wxFocusEvent& event) {
+	if (!search_hotkeys_suspended) {
+		g_hotkeys.DisableHotkeys();
+		search_hotkeys_suspended = true;
+	}
+	event.Skip();
+}
+
+void TilesetMoveQueuePanel::OnSearchBlur(wxFocusEvent& event) {
+	if (search_hotkeys_suspended) {
+		g_hotkeys.EnableHotkeys();
+		search_hotkeys_suspended = false;
+	}
+	event.Skip();
+}
+
+void TilesetMoveQueuePanel::OnSearchModeButton(wxCommandEvent&) {
+	wxMenu menu;
+	const int id_name = wxWindow::NewControlId();
+	const int id_id = wxWindow::NewControlId();
+
+	menu.AppendRadioItem(id_name, "Name");
+	menu.AppendRadioItem(id_id, "ID");
+	menu.Check(search_mode == SearchMode::Name ? id_name : id_id, true);
+
+	menu.Bind(wxEVT_MENU, [this, id_id](wxCommandEvent& event) {
+		search_mode = event.GetId() == id_id ? SearchMode::Id : SearchMode::Name;
+		UpdateSearchHint();
+		ApplyFilter();
+	}, id_name);
+	menu.Bind(wxEVT_MENU, [this, id_id](wxCommandEvent& event) {
+		search_mode = event.GetId() == id_id ? SearchMode::Id : SearchMode::Name;
+		UpdateSearchHint();
+		ApplyFilter();
+	}, id_id);
+
+	search_mode_button->PopupMenu(&menu, 0, search_mode_button->GetSize().y);
+}
+
+void TilesetMoveQueuePanel::OnViewToggle(wxCommandEvent& event) {
+	if (event.GetEventObject() == list_toggle) {
+		view_mode = ViewMode::List;
+	} else if (event.GetEventObject() == grid_toggle) {
+		view_mode = ViewMode::Grid;
+	}
+	UpdateViewMode();
+}
+
+void TilesetMoveQueuePanel::OnApply(wxCommandEvent&) {
+	const auto result = g_gui.GetTilesetMoveQueue().Apply(g_materials);
+	if (!result.success) {
+		wxMessageBox(wxstr(result.error), "Move Queue", wxOK | wxICON_ERROR, this);
+		return;
+	}
+
+	for (PaletteWindow* palette : g_gui.GetPalettes()) {
+		if (!palette) {
+			continue;
+		}
+		palette->InvalidatePage(TILESET_RAW);
+		palette->InvalidatePage(TILESET_ITEM);
+	}
+
+	g_gui.RefreshTilesetMoveQueuePanel(false);
+
+	wxString message = wxString::Format("Applied: %d\nSkipped: %d", result.applied, result.skipped);
+	if (!result.warnings.empty()) {
+		message << wxString::Format("\nWarnings: %zu", result.warnings.size());
+		const size_t preview_count = std::min<size_t>(3, result.warnings.size());
+		for (size_t index = 0; index < preview_count; ++index) {
+			message << "\n- " << wxstr(result.warnings[index]);
+		}
+		if (result.warnings.size() > preview_count) {
+			message << wxString::Format("\n- ...and %zu more", result.warnings.size() - preview_count);
+		}
+	}
+	wxMessageBox(message, "Move Queue", wxOK | wxICON_INFORMATION, this);
+}
+
+void TilesetMoveQueuePanel::OnDiscard(wxCommandEvent&) {
+	g_gui.GetTilesetMoveQueue().Clear();
+	g_gui.RefreshTilesetMoveQueuePanel(false);
+
+	for (PaletteWindow* palette : g_gui.GetPalettes()) {
+		if (!palette) {
+			continue;
+		}
+		palette->Refresh();
+	}
+}

--- a/source/palette/panels/tileset_move_queue_panel.h
+++ b/source/palette/panels/tileset_move_queue_panel.h
@@ -1,0 +1,74 @@
+#ifndef RME_PALETTE_PANELS_TILESET_MOVE_QUEUE_PANEL_H_
+#define RME_PALETTE_PANELS_TILESET_MOVE_QUEUE_PANEL_H_
+
+#include "palette/controls/virtual_brush_grid.h"
+#include "tileset_move_queue/tileset_move_queue.h"
+
+#include <string>
+#include <vector>
+
+class wxBitmapButton;
+class wxBitmapToggleButton;
+class wxButton;
+class wxChoice;
+class wxTextCtrl;
+
+class TilesetMoveQueuePanel : public wxPanel {
+public:
+	TilesetMoveQueuePanel(wxWindow* parent, wxWindowID id = wxID_ANY);
+	~TilesetMoveQueuePanel() override;
+
+	void ReloadFromQueue();
+
+private:
+	enum class SearchMode {
+		Id,
+		Name,
+	};
+
+	enum class ViewMode {
+		List,
+		Grid,
+	};
+
+	struct TilesetOption {
+		std::string tileset_name;
+	};
+
+	wxChoice* palette_choice = nullptr;
+	wxChoice* tileset_choice = nullptr;
+	wxTextCtrl* search_text = nullptr;
+	wxBitmapButton* search_mode_button = nullptr;
+	wxBitmapToggleButton* list_toggle = nullptr;
+	wxBitmapToggleButton* grid_toggle = nullptr;
+	wxButton* apply_button = nullptr;
+	wxButton* discard_button = nullptr;
+	VirtualBrushGrid* results_grid = nullptr;
+
+	SearchMode search_mode = SearchMode::Name;
+	ViewMode view_mode = ViewMode::Grid;
+	bool search_hotkeys_suspended = false;
+
+	std::vector<TilesetOption> tileset_options;
+	VirtualBrushGrid::EntryList visible_entries;
+
+	void RebuildTilesetChoices();
+	void ApplyFilter();
+	PaletteType SelectedPalette() const;
+	std::string SelectedTilesetName() const;
+	void UpdateSearchHint();
+	void UpdateViewMode();
+
+	void OnPaletteChoice(wxCommandEvent& event);
+	void OnTilesetChoice(wxCommandEvent& event);
+	void OnSearchText(wxCommandEvent& event);
+	void OnSearchCharHook(wxKeyEvent& event);
+	void OnSearchFocus(wxFocusEvent& event);
+	void OnSearchBlur(wxFocusEvent& event);
+	void OnSearchModeButton(wxCommandEvent& event);
+	void OnViewToggle(wxCommandEvent& event);
+	void OnApply(wxCommandEvent& event);
+	void OnDiscard(wxCommandEvent& event);
+};
+
+#endif

--- a/source/tileset_move_queue/tileset_move_queue.cpp
+++ b/source/tileset_move_queue/tileset_move_queue.cpp
@@ -1,0 +1,136 @@
+#include "app/main.h"
+#include "tileset_move_queue/tileset_move_queue.h"
+
+#include "game/materials.h"
+#include "item_definitions/core/item_definition_store.h"
+#include "tileset_move_queue/tileset_xml_rewriter.h"
+#include "util/file_system.h"
+
+#include <algorithm>
+#include <spdlog/spdlog.h>
+
+void TilesetMoveQueue::QueueMove(ServerItemId item_id, const Target& source, const Target& target) {
+	if (item_id == 0 || !source.isValid() || !target.isValid()) {
+		return;
+	}
+
+	entries[item_id] = Entry {
+		.item_id = item_id,
+		.source = source,
+		.target = target,
+	};
+
+	RememberRecentTarget(target);
+}
+
+bool TilesetMoveQueue::Remove(ServerItemId item_id) {
+	return entries.erase(item_id) > 0;
+}
+
+void TilesetMoveQueue::Clear() {
+	entries.clear();
+	recent_targets.clear();
+}
+
+TilesetMoveQueue::ApplyResult TilesetMoveQueue::Apply(Materials& materials) {
+	ApplyResult apply_result;
+	const std::vector<Entry> queued_entries = Entries();
+	if (queued_entries.empty()) {
+		apply_result.success = true;
+		return apply_result;
+	}
+
+	TilesetXmlRewriter rewriter;
+	const auto rewrite_result = rewriter.Apply(queued_entries);
+	apply_result.success = rewrite_result.success;
+	apply_result.applied = rewrite_result.applied;
+	apply_result.skipped = rewrite_result.skipped;
+	apply_result.warnings = rewrite_result.warnings;
+	apply_result.error = rewrite_result.error;
+	if (!apply_result.success) {
+		return apply_result;
+	}
+
+	wxString error;
+	std::vector<std::string> reload_warnings;
+	const FileName tilesets_path(wxstr(TilesetXmlRewriter::DefaultTilesetsPath()));
+	materials.clear();
+	if (!materials.loadMaterials(tilesets_path, error, reload_warnings)) {
+		apply_result.success = false;
+		apply_result.error = error.empty() ? "Failed to reload tilesets after apply." : nstr(error);
+		return apply_result;
+	}
+	materials.loadExtensions(FileName(FileSystem::GetExtensionsDirectory()), error, reload_warnings);
+	materials.createOtherTileset();
+	if (!reload_warnings.empty()) {
+		spdlog::warn("Tileset move queue reload produced {} background warnings; omitting them from the user-facing apply summary.", reload_warnings.size());
+	}
+
+	Clear();
+	return apply_result;
+}
+
+bool TilesetMoveQueue::IsQueued(ServerItemId item_id) const {
+	return entries.contains(item_id);
+}
+
+const TilesetMoveQueue::Entry* TilesetMoveQueue::Find(ServerItemId item_id) const {
+	const auto it = entries.find(item_id);
+	if (it == entries.end()) {
+		return nullptr;
+	}
+	return &it->second;
+}
+
+const TilesetMoveQueue::Target* TilesetMoveQueue::QueuedSource(ServerItemId item_id) const {
+	if (const Entry* entry = Find(item_id)) {
+		return &entry->source;
+	}
+	return nullptr;
+}
+
+const TilesetMoveQueue::Target* TilesetMoveQueue::QueuedTarget(ServerItemId item_id) const {
+	if (const Entry* entry = Find(item_id)) {
+		return &entry->target;
+	}
+	return nullptr;
+}
+
+std::vector<TilesetMoveQueue::Entry> TilesetMoveQueue::EntriesForTarget(PaletteType palette, std::string_view tileset_name) const {
+	std::vector<Entry> matches;
+	matches.reserve(entries.size());
+
+	for (const auto& [item_id, entry] : entries) {
+		if (entry.target.palette != palette || entry.target.tileset_name != tileset_name) {
+			continue;
+		}
+		matches.push_back(entry);
+	}
+
+	std::ranges::sort(matches, {}, &Entry::item_id);
+	return matches;
+}
+
+std::vector<TilesetMoveQueue::Entry> TilesetMoveQueue::Entries() const {
+	std::vector<Entry> values;
+	values.reserve(entries.size());
+
+	for (const auto& [item_id, entry] : entries) {
+		values.push_back(entry);
+	}
+
+	std::ranges::sort(values, {}, &Entry::item_id);
+	return values;
+}
+
+void TilesetMoveQueue::RememberRecentTarget(const Target& target) {
+	if (!target.isValid()) {
+		return;
+	}
+
+	std::erase(recent_targets, target);
+	recent_targets.insert(recent_targets.begin(), target);
+	if (recent_targets.size() > 3) {
+		recent_targets.resize(3);
+	}
+}

--- a/source/tileset_move_queue/tileset_move_queue.h
+++ b/source/tileset_move_queue/tileset_move_queue.h
@@ -1,0 +1,75 @@
+#ifndef RME_TILESET_MOVE_QUEUE_H_
+#define RME_TILESET_MOVE_QUEUE_H_
+
+#include "brushes/brush_enums.h"
+#include "item_definitions/core/item_definition_types.h"
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+class Materials;
+
+class TilesetMoveQueue {
+public:
+	struct Target {
+		PaletteType palette = TILESET_UNKNOWN;
+		std::string tileset_name;
+
+		bool operator==(const Target& other) const {
+			return palette == other.palette && tileset_name == other.tileset_name;
+		}
+
+		bool isValid() const {
+			return palette != TILESET_UNKNOWN && !tileset_name.empty();
+		}
+	};
+
+	struct Entry {
+		ServerItemId item_id = 0;
+		Target source;
+		Target target;
+	};
+
+	struct ApplyResult {
+		bool success = false;
+		int applied = 0;
+		int skipped = 0;
+		std::vector<std::string> warnings;
+		std::string error;
+	};
+
+	void QueueMove(ServerItemId item_id, const Target& source, const Target& target);
+	bool Remove(ServerItemId item_id);
+	void Clear();
+	ApplyResult Apply(Materials& materials);
+
+	bool Empty() const {
+		return entries.empty();
+	}
+
+	size_t Size() const {
+		return entries.size();
+	}
+
+	bool IsQueued(ServerItemId item_id) const;
+	const Entry* Find(ServerItemId item_id) const;
+	const Target* QueuedSource(ServerItemId item_id) const;
+	const Target* QueuedTarget(ServerItemId item_id) const;
+
+	std::vector<Entry> EntriesForTarget(PaletteType palette, std::string_view tileset_name) const;
+	std::vector<Entry> Entries() const;
+
+	const std::vector<Target>& RecentTargets() const {
+		return recent_targets;
+	}
+
+private:
+	void RememberRecentTarget(const Target& target);
+
+	std::unordered_map<ServerItemId, Entry> entries;
+	std::vector<Target> recent_targets;
+};
+
+#endif

--- a/source/tileset_move_queue/tileset_xml_rewriter.cpp
+++ b/source/tileset_move_queue/tileset_xml_rewriter.cpp
@@ -1,0 +1,255 @@
+#include "app/main.h"
+#include "tileset_move_queue/tileset_xml_rewriter.h"
+
+#include "ext/pugixml.hpp"
+#include "util/file_system.h"
+
+#include <algorithm>
+#include <string_view>
+#include <unordered_set>
+
+namespace {
+	struct ItemRange {
+		uint16_t start = 0;
+		uint16_t end = 0;
+		pugi::xml_node node;
+	};
+
+	[[nodiscard]] bool supportsPalette(const std::string& section_name, PaletteType palette) {
+		if (palette == TILESET_RAW) {
+			return section_name == "raw"
+				|| section_name == "terrain_and_raw"
+				|| section_name == "collections_and_raw"
+				|| section_name == "doodad_and_raw"
+				|| section_name == "items_and_raw";
+		}
+
+		if (palette == TILESET_ITEM) {
+			return section_name == "items" || section_name == "items_and_raw";
+		}
+
+		return false;
+	}
+
+	[[nodiscard]] std::string directSectionName(PaletteType palette) {
+		return palette == TILESET_ITEM ? "items" : "raw";
+	}
+
+	[[nodiscard]] ItemRange readRange(const pugi::xml_node& node) {
+		const auto id_attribute = node.attribute("id");
+		if (id_attribute) {
+			const uint16_t id = id_attribute.as_ushort();
+			return ItemRange { .start = id, .end = id, .node = node };
+		}
+
+		const uint16_t from_id = node.attribute("fromid").as_ushort();
+		const uint16_t to_id = std::max<uint16_t>(from_id, node.attribute("toid").as_ushort());
+		return ItemRange { .start = from_id, .end = to_id, .node = node };
+	}
+
+	void assignNodeRange(pugi::xml_node node, uint16_t start, uint16_t end) {
+		node.remove_attribute("id");
+		node.remove_attribute("fromid");
+		node.remove_attribute("toid");
+
+		if (start == end) {
+			node.append_attribute("id").set_value(start);
+			return;
+		}
+
+		node.append_attribute("fromid").set_value(start);
+		node.append_attribute("toid").set_value(end);
+	}
+
+	[[nodiscard]] pugi::xml_node findTilesetNode(pugi::xml_node root, const std::string& tileset_name) {
+		for (pugi::xml_node tileset = root.child("tileset"); tileset; tileset = tileset.next_sibling("tileset")) {
+			if (tileset.attribute("name").as_string() == tileset_name) {
+				return tileset;
+			}
+		}
+		return {};
+	}
+
+	[[nodiscard]] std::vector<pugi::xml_node> findSectionNodes(pugi::xml_node tileset_node, PaletteType palette) {
+		std::vector<pugi::xml_node> nodes;
+		for (pugi::xml_node child = tileset_node.first_child(); child; child = child.next_sibling()) {
+			if (supportsPalette(child.name(), palette)) {
+				nodes.push_back(child);
+			}
+		}
+		return nodes;
+	}
+
+	[[nodiscard]] pugi::xml_node ensureTargetSection(pugi::xml_node tileset_node, PaletteType palette) {
+		const std::string direct_name = directSectionName(palette);
+		for (pugi::xml_node child = tileset_node.first_child(); child; child = child.next_sibling()) {
+			if (direct_name == child.name()) {
+				return child;
+			}
+		}
+
+		pugi::xml_node section = tileset_node.append_child(direct_name.c_str());
+		tileset_node.append_child(pugi::node_pcdata).set_value("\n\t");
+		return section;
+	}
+
+	[[nodiscard]] bool sectionContainsItem(pugi::xml_node section, uint16_t item_id) {
+		for (pugi::xml_node item = section.child("item"); item; item = item.next_sibling("item")) {
+			const ItemRange range = readRange(item);
+			if (range.start <= item_id && item_id <= range.end) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	bool removeItemFromSection(pugi::xml_node section, uint16_t item_id) {
+		bool removed = false;
+		for (pugi::xml_node item = section.child("item"); item;) {
+			pugi::xml_node next = item.next_sibling("item");
+			const ItemRange range = readRange(item);
+			if (range.start <= item_id && item_id <= range.end) {
+				removed = true;
+				if (range.start == range.end) {
+					section.remove_child(item);
+				} else if (item_id == range.start) {
+					assignNodeRange(item, static_cast<uint16_t>(range.start + 1), range.end);
+				} else if (item_id == range.end) {
+					assignNodeRange(item, range.start, static_cast<uint16_t>(range.end - 1));
+				} else {
+					assignNodeRange(item, range.start, static_cast<uint16_t>(item_id - 1));
+					pugi::xml_node tail = section.insert_child_after("item", item);
+					assignNodeRange(tail, static_cast<uint16_t>(item_id + 1), range.end);
+				}
+			}
+			item = next;
+		}
+		return removed;
+	}
+
+	void insertItemSorted(pugi::xml_node section, uint16_t item_id) {
+		for (pugi::xml_node item = section.child("item"); item; item = item.next_sibling("item")) {
+			const ItemRange range = readRange(item);
+			if (range.start <= item_id && item_id <= range.end) {
+				return;
+			}
+
+			if (range.start > item_id) {
+				pugi::xml_node inserted = section.insert_child_before("item", item);
+				assignNodeRange(inserted, item_id, item_id);
+				return;
+			}
+		}
+
+		pugi::xml_node inserted = section.append_child("item");
+		assignNodeRange(inserted, item_id, item_id);
+	}
+}
+
+std::unordered_set<std::string> TilesetXmlRewriter::LoadXmlTilesetNames() {
+	std::unordered_set<std::string> names;
+
+	pugi::xml_document document;
+	const std::string path = ResolveTilesetsPath();
+	if (!document.load_file(path.c_str())) {
+		return names;
+	}
+
+	pugi::xml_node materials = document.child("materials");
+	if (!materials) {
+		return names;
+	}
+
+	for (pugi::xml_node tileset = materials.child("tileset"); tileset; tileset = tileset.next_sibling("tileset")) {
+		const auto name = tileset.attribute("name");
+		if (!name) {
+			continue;
+		}
+
+		names.emplace(name.as_string());
+	}
+
+	return names;
+}
+
+bool TilesetXmlRewriter::IsVirtualRuntimeTilesetName(std::string_view tileset_name) {
+	return tileset_name == "Others" || tileset_name == "NPCs";
+}
+
+TilesetXmlRewriter::Result TilesetXmlRewriter::Apply(const std::vector<TilesetMoveQueue::Entry>& entries) const {
+	Result result;
+
+	pugi::xml_document document;
+	const std::string path = ResolveTilesetsPath();
+	const pugi::xml_parse_result parse_result = document.load_file(path.c_str());
+	if (!parse_result) {
+		result.error = "Could not open tilesets.xml.";
+		return result;
+	}
+
+	pugi::xml_node materials = document.child("materials");
+	if (!materials) {
+		result.error = "Invalid materials root in tilesets.xml.";
+		return result;
+	}
+
+	for (const auto& entry : entries) {
+		pugi::xml_node source_tileset = findTilesetNode(materials, entry.source.tileset_name);
+		pugi::xml_node target_tileset = findTilesetNode(materials, entry.target.tileset_name);
+
+		if (!target_tileset) {
+			result.warnings.push_back(
+				"Skipped item " + std::to_string(entry.item_id)
+				+ " because target tileset '" + entry.target.tileset_name + "' was not found in tilesets.xml."
+			);
+			++result.skipped;
+			continue;
+		}
+
+		if (!source_tileset && !IsVirtualRuntimeTilesetName(entry.source.tileset_name)) {
+			result.warnings.push_back(
+				"Skipped item " + std::to_string(entry.item_id)
+				+ " because source tileset '" + entry.source.tileset_name + "' was not found in tilesets.xml."
+			);
+			++result.skipped;
+			continue;
+		}
+
+		if (source_tileset) {
+			for (const pugi::xml_node& section : findSectionNodes(source_tileset, entry.source.palette)) {
+				removeItemFromSection(section, entry.item_id);
+			}
+		}
+
+		pugi::xml_node target_section = ensureTargetSection(target_tileset, entry.target.palette);
+		if (sectionContainsItem(target_section, entry.item_id)) {
+			result.warnings.push_back("Skipped item " + std::to_string(entry.item_id) + " because the target tileset already contains it.");
+			++result.skipped;
+			continue;
+		}
+
+		insertItemSorted(target_section, entry.item_id);
+		++result.applied;
+	}
+
+	if (!document.save_file(path.c_str(), PUGIXML_TEXT("\t"))) {
+		result.error = "Could not save tilesets.xml.";
+		return result;
+	}
+
+	result.success = true;
+	return result;
+}
+
+std::string TilesetXmlRewriter::ResolveTilesetsPath() {
+	wxString base = FileSystem::GetFoundDataDirectory();
+	if (base.empty()) {
+		base = FileSystem::GetDataDirectory();
+	}
+
+	FileName file;
+	file.Assign(base);
+	file.AppendDir("1310");
+	file.SetFullName("tilesets.xml");
+	return nstr(file.GetFullPath());
+}

--- a/source/tileset_move_queue/tileset_xml_rewriter.h
+++ b/source/tileset_move_queue/tileset_xml_rewriter.h
@@ -1,0 +1,35 @@
+#ifndef RME_TILESET_XML_REWRITER_H_
+#define RME_TILESET_XML_REWRITER_H_
+
+#include "tileset_move_queue/tileset_move_queue.h"
+
+#include <string>
+#include <string_view>
+#include <unordered_set>
+#include <vector>
+
+class TilesetXmlRewriter {
+public:
+	struct Result {
+		bool success = false;
+		int applied = 0;
+		int skipped = 0;
+		std::vector<std::string> warnings;
+		std::string error;
+	};
+
+	Result Apply(const std::vector<TilesetMoveQueue::Entry>& entries) const;
+
+private:
+	static std::string ResolveTilesetsPath();
+
+public:
+	static std::string DefaultTilesetsPath() {
+		return ResolveTilesetsPath();
+	}
+
+	static std::unordered_set<std::string> LoadXmlTilesetNames();
+	static bool IsVirtualRuntimeTilesetName(std::string_view tileset_name);
+};
+
+#endif

--- a/source/ui/gui.cpp
+++ b/source/ui/gui.cpp
@@ -46,6 +46,7 @@
 #include "ui/result_window.h"
 #include "rendering/ui/minimap_window.h"
 #include "palette/palette_window.h"
+#include "palette/panels/tileset_move_queue_panel.h"
 #include "palette/house/house_palette.h"
 #include "rendering/ui/map_display.h"
 #include "app/application.h"
@@ -102,6 +103,7 @@ GUI::GUI() :
 	root(nullptr),
 	tool_options(nullptr),
 	tile_properties_panel(nullptr),
+	tileset_move_queue_panel(nullptr),
 	pasting(false),
 	disabled_counter(0),
 	hotkeys_enabled(true) {
@@ -146,6 +148,39 @@ bool GUI::IsDrawingMode() const {
 	return mapTab ? mapTab->GetMode() == DRAWING_MODE : false;
 }
 
+void GUI::SetPaletteMultiSelectionCount(size_t count) {
+	const bool was_active = palette_multi_selection_count > 1;
+	palette_multi_selection_count = count;
+	const bool is_active = palette_multi_selection_count > 1;
+
+	if (was_active == is_active) {
+		return;
+	}
+
+	if (is_active) {
+		g_brush_manager.SelectBrush();
+		if (tool_options) {
+			tool_options->SetActiveBrush(nullptr);
+		}
+		if (IsDrawingMode()) {
+			SetSelectionMode();
+		} else {
+			SyncCurrentMapCanvasPreviewState();
+		}
+		SetStatusText("Multi-selection active. Choose a single item to draw on the map.");
+		return;
+	}
+
+	if (tool_options) {
+		tool_options->SetActiveBrush(GetCurrentBrush());
+	}
+	SyncCurrentMapCanvasPreviewState();
+}
+
+bool GUI::HasPaletteMultiSelection() const {
+	return palette_multi_selection_count > 1;
+}
+
 void GUI::SwitchMode() {
 	MapTab* mapTab = GetCurrentMapTab();
 	if (mapTab) {
@@ -174,6 +209,11 @@ void GUI::SetSelectionMode() {
 void GUI::SetDrawingMode() {
 	MapTab* mapTab = GetCurrentMapTab();
 	if (!mapTab || mapTab->GetMode() == DRAWING_MODE) {
+		return;
+	}
+
+	if (HasPaletteMultiSelection()) {
+		SetStatusText("Multi-selection is active. Choose a single item before drawing.");
 		return;
 	}
 
@@ -348,6 +388,7 @@ void GUI::FillDoodadPreviewBuffer() {
 }
 
 void GUI::SelectBrush() {
+	palette_multi_selection_count = 0;
 	g_brush_manager.SelectBrush();
 	if (tool_options) {
 		tool_options->SetActiveBrush(GetCurrentBrush());
@@ -356,6 +397,7 @@ void GUI::SelectBrush() {
 	emitBrushChangeIfNeeded(*this);
 }
 bool GUI::SelectBrush(const Brush* brush, PaletteType pt) {
+	palette_multi_selection_count = 0;
 	const bool changed = g_brush_manager.SelectBrush(brush, pt);
 	if (tool_options) {
 		tool_options->SetActiveBrush(GetCurrentBrush());
@@ -365,6 +407,7 @@ bool GUI::SelectBrush(const Brush* brush, PaletteType pt) {
 	return changed;
 }
 void GUI::SelectPreviousBrush() {
+	palette_multi_selection_count = 0;
 	g_brush_manager.SelectPreviousBrush();
 	if (tool_options) {
 		tool_options->SetActiveBrush(GetCurrentBrush());
@@ -373,6 +416,7 @@ void GUI::SelectPreviousBrush() {
 	emitBrushChangeIfNeeded(*this);
 }
 void GUI::SelectBrushInternal(Brush* brush) {
+	palette_multi_selection_count = 0;
 	g_brush_manager.SelectBrushInternal(brush);
 	if (tool_options) {
 		tool_options->SetActiveBrush(GetCurrentBrush());
@@ -655,6 +699,26 @@ void GUI::DestroyPalettes() {
 }
 PaletteWindow* GUI::CreatePalette() {
 	return g_palettes.CreatePalette();
+}
+
+void GUI::RefreshTilesetMoveQueuePanel(bool auto_show) {
+	if (!tileset_move_queue_panel) {
+		return;
+	}
+
+	tileset_move_queue_panel->ReloadFromQueue();
+	if (auto_show && !tileset_move_queue.Empty()) {
+		ShowTilesetMoveQueuePanel(true);
+	}
+}
+
+void GUI::ShowTilesetMoveQueuePanel(bool show) {
+	if (!tileset_move_queue_panel || !aui_manager) {
+		return;
+	}
+
+	aui_manager->GetPane(tileset_move_queue_panel).Show(show);
+	aui_manager->Update();
 }
 
 void SetWindowToolTip(wxWindow* a, const wxString& tip) {

--- a/source/ui/gui.h
+++ b/source/ui/gui.h
@@ -24,6 +24,7 @@
 #include "ui/managers/search_manager.h"
 #include "ui/managers/welcome_manager.h"
 #include "ui/managers/gl_context_manager.h"
+#include "tileset_move_queue/tileset_move_queue.h"
 
 class BaseMap;
 class Map;
@@ -58,6 +59,7 @@ class LiveSocket;
 class SidebarWindow;
 class ToolOptionsWindow;
 class TilePropertiesPanel;
+class TilesetMoveQueuePanel;
 
 wxDECLARE_EVENT(EVT_UPDATE_MENUS, wxCommandEvent);
 
@@ -205,6 +207,8 @@ public:
 	void SetDrawingMode();
 	bool IsSelectionMode() const;
 	bool IsDrawingMode() const;
+	void SetPaletteMultiSelectionCount(size_t count);
+	bool HasPaletteMultiSelection() const;
 
 	// Brushes
 	void FillDoodadPreviewBuffer();
@@ -348,6 +352,17 @@ public:
 
 	void DestroyPalettes();
 	PaletteWindow* CreatePalette();
+	TilesetMoveQueue& GetTilesetMoveQueue() {
+		return tileset_move_queue;
+	}
+	const TilesetMoveQueue& GetTilesetMoveQueue() const {
+		return tileset_move_queue;
+	}
+	TilesetMoveQueuePanel* GetTilesetMoveQueuePanel() const {
+		return tileset_move_queue_panel;
+	}
+	void RefreshTilesetMoveQueuePanel(bool auto_show = false);
+	void ShowTilesetMoveQueuePanel(bool show = true);
 
 protected:
 	//=========================================================================
@@ -365,6 +380,7 @@ public:
 
 	ToolOptionsWindow* tool_options;
 	TilePropertiesPanel* tile_properties_panel;
+	TilesetMoveQueuePanel* tileset_move_queue_panel;
 
 	bool pasting;
 
@@ -375,9 +391,11 @@ protected:
 	wxWindowDisabler* winDisabler;
 
 	int disabled_counter;
+	size_t palette_multi_selection_count = 0;
 
 	std::mutex pending_live_clients_mutex;
 	std::vector<std::unique_ptr<LiveClient>> pending_live_clients;
+	TilesetMoveQueue tileset_move_queue;
 
 	friend class RenderingLock;
 	friend class MapTab;

--- a/source/ui/main_frame.cpp
+++ b/source/ui/main_frame.cpp
@@ -25,6 +25,7 @@
 #include "app/updater.h"
 #include "ui/map/export_tilesets_window.h"
 #include "ui/tile_properties/tile_properties_panel.h"
+#include "palette/panels/tileset_move_queue_panel.h"
 #include <wx/stattext.h>
 #include <wx/slider.h>
 
@@ -75,6 +76,12 @@ MainFrame::MainFrame(const wxString& title, const wxPoint& pos, const wxSize& si
 
 	g_gui.tile_properties_panel = newd TilePropertiesPanel(this);
 	g_gui.aui_manager->AddPane(g_gui.tile_properties_panel, wxAuiPaneInfo().Name("TileProperties").Caption("Tile Properties").Right().Layer(1).Position(1).CloseButton(true).MaximizeButton(true).Hide());
+
+	g_gui.tileset_move_queue_panel = newd TilesetMoveQueuePanel(this);
+	g_gui.aui_manager->AddPane(
+		g_gui.tileset_move_queue_panel,
+		wxAuiPaneInfo().Name("TilesetMoveQueue").Caption("Move Queue").Right().Layer(1).Position(2).CloseButton(true).MaximizeButton(false).MinimizeButton(false).BestSize(260, 400).Hide()
+	);
 
 	// Create Script Manager panel (dockable)
 	LuaScriptsWindow* scriptsWindow = newd LuaScriptsWindow(this);


### PR DESCRIPTION
Brush/Border/Ground Studio scripts and required RME source changes for building and publishing custom grounds, borders, composers, and palette entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Border Studio—a focused step-by-step editor for creating and managing border sets with live preview and XML export.
  * Added Ground Studio—a terrain brush editor supporting variants, chance placement, and surface preview.
  * Added Brush Studio—a composition tool for creating brushes by combining grounds and borders, with palette publishing support.
  * Extended app API: added `app.grounds` property to access ground brush data and expanded storage operations (file checks, text reading, XML manipulation).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->